### PR TITLE
feat(#42): strip observer companion to minima + delete dead ring buffer

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -381,7 +381,10 @@ uint8_t MyMesh::getAutoAddMaxHops() const {
 
 void MyMesh::onContactOverwrite(const uint8_t* pub_key) {
     _store->deleteBlobByKey(pub_key, PUB_KEY_SIZE); // delete from storage
-  if (_serial->isConnected()) {
+  // _serial is NULL during boot-time loadContacts (transport not set up yet);
+  // guard it so the overwrite-oldest path during a populated-store load -- e.g.
+  // after MAX_CONTACTS is reduced (Strycher/Crosswire#42) -- does not NULL-deref.
+  if (_serial && _serial->isConnected()) {
     out_frame[0] = PUSH_CODE_CONTACT_DELETED;
     memcpy(&out_frame[1], pub_key, PUB_KEY_SIZE);
     _serial->writeFrame(out_frame, 1 + PUB_KEY_SIZE);

--- a/scripts/test_observer_env_matrix.py
+++ b/scripts/test_observer_env_matrix.py
@@ -37,6 +37,17 @@ REQUIRED_FLAGS_ALL = [
 ]
 REQUIRED_SRC_FILTER = "+<helpers/wifi_observer/*.cpp>"
 
+# Phase-1 strip (Strycher/Crosswire#42): observer envs override the inherited
+# companion defaults down to observer minima to free static .bss. The strings
+# below must match the platformio.ini byte-for-byte -- MAX_GROUP_CHANNELS uses
+# the no-space second-D form; MAX_CONTACTS / OFFLINE_QUEUE_SIZE use the spaced
+# form (matching the _ble base flags they override).
+REQUIRED_STRIP_FLAGS = [
+    "-D MAX_CONTACTS=50",
+    "-DMAX_GROUP_CHANNELS=11",
+    "-D OFFLINE_QUEUE_SIZE=16",
+]
+
 failures = []
 
 for ini_path, env_names in EXPECTED:
@@ -56,6 +67,10 @@ for ini_path, env_names in EXPECTED:
             if flag not in flags:
                 failures.append(
                     f"{ini_path} [{env}]: missing build_flag '{flag}'")
+        for flag in REQUIRED_STRIP_FLAGS:
+            if flag not in flags:
+                failures.append(
+                    f"{ini_path} [{env}]: missing strip flag '{flag}' (#42)")
         if REQUIRED_SRC_FILTER not in src_filter:
             failures.append(
                 f"{ini_path} [{env}]: build_src_filter missing "

--- a/src/helpers/wifi_observer/ConfigSchema.h
+++ b/src/helpers/wifi_observer/ConfigSchema.h
@@ -64,12 +64,6 @@ constexpr uint16_t kDefaultWssPort = 9001;
 constexpr const char* kDefaultTopicPrefix = "meshcore";
 
 // ---------------------------------------------------------------------------
-// observer.* keys (in "observer" namespace)
-// ---------------------------------------------------------------------------
-constexpr const char* kKeyRecentPacketsBuf = "ring_size";
-constexpr uint8_t kDefaultRecentPacketsBuf = CROSSWIRE_MAX_RECENT_PACKETS;
-
-// ---------------------------------------------------------------------------
 // Typed accessors (in ConfigSchema.cpp)
 // ---------------------------------------------------------------------------
 // Returns false if NVS error / missing. Defaults applied at call site.

--- a/src/helpers/wifi_observer/ObserverPipeline.cpp
+++ b/src/helpers/wifi_observer/ObserverPipeline.cpp
@@ -13,8 +13,6 @@ namespace crosswire {
 
 void ObserverPipeline::begin(MqttBrokerPool* pool) {
     pool_  = pool;
-    head_  = 0;
-    count_ = 0;
 }
 
 void ObserverPipeline::onRawReceived(const uint8_t* raw, int len, float rssi, float snr) {
@@ -22,19 +20,7 @@ void ObserverPipeline::onRawReceived(const uint8_t* raw, int len, float rssi, fl
     if (pool_ == nullptr) return;
 
 #ifdef ARDUINO
-    // 1. Capture into ring at head_, advance + saturate count.
-    ObservedPacket& slot = ring_[head_];
-    slot.recv_at_ms = millis();
-    slot.rssi       = rssi;
-    slot.snr        = snr;
-    int copy_len = len;
-    if (copy_len > (int)sizeof(slot.raw)) copy_len = sizeof(slot.raw);
-    memcpy(slot.raw, raw, copy_len);
-    slot.raw_len = (uint8_t)copy_len;
-    head_ = (head_ + 1) % CROSSWIRE_MAX_RECENT_PACKETS;
-    if (count_ < CROSSWIRE_MAX_RECENT_PACKETS) count_++;
-
-    // 2. Fan-out via pool (pool handles cached strings + per-broker ctx).
+    // Fan-out via pool (pool handles cached strings + per-broker ctx).
     pool_->publishRawFromBytes(raw, (size_t)len, rssi, snr);
 #else
     (void)raw; (void)len; (void)rssi; (void)snr;
@@ -50,12 +36,6 @@ void ObserverPipeline::onParsedReceived(const mesh::Packet& packet, int rssi,
 #else
     (void)packet; (void)rssi; (void)snr; (void)score; (void)duration;
 #endif
-}
-
-const ObservedPacket& ObserverPipeline::recent(uint8_t idx) const {
-    uint8_t base = (head_ + CROSSWIRE_MAX_RECENT_PACKETS - count_) % CROSSWIRE_MAX_RECENT_PACKETS;
-    uint8_t real = (base + idx) % CROSSWIRE_MAX_RECENT_PACKETS;
-    return ring_[real];
 }
 
 // ---------------------------------------------------------------------------

--- a/src/helpers/wifi_observer/ObserverPipeline.h
+++ b/src/helpers/wifi_observer/ObserverPipeline.h
@@ -1,8 +1,8 @@
 // src/helpers/wifi_observer/ObserverPipeline.h
 //
-// Plan 2 v2 Task 9: LoRa RX hook + bounded ring buffer of recent packets.
-// Hooks MyMesh::logRxRaw (which fires for every raw RX with rssi+snr).
-// Fans every received packet out to the broker pool via the /raw topic.
+// Plan 2 v2 Task 9 (ring removed in Strycher/Crosswire#42): LoRa RX hooks
+// -> broker-pool publish. Hooks MyMesh::logRxRaw (every raw RX, rssi+snr)
+// and MyMesh::logRx (parsed), fanning each out to the pool via /raw + /packets.
 //
 // MyMesh calibration (recorded during Task 9 Step 1 audit):
 //   * Dispatcher.cpp:198 calls `logRxRaw(snr, rssi, raw, len)` for every
@@ -25,16 +25,6 @@
 
 namespace crosswire {
 
-// Captured packet snapshot for the in-memory ring (web UI in Plan 3
-// consumes this). Bounded to 256 raw bytes (MeshCore's max packet size).
-struct ObservedPacket {
-    uint32_t recv_at_ms;
-    float    rssi;
-    float    snr;
-    uint8_t  raw_len;
-    uint8_t  raw[256];
-};
-
 class ObserverPipeline {
 public:
     // Wire the pipeline to its pool. Caller (WifiObserver) owns the pool;
@@ -42,25 +32,17 @@ public:
     void begin(MqttBrokerPool* pool);
 
     // Called via the trampoline below from MyMesh::logRxRaw.
-    // Captures the packet in the ring + fans out via the pool's /raw publish.
+    // Fans the raw packet out via the pool's /raw publish.
     void onRawReceived(const uint8_t* raw, int len, float rssi, float snr);
 
     // Called via the parsed trampoline below from MyMesh::logRx (Strycher/
     // LoRa#335). Fans the PARSED packet out via the pool's /packets publish
     // (route/payload_type/dedupe-hash JSON -- the topic CoreScope ingests).
-    // Does not touch the ring (that mirrors the raw RX stream).
     void onParsedReceived(const mesh::Packet& packet, int rssi, float snr,
                           int score, int duration);
 
-    // Ring accessors (Plan 3 web UI will read these).
-    uint8_t recentCount() const { return count_; }
-    const ObservedPacket& recent(uint8_t idx) const;
-
 private:
     MqttBrokerPool* pool_  = nullptr;
-    ObservedPacket  ring_[CROSSWIRE_MAX_RECENT_PACKETS];
-    uint8_t         head_  = 0;
-    uint8_t         count_ = 0;
 };
 
 // Process-wide singleton accessor. ObserverPipeline is intentionally a

--- a/src/helpers/wifi_observer/SystemChannelCli.cpp
+++ b/src/helpers/wifi_observer/SystemChannelCli.cpp
@@ -236,7 +236,7 @@ bool systemChannelInit(const mesh::Identity& self_id) {
             if (existing.channel.secret[i] != 0) { upper_zero = false; break; }
         }
         if (name_match && psk_match && upper_zero) {
-            Serial.println("[SystemChannelCli] slot 40 already provisioned; no-op.");
+            Serial.printf("[SystemChannelCli] slot %u already provisioned; no-op.\n", (unsigned)kSystemChannelSlot);
             return false;
         }
     }
@@ -251,14 +251,15 @@ bool systemChannelInit(const mesh::Identity& self_id) {
     // Upper 16 bytes already zero from memset; setChannel will
     // detect the zero tail and compute the 128-bit hash.
     if (!mesh_ptr->setChannel(kSystemChannelSlot, want)) {
-        Serial.printf("[SystemChannelCli] setChannel(%u) failed -- "
-                      "MAX_GROUP_CHANNELS probably not 41 in this env\n",
-                      (unsigned)kSystemChannelSlot);
+        Serial.printf("[SystemChannelCli] setChannel(%u) failed -- slot >= "
+                      "MAX_GROUP_CHANNELS (%u)?\n",
+                      (unsigned)kSystemChannelSlot,
+                      (unsigned)MAX_GROUP_CHANNELS);
         return false;
     }
-    Serial.printf("[SystemChannelCli] slot 40 provisioned: name='%s' "
+    Serial.printf("[SystemChannelCli] slot %u provisioned: name='%s' "
                   "(caller should persist via saveChannels)\n",
-                  want_name);
+                  (unsigned)kSystemChannelSlot, want_name);
     return true;
 }
 

--- a/src/helpers/wifi_observer/SystemChannelCli.h
+++ b/src/helpers/wifi_observer/SystemChannelCli.h
@@ -1,8 +1,9 @@
 // src/helpers/wifi_observer/SystemChannelCli.h
 //
-// BLE-side first-contact CLI exposed as a locked group channel at
-// slot kSystemChannelSlot (40). On first boot, this module writes
-// a deterministic name + PSK into slot 40 derived from the device
+// BLE-side first-contact CLI exposed as a locked group channel at slot
+// kSystemChannelSlot (the LAST slot, MAX_GROUP_CHANNELS-1). On first boot,
+// this module writes a deterministic name + PSK into that slot, derived
+// from the device
 // identity public key. The slot is "locked": MyMesh refuses
 // CMD_SET_CHANNEL targeting it so the user cannot accidentally
 // delete it from their MeshCore Companion / Open Web app.
@@ -45,9 +46,16 @@ class Identity;
 
 namespace crosswire {
 
-// Reserved slot index. MAX_GROUP_CHANNELS for the companion
-// observer envs is bumped to 41 (user slots 0-39, system slot 40).
-constexpr uint8_t kSystemChannelSlot = 40;
+// Reserved _sys slot = the LAST channel slot (MAX_GROUP_CHANNELS - 1).
+// Observer envs set MAX_GROUP_CHANNELS via -D (Phase-1 strip #42: =11 ->
+// user slots 0-9 + system slot 10; pre-strip was 41 -> slot 40). Deriving
+// keeps this in lockstep with the env's -D; the #else covers pure-logic
+// host builds compiled without the -D (matches the stripped observer value).
+#ifdef MAX_GROUP_CHANNELS
+constexpr uint8_t kSystemChannelSlot = MAX_GROUP_CHANNELS - 1;
+#else
+constexpr uint8_t kSystemChannelSlot = 10;
+#endif
 
 // Rate-limit window for systemChannelPostStatus(), in
 // milliseconds. Status messages dropped silently when called

--- a/src/helpers/wifi_observer/WifiObserverConfig.h
+++ b/src/helpers/wifi_observer/WifiObserverConfig.h
@@ -37,16 +37,6 @@
 #endif
 
 // ---------------------------------------------------------------------------
-// Observer ring buffer
-// ---------------------------------------------------------------------------
-// Most-recent LoRa packets retained for web UI display. Memory budget
-// sized for V3 (no PSRAM, ~280KB free heap). Plan 1 does not exercise
-// this buffer; Plan 2 wires the LoRa observer pipeline.
-#ifndef CROSSWIRE_MAX_RECENT_PACKETS
-  #define CROSSWIRE_MAX_RECENT_PACKETS 50
-#endif
-
-// ---------------------------------------------------------------------------
 // AP-mode SSID prefix
 // ---------------------------------------------------------------------------
 // SSID broadcast in first-boot AP mode: <prefix>-<MAC last 6 hex chars>.

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -417,20 +417,24 @@ lib_deps =
 extends = env:Heltec_v3_companion_radio_ble
 monitor_rts = 0
 monitor_dtr = 0
-; Plan 3 Task 10 (Strycher/LoRa#272): bump MAX_GROUP_CHANNELS 40 -> 41
-; to reserve slot 40 for the locked system CLI channel; user channels
-; still get 0..39. We let the redefinition land via a second -D rather
-; than -U-then-redefine -- PlatformIO reorders -U to the end of the
-; flag list which would re-undefine after both -Ds applied, leaving
-; the macro completely undefined. -Wno-builtin-macro-redefined silences
-; the redefinition warning on gcc.
+; MAX_GROUP_CHANNELS reserves the LAST slot for the locked system CLI
+; channel. Phase-1 strip (Strycher/Crosswire#42): 41 -> 11 (user slots
+; 0-9 + system slot 10; was 0-39 + slot 40 pre-strip), plus the inherited
+; companion defaults are overridden down to observer minima to free
+; static .bss: MAX_CONTACTS 350->50, OFFLINE_QUEUE_SIZE 256->16.
+; The MAX_GROUP_CHANNELS redefinition lands via a second -D rather than
+; -U-then-redefine -- PlatformIO reorders -U to the end of the flag list
+; which would re-undefine after both -Ds applied, leaving the macro
+; completely undefined. -Wno-builtin-macro-redefined silences the gcc warning.
 build_flags =
   ${env:Heltec_v3_companion_radio_ble.build_flags}
-  -DMAX_GROUP_CHANNELS=41
+  -DMAX_GROUP_CHANNELS=11
   -Wno-builtin-macro-redefined
   -D CROSSWIRE_OBSERVER
   -D CROSSWIRE_OBSERVER_BLE_COMPANION
   -D WITH_MQTT_UPLINK
+  -D MAX_CONTACTS=50
+  -D OFFLINE_QUEUE_SIZE=16
 build_src_filter =
   ${env:Heltec_v3_companion_radio_ble.build_src_filter}
   +<helpers/wifi_observer/*.cpp>

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -535,17 +535,23 @@ lib_deps =
 extends = env:heltec_v4_companion_radio_ble
 monitor_rts = 0
 monitor_dtr = 0
-; Plan 3 Task 10 (Strycher/LoRa#272): bump MAX_GROUP_CHANNELS 40 -> 41
-; via a second -D (parent _ble defines =40). PlatformIO reorders -U to
-; the end, so an explicit undef would leave the macro unset. See V3
+; MAX_GROUP_CHANNELS reserves the LAST slot for the locked system CLI
+; channel. Phase-1 strip (Strycher/Crosswire#42): 41 -> 11 (user slots
+; 0-9 + system slot 10), plus the inherited companion defaults overridden
+; to observer minima to free static .bss: MAX_CONTACTS 350->50,
+; OFFLINE_QUEUE_SIZE 256->16. The MAX_GROUP_CHANNELS redefinition lands
+; via a second -D (parent _ble defines =40); PlatformIO reorders -U to the
+; end, so an explicit undef would leave the macro unset. See V3
 ; platformio.ini for the full rationale.
 build_flags =
   ${env:heltec_v4_companion_radio_ble.build_flags}
-  -DMAX_GROUP_CHANNELS=41
+  -DMAX_GROUP_CHANNELS=11
   -Wno-builtin-macro-redefined
   -D CROSSWIRE_OBSERVER
   -D CROSSWIRE_OBSERVER_BLE_COMPANION
   -D WITH_MQTT_UPLINK
+  -D MAX_CONTACTS=50
+  -D OFFLINE_QUEUE_SIZE=16
 build_src_filter =
   ${env:heltec_v4_companion_radio_ble.build_src_filter}
   +<helpers/wifi_observer/*.cpp>

--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -249,17 +249,23 @@ lib_deps =
 extends = env:Xiao_S3_WIO_companion_radio_ble
 monitor_rts = 0
 monitor_dtr = 0
-; Plan 3 Task 10 (Strycher/LoRa#272): bump MAX_GROUP_CHANNELS 40 -> 41
-; via a second -D (parent _ble defines =40). PlatformIO reorders -U to
-; the end, so an explicit undef would leave the macro unset. See V3
+; MAX_GROUP_CHANNELS reserves the LAST slot for the locked system CLI
+; channel. Phase-1 strip (Strycher/Crosswire#42): 41 -> 11 (user slots
+; 0-9 + system slot 10), plus the inherited companion defaults overridden
+; to observer minima to free static .bss: MAX_CONTACTS 350->50,
+; OFFLINE_QUEUE_SIZE 256->16. The MAX_GROUP_CHANNELS redefinition lands
+; via a second -D (parent _ble defines =40); PlatformIO reorders -U to the
+; end, so an explicit undef would leave the macro unset. See V3
 ; platformio.ini for the full rationale.
 build_flags =
   ${env:Xiao_S3_WIO_companion_radio_ble.build_flags}
-  -DMAX_GROUP_CHANNELS=41
+  -DMAX_GROUP_CHANNELS=11
   -Wno-builtin-macro-redefined
   -D CROSSWIRE_OBSERVER
   -D CROSSWIRE_OBSERVER_BLE_COMPANION
   -D WITH_MQTT_UPLINK
+  -D MAX_CONTACTS=50
+  -D OFFLINE_QUEUE_SIZE=16
 build_src_filter =
   ${env:Xiao_S3_WIO_companion_radio_ble.build_src_filter}
   +<helpers/wifi_observer/*.cpp>


### PR DESCRIPTION
## Summary

Phase 1 of the streamline-observer epic (#41). Strips the companion-observer build to its operational minima to free internal DRAM on the no-PSRAM boards, and deletes a dead ring buffer.

**Strip (commit `11219ca`):**
- `MAX_CONTACTS` 350 -> 50, `MAX_GROUP_CHANNELS` 41 -> 11 (`_sys` at slot 10, now derived), `OFFLINE_QUEUE_SIZE` -> 16, across the 3 observer envs (heltec_v3 / heltec_v4 / xiao_s3_wio).
- Deleted dead `ObserverPipeline::ring_` + `recent()`/`recentCount()` (verified zero consumers) and the `CROSSWIRE_MAX_RECENT_PACKETS` config plumbing.
- `kSystemChannelSlot` derives from `MAX_GROUP_CHANNELS - 1`; self-check + log strings de-hardcoded.
- env-matrix test updated to assert the strip flags.

**Fix (commit `7bda621`):**
- Guard `_serial` in `MyMesh::onContactOverwrite` -- it is NULL during boot-time `loadContacts`, so the overwrite-oldest path triggered by a reduced `MAX_CONTACTS` on a populated store NULL-derefed and boot-looped. Latent upstream bug the strip exposed.

## Validation (hardware, all 3 boards)

| board | free heap before -> after |
|---|---|
| HV3 (no PSRAM) | 11,288 -> ~125,700 |
| HV4 | 14,504 -> 127,644 |
| XIAO | 40,580 -> 153,872 |

~113 KB internal DRAM freed per board; all boot clean; companion BLE + `_sys` (slot 10) + broker-config CLI round-trip all confirmed.

**Live MQTT proof:** on the no-PSRAM HV3, the freed headroom absorbs the ~43 KB mbedTLS TLS-handshake transient (124,856 -> 81,620, no OOM) -- the allocation that was *impossible* at the 11 KB pre-strip floor -- and **CoreScope plaintext MQTT reaches `state=up`**. That is the wall the design-of-record (§2d) said needed #87, cleared by the strip alone.

Closes #42. Epic #41. Follow-ups: #45 (CLI grammar), #46 (version-stamp), #48 (Phase 2), #49 (send --env).
