### PR TITLE
fix(#70,#66): observer mqtt status: refresh cfg_ on disabled-slot set + cert/aud

### DIFF
--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -118,6 +118,21 @@ static bool handleStatus(char* reply, size_t reply_size, MqttBrokerPool& pool) {
                           cfg.jwt_owner[0] ? 'Y' : 'N',
                           cfg.jwt_email[0] ? 'Y' : 'N');
         }
+        // #66: on TLS/WSS slots surface the trust source (and JWT audience
+        // presence). cert=NONE on a wss slot is the smoking gun for a missing
+        // CA -- TLS handshakes then fail into permanent backoff while every
+        // other visible field looks correct.
+        if ((cfg.transport == BrokerTransport::Tls ||
+             cfg.transport == BrokerTransport::Wss) &&
+            n >= 0 && (size_t)n < reply_size) {
+            n += snprintf(reply + n, reply_size - (size_t)n, " cert=%s",
+                          cfg.ca_cert_name[0] ? cfg.ca_cert_name : "NONE");
+            if (cfg.auth_type == BrokerAuthType::Jwt &&
+                n >= 0 && (size_t)n < reply_size) {
+                n += snprintf(reply + n, reply_size - (size_t)n, " aud=%c",
+                              cfg.jwt_audience[0] ? 'Y' : 'N');
+            }
+        }
         if (n >= 0 && (size_t)n < reply_size) {
             n += snprintf(reply + n, reply_size - (size_t)n, "\n");
         }
@@ -283,9 +298,17 @@ static bool handleSetBrokerField(char* reply, size_t reply_size,
         return true;
     }
 
+    // #70/#67: refresh the broker's cached cfg_ so `mqtt status` reflects the
+    // new value immediately. Previously only the was_enabled path reloaded (via
+    // the live-client teardown); a set on an already-DISABLED slot wrote NVS but
+    // never refreshed cfg_, so status kept showing the boot-time config until the
+    // slot was enabled or the device rebooted. reloadSlot() is async + worker-
+    // owned (the reconciling_[] guard serializes it against loopTask), so this is
+    // race-safe; for a disabled slot the worker just re-reads NVS into cfg_ with
+    // no client touch.
+    pool.reloadSlot((uint8_t)slot);
+
     if (was_enabled) {
-        // Tear the live client down OFF loopTask (async; returns immediately).
-        pool.reloadSlot((uint8_t)slot);
         snprintf(reply, reply_size,
                  "mqtt.broker.%d.%s set; slot disabled -- 'mqtt enable %d' to apply\n",
                  slot, key, slot);


### PR DESCRIPTION
Fixes the observer `mqtt status` display bugs from the #53/#48/#63 hardware-test cluster. One file (`ObserverCli.cpp`), compiled clean on `Heltec_v3_companion_observer_wifi`.

## #70 + #67 (stale display) -- root cause
On a **disabled** slot, `set mqtt.broker.N.<field>` wrote NVS correctly but never refreshed the broker object's cached `cfg_`. `handleStatus` renders from `cfg_`, so status kept showing the boot-time config (`own=N eml=N`, old url) until the slot was enabled or the device rebooted -- only the was-enabled path reloaded.

**Fix:** `handleSetBrokerField` now calls `pool.reloadSlot(slot)` after every successful write. It is async + worker-owned (the `reconciling_[]` guard serializes it against loopTask), so it is race-safe; for a disabled slot the worker just re-reads NVS into `cfg_` with no client touch.

## #66 -- invisible TLS fields
`handleStatus` now appends `cert=<name|NONE>` on tls/wss slots and `aud=Y/N` on jwt slots. `cert=NONE` on a wss slot is the smoking gun for a missing CA that otherwise looks healthy until permanent backoff.

## Deliberately NOT included
#67's **second** defect -- `writeBrokerConfig` ignoring NVS write results -- stays open. The naive `ok &= put>0` fix is itself buggy (empty strings legitimately return 0 from `putString`), and whether it actively fires was never confirmed. Needs a read-back-verify or `nvs_get_stats` diag; tracked under #67.

## Verification
- `pio run -e Heltec_v3_companion_observer_wifi` -> SUCCESS (Flash 42.5%, RAM 25.9%).
- Hardware validation on HV3 is the owner's tollgate.

Closes #70
Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)