### PR TITLE
pio-flash artifact-flash: flash CI release artifacts through the identity gate (#29, #34)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ Thumbs.db
 
 # per-host device registry (LAN IPs/MACs) -- never commit; use hardware-devices.example.yaml
 hardware-devices.yaml
+
+# per-host flash audit log + full-flash backups (device MACs/DeviceIDs) -- never commit
+flash-history.jsonl
+flash-backups/

--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -84,6 +84,15 @@ ESP32_APP0_OFFSET = 0x10000      # ota_0 (app) partition start
 ESP32_OTADATA_OFFSET = 0xe000    # boot selector
 ESP32_OTADATA_SIZE = 0x2000
 
+# Bootloader-discovery (Strycher/Crosswire#34): native-USB boards change USB
+# identity + COM number entering bootloader (ESP32-S3 303A:0002->303A:1001;
+# nRF52/Adafruit 239A:8029->239A:00xx). After triggering bootloader entry on the
+# verified running port, the wrapper re-enumerates and discovers the new port by
+# vendor VID + a changed PID.
+ESP32S3_VENDOR = "303A"
+NRF52_VENDOR = "239A"
+BOOTLOADER_DISCOVER_TIMEOUT = 20   # seconds to wait for re-enumeration
+
 
 # ---------------------------------------------------------------------------
 # Output helpers - uniform formatting so the agent can parse refusal messages.
@@ -516,75 +525,196 @@ def _preview_artifact(args, port: dict, entry: dict) -> int:
     return 2
 
 
-def _flash_esp32_app_slot(artifact: Path, com: str, env_d: dict) -> int:
-    """NVS-preserving ESP32 update: write the app image to app0, then erase
-    otadata so the bootloader deterministically boots the image just written
-    (regardless of which OTA slot was previously active). NVS is never touched.
+def env_with_auth() -> dict:
+    """os.environ copy with the wrapper-authorization marker the future
+    pass-through hook keys on."""
+    e = os.environ.copy()
+    e["PIO_FLASH_AUTHORIZED"] = "1"
+    return e
 
-    ESP32-S3 native-USB (Strycher/Crosswire#29): the chip must ALREADY be in
-    ROM download mode (USB-Serial-JTAG identity) when this runs - the COM port
-    changes on reset, so the wrapper cannot reliably auto-enter download from
-    the running app. The write uses --after no_reset so the chip STAYS in
-    download for the otadata erase; the erase then resets it (default hard
-    reset) so it boots app0. Same download-chaining the factory-reset uses."""
-    out(f"[1/2] write-flash 0x{ESP32_APP0_OFFSET:x} {artifact.name} (app0 / ota_0; stay in download)")
-    rc1 = subprocess.call(
-        ["python", "-m", "esptool", "--port", com, "--after", "no-reset",
-         "write-flash", hex(ESP32_APP0_OFFSET), str(artifact)],
-        env=env_d,
+
+# esptool / adafruit-nrfutil output markers for output-parsed verification
+# (Strycher/Crosswire#34). Markers are matched case-insensitively.
+_ESPTOOL_WRITE_OK = ["hash of data verified"]
+_ESPTOOL_ERASE_OK = ["erased successfully", "erased in"]
+_ESPTOOL_FAIL = ["a fatal error", "serial exception", "failed", "traceback (most recent call"]
+_NRFUTIL_OK = ["device programmed"]
+_NRFUTIL_FAIL = ["failed to upgrade", "traceback (most recent call", "could not open port", "exception"]
+
+
+def _run_flasher(cmd: list, env_d: dict, success_markers: list,
+                 failure_markers: list) -> tuple[int, bool]:
+    """Run a flasher subprocess, capture + print its output, and decide success
+    by PARSING that output - never by exit code alone.
+
+    Rationale (Strycher/Crosswire#34): adafruit-nrfutil exits 0 even on a fatal
+    "Failed to upgrade target", which reported false success (the OTA-incident
+    class of bug). A flash is "ok" only when exit code 0 AND a positive success
+    marker is present AND no failure marker is present. Conservative by design:
+    anything ambiguous reads as FAILURE."""
+    proc = subprocess.run(cmd, env=env_d, capture_output=True, text=True)
+    output = (proc.stdout or "") + (proc.stderr or "")
+    if output.strip():
+        print(output)
+    low = output.lower()
+    failed = any(m in low for m in failure_markers)
+    succeeded = any(m in low for m in success_markers)
+    ok = (proc.returncode == 0) and succeeded and not failed
+    if not ok:
+        err(f"flasher result NOT verified (rc={proc.returncode}, "
+            f"success_marker={'yes' if succeeded else 'NO'}, "
+            f"failure_marker={'YES' if failed else 'no'})")
+    return proc.returncode, ok
+
+
+def _touch_1200(com: str) -> None:
+    """Pulse a serial port at 1200 baud to trigger reset-into-bootloader (the
+    Arduino / Adafruit auto-reset convention). The device re-enumerates as its
+    bootloader identity shortly after; the port dropping mid-touch is normal."""
+    try:
+        import serial
+    except ImportError:
+        refuse("pyserial not available; pip install pyserial")
+    try:
+        s = serial.Serial(com, baudrate=1200)
+        try:
+            s.dtr = False
+            time.sleep(0.15)
+        finally:
+            s.close()
+    except Exception as e:
+        out(f"  (1200-baud touch on {com} raised, normal on reset: {e})")
+
+
+def _esp32_trigger_download(com: str) -> None:
+    """Reset an ESP32-S3 into ROM download mode via esptool's default reset.
+    The connect then fails because the running USB-CDC port vanishes on reset -
+    that is expected; the reset is the point. The download port is discovered by
+    re-enumeration afterward."""
+    out(f"  (esptool default-reset {com} into download; connect failure is expected)")
+    try:
+        subprocess.run(
+            ["python", "-m", "esptool", "--port", com,
+             "--before", "default-reset", "--after", "no-reset",
+             "--connect-attempts", "1", "chip-id"],
+            env=env_with_auth(), capture_output=True, text=True, timeout=30,
+        )
+    except Exception:
+        pass
+
+
+def _discover_bootloader_port(before: list, vendor: str, running_pid: str,
+                              timeout: int) -> dict:
+    """After a bootloader-entry trigger, poll enumeration until exactly one NEW
+    port appears with the device's vendor VID and a PID different from the
+    running PID (i.e. it transitioned to a bootloader identity). Returns that
+    port. Refuses on zero (timeout) or more than one (ambiguous) - this is what
+    keeps the discovery from ever flashing the wrong device."""
+    before_coms = {p["com"] for p in before}
+    vendor = vendor.upper()
+    running_pid = running_pid.upper()
+    deadline = time.time() + timeout
+    last_seen: list = []
+    while time.time() < deadline:
+        now = enumerate_ports()
+        new = [p for p in now if p["com"] not in before_coms]
+        cands = [
+            p for p in new
+            if p["vid_pid"].split(":")[0].upper() == vendor
+            and p["vid_pid"].split(":")[1].upper() != running_pid
+        ]
+        last_seen = cands
+        if len(cands) == 1:
+            return cands[0]
+        if len(cands) > 1:
+            coms = ", ".join(f"{p['com']}({p['vid_pid']})" for p in cands)
+            refuse(
+                f"multiple new {vendor} bootloader ports appeared ({coms}); "
+                "refusing rather than guessing. Disconnect other devices and retry."
+            )
+        time.sleep(0.5)
+    refuse(
+        f"no bootloader port appeared within {timeout}s after the trigger "
+        f"(expected a new {vendor} port with PID != {running_pid}). The device "
+        "may not have entered bootloader mode. Last candidates: "
+        + (", ".join(p["com"] for p in last_seen) or "none")
     )
-    if rc1 != 0:
-        err(f"app write-flash failed (rc={rc1}); not touching otadata.")
-        return rc1
+
+
+def _enter_bootloader_and_discover(running_port: dict, platform: str) -> dict:
+    """Trigger bootloader entry on the verified running port, then discover the
+    device on its new (bootloader) COM. Unified for both chip families - they
+    all change identity + COM entering bootloader (Strycher/Crosswire#34)."""
+    vendor = NRF52_VENDOR if platform == "nrf52" else ESP32S3_VENDOR
+    running_pid = running_port["vid_pid"].split(":")[1]
+    out(f"Triggering bootloader entry on {running_port['com']} "
+        f"({running_port['vid_pid']}, {platform})...")
+    before = enumerate_ports()
+    if platform == "nrf52":
+        _touch_1200(running_port["com"])
+    else:
+        _esp32_trigger_download(running_port["com"])
+    bl = _discover_bootloader_port(before, vendor, running_pid,
+                                   BOOTLOADER_DISCOVER_TIMEOUT)
+    out(f"Discovered bootloader port: {bl['com']} "
+        f"({bl['vid_pid']}, hash {bl['instance_hash']})")
+    return bl
+
+
+def _flash_esp32_app_slot(artifact: Path, bl_com: str, env_d: dict) -> bool:
+    """NVS-preserving ESP32 update on the DISCOVERED download port: write the app
+    to app0 (--after no-reset, stay in download), then erase otadata so the
+    bootloader deterministically boots the written app. NVS (0x9000) untouched.
+    Each step verified by output, not exit code."""
+    out(f"[1/2] write-flash 0x{ESP32_APP0_OFFSET:x} {artifact.name} (app0; stay in download)")
+    _, ok1 = _run_flasher(
+        ["python", "-m", "esptool", "--port", bl_com, "--after", "no-reset",
+         "write-flash", hex(ESP32_APP0_OFFSET), str(artifact)],
+        env_d, _ESPTOOL_WRITE_OK, _ESPTOOL_FAIL,
+    )
+    if not ok1:
+        err("app write-flash did not verify; aborting before otadata erase.")
+        return False
     out(f"[2/2] erase-region 0x{ESP32_OTADATA_OFFSET:x} 0x{ESP32_OTADATA_SIZE:x} "
         "(otadata reset -> boot app0; chip resets after)")
-    rc2 = subprocess.call(
-        ["python", "-m", "esptool", "--port", com,
+    _, ok2 = _run_flasher(
+        ["python", "-m", "esptool", "--port", bl_com,
          "erase-region", hex(ESP32_OTADATA_OFFSET), hex(ESP32_OTADATA_SIZE)],
-        env=env_d,
+        env_d, _ESPTOOL_ERASE_OK, _ESPTOOL_FAIL,
     )
-    if rc2 != 0:
-        err(f"otadata erase failed (rc={rc2}). App is written but the boot "
-            "selector was not reset; the device may boot the OTHER slot. "
-            "Re-run, or use --erase for a clean factory flash.")
-    return rc2
+    return ok2
 
 
-def _flash_esp32_merged_full(artifact: Path, com: str, env_d: dict) -> int:
-    """Factory ESP32 flash: write the full merged image at 0x0. This spans the
-    NVS region, so it WIPES NVS and all stored config (intentional, --erase).
-    Chip must be in ROM download mode (see _flash_esp32_app_slot note)."""
+def _flash_esp32_merged_full(artifact: Path, bl_com: str, env_d: dict) -> bool:
+    """Factory ESP32 flash on the discovered download port: write the full merged
+    image at 0x0 (spans NVS -> WIPES it; intentional, --erase). Verified by output."""
     out(f"[1/1] write-flash 0x0 {artifact.name} (FULL merged - WIPES NVS)")
-    return subprocess.call(
-        ["python", "-m", "esptool", "--port", com,
+    _, ok = _run_flasher(
+        ["python", "-m", "esptool", "--port", bl_com,
          "write-flash", "0x0", str(artifact)],
-        env=env_d,
+        env_d, _ESPTOOL_WRITE_OK, _ESPTOOL_FAIL,
     )
+    return ok
 
 
-def _flash_nrf52_dfu(artifact: Path, com: str, env_d: dict) -> int:
-    """nRF52 serial DFU of the .zip via adafruit-nrfutil. --touch 1200 pulses
-    the port at 1200 baud to drop the running app into the UF2 bootloader, then
-    flashes. A normal app DFU preserves the internal config filesystem.
-
-    NOTE (Strycher/Crosswire#29): the ESP32 paths are hardware-validated; this
-    nRF52 path is implemented to the standard Adafruit invocation but is
-    UNVALIDATED on hardware until an nRF52 device is available. If the
-    bootloader re-enumerates on a different COM after the 1200-baud touch,
-    flash from an already-in-DFU device (double-tap reset) with its bootloader
-    identity registered instead."""
-    out(f"[1/1] adafruit-nrfutil dfu serial {artifact.name} -> {com} (--touch 1200)")
-    return subprocess.call(
+def _flash_nrf52_dfu(artifact: Path, bl_com: str, env_d: dict) -> bool:
+    """nRF52 serial DFU of the .zip on the DISCOVERED DFU port (no --touch - the
+    device is already in the bootloader). Success is decided by PARSING output:
+    adafruit-nrfutil exits 0 even when it fails (Strycher/Crosswire#34). A normal
+    app DFU preserves the internal config filesystem."""
+    out(f"[1/1] adafruit-nrfutil dfu serial {artifact.name} -> {bl_com}")
+    _, ok = _run_flasher(
         ["adafruit-nrfutil", "--verbose", "dfu", "serial",
-         "--package", str(artifact), "-p", com, "-b", "115200", "--touch", "1200"],
-        env=env_d,
+         "--package", str(artifact), "-p", bl_com, "-b", "115200"],
+        env_d, _NRFUTIL_OK, _NRFUTIL_FAIL,
     )
+    return ok
 
 
 def _confirm_artifact(args, token: dict, port: dict) -> int:
-    """Tier A stage 2 for an artifact flash: re-verify sha, then flash by the
-    method captured at preview. resolve_device + port/DeviceID re-checks have
-    ALREADY passed in cmd_confirm before this is called."""
+    """Tier A stage 2 for an artifact flash. The running identity has ALREADY
+    been re-verified in cmd_confirm. Here: re-check sha, trigger bootloader entry
+    + discover the bootloader port, flash it, verify by output, record."""
     artifact = Path(token["artifact_path"])
     if not artifact.exists():
         refuse(f"artifact {artifact} missing since preview")
@@ -596,19 +726,23 @@ def _confirm_artifact(args, token: dict, port: dict) -> int:
         )
 
     method = token.get("flash_method")
+    platform = token.get("platform")
     out("============================================================")
-    out(f"FLASHING {args.device} on {port['com']} (artifact: {method})")
+    out(f"FLASHING {args.device} (artifact: {method})")
+    out(f"Verified running identity: {port['com']} ({port['vid_pid']})")
     out("============================================================")
 
-    env_d = os.environ.copy()
-    env_d["PIO_FLASH_AUTHORIZED"] = "1"
+    # Trigger bootloader entry on the verified running port, then discover the
+    # device on its new bootloader COM (it changes identity + port).
+    bl = _enter_bootloader_and_discover(port, platform)
 
+    env_d = env_with_auth()
     if method == "esptool_app_slot":
-        rc = _flash_esp32_app_slot(artifact, port["com"], env_d)
+        ok = _flash_esp32_app_slot(artifact, bl["com"], env_d)
     elif method == "esptool_merged_full":
-        rc = _flash_esp32_merged_full(artifact, port["com"], env_d)
+        ok = _flash_esp32_merged_full(artifact, bl["com"], env_d)
     elif method == "nrfutil_dfu":
-        rc = _flash_nrf52_dfu(artifact, port["com"], env_d)
+        ok = _flash_nrf52_dfu(artifact, bl["com"], env_d)
     else:
         refuse(f"unknown flash_method in token: {method!r}")
 
@@ -616,20 +750,24 @@ def _confirm_artifact(args, token: dict, port: dict) -> int:
         "ts_unix": int(time.time()),
         "mode": "artifact-flash",
         "flash_method": method,
-        "platform": token.get("platform"),
+        "platform": platform,
         "erase": token.get("erase", False),
         "device": args.device,
-        "port": port["com"],
-        "deviceid_full": port["deviceid_full"],
-        "vid_pid": port["vid_pid"],
-        "instance_hash": port["instance_hash"],
+        "running_port": port["com"],
+        "running_vid_pid": port["vid_pid"],
+        "running_instance_hash": port["instance_hash"],
+        "bootloader_port": bl["com"],
+        "bootloader_vid_pid": bl["vid_pid"],
+        "bootloader_instance_hash": bl["instance_hash"],
+        "deviceid_full": bl["deviceid_full"],
         "artifact_path": token.get("artifact_path"),
         "firmware_sha256": token.get("firmware_sha256"),
         "firmware_size": token.get("firmware_size"),
         "crosswire_version": token.get("crosswire_version", "unknown"),
         "crosswire_git_sha": token.get("crosswire_git_sha", "unknown"),
         "firmware_identity_source": token.get("firmware_identity_source", "unknown"),
-        "exit_code": rc,
+        "verified_ok": ok,
+        "exit_code": 0 if ok else 1,
         "user_confirmation": args.device,
     })
 
@@ -638,8 +776,13 @@ def _confirm_artifact(args, token: dict, port: dict) -> int:
     except OSError:
         pass
 
-    out(f"artifact-flash exit code: {rc}")
-    return rc
+    if ok:
+        out("artifact-flash VERIFIED OK (output-parsed). Device should be "
+            "booting the new firmware.")
+        return 0
+    err("artifact-flash FAILED or NOT VERIFIED. See output above. The device "
+        "may still be in bootloader mode; reset it to recover.")
+    return 1
 
 
 def cmd_preview(args, registry):

--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -18,6 +18,7 @@ Proposal: C:\\Dev\\LoRa\\proposal-flash-discipline.md
 Usage:
     pio-flash list
     pio-flash preview  <device> --env <pio-env>
+    pio-flash preview  <device> --artifact <path> [--erase]
     pio-flash confirm  <device> --token <token-file>
     pio-flash monitor  <device> [--env <env>] [--baud 115200]
     pio-flash info     <device>
@@ -73,6 +74,15 @@ FIRMWARE_DIR = Path(os.environ.get(
     "PIO_FLASH_FIRMWARE_DIR",
     str(PROJECT_ROOT),
 ))
+
+# ESP32 OTA partition offsets. Universal across this repo's ESP32 partition
+# tables (default*.csv / min_spiffs.csv / max_app_*.csv place the low region
+# identically; only the high-region app/spiffs sizes vary). Verified against
+# the partition table embedded in CI -merged.bin images (Strycher/Crosswire#29):
+# nvs@0x9000, otadata@0xe000, app0(ota_0)@0x10000.
+ESP32_APP0_OFFSET = 0x10000      # ota_0 (app) partition start
+ESP32_OTADATA_OFFSET = 0xe000    # boot selector
+ESP32_OTADATA_SIZE = 0x2000
 
 
 # ---------------------------------------------------------------------------
@@ -359,9 +369,287 @@ def cmd_list(args, registry):
     return 0
 
 
+# ---------------------------------------------------------------------------
+# Artifact-flash (Strycher/Crosswire#29): flash a downloaded CI release
+# artifact through the SAME resolve_device identity gate as an env flash.
+# ESP32 default = NVS-preserving app-slot update (write app0 + reset otadata);
+# --erase = full factory write of the -merged.bin at 0x0. nRF52 = serial DFU
+# of the .zip (preserves the config filesystem).
+# ---------------------------------------------------------------------------
+ARTIFACT_RE = re.compile(
+    r"-(v\d+\.\d+\.\d+(?:-rc\d+)?)-([0-9a-fA-F]{7,40})(?:-merged)?\.(?:bin|zip|uf2)$"
+)
+
+
+def _artifact_identity(artifact: Path) -> dict:
+    """Identity from the CI artifact filename (<env>-<version>-<gitsha>[-merged].ext).
+
+    Deliberately does NOT fall back to the current repo's git state - an
+    artifact's identity is whatever the CI stamped into its name, never the
+    checkout the wrapper happens to run from.
+    """
+    m = ARTIFACT_RE.search(artifact.name)
+    if m:
+        return {
+            "crosswire_version": m.group(1),
+            "crosswire_git_sha": m.group(2),
+            "crosswire_branch": "unknown",
+            "crosswire_build_date": "unknown",
+            "firmware_identity_source": "ci-artifact-filename",
+        }
+    return {
+        "crosswire_version": "unknown",
+        "crosswire_git_sha": "unknown",
+        "crosswire_branch": "unknown",
+        "crosswire_build_date": "unknown",
+        "firmware_identity_source": "artifact-filename-unparsed",
+    }
+
+
+def _classify_artifact(path: Path, erase: bool) -> tuple[str, str]:
+    """Map an artifact path + --erase to (platform, flash_method). Refuses on
+    unsupported combinations rather than guessing."""
+    name = path.name.lower()
+    suffix = path.suffix.lower()
+    if suffix == ".zip":
+        if erase:
+            refuse(
+                "nRF52 --erase is not supported: serial DFU cannot wipe the "
+                "config filesystem. Re-run without --erase (DFU preserves it)."
+            )
+        return ("nrf52", "nrfutil_dfu")
+    if suffix == ".uf2":
+        refuse(
+            "nRF52 .uf2 drive-copy is not supported through the wrapper (it "
+            "bypasses the identity gate). Use the .zip DFU package instead."
+        )
+    if suffix == ".bin":
+        is_merged = "merged" in name
+        if erase:
+            if not is_merged:
+                refuse(
+                    f"--erase requires the full -merged.bin, but '{path.name}' "
+                    "looks like an app-only bin. Pass the *-merged.bin, or drop "
+                    "--erase for an NVS-preserving app-slot update."
+                )
+            return ("esp32", "esptool_merged_full")
+        if is_merged:
+            refuse(
+                f"default (NVS-preserving) mode expects the app-only .bin, not "
+                f"'{path.name}'. Pass the non-merged *.bin, or add --erase to "
+                "factory-flash the -merged.bin (this WIPES NVS)."
+            )
+        return ("esp32", "esptool_app_slot")
+    refuse(
+        f"unrecognized artifact type '{suffix}'. Expected .bin (ESP32) or "
+        ".zip (nRF52 DFU package)."
+    )
+
+
+def _preview_artifact(args, port: dict, entry: dict) -> int:
+    """Tier A stage 1 for an artifact flash: validate + write token, exit 2.
+    resolve_device (the identity gate) has ALREADY run before this is called."""
+    artifact = Path(args.artifact).resolve()
+    if not artifact.exists():
+        refuse(f"artifact {artifact} not found")
+    platform, method = _classify_artifact(artifact, args.erase)
+    sha = sha256_of(artifact)
+    size = artifact.stat().st_size
+    ident = _artifact_identity(artifact)
+
+    if method == "esptool_app_slot":
+        mode_desc = (
+            f"app-slot update: write app0 @ 0x{ESP32_APP0_OFFSET:x}, "
+            f"erase otadata @ 0x{ESP32_OTADATA_OFFSET:x} -> PRESERVES NVS"
+        )
+    elif method == "esptool_merged_full":
+        mode_desc = "FULL FACTORY: merged @ 0x0 -> ERASES NVS and all data"
+    else:
+        mode_desc = "nRF52 serial DFU (.zip) -> PRESERVES config filesystem"
+
+    out("============================================================")
+    out("PREVIEW (Tier A artifact-flash) - no device touch yet")
+    out("============================================================")
+    out(f"Target device : {args.device}")
+    out(f"Registered MAC: {entry.get('mac')}")
+    out(f"Resolved port : {port['com']}")
+    out(f"Port VID:PID  : {port['vid_pid']}")
+    out(f"Port DeviceID : {port['deviceid_full']}")
+    out(f"Hash match    : {port['instance_hash']}")
+    out(f"Artifact      : {artifact}")
+    out(f"Artifact sha256: {sha}")
+    out(f"Artifact size : {size} bytes")
+    out(f"Platform      : {platform}")
+    out(f"Flash method  : {method}")
+    out(f"Mode          : {mode_desc}")
+    out(f"Crosswire ver : {ident['crosswire_version']}")
+    out(f"Crosswire SHA : {ident['crosswire_git_sha']}")
+    out(f"Identity src  : {ident['firmware_identity_source']}")
+    out("------------------------------------------------------------")
+    out("To proceed, get explicit user GO in chat naming the device, then run:")
+    out(f"  scripts/pio-flash confirm {args.device} --token {token_path(args.device)}")
+    out(f"Token TTL: {TOKEN_TTL_SEC}s. Token invalidates if port/DeviceID/")
+    out("artifact sha changes before confirm.")
+    out("============================================================")
+
+    payload = {
+        "device": args.device,
+        "mode": "artifact",
+        "platform": platform,
+        "flash_method": method,
+        "erase": bool(args.erase),
+        "port": port["com"],
+        "deviceid_full": port["deviceid_full"],
+        "vid_pid": port["vid_pid"],
+        "instance_hash": port["instance_hash"],
+        "artifact_path": str(artifact),
+        "firmware_sha256": sha,
+        "firmware_size": size,
+        "crosswire_version": ident["crosswire_version"],
+        "crosswire_git_sha": ident["crosswire_git_sha"],
+        "crosswire_branch": ident["crosswire_branch"],
+        "crosswire_build_date": ident["crosswire_build_date"],
+        "firmware_identity_source": ident["firmware_identity_source"],
+    }
+    p = write_token(args.device, payload)
+    out(f"Token written: {p}")
+    return 2
+
+
+def _flash_esp32_app_slot(artifact: Path, com: str, env_d: dict) -> int:
+    """NVS-preserving ESP32 update: write the app image to app0, then erase
+    otadata so the bootloader deterministically boots the image just written
+    (regardless of which OTA slot was previously active). NVS is never touched.
+
+    ESP32-S3 native-USB (Strycher/Crosswire#29): the chip must ALREADY be in
+    ROM download mode (USB-Serial-JTAG identity) when this runs - the COM port
+    changes on reset, so the wrapper cannot reliably auto-enter download from
+    the running app. The write uses --after no_reset so the chip STAYS in
+    download for the otadata erase; the erase then resets it (default hard
+    reset) so it boots app0. Same download-chaining the factory-reset uses."""
+    out(f"[1/2] write-flash 0x{ESP32_APP0_OFFSET:x} {artifact.name} (app0 / ota_0; stay in download)")
+    rc1 = subprocess.call(
+        ["python", "-m", "esptool", "--port", com, "--after", "no-reset",
+         "write-flash", hex(ESP32_APP0_OFFSET), str(artifact)],
+        env=env_d,
+    )
+    if rc1 != 0:
+        err(f"app write-flash failed (rc={rc1}); not touching otadata.")
+        return rc1
+    out(f"[2/2] erase-region 0x{ESP32_OTADATA_OFFSET:x} 0x{ESP32_OTADATA_SIZE:x} "
+        "(otadata reset -> boot app0; chip resets after)")
+    rc2 = subprocess.call(
+        ["python", "-m", "esptool", "--port", com,
+         "erase-region", hex(ESP32_OTADATA_OFFSET), hex(ESP32_OTADATA_SIZE)],
+        env=env_d,
+    )
+    if rc2 != 0:
+        err(f"otadata erase failed (rc={rc2}). App is written but the boot "
+            "selector was not reset; the device may boot the OTHER slot. "
+            "Re-run, or use --erase for a clean factory flash.")
+    return rc2
+
+
+def _flash_esp32_merged_full(artifact: Path, com: str, env_d: dict) -> int:
+    """Factory ESP32 flash: write the full merged image at 0x0. This spans the
+    NVS region, so it WIPES NVS and all stored config (intentional, --erase).
+    Chip must be in ROM download mode (see _flash_esp32_app_slot note)."""
+    out(f"[1/1] write-flash 0x0 {artifact.name} (FULL merged - WIPES NVS)")
+    return subprocess.call(
+        ["python", "-m", "esptool", "--port", com,
+         "write-flash", "0x0", str(artifact)],
+        env=env_d,
+    )
+
+
+def _flash_nrf52_dfu(artifact: Path, com: str, env_d: dict) -> int:
+    """nRF52 serial DFU of the .zip via adafruit-nrfutil. --touch 1200 pulses
+    the port at 1200 baud to drop the running app into the UF2 bootloader, then
+    flashes. A normal app DFU preserves the internal config filesystem.
+
+    NOTE (Strycher/Crosswire#29): the ESP32 paths are hardware-validated; this
+    nRF52 path is implemented to the standard Adafruit invocation but is
+    UNVALIDATED on hardware until an nRF52 device is available. If the
+    bootloader re-enumerates on a different COM after the 1200-baud touch,
+    flash from an already-in-DFU device (double-tap reset) with its bootloader
+    identity registered instead."""
+    out(f"[1/1] adafruit-nrfutil dfu serial {artifact.name} -> {com} (--touch 1200)")
+    return subprocess.call(
+        ["adafruit-nrfutil", "--verbose", "dfu", "serial",
+         "--package", str(artifact), "-p", com, "-b", "115200", "--touch", "1200"],
+        env=env_d,
+    )
+
+
+def _confirm_artifact(args, token: dict, port: dict) -> int:
+    """Tier A stage 2 for an artifact flash: re-verify sha, then flash by the
+    method captured at preview. resolve_device + port/DeviceID re-checks have
+    ALREADY passed in cmd_confirm before this is called."""
+    artifact = Path(token["artifact_path"])
+    if not artifact.exists():
+        refuse(f"artifact {artifact} missing since preview")
+    sha_now = sha256_of(artifact)
+    if sha_now != token["firmware_sha256"]:
+        refuse(
+            f"artifact sha256 changed since preview "
+            f"({token['firmware_sha256']} -> {sha_now}). Re-run preview."
+        )
+
+    method = token.get("flash_method")
+    out("============================================================")
+    out(f"FLASHING {args.device} on {port['com']} (artifact: {method})")
+    out("============================================================")
+
+    env_d = os.environ.copy()
+    env_d["PIO_FLASH_AUTHORIZED"] = "1"
+
+    if method == "esptool_app_slot":
+        rc = _flash_esp32_app_slot(artifact, port["com"], env_d)
+    elif method == "esptool_merged_full":
+        rc = _flash_esp32_merged_full(artifact, port["com"], env_d)
+    elif method == "nrfutil_dfu":
+        rc = _flash_nrf52_dfu(artifact, port["com"], env_d)
+    else:
+        refuse(f"unknown flash_method in token: {method!r}")
+
+    log_history({
+        "ts_unix": int(time.time()),
+        "mode": "artifact-flash",
+        "flash_method": method,
+        "platform": token.get("platform"),
+        "erase": token.get("erase", False),
+        "device": args.device,
+        "port": port["com"],
+        "deviceid_full": port["deviceid_full"],
+        "vid_pid": port["vid_pid"],
+        "instance_hash": port["instance_hash"],
+        "artifact_path": token.get("artifact_path"),
+        "firmware_sha256": token.get("firmware_sha256"),
+        "firmware_size": token.get("firmware_size"),
+        "crosswire_version": token.get("crosswire_version", "unknown"),
+        "crosswire_git_sha": token.get("crosswire_git_sha", "unknown"),
+        "firmware_identity_source": token.get("firmware_identity_source", "unknown"),
+        "exit_code": rc,
+        "user_confirmation": args.device,
+    })
+
+    try:
+        Path(args.token).unlink()
+    except OSError:
+        pass
+
+    out(f"artifact-flash exit code: {rc}")
+    return rc
+
+
 def cmd_preview(args, registry):
     """Tier A stage 1: resolve target, validate firmware, write token, exit 2."""
     port, entry = resolve_device(args.device, registry)
+    if getattr(args, "artifact", None):
+        return _preview_artifact(args, port, entry)
+    if getattr(args, "erase", False):
+        refuse("--erase only applies to --artifact flashes (the --env path "
+               "uses pio upload, which does not erase).")
     env = args.env
     firmware_bin = FIRMWARE_DIR / ".pio" / "build" / env / "firmware.bin"
     if not firmware_bin.exists():
@@ -450,6 +738,9 @@ def cmd_confirm(args, registry):
             f"({token['deviceid_full']} -> {port['deviceid_full']}). "
             "Re-run preview."
         )
+
+    if token.get("mode") == "artifact":
+        return _confirm_artifact(args, token, port)
 
     firmware_bin = Path(token["firmware_bin"])
     if not firmware_bin.exists():
@@ -1081,7 +1372,16 @@ def build_parser() -> argparse.ArgumentParser:
 
     s = sub.add_parser("preview", help="stage a Tier A flash (writes token, no flash)")
     s.add_argument("device", help="registered device name (e.g. ST-P)")
-    s.add_argument("--env", required=True, help="pio env (e.g. heltec_v4_repeater_telemetry)")
+    g = s.add_mutually_exclusive_group(required=True)
+    g.add_argument("--env", help="pio env to build + upload (e.g. heltec_v4_companion_radio_ble)")
+    g.add_argument("--artifact", help="path to a downloaded CI firmware artifact to flash "
+                   "through the identity gate. ESP32: app '.bin' (default, NVS-preserving) "
+                   "or '-merged.bin' with --erase (factory wipe). nRF52: '.zip' DFU package. "
+                   "Mutually exclusive with --env.")
+    s.add_argument("--erase", action="store_true",
+                   help="ESP32 artifact-flash only: write the full -merged.bin at 0x0 "
+                        "including NVS (factory wipe). Without it, an app .bin is written "
+                        "to app0 and otadata is reset, preserving NVS.")
 
     s = sub.add_parser("confirm", help="execute the staged Tier A flash")
     s.add_argument("device", help="must match the device in the token")


### PR DESCRIPTION
## Summary
Adds artifact-flash to `scripts/pio-flash.py`: flash a downloaded CI release artifact onto a device **through the same `resolve_device` identity gate** as an env flash. Hardware-validated on ST-P (ESP32-S3) and a RAK4631 (nRF52) with `crosswire-v0.14.0-rc1`.

Closes #29. Closes #34.

## What's new
- `preview --artifact <path> [--erase]` (mutually exclusive with `--env`) + an artifact-mode `confirm`. No bypass: `resolve_device` runs first; a write happens only if it passes. Single-use token, 300s TTL.
- **ESP32:** default = NVS-preserving app-slot update (write app0 + reset otadata); `--erase` = factory write of the `-merged.bin` at `0x0` (wipes NVS).
- **nRF52:** serial DFU of the `.zip` (preserves the config filesystem).
- Artifact identity read from the CI filename; classification by type + `--erase` (refuses unsupported combos).

## Native-USB handling (#34)
These boards change USB identity + COM entering bootloader (ESP32-S3 `303A:0002`->`303A:1001`; nRF52 `239A:8029`->`239A:00xx`). The wrapper now: verify running identity (gate) -> trigger bootloader entry (nRF52 1200-baud touch; ESP32 esptool default-reset) -> **re-enumerate and discover** the single new same-vendor port with a changed PID (refuse on zero/multiple - no wrong-device guess) -> flash that port -> record the discovered bootloader identity.

## Silent-success fix (#34, critical)
Flash success is decided by **parsing flasher output**, never the exit code - `adafruit-nrfutil` exits 0 even on a fatal "Failed to upgrade". `ok = exit 0 AND a success marker present AND no failure marker`. This is the OTA-incident class of bug; the parse caught it.

## Hardware validation (this session, both `verified_ok=true` in flash-history)
- **ST-P ESP32-S3:** discovered `303A:1001`/COM9, app0 + otadata, hash verified, booted `v0.14.0-rc1`, NVS preserved (device displays "Crosswire 0.14.0").
- **RAK4631 nRF52:** discovered `239A:002A`/COM13, DFU "Device programmed", booted.

## Also
- `.gitignore`: `flash-history.jsonl` + `flash-backups/` (per-host audit logs hold device MACs; this repo is public).

## Follow-ups (filed, not in this PR)
- #33: on-device version drops the `-rc` pre-release identifier + must fit OLED width.
- #22: pre-commit/pre-push project resolution in worktrees (DW_PROJECT workaround).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
