### PR TITLE
chore: relocate to C:/Dev/Crosswire — canonical hook sync + AM repin

### DIFF
--- a/.claude/hooks/post-commit
+++ b/.claude/hooks/post-commit
@@ -58,7 +58,7 @@ done
 # Keep .claude/agent-session.json fresh without requiring agent discipline.
 # Best-effort; never blocks the commit. Snapshot includes claimed Citadel
 # tasks, active worktree, open PRs, last Tier 2 approval, agent notes.
-# Read at next SessionStart by preflight.sh §6 (via the session-state.sh shim).
+# Read at next SessionStart by preflight.sh §6.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SESSION_STATE_SCRIPT="$HOOK_DIR/session-state.py"
 PYTHON_BIN="$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"

--- a/.claude/hooks/pre-push
+++ b/.claude/hooks/pre-push
@@ -9,20 +9,19 @@
 # Portable: auto-detects project name from git repo basename.
 # Deploy: copy to .claude/hooks/pre-push in any DW project.
 #
-# Override: set DW_SKIP_CLOSE_CHECK=1 for emergency pushes (logged).
+# Overrides (each gates ONE check; bypasses are NOT composable into a
+# global skip — set the specific one for the specific gate you mean to
+# bypass):
+#   DW_SKIP_CLOSE_CHECK=1                  # skip the open-issue check (the original behavior of this hook)
+#   DW_SKIP_INCIDENT_AUTOCLOSE_CHECK=1     # skip the type:incident auto-close-keyword check (standards#100)
 # =============================================================================
-
-if [ "${DW_SKIP_CLOSE_CHECK:-0}" = "1" ]; then
-  echo "⚠ CLOSE CHECK BYPASSED — DW_SKIP_CLOSE_CHECK=1" >&2
-  exit 0
-fi
 
 CITADEL_API="https://getunfocused.app/citadel"
 PROJECT="${DW_PROJECT:-$(basename "$(git rev-parse --show-toplevel 2>/dev/null)")}"
 
 # Read the push refs from stdin (provided by git)
 while read local_ref local_sha remote_ref remote_sha; do
-  # Get commits being pushed
+  # Get commits being pushed (subjects only; new check below also reads bodies)
   if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
     # New branch — check all commits
     COMMITS=$(git log --format=%s "$local_sha" --not --remotes 2>/dev/null)
@@ -30,23 +29,24 @@ while read local_ref local_sha remote_ref remote_sha; do
     COMMITS=$(git log --format=%s "${remote_sha}..${local_sha}" 2>/dev/null)
   fi
 
-  # Extract all unique issue numbers from commit messages
-  ISSUE_NUMS=$(echo "$COMMITS" | grep -oE '#[0-9]+' | tr -d '#' | sort -u)
+  # ─── Check 1: Open-issue check (original close-check behavior) ───────
+  if [ "${DW_SKIP_CLOSE_CHECK:-0}" = "1" ]; then
+    echo "⚠ CLOSE CHECK BYPASSED — DW_SKIP_CLOSE_CHECK=1" >&2
+  else
+    # Extract all unique issue numbers from commit subjects
+    ISSUE_NUMS=$(echo "$COMMITS" | grep -oE '#[0-9]+' | tr -d '#' | sort -u)
 
-  if [ -z "$ISSUE_NUMS" ]; then
-    continue  # No issue references in these commits
-  fi
+    if [ -n "$ISSUE_NUMS" ]; then
+      OPEN_ISSUES=""
 
-  OPEN_ISSUES=""
+      for ISSUE_NUM in $ISSUE_NUMS; do
+        # Check Citadel
+        TASK_JSON=$(curl -s --max-time 5 "${CITADEL_API}/projects/${PROJECT}/tasks?external_issue_number=${ISSUE_NUM}" 2>/dev/null)
 
-  for ISSUE_NUM in $ISSUE_NUMS; do
-    # Check Citadel
-    TASK_JSON=$(curl -s --max-time 5 "${CITADEL_API}/projects/${PROJECT}/tasks?external_issue_number=${ISSUE_NUM}" 2>/dev/null)
-
-    # Lenient multi-task rule: if ANY matching task is done, the issue has been
-    # resolved at least once — allow. Only block when zero tasks are done.
-    # See DifferentWire/standards#19 for the decision rationale.
-    STATUS=$(echo "$TASK_JSON" | python3 -c "
+        # Lenient multi-task rule: if ANY matching task is done, the issue has been
+        # resolved at least once — allow. Only block when zero tasks are done.
+        # See DifferentWire/standards#19 for the decision rationale.
+        STATUS=$(echo "$TASK_JSON" | python3 -c "
 import json, sys
 try:
     tasks = json.load(sys.stdin)
@@ -66,30 +66,107 @@ try:
 except: print('error|?')
 " 2>/dev/null)
 
-    TASK_STATUS=$(echo "$STATUS" | cut -d'|' -f1)
-    TASK_DETAIL=$(echo "$STATUS" | cut -d'|' -f2-)
+        TASK_STATUS=$(echo "$STATUS" | cut -d'|' -f1)
+        TASK_DETAIL=$(echo "$STATUS" | cut -d'|' -f2-)
 
-    case "$TASK_STATUS" in
-      done|not_found|error)
-        ;; # OK or can't check — don't block
-      *)
-        OPEN_ISSUES="${OPEN_ISSUES}  #${ISSUE_NUM} (Citadel: ${TASK_DETAIL})\n"
-        ;;
-    esac
-  done
+        case "$TASK_STATUS" in
+          done|not_found|error)
+            ;; # OK or can't check — don't block
+          *)
+            OPEN_ISSUES="${OPEN_ISSUES}  #${ISSUE_NUM} (Citadel: ${TASK_DETAIL})\n"
+            ;;
+        esac
+      done
 
-  if [ -n "$OPEN_ISSUES" ]; then
-    echo "=======================================================" >&2
-    echo "BLOCKED: Push contains commits referencing open issues." >&2
-    echo "" >&2
-    echo -e "$OPEN_ISSUES" >&2
-    echo "Close these in Citadel AND GitHub before pushing:" >&2
-    echo "  dw --project ${PROJECT} close <task-id> --reason \"...\"" >&2
-    echo "  gh issue close <number>" >&2
-    echo "" >&2
-    echo "Emergency bypass: DW_SKIP_CLOSE_CHECK=1 git push" >&2
-    echo "=======================================================" >&2
-    exit 1
+      if [ -n "$OPEN_ISSUES" ]; then
+        echo "=======================================================" >&2
+        echo "BLOCKED: Push contains commits referencing open issues." >&2
+        echo "" >&2
+        echo -e "$OPEN_ISSUES" >&2
+        echo "Close these in Citadel AND GitHub before pushing:" >&2
+        echo "  dw --project ${PROJECT} close <task-id> --reason \"...\"" >&2
+        echo "  gh issue close <number>" >&2
+        echo "" >&2
+        echo "Emergency bypass: DW_SKIP_CLOSE_CHECK=1 git push" >&2
+        echo "=======================================================" >&2
+        exit 1
+      fi
+    fi
+  fi
+
+  # ─── Incident auto-close keyword check (standards#100) ────────────────
+  # Block commits whose messages contain `Closes/Fixes/Resolves #N` for
+  # a GH issue labeled `type:incident`. Incident closure is a human-
+  # judgment gate (root cause + immediate fix + defense in depth +
+  # follow-ups tracked + post-incident write-up), not a side effect of
+  # PR merge. Use `Refs #N` or `Part of #N` instead — keeps the issue
+  # open until a human explicitly decides the incident is resolved.
+  #
+  # Source: citadel#70 — incident auto-closed via PR `Closes #N` keyword
+  # before user was aware. See standards#100 for the rationale.
+  #
+  # Scope: covers commit-message keywords only. PR-body keywords are NOT
+  # caught here (they're created via `gh pr create` after push); a
+  # server-side GH Actions workflow is the next layer. See follow-up
+  # issue when filed.
+  #
+  # Fail-OPEN with strong warning on GH API failure — matches the
+  # existing canonical hook fail-safety convention so a brief GH blip
+  # doesn't block legitimate pushes.
+
+  if [ "${DW_SKIP_INCIDENT_AUTOCLOSE_CHECK:-0}" = "1" ]; then
+    echo "⚠ INCIDENT AUTOCLOSE CHECK BYPASSED — DW_SKIP_INCIDENT_AUTOCLOSE_CHECK=1" >&2
+    echo "  Only use when the incident really is resolved by THIS PR AND" >&2
+    echo "  you have explicit user approval to close it via the PR merge." >&2
+  else
+    # Get full commit messages (subject + body) for the keyword search.
+    if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+      COMMITS_FULL=$(git log --format='%B%n---END-COMMIT---' "$local_sha" --not --remotes 2>/dev/null)
+    else
+      COMMITS_FULL=$(git log --format='%B%n---END-COMMIT---' "${remote_sha}..${local_sha}" 2>/dev/null)
+    fi
+
+    # GitHub-recognized auto-close keywords (case insensitive):
+    #   close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved
+    AUTOCLOSE_NUMS=$(echo "$COMMITS_FULL" \
+      | grep -ohiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?) +#[0-9]+' \
+      | grep -oE '#[0-9]+' \
+      | tr -d '#' \
+      | sort -u)
+
+    if [ -n "$AUTOCLOSE_NUMS" ]; then
+      BLOCKED_INCIDENTS=""
+      for ISSUE_NUM in $AUTOCLOSE_NUMS; do
+        LABELS=$(gh issue view "$ISSUE_NUM" --json labels --jq '.labels[].name' 2>/dev/null)
+        if [ -z "$LABELS" ]; then
+          echo "⚠ Could not query GH for issue #${ISSUE_NUM} labels — failing OPEN (push allowed)" >&2
+          echo "  Network blip? gh auth issue? Set DW_SKIP_INCIDENT_AUTOCLOSE_CHECK=1 to silence." >&2
+          continue
+        fi
+        if echo "$LABELS" | grep -qFx 'type:incident'; then
+          BLOCKED_INCIDENTS="${BLOCKED_INCIDENTS}  #${ISSUE_NUM}\n"
+        fi
+      done
+
+      if [ -n "$BLOCKED_INCIDENTS" ]; then
+        echo "=======================================================" >&2
+        echo "BLOCKED: Auto-close keyword targets type:incident issue(s)." >&2
+        echo "" >&2
+        echo -e "$BLOCKED_INCIDENTS" >&2
+        echo "Incident closure requires explicit human judgment, not a" >&2
+        echo "PR-merge side effect. Use 'Refs #N' or 'Part of #N' in the" >&2
+        echo "commit message instead so the issue stays open until a" >&2
+        echo "human explicitly closes it after verifying full resolution" >&2
+        echo "(root cause + immediate fix + defense in depth + follow-ups" >&2
+        echo "tracked + post-incident write-up)." >&2
+        echo "" >&2
+        echo "To override (only if THIS PR really resolves the incident" >&2
+        echo "AND you have explicit user approval to close):" >&2
+        echo "  DW_SKIP_INCIDENT_AUTOCLOSE_CHECK=1 git push" >&2
+        echo "=======================================================" >&2
+        exit 1
+      fi
+    fi
   fi
 done
 

--- a/.claude/hooks/preflight.sh
+++ b/.claude/hooks/preflight.sh
@@ -113,6 +113,7 @@ if [ -d "$CANONICAL_CMDS" ]; then
   mkdir -p "$PROJECT_CMDS"
   synced=0
   installed=0
+  backed_up=0
   # Guard against `set -e` aborting on the cmp/cp non-zero returns
   for canonical in "$CANONICAL_CMDS"/*.md; do
     [ -f "$canonical" ] || continue
@@ -121,11 +122,26 @@ if [ -d "$CANONICAL_CMDS" ]; then
     if [ ! -f "$local" ]; then
       cp "$canonical" "$local" && installed=$((installed + 1)) || true
     elif ! cmp -s "$canonical" "$local"; then
+      # First-install backup for commands that were project-local before
+      # becoming canonical (e.g., work.md prior to standards#112). If a
+      # ".pre-canonical.bak" doesn't already exist for this command, the
+      # current local file is a project-local hand-roll — preserve it
+      # before the sync overwrites with canonical. Subsequent updates to
+      # the synced file are overwritten without backup (canonical owns
+      # the file once installed).
+      backup="$PROJECT_CMDS/${name}.pre-canonical.bak"
+      if [ ! -f "$backup" ]; then
+        cp "$local" "$backup" 2>/dev/null && backed_up=$((backed_up + 1)) || true
+      fi
       cp "$canonical" "$local" && synced=$((synced + 1)) || true
     fi
   done
-  if [ "$installed" -gt 0 ] || [ "$synced" -gt 0 ]; then
-    pass "Canonical commands: $installed installed, $synced updated"
+  if [ "$installed" -gt 0 ] || [ "$synced" -gt 0 ] || [ "$backed_up" -gt 0 ]; then
+    if [ "$backed_up" -gt 0 ]; then
+      pass "Canonical commands: $installed installed, $synced updated, $backed_up pre-canonical backup(s) saved (.pre-canonical.bak)"
+    else
+      pass "Canonical commands: $installed installed, $synced updated"
+    fi
   else
     pass "Canonical commands: up to date"
   fi
@@ -134,12 +150,38 @@ else
 fi
 
 # ─── 6. Session State Recovery ───────────────────────────────────────────
+#
+# Hook-point for the session-state script — a per-project tool that writes
+# a snapshot of the agent's volatile state (claimed Citadel tasks, active
+# worktree, Agent Mail identity, open PRs, last Tier 2 approval, in-flight
+# notes) to .claude/agent-session.json. Preflight reads it here so post-
+# compaction sessions resume with structured handoff.
+#
+# Canonical writer (as of standards#107): hooks/session-state.py. Lifted
+# from the Strycher/LoRa#260 prototype on 2026-06-04. Projects install via
+# copy + post-commit wire-up (REPOCONFIG.md §Enforcement Hooks); future
+# auto-propagation tracked at standards#76.
+#
+# This block tries .py FIRST (canonical), then .sh as transition fallback
+# for any project still on a hand-rolled bash variant.
+#
 PREFLIGHT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SESSION_STATE_SCRIPT="$PREFLIGHT_DIR/session-state.sh"
 SESSION_STATE_FILE="$PROJECT_DIR/.claude/agent-session.json"
+SESSION_STATE_SCRIPT_PY="$PREFLIGHT_DIR/session-state.py"
+SESSION_STATE_SCRIPT_SH="$PREFLIGHT_DIR/session-state.sh"
 
-if [ -f "$SESSION_STATE_FILE" ] && [ -f "$SESSION_STATE_SCRIPT" ]; then
-  SESSION_OUTPUT=$(bash "$SESSION_STATE_SCRIPT" read 2>/dev/null || true)
+if [ -f "$SESSION_STATE_FILE" ]; then
+  SESSION_OUTPUT=""
+  if [ -f "$SESSION_STATE_SCRIPT_PY" ]; then
+    # Prefer python3 if present, else python.
+    if command -v python3 >/dev/null 2>&1; then
+      SESSION_OUTPUT=$(python3 "$SESSION_STATE_SCRIPT_PY" read 2>/dev/null || true)
+    elif command -v python >/dev/null 2>&1; then
+      SESSION_OUTPUT=$(python "$SESSION_STATE_SCRIPT_PY" read 2>/dev/null || true)
+    fi
+  elif [ -f "$SESSION_STATE_SCRIPT_SH" ]; then
+    SESSION_OUTPUT=$(bash "$SESSION_STATE_SCRIPT_SH" read 2>/dev/null || true)
+  fi
   if [ -n "$SESSION_OUTPUT" ]; then
     log ""
     log "═══ Active Agent Session ═══"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,25 +13,25 @@ A standalone MIT fork of [MeshCore](https://github.com/meshcore-dev/MeshCore) fo
 
 ## Project identity (READ FIRST -- do NOT conflate with LoRa)
 
-Crosswire is its **own** project. `Strycher/LoRa` is the **separate personal origin** repo; the Crosswire fork is no longer part of LoRa. For ALL work in `C:\Dev\LoRa\Crosswire` (including worktrees under `.worktrees/*`):
+Crosswire is its **own** project. `Strycher/LoRa` is the **separate personal origin** repo; the Crosswire fork is no longer part of LoRa. For ALL work in `C:\Dev\Crosswire` (including worktrees under `.worktrees/*`):
 
 | Channel | Value |
 |---|---|
 | Citadel | `DW_PROJECT=Crosswire` (Strycher/Crosswire). **Never** `LoRa`. |
 | GitHub issues/PRs | `Strycher/Crosswire` |
-| Agent Mail `project_key` | **`app-c-dev-lora-crosswire`** (path slug of `C:\Dev\LoRa\Crosswire`). Register + send + read HERE. NOT `app-c-dev-lora` (the LoRa workspace), NOT `app-crosswire` (stray). |
+| Agent Mail `project_key` | **`app-c-dev-crosswire`** (path slug of `C:\Dev\Crosswire`). Register + send + read HERE. NOT `app-c-dev-lora` (the LoRa workspace), NOT `app-crosswire` (stray), NOT `app-c-dev-lora-crosswire` (RETIRED 2026-06-10 — pitched in the relocation). |
 | Active agents (2026-06-10) | DustyFox, RedCreek |
 
-Worktrees coordinate in the SAME `app-c-dev-lora-crosswire` (resolve from the repo common dir, not the worktree path). The stale "in-flight firmware work tracked under the LoRa Citadel project" note in Migration status below is RETIRED: net-new Crosswire work is tracked under Crosswire (Citadel) + Strycher/Crosswire (issues) + `app-c-dev-lora-crosswire` (Agent Mail).
+Worktrees coordinate in the SAME `app-c-dev-crosswire` (resolve from the repo common dir, not the worktree path). The stale "in-flight firmware work tracked under the LoRa Citadel project" note in Migration status below is RETIRED: net-new Crosswire work is tracked under Crosswire (Citadel) + Strycher/Crosswire (issues) + `app-c-dev-crosswire` (Agent Mail).
 
 ## Project Parameters
 
 | Parameter | Value |
 |-----------|-------|
 | `PROJECT_NAME` | Crosswire |
-| `PROJECT_DIR` | `C:\Dev\LoRa\Crosswire` (nested under the LoRa workspace, gitignored by LoRa) |
+| `PROJECT_DIR` | `C:\Dev\Crosswire` (standalone repo; relocated out of the LoRa workspace 2026-06-10) |
 | `INFRA_PROFILE` | Maker |
-| `BUILD_COMMAND` | `pio run -e <env>` (run from this repo's working tree at `C:\Dev\LoRa\Crosswire`) |
+| `BUILD_COMMAND` | `pio run -e <env>` (run from this repo's working tree at `C:\Dev\Crosswire`) |
 | `DEPLOY_TARGET` | Device flash over USB / OTA (no SCP deploy; firmware is flashed, not server-deployed) |
 | `CITADEL_PROJECT` | `Crosswire` (Strycher/Crosswire) |
 | `GITHUB_PROJECT_ID` | `PVT_kwHODGcOBc4BZuj8` (Project #14, "Crosswire Project Board") |
@@ -52,7 +52,7 @@ Recorded per REPOCONFIG (board field IDs captured in project CLAUDE.md). Consume
 **Firmware has migrated here.** `firmware-base` (this repo's default branch) is the canonical Crosswire firmware tree. The old `crosswire` branch of `Strycher/MeshCore` is retired and that **fork is archived** (2026-06-04, read-only; reversible via `gh repo unarchive`). Full history is preserved in this repo: branches (patch-id verified), all `crosswire-v*` release tags + `archive/*` tags, and Plan 3 (see Preserved artifacts). Design-of-record: `docs/architecture/2026-06-01-observer-architecture-review.md`.
 
 Working-tree cutover COMPLETE (Strycher/Crosswire#10, 2026-06-10) -- the legacy `meshcore-firmware` clone is **retired/deleted**:
-- **Build/flash run from THIS repo's working tree** (`C:\Dev\LoRa\Crosswire`). Upstream MeshCore remotes live here: `upstream` = meshcore-dev/MeshCore and `iotthinks`, both **fetch-only** (`no-push`); `origin` = Strycher/Crosswire (push). `firmware-base` is a self-contained MeshCore fork (full `src/` tree), so future upstream merges (e.g. the deferred 1.16.0 base-update) fetch + merge directly here. Firmware work is tracked under the **Crosswire** Citadel project + Strycher/Crosswire issues (legacy Strycher/LoRa firmware issues are being migrated).
+- **Build/flash run from THIS repo's working tree** (`C:\Dev\Crosswire`). Upstream MeshCore remotes live here: `upstream` = meshcore-dev/MeshCore and `iotthinks`, both **fetch-only** (`no-push`); `origin` = Strycher/Crosswire (push). `firmware-base` is a self-contained MeshCore fork (full `src/` tree), so future upstream merges (e.g. the deferred 1.16.0 base-update) fetch + merge directly here. Firmware work is tracked under the **Crosswire** Citadel project + Strycher/Crosswire issues (legacy Strycher/LoRa firmware issues are being migrated).
 - **Net-new Crosswire requests / bugs / design-of-record are filed here** under the **Crosswire** Citadel project.
 - **Flash discipline PORTED (P5.2):** `scripts/pio-flash` (+`.py`), `scripts/ota-push.py`, and the `block-raw-flash` / `block-raw-curl-ota` / `require-agent-mail-check` PreToolUse hooks live in this repo. The device registry `hardware-devices.yaml` is **gitignored** (per-host; holds LAN IPs/MACs) — copy `hardware-devices.example.yaml` to `hardware-devices.yaml` and populate it before flashing from this repo.
 


### PR DESCRIPTION
Post-relocation bring-up to REPOCONFIG canonical (LoRa firmware enhancements preserved). The directory move (`C:\Dev\LoRa\Crosswire` -> `C:\Dev\Crosswire`) is already complete; this PR fixes in-repo references + re-syncs drifted hooks.

### Changes
- **CLAUDE.md** -- `PROJECT_DIR` + all `C:\Dev\LoRa\Crosswire` refs -> `C:\Dev\Crosswire`; Agent Mail `project_key` `app-c-dev-lora-crosswire` -> **`app-c-dev-crosswire`** (mailbox id 16; old slug retired + added to exclusion list).
- **Hooks synced to standards canonical** (drifted older versions, no firmware customizations):
  - `preflight.sh` (+48/-6): #112 `.pre-canonical.bak` backup logic + session-state hook-point; `PROJECT_DIR=/c/Dev/Crosswire`
  - `pre-push` (+120/-43): standards#100/#106 incident-autoclose block
  - `post-commit` (+1/-1): comment
- **Firmware hooks untouched** -- `block-raw-flash` / `block-raw-curl-ota` / `require-agent-mail-check`.

### Already canonical
SAFELANE/CLAUDE-BASE inheritance, 21 labels, board #14, Citadel project, `pre-commit`/`commit-msg`/`session-state.py`/`block-direct-citadel-db` match canonical.

Refs: #77 -- Deferred `block-incident-autoclose.yml` (standards#141).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
