### PR TITLE
docs: MeshCore 1.16.0 base-update impact assessment (spike #54)

### DIFF
--- a/docs/assessments/2026-06-10-meshcore-1.16.0-base-update-impact.md
+++ b/docs/assessments/2026-06-10-meshcore-1.16.0-base-update-impact.md
@@ -1,0 +1,173 @@
+# MeshCore 1.16.0 Base-Update Impact Assessment - Crosswire `firmware-base`
+
+| | |
+|---|---|
+| **Date** | 2026-06-10 |
+| **Author** | DustyFox (claude-opus-4-8) |
+| **Tracking** | Strycher/Crosswire#54 / Citadel `Crosswire-qzp` |
+| **Type** | Spike (read-only assessment; no migration performed) |
+| **Status** | For review |
+
+> **Scope note:** This is a *diagnostics* spike per SAFELANE. It maps the impact surface only. It does **not** perform the migration and proposes no code changes. The migration itself is a separate, not-yet-started epic gated on review of this document.
+
+---
+
+## 1. TL;DR
+
+Updating Crosswire's MeshCore base from its current point (`companion-v1.15.0`+14) to **1.16.0** is **feasible and bounded**, but it is a multi-session migration epic, not a one-shot pull.
+
+- The fork is **overwhelmingly additive** (92 brand-new files, +24k lines). The bulk of Crosswire (observer, SafeBoot, CLI, etc.) lands on top of 1.16.0 with **no conflict**.
+- The integration risk concentrates in **70 files** that both the fork modified and 1.16.0 changed. Of those:
+  - **48** are `variants/*/platformio.ini` - mechanical build-flag merges (tedious, low logic risk).
+  - **5** are upstream CI workflows the fork *deleted* - trivial "keep-deleted" modify/delete conflicts.
+  - **~15-17** are genuine semantic reconciliations (core library, Heltec V4 board + FEM, the companion/repeater apps). **This is the real work.**
+- A handful of concrete upstream **breaking renames** must be chased through our code.
+- **The migration must be sequenced after** the in-flight Observer work and the base-unification task (#2 / `Crosswire-tb5`) land - their files are inside the conflict set.
+
+**Recommendation:** a single controlled **merge** of the 1.16.0 line into a fresh integration branch (one reviewable conflict pass), executed as a follow-up epic, after the in-flight base work settles. See section 7.
+
+---
+
+## 2. Scope and method (pinned, read-only)
+
+All findings are commit-to-commit diffs against fetched upstream objects. **The live working tree was never modified** (no checkout/merge/pull/reset). Reproducible from these refs:
+
+| Ref | SHA | Meaning |
+|---|---|---|
+| **Base** | `c940ea5f` | merge-base of `firmware-base` vs `meshcore-dev/MeshCore`. Described as `companion-v1.15.0-14-gc940ea5f` (= 14 commits past `companion-v1.15.0`). |
+| **Fork** | `d2d63a23` | `firmware-base` local tip at assessment time (= `crosswire-v0.14.0-rc1-6`). |
+| **Target** | `companion-v1.16.0` (`24fe7d4b`) | The 1.16.0 line. `companion`/`repeater`/`room-server` v1.16.0 are co-located at `upstream/main` (all +257 over base, 0 behind main), so this diff covers the whole 1.16.0 tree, role-agnostic. |
+
+**Caveats (must re-check at migration time):**
+- `origin/firmware-base` is **+2 ahead** of the pinned `d2d63a23` (`98a9e359`, a `#42` serial-guard fix). Negligible for the surface, but the migration must re-pin to the then-current tip.
+- MeshCore ships **no `CHANGELOG.md`** at the tag. Human-readable 1.16.0 release notes live only on GitHub Releases (`meshcore-dev/MeshCore`) and should be cross-referenced before migration.
+- Per-file *semantic* diff analysis (what exactly conflicts inside each of the ~15 core files) is **deliberately deferred to the migration epic** - this spike sizes the surface, it does not resolve it.
+
+---
+
+## 3. Version landscape
+
+- **Current base:** `companion-v1.15.0` + 14 commits. Crosswire builds companion/observer + repeater (room/bridge not active), so the relevant upstream lines are `companion-v1.16.0` and `repeater-v1.16.0`.
+- **Target:** the 1.16.0 release line, currently == `upstream/main` tip.
+- **Delta to absorb:** **257 upstream commits.**
+- **Remotes available in the repo:** `origin` = Strycher/Crosswire (push), `upstream` = meshcore-dev (fetch), `iotthinks` = IoTThinks/MeshCore (fetch). "MeshCore 1.16.0" here = meshcore-dev's tags. (Open question 8.3 re: IoTThinks.)
+
+---
+
+## 4. Upstream delta - what 1.16.0 changed
+
+**257 commits, 362 files, +6680 / -3099.**
+
+Top-changed areas (file counts):
+
+| Area | Files | Relevance to Crosswire |
+|---|---|---|
+| `src/helpers/ui`, `src/helpers` | ~21 | Display/UI + core helpers. The companion app pulls these. |
+| `src/helpers/radiolib` | 9 | Radio driver layer (SX126x). Touches our FEM/TX-power path. |
+| `variants/*` (many boards) | large | Per-board configs. Includes `heltec_v4` (6), `rak4631` (5), `xiao_s3` (4) - **our boards**. |
+| `boards/*.json` | 6 | PlatformIO board defs. |
+| `.github/workflows`, examples | several | Upstream CI + example apps (we fork the examples). |
+
+### 4.1 Known breaking changes (from commit-message scan)
+
+These are confirmed renames/removals that will break references in our modified files:
+
+| Upstream change | Commit | Impact on us |
+|---|---|---|
+| `CMD_DEVICE_QEURY` -> `CMD_DEVICE_QUERY` | `bbe41eb3` | Any of our code referencing the old (mis-spelled) enum breaks. |
+| `bootComplete()` -> `onBootComplete()` | `e5dab6b9` | If SafeBoot/observer hooks override or call `bootComplete()`, they break. |
+| Removed `radio_rng_seed()`, `radio_set_params()`, `radio_set_tx_power()` (de-dup refactor) | `0a8a0a49` | Our FEM / TX-power code may call these. **Verify Heltec V4 + WisMesh PA path.** |
+| Removed deprecated functions, style fixes | `7c8d84ff` | Broad - re-verify after merge. |
+
+> Scan was keyword-based (`break|renam|remov|deprecat|migrat`). The migration epic should also read the GitHub 1.16.0 release notes for protocol/behavior changes that don't show up as renames.
+
+---
+
+## 5. Fork delta - what Crosswire adds on top of base
+
+**148 commits, 173 files, +24021 / -440.** Breakdown by change type:
+
+| Type | Count | Merge behavior |
+|---|---|---|
+| **Added (new files)** | 92 | Clean - new paths, no upstream collision. The additive bulk of Crosswire. |
+| **Modified (existing files)** | 76 | The integration-relevant set (see section 6). |
+| **Deleted** | 5 | All upstream CI workflows (we run our own `ci.yml`). |
+
+The +24k/-440 ratio confirms the fork is far more *additive* than *invasive* - good news for merge conflict volume.
+
+---
+
+## 6. Conflict surface (core finding)
+
+**70 files were modified by the fork AND changed by 1.16.0.** Three buckets:
+
+### Bucket A - Mechanical: `variants/*/platformio.ini` (48 files)
+Build-flag / env merges. Low logic risk, high tedium. Includes our active boards: `heltec_v4`, `rak4631`, `rak3401` (WisMesh), `xiao_*`. Strategy: re-apply our per-variant build flags/defines on top of upstream's variant edits; scriptable and reviewable per-file.
+
+### Bucket B - Modify/delete: deleted CI workflows (5 files)
+The fork deleted these; 1.16.0 changed all five. A merge produces modify/delete conflicts:
+`build-companion-firmwares.yml`, `build-repeater-firmwares.yml`, `build-room-server-firmwares.yml`, `github-pages.yml`, `pr-build-check.yml`.
+Resolution is trivial (**keep deleted** - Crosswire has its own CI), but each must be handled deliberately or upstream CI gets resurrected.
+
+### Bucket C - Semantic core code (~15-17 files) - THE REAL WORK
+| File(s) | What it is | Why risky |
+|---|---|---|
+| `src/MeshCore.h` | Core public header | API surface; both sides touched. |
+| `src/helpers/CommonCLI.cpp` / `.h` | Shared CLI layer | Our ObserverCli / SafeBoot CLI extends this; upstream changed it. **Hot spot.** |
+| `src/helpers/ESP32Board.h` | ESP32 base board class | Board init / power; our subclasses depend on it. |
+| `src/helpers/NRF52Board.cpp` | nRF52 base | SafeBoot nRF52 path. |
+| `variants/heltec_v4/HeltecV4Board.cpp` / `.h` | Heltec V4 board driver | Our FEM/PA work vs upstream heltec_v4 edits. **Hot spot.** |
+| `variants/heltec_v4/LoRaFEMControl.h` | FEM (GC1109/SKY66122) control | Ties to the removed `radio_set_tx_power` refactor (section 4.1). |
+| `examples/companion_radio/{MyMesh.cpp,MyMesh.h,main.cpp,ui-new/UITask.cpp}` | Companion firmware app | Our observer/companion customization; upstream changed UI + mesh heavily. **Hottest spot.** |
+| `examples/simple_repeater/{MyMesh.cpp,MyMesh.h,main.cpp}` | Repeater firmware app | SafeBoot repeater; upstream repeater changes. **Hot spot.** |
+| `examples/{kiss_modem,simple_room_server,simple_secure_chat,simple_sensor}/main.cpp` | Other example mains | We touched lightly; upstream changed. Lower risk, still verify. |
+| `platformio.ini` (root), `.github/actions/setup-build-environment/action.yml`, `README.md` | Build/meta | Config + branding reconciliation. |
+
+---
+
+## 7. Migration strategy options
+
+| Option | What | Pros | Cons |
+|---|---|---|---|
+| **1. Controlled merge** (recommended) | Merge the 1.16.0 line into a fresh integration branch off `firmware-base`; resolve all 70 in one pass. | One reviewable conflict pass; additive 92 files arrive clean; fork history preserved; single revert if wrong. | Big-bang conflict resolution; non-linear merge commit. |
+| **2. Full rebase** | `git rebase --onto companion-v1.16.0 c940ea5f firmware-base` (replay 148 commits). | Linear history; fork sits cleanly atop 1.16.0. | 148-commit replay; same file re-conflicts across commits; rewrites SHAs (crosswire-v* tags/branches need re-pointing). High tedium/risk. |
+| **3. Curated re-apply** | Re-apply fork as cohesive subsystem chunks (squash-per-subsystem) onto 1.16.0. | Cleanest end-state; conflicts resolved once per subsystem; chance to drop dead commits. | Most upfront planning; loses granular history. |
+
+**Recommendation:** **Option 1** for the first 1.16.0 bump - lowest chance of spiraling, all conflicts visible at once, additive bulk free. Keep Option 3 in reserve if we later want to formally re-baseline the fork against upstream. Avoid Option 2 (worst effort:benefit here).
+
+**Effort shape (qualitative, not a fabricated hour count):** the 48 `.ini` merges are mechanical/scriptable; the ~15 core files are real 3-way reconciliations (companion app + CLI + FEM are the hot spots); then build-verify across our 6 CI envs + on-hardware smoke test (Heltec V4, RAK/WisMesh). This is a focused multi-session epic.
+
+---
+
+## 8. Sequencing, coordination, and open questions
+
+### 8.1 Hard sequencing constraints (must account for)
+- **Live Observer work** (`feat/48-phase2`, `feat/53-mqtt-lifecycle`; `Crosswire-03m`/`Crosswire-tme`) modifies `examples/companion_radio/*` and CLI/MQTT code - **inside the conflict set**. Migrating first = rebasing their moving target.
+- **`Crosswire-tb5` (#2)** "Unify firmware base: Observer onto feature/safeboot" is restructuring the base itself - must land first, or we bump 1.16.0 onto a base being re-laid underneath us.
+- **Therefore:** gate the migration epic on (a) #2 closed, (b) the two observer feature branches merged to `firmware-base`, (c) **re-pin** this assessment to the then-current `firmware-base` (the conflict set will shift), (d) re-fetch upstream (1.16.x patch releases may land).
+
+### 8.1a Coordination outcome (verified with the live Observer session, 2026-06-10)
+
+Reconciled directly with RedCreek (the in-flight Observer session; `#48`/`#53` on `firmware-base`):
+- **No file-level collision.** The entire `src/helpers/wifi_observer/` tree (MqttBroker, MqttBrokerPool, ObserverCli, ConfigSchema, WifiObserver, +24 more) is fork-added with no upstream counterpart - the 1.16.0 bump does not touch it. `#48`/`#53` land on `firmware-base` independent of the version bump.
+- **Indirect coupling only:** `wifi_observer/` builds on `src/MeshCore.h`, `src/helpers/CommonCLI.{cpp,h}`, `src/helpers/ESP32Board.h`, all of which 1.16.0 changes. Expect post-merge *compile-fixups* in the observer code (not merge conflicts), e.g. CommonCLI command registration + the `bootComplete()`->`onBootComplete()` rename.
+- **Agreed order:** land `#53` (correctness) -> rebase `#48` -> then base-update on top + re-pin. The 1.16.0 migration is gated on the Observer work landing.
+- **#334** ("unify Observer onto feature/safeboot") is owned by RedCreek to validate and close/retire; it is distinct from this upstream version-bump assessment.
+
+### 8.2 Build/CI implications
+- The 5 deleted upstream workflows confirm Crosswire owns its CI. After merge, do **not** resurrect upstream CI; re-verify our `ci.yml` 6-env matrix still covers the post-merge tree.
+- `boards/*.json` and root `platformio.ini` changed upstream - re-verify our board defs and shared build settings.
+
+### 8.3 Open questions for the human / migration epic
+1. **Target pin:** lock the migration to the `companion-v1.16.0` / `repeater-v1.16.0` tags (reproducible) rather than the moving `upstream/main`? (Recommended.)
+2. **IoTThinks remote:** the repo carries an `iotthinks` fetch remote. Is any observer/feature code expected to flow from IoTThinks rather than meshcore-dev, or is `iotthinks` vestigial? Confirm before choosing the merge source.
+3. **Room-server / bridge:** still out of scope for 1.16.0, or fold in now while we're in the base?
+
+---
+
+## 9. What was NOT done (honesty boundary)
+
+- No migration, no branch off the live tree, no code changes.
+- No per-file semantic diff of the ~15 core files (sized only).
+- No reading of GitHub 1.16.0 release notes prose (network-gated this session; flagged for the epic).
+- Conflict counts are exact as of the pinned SHAs; they **will** change once in-flight work lands.


### PR DESCRIPTION
Lands the read-only MeshCore 1.16.0 base-update impact assessment (spike, ref #54 - accepted/closed).

**Doc-only** - 1 file, no code. Cannot affect the build or any in-flight branch.

Coordinated with the live Observer session (RedCreek, #48/#53): zero `wifi_observer/` collision; sequencing agreed (land #53 -> rebase #48 -> then base-update + re-pin).

## Summary
- Base `companion-v1.15.0`+14 (`c940ea5f`) -> 1.16.0 = **257 upstream commits**.
- Fork is mostly additive (92 new files clean). **Conflict surface = 70 files**: 48 `variants/*.ini` (mechanical), 5 CI modify/delete (trivial), ~15-17 core code (companion app, CommonCLI, Heltec V4 board+FEM).
- Migration = separate follow-up epic, gated on Observer work landing.

Detail: `docs/assessments/2026-06-10-meshcore-1.16.0-base-update-impact.md`