### PR TITLE
chore: roll CHANGELOG to v0.13.2 + fix em-dashes to ASCII (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to Crosswire are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This
-project uses **Pattern B fork versioning** — an independent
+project uses **Pattern B fork versioning** -- an independent
 `crosswire-vMAJOR.MINOR.PATCH` line with the upstream MeshCore baseline tracked
 separately. See [VERSIONING.md](VERSIONING.md) for the cadence (commit per task /
 compile, PR per epic, tag per landing), the `+N` dev-build suffix, and the
@@ -16,12 +16,14 @@ Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [0.13.2] - 2026-06-05
+
 ### Added
 - Versioning + release discipline: this `CHANGELOG.md`, the cadence and
   release-channel sections in `VERSIONING.md`, and a Releases & versioning
   pointer in `README.md`. (#11)
-
-_On merge this rolls into the next version tag (PATCH — docs landing)._
 
 ## [0.13.1] - 2026-06-05
 
@@ -34,12 +36,12 @@ _On merge this rolls into the next version tag (PATCH — docs landing)._
 ### Fixed
 - nRF52 companion builds: guard `ESP.getFreeHeap()` in the HomeScreen so
   non-ESP32 targets compile. (#8)
-- Added `scripts/firmware_identity.py` to the repo — closes the P5.2 pio-flash
+- Added `scripts/firmware_identity.py` to the repo -- closes the P5.2 pio-flash
   wrapper gap (the wrapper imported a module that wasn't present). (#6)
 
 ## [0.13.0] - 2026-06-05
 
-Baseline of the unified `firmware-base` line — the first version tag after the
+Baseline of the unified `firmware-base` line -- the first version tag after the
 firmware migrated out of the `Strycher/MeshCore` fork into this repository. It
 carries the full migrated feature set (observer Plans 1-2, the NimBLE stack, the
 SafeBoot port, and repeater-telemetry).

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -7,7 +7,7 @@ upstream MeshCore version captured as a separate baseline field.
 
 A suffix-style version (e.g., `v1.15.0-strycher.3`) anchors the fork's
 identity to a specific upstream release and resets at every rebase. Pattern B
-keeps a monotonic fork-version counter that survives upstream rebases —
+keeps a monotonic fork-version counter that survives upstream rebases --
 better for a fork with feature lines that outlive multiple upstream releases.
 
 The two versions (upstream + fork) are exposed separately in MQTT, CLI, and
@@ -58,14 +58,14 @@ the SafeBoot release tags travel cleanly without Crosswire-specific branding.
 
 A `crosswire-<feature>-vX.Y.Z` form (e.g., `crosswire-safeboot-v0.1.0`) is on
 the table for feature-specific Crosswire releases that are intentionally NOT
-upstream-bound — i.e., features that only make sense under Crosswire branding
+upstream-bound -- i.e., features that only make sense under Crosswire branding
 (deployment-config, MQTT topic conventions tied to SWOH infrastructure, etc.).
 Not used yet; will be defined when the first such release ships.
 
 ## Release channels (community availability)
 
 A *version tag* is an internal milestone; a *release* is the subset of tags
-published to the community. The split uses GitHub's native flags — no custom
+published to the community. The split uses GitHub's native flags -- no custom
 labels:
 
 | Channel | Mechanism | Audience |
@@ -76,7 +76,7 @@ labels:
 
 Publishing a GitHub Release is the deliberate "make this available to the
 community" action. The **release gate is hardware validation** (the maintainer's
-hands-on test on real devices), not CI-green — CI-green only means "worth
+hands-on test on real devices), not CI-green -- CI-green only means "worth
 flashing to test." `-rc` is the single pre-release tier for now: testers arrive
 after the internal minimum bar, so they're already past "alpha". Add `-beta` only
 if a rougher tier below `-rc` is ever needed.
@@ -86,7 +86,7 @@ if a rougher tier below `-rc` is ever needed.
 The upstream MeshCore version that a given Crosswire build rides on is
 captured separately at build time as `UPSTREAM_VERSION` (see FF2 / #179).
 The fork version `crosswire-vX.Y.Z` does NOT need to match upstream's
-version — they are independent counters.
+version -- they are independent counters.
 
 Example: Crosswire v0.5.0 riding on upstream MeshCore v1.15.0 is reported by
 firmware as:
@@ -100,12 +100,12 @@ firmware as:
 
 When upstream releases v1.16.0 and we rebase, the Crosswire version increments
 independently based on what NEW fork-side work landed during/around the
-rebase — not because of the upstream change itself.
+rebase -- not because of the upstream change itself.
 
 ## Initial backfill (2026-05-21)
 
 The first Crosswire version tag is **`crosswire-v0.5.0`**, applied to
-`crosswire` (the fork's active integration branch — renamed from
+`crosswire` (the fork's active integration branch -- renamed from
 `deploy/issues-84-86-87-combined` 2026-05-23 per LoRa#212) as of 2026-05-21.
 
 ### Why v0.5.0 (not v0.1.0 or v1.0.0)
@@ -151,8 +151,8 @@ see FF2 / #179).
 ## Related references
 
 - CLAUDE-BASE §Versioning (`C:\Dev\DifferentWire\standards\CLAUDE-BASE.md`)
-- `docs/cli-and-mqtt-commands.md` — CLI + MQTT command reference (`version` command, `wifi on N`, MQTT `ota_enable`, etc.)
-- `docs/safeboot-maintenance.md` — SafeBoot-specific tag scheme details
-- Epic #176 / LoRa-edl — this versioning discipline initiative
-- FF1 (#178 / LoRa-ry7) — this file's establishment
-- FF2 (#179 / LoRa-nnc) — embedding identity in firmware build (depends on this scheme)
+- `docs/cli-and-mqtt-commands.md` -- CLI + MQTT command reference (`version` command, `wifi on N`, MQTT `ota_enable`, etc.)
+- `docs/safeboot-maintenance.md` -- SafeBoot-specific tag scheme details
+- Epic #176 / LoRa-edl -- this versioning discipline initiative
+- FF1 (#178 / LoRa-ry7) -- this file's establishment
+- FF2 (#179 / LoRa-nnc) -- embedding identity in firmware build (depends on this scheme)


### PR DESCRIPTION
Follow-up to #12, finalizing the v0.13.2 release.

- Rolls CHANGELOG `[Unreleased]` -> `[0.13.2]`.
- Replaces 16 em-dashes with ASCII `--` across CHANGELOG.md + VERSIONING.md (no-em-dash rule; my error introduced in #12).

On merge: cut tag `crosswire-v0.13.2` on firmware-base. Refs #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)