### PR TITLE
chore(#38): gitignore __pycache__/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ platformio.local.ini
 *.map
 build-logs/
 
+# Python bytecode (host tests + script imports under scripts/)
+__pycache__/
+
 # Per-host build secrets (WiFi/MQTT creds, OTA tokens) — never commit
 platformio.local.ini
 platformio.secrets.ini


### PR DESCRIPTION
Add __pycache__/ to .gitignore so Python bytecode dirs (from host tests + script imports under scripts/) stop showing as untracked and cannot be committed. Existing dirs removed. Closes #38.