### PR TITLE
docs: adopt versioning + CHANGELOG + release-channel discipline (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to Crosswire are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This
+project uses **Pattern B fork versioning** — an independent
+`crosswire-vMAJOR.MINOR.PATCH` line with the upstream MeshCore baseline tracked
+separately. See [VERSIONING.md](VERSIONING.md) for the cadence (commit per task /
+compile, PR per epic, tag per landing), the `+N` dev-build suffix, and the
+dev / `-rc` / stable release channels.
+
+This changelog begins at the unified `firmware-base` line (**0.13.0**). Versions
+prior to 0.13.0 predate it; see `git tag -l 'crosswire-v*'` and the tag
+annotations for that history (highlights: v0.12.0 NimBLE migration, v0.11.x
+Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
+
+## [Unreleased]
+
+### Added
+- Versioning + release discipline: this `CHANGELOG.md`, the cadence and
+  release-channel sections in `VERSIONING.md`, and a Releases & versioning
+  pointer in `README.md`. (#11)
+
+_On merge this rolls into the next version tag (PATCH — docs landing)._
+
+## [0.13.1] - 2026-06-05
+
+### Added
+- Green status-LED heartbeat on the RAK4631 BLE companion
+  (`-D PIN_STATUS_LED=LED_BUILTIN`, green LED1 / P1.03). (#7)
+- Repeater heartbeat status LED in `simple_repeater`, enabled on the RAK3401
+  (WisMesh 1W) repeater env. (#9)
+
+### Fixed
+- nRF52 companion builds: guard `ESP.getFreeHeap()` in the HomeScreen so
+  non-ESP32 targets compile. (#8)
+- Added `scripts/firmware_identity.py` to the repo — closes the P5.2 pio-flash
+  wrapper gap (the wrapper imported a module that wasn't present). (#6)
+
+## [0.13.0] - 2026-06-05
+
+Baseline of the unified `firmware-base` line — the first version tag after the
+firmware migrated out of the `Strycher/MeshCore` fork into this repository. It
+carries the full migrated feature set (observer Plans 1-2, the NimBLE stack, the
+SafeBoot port, and repeater-telemetry).
+
+### Added
+- Repo governance folded into the firmware tree: flash / OTA / agent-mail
+  PreToolUse discipline, the Projects-v2 board sync workflow + field IDs, and
+  build-verification CI. (#334)
+
+### Fixed
+- OLED splash build identity: untagged builds self-identify by abbreviated SHA
+  instead of collapsing to a bare tag, and the version line is clamped to the
+  panel width. (#319)
+- Observer: publish heard packets to `/packets` (CoreScope schema) via the
+  `logRx` hook. (#335)
+- Observer: pair `esp_mqtt` stop with start on broker retry to stop a heap
+  leak. (#327)
+- Observer: reach the observer config CLI over USB serial
+  (transport-agnostic). (#325)

--- a/README.md
+++ b/README.md
@@ -13,15 +13,17 @@ A [MeshCore](https://github.com/meshcore-dev/MeshCore) fork for **cross-role fir
 
 Cross-cutting work used by multiple roles: a NimBLE migration off Bluedroid, a CrashLog / boot-survival diagnostics layer, and ongoing heap and power optimization for memory-constrained ESP32-S3 boards (Heltec V3 / V4, XIAO).
 
-## Status: code migration in progress
+## Status
 
-> The firmware currently lives on the `crosswire` branch of the [Strycher/MeshCore](https://github.com/Strycher/MeshCore) fork. It is **migrating into this repository** after an in-progress architecture refactor (moving the observer from inheriting the full MeshCore messenger to composing MeshCore as a dependency). Until that lands, this repo is the **home for issues, requests, and design-of-record** -- the code follows.
-
-The design-of-record for that refactor is in [`docs/architecture/`](docs/architecture/).
+The firmware lives here: **`firmware-base`** is the canonical Crosswire tree (the old `Strycher/MeshCore` fork is archived). Design-of-record for the observer architecture is in [`docs/architecture/`](docs/architecture/).
 
 ## Filing requests
 
 Requests and bug reports are welcome now -- use the issue templates (Bug report / Feature request). When reporting a bug, include the role, board, and the Crosswire version from the OLED splash or serial banner, and **never paste WiFi/MQTT credentials**.
+
+## Releases & versioning
+
+Crosswire uses an independent `crosswire-vMAJOR.MINOR.PATCH` version (see [VERSIONING.md](VERSIONING.md)); every build self-identifies on the OLED splash + serial banner. Changes are tracked in [CHANGELOG.md](CHANGELOG.md). Releases come in three channels: **dev** (CI artifacts, untested on hardware), **`-rc` pre-releases** (community testing), and **stable** (the "Latest" GitHub Release). The release gate is hardware validation, not just a green build.
 
 ## License
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -23,12 +23,24 @@ Increments per CLAUDE-BASE §Versioning:
 
 | Increment | When |
 |-----------|------|
-| **PATCH** | Every successful compile of fork code (bug fixes, small changes) |
-| **MINOR** | When a fork feature lands on a deploy branch (e.g., MQTT command queue ships, SafeBoot bench-validates) |
-| **MAJOR** | Release milestones (e.g., first public release, breaking compatibility changes) |
+| **PATCH** | Bug fixes, small changes, a landing that adds no user-facing capability (incl. docs) |
+| **MINOR** | A fork feature lands (e.g., a new LED behavior, MQTT command queue, SafeBoot bench-validates) |
+| **MAJOR** | Release milestones (first public release, breaking compatibility changes) |
 
-Tags are pushed to the Strycher/MeshCore remote and are accessible to all
-working trees of the fork.
+### Cadence (when each thing happens)
+
+| Action | Trigger | Result |
+|---|---|---|
+| **Commit** | Each completed task, **and after every successful compile** | granular history + clean rollback; shows as the `+N` suffix in `git describe` |
+| **PR** | A confirmed-working iteration of a **closed epic** | review surface + merge to `firmware-base` |
+| **Version bump (tag)** | Each landing on `firmware-base` (the epic PR) | a `crosswire-vX.Y.Z` tag; `CHANGELOG.md` `[Unreleased]` rolls into the new version section |
+
+Between version tags, commits accumulate as `+N` dev builds (e.g.
+`crosswire-v0.13.1-4-gABCDEF` = 4 commits past the tag); each epic landing cuts a
+new tag. **Every landing updates `CHANGELOG.md`.**
+
+Tags are pushed to the **`crosswire` remote** (`Strycher/Crosswire`) and are
+accessible to all working trees of the fork.
 
 ### Feature-scoped release tags
 
@@ -49,6 +61,25 @@ the table for feature-specific Crosswire releases that are intentionally NOT
 upstream-bound — i.e., features that only make sense under Crosswire branding
 (deployment-config, MQTT topic conventions tied to SWOH infrastructure, etc.).
 Not used yet; will be defined when the first such release ships.
+
+## Release channels (community availability)
+
+A *version tag* is an internal milestone; a *release* is the subset of tags
+published to the community. The split uses GitHub's native flags — no custom
+labels:
+
+| Channel | Mechanism | Audience |
+|---|---|---|
+| **dev** | CI build **artifact** only (downloadable from the Actions run); no GitHub Release | maintainer only |
+| **pre-release (`-rcN`)** | tag `crosswire-vX.Y.Z-rc1` → GitHub Release with the **pre-release** flag set | community testers; shown as "Pre-release", not "Latest" |
+| **stable** | tag `crosswire-vX.Y.Z` → GitHub Release marked **"Latest"** | everyone; the recommended download |
+
+Publishing a GitHub Release is the deliberate "make this available to the
+community" action. The **release gate is hardware validation** (the maintainer's
+hands-on test on real devices), not CI-green — CI-green only means "worth
+flashing to test." `-rc` is the single pre-release tier for now: testers arrive
+after the internal minimum bar, so they're already past "alpha". Add `-beta` only
+if a rougher tier below `-rc` is ever needed.
 
 ## Upstream baseline tracking
 
@@ -96,16 +127,21 @@ exceeds the tagging cost. Not done by default; case-by-case.
 
 ## How to increment the Crosswire version
 
-After landing a fork-side commit on the deploy branch:
+After an epic lands on `firmware-base` (and `CHANGELOG.md` `[Unreleased]` has been
+rolled into the new version section):
 
 ```bash
-# PATCH (most common: build artifact, small fix)
-git tag -a crosswire-v0.5.1 -m "PATCH: <one-line description>"
-git push strycher crosswire-v0.5.1
+# PATCH (small fix / docs / non-feature landing)
+git tag -a crosswire-v0.13.2 -m "PATCH: <one-line description>"
+git push crosswire crosswire-v0.13.2
 
 # MINOR (a feature lands)
-git tag -a crosswire-v0.6.0 -m "MINOR: <feature> landed"
-git push strycher crosswire-v0.6.0
+git tag -a crosswire-v0.14.0 -m "MINOR: <feature> landed"
+git push crosswire crosswire-v0.14.0
+
+# Pre-release for community testers (then publish a GitHub Release, pre-release flag)
+git tag -a crosswire-v0.14.0-rc1 -m "RC1: <feature> -- community test"
+git push crosswire crosswire-v0.14.0-rc1
 ```
 
 The firmware build picks up the latest matching tag via


### PR DESCRIPTION
Closes #11.

Encodes the agreed release/versioning process (part **(a)** of the CI/release discussion) so it stops depending on memory.

## Changes
- **NEW `CHANGELOG.md`** (Keep a Changelog) — backfilled `0.13.0` + `0.13.1`; `[Unreleased]` carries this docs landing (dogfoods the discipline).
- **`VERSIONING.md`** — added **Cadence** (commit per task + every compile → `+N`; PR per closed epic; tag/version-bump per landing) and **Release channels** (dev CI-artifact / `-rc` pre-release / stable 'Latest'); fixed stale `Strycher/MeshCore` + `strycher` remote refs → `crosswire`.
- **`README.md`** — migration status now complete (firmware-base is canonical); added a Releases & versioning pointer.

## On merge
Cut **`crosswire-v0.13.2`** (PATCH — docs landing) and roll `[Unreleased]` → `[0.13.2]`, exercising the new tag-per-landing rule for the first time.

Part **(b)** — CI artifact upload + tag→GitHub-Release wiring (auditing the inherited `build-*-firmwares.yml`) — follows behind the cutover build-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)