### PR TITLE
fix(#27): pio-flash firmware_dir -> repo root + --firmware-dir override

### DIFF
--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -64,12 +64,14 @@ REGISTRY_PATH = PROJECT_ROOT / "hardware-devices.yaml"
 FLASH_HISTORY_PATH = PROJECT_ROOT / "flash-history.jsonl"
 TOKEN_TTL_SEC = 300   # 5 min per Standards design note #1
 
-# Directory holding the firmware repo / pio.ini for upload + monitor invocations.
-# Per CLAUDE.md BUILD_COMMAND, the firmware lives at meshcore-firmware/ within
-# the LoRa project. Override at runtime if needed via PIO_FLASH_FIRMWARE_DIR.
+# Directory holding the firmware tree (platformio.ini + variants/) for build +
+# upload + monitor invocations. Post-migration the Crosswire repo root IS the
+# firmware tree, so the default is PROJECT_ROOT. Override per-host via the
+# PIO_FLASH_FIRMWARE_DIR env var, or per-invocation via --firmware-dir.
+# Precedence: --firmware-dir > PIO_FLASH_FIRMWARE_DIR > default. See #27.
 FIRMWARE_DIR = Path(os.environ.get(
     "PIO_FLASH_FIRMWARE_DIR",
-    str(PROJECT_ROOT / "meshcore-firmware"),
+    str(PROJECT_ROOT),
 ))
 
 
@@ -1065,6 +1067,14 @@ def build_parser() -> argparse.ArgumentParser:
         prog="pio-flash",
         description="LoRa flash-discipline wrapper (Epic A #44 / A2 #47).",
     )
+    p.add_argument(
+        "--firmware-dir",
+        default=None,
+        help="override the firmware tree (platformio.ini location) for this "
+             "invocation; must precede the subcommand. Precedence: "
+             "--firmware-dir > PIO_FLASH_FIRMWARE_DIR env > default "
+             "(Crosswire repo root). See #27.",
+    )
     sub = p.add_subparsers(dest="cmd", required=True)
 
     sub.add_parser("list", help="enumerate present ports vs registry (Tier 0)")
@@ -1130,7 +1140,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main() -> int:
+    global FIRMWARE_DIR
     args = build_parser().parse_args()
+    if getattr(args, "firmware_dir", None):
+        FIRMWARE_DIR = Path(args.firmware_dir).resolve()
     registry = load_registry()
     dispatch = {
         "list": cmd_list,


### PR DESCRIPTION
**Root cause:** `FIRMWARE_DIR` defaulted to `PROJECT_ROOT/meshcore-firmware`. After the wrapper was ported into Crosswire (P5.2), `PROJECT_ROOT` is the Crosswire repo, so the default resolved to a **missing** `Crosswire/meshcore-firmware`. Post-migration the firmware tree is the repo root. Every flash/preview refused. Surfaced during T5 (#19).

**Fix:**
- Default `FIRMWARE_DIR = PROJECT_ROOT` (the Crosswire repo / firmware tree).
- New global `--firmware-dir` flag for per-invocation tree switching. Precedence: `--firmware-dir` > `PIO_FLASH_FIRMWARE_DIR` env > default.

**Test (host-runnable):** syntax OK; `default == PROJECT_ROOT` and it contains `platformio.ini`; `--firmware-dir` parses; `PIO_FLASH_FIRMWARE_DIR` sets the default. DIAGNOSE/ROOT CAUSE/PLAN in #27.

Closes #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)