### PR TITLE
ci: upload dev-channel firmware artifacts (#16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,20 @@ jobs:
 
       - name: Build ${{ matrix.env }}
         run: pio run -e ${{ matrix.env }}
+
+      # Dev-channel artifact (Strycher/Crosswire#16, epic #14 / T2). These are
+      # built with the PLACEHOLDER secrets stub above -- configure WiFi/MQTT at
+      # runtime (observer/companion) or rebuild with real secrets. They are
+      # dev/test builds, NOT releases (see VERSIONING.md release channels).
+      - name: Upload firmware artifact (dev channel)
+        uses: actions/upload-artifact@v4
+        with:
+          name: crosswire-dev-${{ matrix.env }}
+          path: |
+            .pio/build/${{ matrix.env }}/firmware.bin
+            .pio/build/${{ matrix.env }}/firmware.elf
+            .pio/build/${{ matrix.env }}/firmware.hex
+            .pio/build/${{ matrix.env }}/firmware.zip
+            .pio/build/${{ matrix.env }}/firmware.uf2
+          if-no-files-found: warn
+          retention-days: 90


### PR DESCRIPTION
Closes #16 (epic #14, **T2** -- the dev channel).

Each matrix build now uploads its `firmware.*` (.bin/.elf/.hex/.zip/.uf2; `if-no-files-found: warn`, 90-day retention) as `crosswire-dev-<env>`. This closes the 'CI compiles then discards the binary' gap -- dev builds are now downloadable from the Actions run.

**Caveat (in the workflow comment too):** built with the placeholder CI secrets stub, so these are **dev/test builds** -- configure WiFi/MQTT at runtime (observer/companion) or rebuild with real secrets. NOT releases.

**Verification gate:** this PR's own CI run is the test -- T2/`Crosswire-2nc` stays OPEN until I confirm the 6 `crosswire-dev-*` artifacts actually appear on the run (verify-after-push; pushed with DW_SKIP_CLOSE_CHECK, not a false-close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)