### PR TITLE
docs: 2026-06-10 observer-MQTT session handoff — #75

### DIFF
--- a/docs/handoffs/2026-06-10-observer-mqtt-session-handoff.md
+++ b/docs/handoffs/2026-06-10-observer-mqtt-session-handoff.md
@@ -1,0 +1,130 @@
+# Crosswire Session Handoff -- 2026-06-10
+
+**Purpose:** start a fresh session and pick up exactly where this one left off, without losing the technical findings or the process lessons. Read this top-to-bottom before doing anything.
+
+---
+
+## 0. TL;DR
+
+- **Observer MQTT connectivity shipped as `crosswire-v0.15.0`** -- hardware-validated against 3 real brokers (CoreScope tcp/anon, eastme.sh wss/jwt, LetsMesh-US wss/jwt). Packets confirmed landing on eastme.sh.
+- The whole multi-hour failure (`rc=5` on wss/jwt brokers) came down to **one missing field**: the firmware sent MQTT CONNECT `username = nullptr`; the brokers require `v1_<UPPERCASE 64-hex pubkey>`. Fixed (#68).
+- Repo is **clean and releasable**: `firmware-base @ e03ef09a`, one worktree, one local branch, remote = `firmware-base` + 3 intentional experimental branches. The owner's stated next goal is to **transfer the filesystem location** -- the repo is ready for that.
+- **The biggest takeaway is process, not code** (see section 6). This session started by violating SAFELANE (guessing root causes and having the user hardware-test each guess) and recovered by switching to **empirical diagnosis** (probe the live broker). Do not regress.
+
+---
+
+## 1. Identity & coordination (READ -- do not conflate with LoRa)
+
+| Channel | Value |
+|---|---|
+| Firmware repo | `C:\Dev\LoRa\Crosswire` -- GitHub `Strycher/Crosswire`, default branch **`firmware-base`** |
+| Citadel | `DW_PROJECT=Crosswire` (prefix every `dw` and `git commit` from a worktree). **Never** `LoRa`. |
+| Agent Mail | project_key **`app-c-dev-lora-crosswire`** (path slug). NOT `app-c-dev-lora`, NOT `app-crosswire`. |
+| Other agents | **DustyFox** (owns the deferred MeshCore 1.16.0 base-update), HazyForest (meshcore-open client fork -- separate). I was **RedCreek**. |
+| Upstream remotes on the repo | `upstream` = meshcore-dev/MeshCore, `iotthinks` -- both fetch-only (`no-push`). `origin` = Strycher/Crosswire (push). |
+
+`Strycher/LoRa` is the **separate personal origin** repo -- the Crosswire fork is no longer part of it. Bash sandbox blocks network; use `dangerouslyDisableSandbox: true` for git fetch/push/pull and any broker/Pi5 network call.
+
+---
+
+## 2. Current repo state (verified at handoff)
+
+- `firmware-base` HEAD = **`e03ef09a`** (`docs(#73): fix README license link`).
+- Tags pushed this session: **`crosswire-v0.15.0`** (observer MQTT, at HEAD's parent line) + **`crosswire-v0.14.0`** (finalized at `26464b3e`). Both are stable (non-rc) tags -> `release.yml` auto-publishes community GitHub Releases. **TODO: confirm both Releases actually published** (workflows were queued; run IDs were `27313343452`/`...3460`).
+- **Worktrees: 1** (the `firmware-base` checkout). **Local branches: 1** (`firmware-base`).
+- **Remote branches: 4** --
+  - `firmware-base` (canonical)
+  - `feat/265-stopgap-rapid-reboot`, `feat/318-wifi-esp-takeover`, `feat/318-wifi-static-buffers` -- **intentional experimental branches, DO NOT DELETE** (each carries ~2 unmerged patches the owner keeps on purpose; feat/318 = the "committed, unmeasured" WiFi-buffer variants).
+- `main` was **deleted** this session (local + remote) -- it was the dead original-bootstrap branch; its 2 commits (#1 bootstrap, #3 migration plan) are content-preserved on firmware-base. Recovery SHAs: `ab30477e` / `8b9adbed`.
+
+---
+
+## 3. What landed this session (`crosswire-v0.15.0`, PR #72, rebase-merged)
+
+| Issue | What |
+|---|---|
+| **#53** | BLE-safe MQTT lifecycle: blocking `esp_mqtt` connect/destroy moved off `loopTask` to a dedicated `mqtt_worker` FreeRTOS task (per-broker recursive lock + per-slot `reconciling_[]` flag). `set/enable/disable` over BLE `_sys` no longer hang the channel. |
+| **#48** | Phase 2: owner 6-slot broker registry seed + `iata=HAO`; GTS Root R4 + ISRG Root X2 CA certs added & mapped; multi-frame `mqtt status` over `_sys`. |
+| **#63** | Per-broker JWT identity claims `jwt_owner` / `jwt_email` (`set mqtt.broker.<N>.jwt_owner|jwt_email`); `makeAuth()` previously hardcoded email=null + truncated owner-from-username. |
+| **#68** | **THE root-cause fix:** MQTT CONNECT `username = "v1_" + UPPERCASE hex(pubkey)` (was `nullptr`). `MqttAuth.cpp::MqttAuthJwt::apply()` builds `username_` once. |
+| #73 / PR #74 | Doc: README license link `LICENSE.txt` -> `license.txt` (the file is lowercase, from upstream; link 404'd on case-sensitive GitHub). |
+
+Also: CHANGELOG `[0.15.0]` added + `[0.14.0]` completed (it had only documented the CI pipeline; 13 post-rc1 commits were missing); README observer row dropped the deferred/archived "web UI" (Plan 3 is an archive tag, not in firmware-base).
+
+---
+
+## 4. Hard-won technical knowledge -- MeshCore observer broker auth
+
+**This is memorialized in memory `findings_2026-06-10_eastmesh_jwt_username.md` and `reference_mqtt_broker_configs.md`. Summary:**
+
+- **The gate is the MQTT username** `v1_<UPPERCASE 64-hex pubkey>` (broker strips `v1_`, verifies the token's `publicKey` claim against it). Password = the JWT.
+- **NO registration / allowlist.** A fresh, never-seen Ed25519 keypair is accepted (proven). Possession of the private key IS the credential. (The owner was right; my "device not registered" theory was invented.)
+- **Brokers differ in strictness -- verify per broker:**
+  - **eastme.sh** = LAX: accepts `alg:EdDSA` *and* `Ed25519`, accepts an `exp=1970` (expired) token, accepts base64url *or* hex signatures, accepts `https://` *or* bare audience. Gates only on username + a parseable token whose `publicKey` matches.
+  - **LetsMesh-US** = STRICT: audience must be **bare host** (`https://...` REJECTED), and `exp` is enforced (1970 token REJECTED -> **needs a valid wall clock**).
+- **Device clock:** firmware has **no SNTP**; it only gets time from the companion app (`CMD_SET_DEVICE_TIME` on BLE connect). Power-cycle wipes it. So an **unattended** LetsMesh observer fails until SNTP lands (epic #69). eastme.sh doesn't care (lax on exp).
+- **`analyzer.eastme.sh/api/observers` is a ~40-min STALE periodic snapshot** (timestamps batch-clustered). **Do not read freshness from it.** To verify a device is publishing live, **SUBSCRIBE to the broker** with a minted observer token and watch for `meshcore/<IATA>/<PUBKEY>/{status,packets,raw}`.
+- **Verified broker config values** (so they're never re-asked): see `reference_mqtt_broker_configs.md`. eastme.sh -> `ca_cert letsencrypt`, audience `mqtt.eastme.sh`. LetsMesh-US -> `ca_cert gts-r4`, audience `mqtt-us-v1.letsmesh.net` (bare). Owner pubkey `18315e8b...`, email `strycher@gmail.com`, IATA `HAO`.
+
+### The diagnostic method (the antidote to guessing -- reuse it)
+For ANY broker-auth question: mint a real MeshCore token in Python (`cryptography` Ed25519 + `paho` wss), **prove the minter correct locally** (sign+verify roundtrip) so a rejection means the *broker* rejected a *valid* token, then **probe the live broker one variable at a time** reading the actual CONNACK rc, then **subscribe** to confirm packets land. Working scripts/patterns are in this session's transcript. The canonical client-side signer is HA's `mqtt_uploader.py::_create_auth_token_python` on the Pi5.
+
+---
+
+## 5. Open follow-ups (tracked, prioritized)
+
+| Issue | Citadel | Pri | What | Note |
+|---|---|---|---|---|
+| **#66/#67/#70** | Crosswire-cju (#70) | P1 | Cosmetic display bugs: `mqtt status` reads the broker's cached `cfg_`, not NVS; a `set` on a **disabled** slot never refreshes `cfg_` (no `reloadSlot` when `!was_enabled`). Symptoms: status shows stale url / `own=N eml=N` / no `ca_cert` after a `set`. | **One fix closes all three** -- refresh `cfg_` on a disabled-slot `set` (lightweight, no client), or have `handleStatus` read NVS. -> one follow-up PR. |
+| **#69** | Crosswire-y8y | P2 | SNTP/NTP time sync epic. Needed for **unattended LetsMesh** (enforces exp). The HARD part isn't the tag -- it's a valid clock without the phone. | NOT needed for eastme.sh. |
+| **#71** | Crosswire-vr6 | P2 | Per-role versioning (`crosswire-<role>-vX.Y.Z`). **The gating problem is EXPOSING the role version** on every read surface (splash/serial/CLI/app/MQTT/HA/marker), not the tag scheme. | Owner-deferred to a future iteration. |
+| **#64** | -- | -- | `pio-flash` artifact-flash path can't flash UART-bridged boards (waits for a bootloader-port re-enumeration that CP2102 never does; parks the chip in ROM). | **Workaround that works:** `pio-flash --firmware-dir <root> preview --env <env> <device>` + `confirm` (env-upload path). |
+| **#65** | -- | -- | Crash-cycle (~15s) on HV3 after a flash; cleared by power-cycle; conditional, did not recur. 4 ranked hypotheses in the issue. | If it recurs: **don't power-cycle** before reading the RTC CrashLog ring + boot counter. |
+| 1.16.0 base-update | (DustyFox) | -- | Deferred upstream merge. No `wifi_observer/` file conflicts, but base files shift -> post-merge compile-fixups. | **Ping DustyFox** to sequence it now that the observer landed. |
+
+---
+
+## 6. SAFELANE / process lessons -- DO NOT LOSE THESE
+
+The owner explicitly flagged multiple SAFELANE failures this session. They were corrected, but the patterns recur -- internalize them:
+
+1. **Diagnose empirically; do not guess and have the user test your guesses.** The session burned hours cycling hypotheses (audience -> clock -> registration) and asking the owner to hardware-test each. The fix was to **probe the live broker** with a proven-correct minter. SAFELANE section 1/section 2: gather evidence at the failing layer before theorizing.
+2. **A reference implementation existing != verified working.** I called HA "canonical" and diffed against it without ever observing HA's token *accepted* by eastme.sh (its path was down). Don't treat a code-read as proof.
+3. **Use the infra access you already have.** Pi5 / HA / docker / DB access was available the entire time; I asked the owner to "check HA" instead of reading it (`ssh pi5`, `docker exec homeassistant ...`). Read it yourself.
+4. **Agent Mail is communication, not hook-satisfaction.** Registering + `fetch_inbox` to refresh the ack while never *sending* coordination (and ignoring DustyFox's ack-required message all day) is "fetch-only theater." Actually reply and broadcast at milestones.
+5. **Verify the FULL state, not the convenient slice.** I called the repo "pristine" when only *local* was clean -- the remote had 6 stray branches. Check local **and** remote.
+6. **Don't claim verification from an inadequate observation.** "boot verified" was false: a 12s serial read < the 15s crash period, and the read itself (CP2102 port-open) **rebooted the device**. State precisely what was observed and what it does/doesn't show.
+7. **Verify before deleting** (patch-id, not assumption). "Safe to delete" was wrong twice -- `chore/16` was a squash-merged *different* patch; `main` looked like it had unique content. Use `git cherry` / content diff before any force-delete; record recovery SHAs.
+8. **CP2102 boards (HV3) reset on serial port-open** (DTR/RTS). Any read reboots the chip and drops BLE. Class-B "port-opening reads don't reset" only holds for native-USB S3, NOT UART-bridged boards. Bounded reads count as resets in any timing forensics.
+9. **Respect per-PR merge tollgates absolutely.** The owner approves each merge explicitly ("Merge 72"). Never `--auto` a merge off an inherited "proceed."
+
+---
+
+## 7. Hardware & infra map
+
+- **HV3** (bench) = Heltec V3 observer. **COM6**, CP2102 `VID:PID 10C4:EA60`. Node `WSMJ898-HV3-OBS`, pubkey `8AA6DA6C...` (companion `_sys @ 8aa6da6c`). Currently flashed with `crosswire-v0.14.0-rc1-19-ge7b11cb` (= the 0.15.0 content). **Port-open resets it.**
+- **Pi5** = `192.168.50.24`, ssh alias `pi5` (= `strycher@`, key `~/.ssh/id_ed25519`). Runs (docker): `homeassistant` (meshcore-ha integration = the canonical observer client; config in `/config/.storage/core.config_entries`, signer in `custom_components/meshcore/mqtt_uploader.py`), `mosquitto`, `frigate`, `meshmonitor`, etc. `heimdalld` = systemd, currently **inactive**. NOTE: HA's *map.meshcore.io* uploader had a DNS-timeout problem; the MQTT *observer* path works (HEIMDALL node `18315e8b` publishes live).
+- **Brokers:** CoreScope `mqtt.w8oof.net:1883` (tcp/anon); eastme.sh `mqtt.eastme.sh:443` (wss/jwt, `letsencrypt`, aud `mqtt.eastme.sh`); LetsMesh-US `mqtt-us-v1.letsmesh.net:443` (wss/jwt, `gts-r4`, aud bare).
+- **Owner identity:** pubkey `18315e8b...`, email `strycher@gmail.com`, IATA `HAO`.
+- **FOREIGN -- NEVER TOUCH:** `COM3` = CH340K `VID:PID 1A86:7522` = `desk_command_center` (ESP32-P4). Hard-refuse any flash/serial against it.
+
+---
+
+## 8. Working with the owner (Ben / Strycher)
+
+- **Refractory NPDH** (chronic daily headache) -- treat as binding: concise by default, **detail in durable artifacts not chat**, work in plain chat (do NOT use the multiple-choice question tool), respect human tollgates absolutely, document-before-doing (ISSUE FIRST). No mother-hen / no break-suggestions.
+- **No em dashes** in artifacts (ASCII punctuation only) per the no-em-dash memory -- *(note: this handoff uses some; convert if committing).* 
+- Every code change -> GH issue + Citadel task; `(#N)` in every commit; close Citadel IMMEDIATELY after merge.
+- The owner runs the merges/decisions; you do the work up to the tollgate and stop.
+
+---
+
+## 9. First actions for the next session
+
+1. `/refresh-context` (date, preflight, standards, Citadel, the 5 canonical docs) -- and actually read all 5.
+2. Register in Agent Mail `app-c-dev-lora-crosswire`, `fetch_inbox`, and reply to DustyFox if there's a pending thread.
+3. Confirm the `crosswire-v0.14.0` / `v0.15.0` GitHub Releases published (`gh release list -R Strycher/Crosswire`).
+4. Pick from section 5 -- the natural next is the **#66/#67/#70 cosmetic-display fix** (one small PR, same `ObserverCli` status path) and/or pinging DustyFox to start the 1.16.0 merge.
+5. If returning to broker work: re-read section 4 and use the empirical-probe method, not guesses.
+
+**Key memory files:** `findings_2026-06-10_eastmesh_jwt_username.md`, `reference_mqtt_broker_configs.md`, `reference_meshcore_observer_ecosystem.md`, `findings_2026-05-31_heap_optimization_levers.md`, plus the SAFELANE/feedback memories.


### PR DESCRIPTION
Knowledge-transfer doc for picking up the observer-MQTT work in a fresh session (repo state, the broker-auth findings + empirical-probe method, open follow-ups, SAFELANE/process lessons). ASCII-only. Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)