### PR TITLE
fix(#33): OLED splash carries pre-release identifier (v0.14.0-rc1, not v0.14.0+0)

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -62,34 +62,49 @@ public:
     // Crosswire version: strip leading "crosswire-" tag prefix, then render
     // a COMPACT build-identity that distinguishes test builds from the
     // tagged release (Strycher/LoRa#319). git describe form is
-    // "<tag>-<N>-g<sha>[-dirty]"; we render:
-    //   crosswire-v0.12.0                   -> v0.12.0     (clean release)
-    //   crosswire-v0.12.0-4-g369714e        -> v0.12.0+4   (4 commits past tag)
-    //   crosswire-v0.12.0-4-g369714e-dirty  -> v0.12.0+4*  (+ dirty work tree)
-    // The full identity (SHA included) stays available via the `ver` CLI
-    // command + the CROSSWIRE_IDENTITY_BLOB in .rodata; this is just the
-    // at-a-glance form. "Crosswire v0.12.0+4*" is 20 chars, fits 128px size-1.
-    // Prior behavior trimmed at the first dash, collapsing every test build
-    // to the bare tag -- three distinct binaries all showed "v0.12.0",
-    // which actively caused confusion during #318 bench testing.
+    // "<tag>[-<N>-g<sha>][-dirty]", where <tag> may ITSELF contain dashes for
+    // a pre-release (e.g. v0.14.0-rc1). We render:
+    //   crosswire-v0.14.0                  -> v0.14.0        (clean release)
+    //   crosswire-v0.14.0-rc1              -> v0.14.0-rc1    (clean pre-release)
+    //   crosswire-v0.14.0-rc1-4-g369714e   -> v0.14.0-rc1+4  (4 past pre-release)
+    //   crosswire-v0.14.0-4-g369714e       -> v0.14.0+4      (4 past release)
+    //   ...-dirty                          -> ...*           (dirty work tree)
+    // Full identity (SHA included) stays in the `ver` CLI + the
+    // CROSSWIRE_IDENTITY_BLOB in .rodata; this is just the at-a-glance form.
+    // Spec + fixtures: scripts/test_crosswire_version_splash.py.
+    //
+    // The commits-since suffix is identified by git's "-g<sha>" marker, NOT the
+    // first dash. Splitting on the first dash (prior behavior) mis-read a
+    // pre-release tag's "-rcN" as the commits field -> it dropped "-rcN" and
+    // showed a spurious "+0" (Strycher/Crosswire#33).
     const char *cw = CROSSWIRE_VERSION;
     static const char *cw_prefix = "crosswire-";
     if (strncmp(cw, cw_prefix, 10) == 0) cw += 10;
-    const char *cw_dash  = strchr(cw, '-');
     bool        cw_dirty = (strstr(cw, "-dirty") != nullptr);
-    if (cw_dash == nullptr) {
-      // Clean tagged release: no commits-since suffix.
-      int cwlen = strlen(cw);
-      if (cwlen >= (int)sizeof(_crosswire_short)) cwlen = sizeof(_crosswire_short) - 1;
-      memcpy(_crosswire_short, cw, cwlen);
-      _crosswire_short[cwlen] = 0;
+    const char *gmark    = strstr(cw, "-g");   // start of "-g<sha>" iff commits>0
+    int commits = 0;
+    int taglen;
+    if (gmark != nullptr) {
+      // commits = the integer immediately before "-g"; the tag ends at the
+      // dash that precedes that integer.
+      const char *nstart = gmark;
+      while (nstart > cw && nstart[-1] >= '0' && nstart[-1] <= '9') nstart--;
+      commits = atoi(nstart);
+      taglen  = (int)(((nstart > cw) && (nstart[-1] == '-')) ? (nstart - 1 - cw)
+                                                             : (nstart - cw));
     } else {
-      // <tag>+<commits-since>[*]. atoi reads the integer right after the
-      // first dash; stops at the next non-digit ('-g...' or '-dirty').
-      int taglen  = (int)(cw_dash - cw);
-      int commits = atoi(cw_dash + 1);
+      // No commits suffix: exact tag (may be a pre-release). Trim a trailing
+      // "-dirty" so it is not counted as part of the tag.
+      const char *d = strstr(cw, "-dirty");
+      taglen = d ? (int)(d - cw) : (int)strlen(cw);
+    }
+    if (taglen >= (int)sizeof(_crosswire_short)) taglen = (int)sizeof(_crosswire_short) - 1;
+    if (commits > 0) {
       snprintf(_crosswire_short, sizeof(_crosswire_short), "%.*s+%d%s",
                taglen, cw, commits, cw_dirty ? "*" : "");
+    } else {
+      snprintf(_crosswire_short, sizeof(_crosswire_short), "%.*s%s",
+               taglen, cw, cw_dirty ? "*" : "");
     }
 #endif
 

--- a/scripts/test_crosswire_version_splash.py
+++ b/scripts/test_crosswire_version_splash.py
@@ -1,0 +1,78 @@
+# scripts/test_crosswire_version_splash.py
+#
+# Verifies the companion OLED splash compact-version derivation
+# (SplashScreen in examples/companion_radio/ui-new/UITask.cpp) by implementing
+# the same pure parse in Python and testing against known-good fixtures.
+#
+# The C++ implementation is a direct translation of this algorithm; this test
+# is the executable specification (Strycher/Crosswire#33). Portable: no g++.
+#
+# Run with:  python scripts/test_crosswire_version_splash.py
+
+import sys
+
+CW_PREFIX = "crosswire-"
+
+
+def compact_crosswire_version(cw: str) -> str:
+    """Python equivalent of the SplashScreen _crosswire_short derivation.
+
+    CROSSWIRE_VERSION is `git describe` output: "<tag>[-<N>-g<sha>][-dirty]"
+    where <tag> may itself contain dashes for a pre-release (e.g. v0.14.0-rc1).
+    The commits-since suffix is identified by git's "-g<sha>" marker, NOT the
+    first dash (which on a pre-release tag is the "-rcN" separator).
+    """
+    if cw.startswith(CW_PREFIX):
+        cw = cw[len(CW_PREFIX):]
+    cw_dirty = "-dirty" in cw
+    gmark = cw.find("-g")           # start of "-g<sha>" iff commits>0
+    commits = 0
+    if gmark != -1:
+        # commits = the integer immediately before "-g"; tag ends at the dash
+        # that precedes that integer.
+        n_start = gmark
+        while n_start > 0 and cw[n_start - 1].isdigit():
+            n_start -= 1
+        commits = int(cw[n_start:gmark]) if gmark > n_start else 0
+        tag_end = (n_start - 1) if (n_start > 0 and cw[n_start - 1] == "-") else n_start
+        tag = cw[:tag_end]
+    else:
+        # No commits suffix: exact tag (may be a pre-release). Trim trailing -dirty.
+        d = cw.find("-dirty")
+        tag = cw[:d] if d != -1 else cw
+    suffix = ("+%d" % commits) if commits > 0 else ""
+    return tag + suffix + ("*" if cw_dirty else "")
+
+
+FIXTURES = [
+    # (label, CROSSWIRE_VERSION, expected compact form)
+    ("exact release tag",        "crosswire-v0.14.0",                  "v0.14.0"),
+    ("exact pre-release tag",    "crosswire-v0.14.0-rc1",              "v0.14.0-rc1"),
+    ("rc2 exact pre-release",    "crosswire-v1.2.3-rc2",              "v1.2.3-rc2"),
+    ("commits past release",     "crosswire-v0.14.0-4-g369714e",       "v0.14.0+4"),
+    ("commits past pre-release", "crosswire-v0.14.0-rc1-4-g369714e",   "v0.14.0-rc1+4"),
+    ("dirty exact pre-release",  "crosswire-v0.14.0-rc1-dirty",        "v0.14.0-rc1*"),
+    ("dirty commits past tag",   "crosswire-v0.14.0-4-g369714e-dirty", "v0.14.0+4*"),
+    ("untagged SHA fallback",    "369714e",                            "369714e"),
+]
+
+failures = []
+for label, cw, expected in FIXTURES:
+    got = compact_crosswire_version(cw)
+    if got == expected:
+        print(f"OK: '{cw}' -> '{got}' ({label})")
+    else:
+        print(f"FAIL: '{cw}' -> '{got}', expected '{expected}' ({label})")
+        failures.append(label)
+
+# Explicit regression guard for the #33 bug: a clean pre-release tag must NOT
+# collapse to "v0.14.0+0".
+if compact_crosswire_version("crosswire-v0.14.0-rc1") == "v0.14.0+0":
+    print("FAIL: regression -- pre-release tag still renders the spurious '+0'")
+    failures.append("rc1-plus0-regression")
+
+if failures:
+    print(f"\n{len(failures)} check(s) failed.")
+    sys.exit(1)
+print(f"\nAll {len(FIXTURES)} fixtures + regression guard passed.")
+sys.exit(0)


### PR DESCRIPTION
## Summary
The companion OLED splash dropped the pre-release identifier from the on-device version: a `crosswire-v0.14.0-rc1` build displayed **`Crosswire v0.14.0+0`** instead of `v0.14.0-rc1`. Closes #33.

## Root cause
`SplashScreen` (`examples/companion_radio/ui-new/UITask.cpp`) built the compact version by splitting `CROSSWIRE_VERSION` on the **first dash**, assuming git-describe's `<tag>-<N>-g<sha>` commits suffix. For a pre-release tag (no commits suffix) the first dash is the `-rcN` separator -> it read `tag=v0.14.0`, `commits=atoi("rc1")=0` -> rendered `v0.14.0+0`, dropping `-rcN`.

## Fix
Parse by git's `-g<sha>` marker (which only appears in the real commits suffix) instead of the first dash, so the tag -- including `-rcN` -- survives; and omit `+0` when commits==0.

| `CROSSWIRE_VERSION` | splash |
|---|---|
| `v0.14.0` | `Crosswire v0.14.0` |
| `v0.14.0-rc1` | **`Crosswire v0.14.0-rc1`** (21 chars, fits 128px size-1) |
| `v0.14.0-rc1-4-g369714e` | `Crosswire v0.14.0-rc1+4` |
| `v0.14.0-4-g369714e` | `Crosswire v0.14.0+4` |

The existing 21-char width-clamp still guards the rare long form (a dev build past an rc tag clamps the `+N`; releases are unaffected).

## Test
- `scripts/test_crosswire_version_splash.py` — Python executable spec mirroring the C++ parse: **8 fixtures + a regression guard, all pass**.
- Hardware: built `heltec_v4_companion_radio_ble`, flashed ST-P via the artifact-flash wrapper, OLED splash **confirmed reading `Crosswire v0.14.0-rc1`** (was `v0.14.0+0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
