### PR TITLE
docs: fix README license link (LICENSE.txt -> license.txt) — #73

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Crosswire uses an independent `crosswire-vMAJOR.MINOR.PATCH` version (see [VERSI
 
 ## License
 
-MIT, inherited from upstream MeshCore (Copyright (c) 2025 Scott Powell / rippleradios.com). See [`LICENSE.txt`](LICENSE.txt). Crosswire's additions are released under the same terms.
+MIT, inherited from upstream MeshCore (Copyright (c) 2025 Scott Powell / rippleradios.com). See [`license.txt`](license.txt). Crosswire's additions are released under the same terms.
 
 ## Hardware
 


### PR DESCRIPTION
One-line fix: README linked to `LICENSE.txt` but the actual root license file is `license.txt` (lowercase, inherited from upstream MeshCore) — the link 404s on case-sensitive GitHub. Points the link at the real filename instead of renaming the upstream file (avoids friction with the coming 1.16.0 upstream merge).

Found while verifying the `main`-branch deletion (the deleted `main` carried an uppercase `LICENSE.txt`; firmware-base has the byte-identical MIT `license.txt`).

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)