### PR TITLE
feat: port canonical warn-only Gemini reviewer to Crosswire

### DIFF
--- a/.github/gemini-prompts/meshcore-firmware.md
+++ b/.github/gemini-prompts/meshcore-firmware.md
@@ -1,0 +1,128 @@
+# Gemini Review Prompt — Crosswire (MeshCore firmware fork)
+
+You are an automated code-review assistant reviewing a pull-request **diff**
+against **Crosswire**, a fork of [MeshCore](https://github.com/meshcore-dev/MeshCore)
+— C++ Arduino/PlatformIO firmware for ESP32 (incl. S3), nRF52, and similar
+LoRa-mesh MCUs (companion/observer + repeater roles). The fork stages
+enhancements that may later be offered upstream, so flag anything upstream
+maintainers would push back on.
+
+Be concise. Bullets, not paragraphs. For each finding: name the file, the
+line/symbol, the problem, and a concrete fix or question. **Skip praise. Skip
+general observations. Report only issues worth acting on.** Review the **diff
+only** — do not speculate about files not shown or propose unrelated refactors.
+
+## Severity labels
+
+- **BLOCKER** — correctness/memory-safety bug or policy violation that must be
+  fixed before merge. Use sparingly.
+- **MAJOR** — design/convention problem a MeshCore maintainer would push back
+  on upstream.
+- **MINOR** — style, comment, nit.
+- **QUESTION** — looks intentional but worth confirming.
+
+If evidence is ambiguous, downgrade rather than overstate.
+
+## Output format
+
+Do **not** add a top-level heading (the workflow wraps your response).
+
+```
+**Summary:** <1-3 sentences — what the PR does and whether it's in good shape.
+End with a finding count, e.g. "3 issues: 1 BLOCKER, 2 MAJOR." If none, say so.>
+
+### Issues
+- **[BLOCKER] path/to/file.cpp:123** — <one-sentence problem>. <one-sentence fix.>
+- **[MAJOR] ...**
+- **[MINOR] ...**
+- **[QUESTION] ...**
+
+### Upstream readiness
+<One paragraph: ready to offer upstream to meshcore-dev/MeshCore, or issues a
+maintainer would push back on? What to fix before upstreaming?>
+```
+
+Omit empty sections. Do not pad.
+
+---
+
+## Universal concerns (every diff)
+
+### No silent failures (SAFELANE §6 — BLOCKER)
+- Error paths must `LOG_*` with enough context to diagnose from a field serial
+  log. `return false;` / early-return on error **without a log** is a silent
+  failure — flag it.
+- Empty/ignored error handling; unchecked return values from APIs that can
+  fail (`Preferences::begin`, `esp_wifi_*`, radio init, file I/O). Flag.
+
+### Memory safety (ESP32/nRF52 — BLOCKER for clear bugs)
+- Fixed-size `char[]` + `sprintf`/`strcpy` — prefer `snprintf` with
+  `sizeof(buf)` bounds. Check every string-format call in the diff.
+- Large stack-resident arrays in hot paths / ISR-adjacent context.
+- Large non-`PROGMEM` `const` data (bitmaps, strings) wasting RAM.
+- Buffer/index math: off-by-one, unbounded copies, unchecked lengths.
+
+### Security
+- Secrets/keys/tokens/credentials or internal LAN IPs/MACs/hostnames in code,
+  config, fixtures, logs, or commit messages. **BLOCKER**. (`hardware-devices.yaml`
+  is gitignored per-host — never hardcode device identifiers.)
+
+---
+
+## Firmware-platform concerns (ESP32 / embedded — apply when relevant)
+
+These transfer across MeshCore/Meshtastic-class ESP32 firmware:
+
+- **NimBLE `deinit()` is one-way on ESP32** — BLE cannot re-init without a
+  reboot. Any path that deinits BLE must either reboot or clearly document the
+  "dead-until-reboot" contract. **MAJOR/BLOCKER**.
+- **WiFi+BLE coex on ESP32-S3 is time-sliced.** `esp_wifi_set_ps(WIFI_PS_NONE)`
+  with BLE enabled starves BLE advertising. A WiFi patch that sets power-save
+  mode must not regress BLE. **MAJOR**.
+- **NVS (`Preferences`) key names have a 15-char limit** — longer keys silently
+  fail to save. Flag new keys that exceed it.
+- **ISR-adjacent / button-thread callbacks** must not do synchronous blocking
+  work (`esp_wifi_stop()`, BLE deinit, blocking I/O) — defer to the main loop
+  or a scheduled reboot. **BLOCKER** for blocking calls in ISR context.
+- **Build-flag discipline** — changes to default behavior must be gated behind
+  an opt-in build flag, not unconditional; a patch that helps ESP32-S3 may
+  regress nRF52. New flags follow the existing naming convention. **MAJOR**.
+- **Cross-variant impact** — does this build/regress on the other variants
+  (`heltec_v4_*`, `Xiao_S3_*`, `RAK_4631_*`)? Flag changes that likely break a
+  non-ESP32 path.
+
+---
+
+## ⚠ MeshCore-specific conventions — VERIFY, do not assume Meshtastic's
+
+> **This section is a stub to be completed by someone who knows MeshCore's
+> codebase** (the prior-art prompt this was derived from used *Meshtastic*
+> conventions — `LOG_DEBUG`, `concurrency::OSThread`, `Observable<T>`,
+> `config.X` + `nodeDB->saveToDisk()`, `rebootAtMsec`, `meshtastic/protobufs`
+> — which are **Meshtastic, not MeshCore**, and must not be asserted here).
+>
+> Until filled in, do **not** flag MeshCore code for violating Meshtastic
+> conventions. Flag only the universal + firmware-platform concerns above, and
+> raise a **QUESTION** if a convention looks project-specific and you're unsure.
+>
+> TODO (fill from MeshCore): logging macros/levels · concurrency/threading
+> primitives · config persistence pattern · reboot/scheduling idiom · protobuf
+> /schema change process · module/file layout conventions.
+
+---
+
+## Upstream-friendly shape (this is a fork that may upstream)
+- One commit, one thing — no "refactor + feature + fix" mega-commits.
+- Commit subject ≤ 72 chars; body explains **why**, references issues in a
+  trailer.
+- New files in conventional directories for the codebase.
+
+## What to ignore
+- Formatting/whitespace/semicolons (clang-format territory).
+- Per-variant `platformio.ini` verbosity (copy-heavy by necessity).
+- Pre-existing code outside the diff, unless the diff makes it worse.
+
+---
+
+The PR diff begins after the separator below. Apply the rules and produce the
+Markdown report.

--- a/.github/workflows/gemini-override.yml
+++ b/.github/workflows/gemini-override.yml
@@ -1,0 +1,123 @@
+name: Gemini Review Override (audit-only)
+
+# Audit-only parser for repo-maintainer `/gemini override: <reason>` PR comments.
+# Parses repo-maintainer PR comments of the form
+#
+#     /gemini override: <reason>
+#
+# and records an audit entry (PR comment + workflow summary). This is
+# scaffolding for a later phase, when the Gemini review promotes to a required
+# check and the override actually unblocks merge. In Phase 1 the Gemini
+# review is warn-only, so this workflow does NOT change merge gating —
+# it only produces an audit trail so Phase 3 can be turned on with
+# confidence about how the override command has been used historically.
+#
+# Trigger scope:
+#   - issue_comment / created only (edits are ignored so each audit event
+#     is tied to a distinct, immutable comment).
+#   - PR comments only (not plain issues).
+#   - Comment body's first line must start with "/gemini override:".
+#   - Bot users are ignored defensively.
+#
+# Maintainer check: author_association ∈ {OWNER, MEMBER, COLLABORATOR}.
+# Non-maintainer overrides are still logged (as rejected) so misuse is
+# visible in the audit record.
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: gemini-override-${{ github.event.issue.number }}-${{ github.event.comment.id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  audit-override:
+    if: >-
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.type != 'Bot' &&
+      startsWith(github.event.comment.body, '/gemini override:')
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Parse and audit override
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          AUTHOR_ASSOC: ${{ github.event.comment.author_association }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_URL: ${{ github.event.comment.html_url }}
+          TIMESTAMP: ${{ github.event.comment.created_at }}
+        run: |
+          set -u
+
+          # Extract the reason from the first line. Everything after the
+          # marker (with surrounding whitespace trimmed) is the reason.
+          first_line=$(printf '%s' "$COMMENT_BODY" | head -n1)
+          reason=$(printf '%s' "$first_line" \
+            | sed -E 's|^/gemini override:[[:space:]]*||' \
+            | sed -E 's|[[:space:]]+$||')
+          if [ -z "$reason" ]; then
+            reason_display="_(none provided)_"
+          else
+            reason_display="$reason"
+          fi
+
+          # Classify the commenter. Only repo maintainers may record an
+          # authorized override; anyone else is logged as rejected so the
+          # audit surface still captures misuse attempts.
+          case "$AUTHOR_ASSOC" in
+            OWNER|MEMBER|COLLABORATOR)
+              is_maintainer=true
+              ;;
+            *)
+              is_maintainer=false
+              ;;
+          esac
+
+          # Workflow-summary audit record (searchable via the Actions run
+          # history — no repo commit required, no extra permissions).
+          {
+            echo "## Gemini Review Override — Audit Record"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| PR | #${PR_NUMBER} |"
+            echo "| Commenter | @${COMMENTER} |"
+            echo "| Author association | \`${AUTHOR_ASSOC}\` |"
+            echo "| Authorized maintainer | ${is_maintainer} |"
+            echo "| Timestamp | ${TIMESTAMP} |"
+            echo "| Reason | ${reason_display} |"
+            echo "| Comment | ${COMMENT_URL} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Acknowledgment comment on the PR (the primary audit surface —
+          # searchable via GitHub issue search and visible in-thread to
+          # reviewers evaluating the override).
+          body_file=$(mktemp)
+          if [ "$is_maintainer" = "true" ]; then
+            {
+              echo "### 🟢 Gemini override acknowledged (audit-only, Phase 1)"
+              echo ""
+              echo "**Overridden by:** @${COMMENTER} (\`${AUTHOR_ASSOC}\`)"
+              echo "**Reason:** ${reason_display}"
+              echo "**Logged at:** ${TIMESTAMP}"
+              echo ""
+              echo "<sub>Phase 1 is warn-only — the Gemini review never blocks merge, so this override has no gating effect. Recorded here as audit scaffolding for Phase 3 (required-mode promotion). See a later phase (required-mode).</sub>"
+            } > "$body_file"
+          else
+            {
+              echo "### ⚠️ Gemini override ignored — not a repo maintainer"
+              echo ""
+              echo "@${COMMENTER} has \`author_association=${AUTHOR_ASSOC}\`. Only \`OWNER\`, \`MEMBER\`, or \`COLLABORATOR\` may record an override."
+              echo ""
+              echo "<sub>Audit-only — this comment does not affect merge gating. Logged so maintainers can review misuse attempts. See a later phase (required-mode).</sub>"
+            } > "$body_file"
+          fi
+
+          gh pr comment "${PR_NUMBER}" --body-file "$body_file"

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -1,0 +1,314 @@
+name: Gemini Review (general code review, warn-only)
+
+# General-purpose Gemini 2.5 Pro code review on PRs that touch real
+# code (Dart, tests, migrations, workflows). Sends the diff plus a
+# comprehensive review prompt and posts the response as a PR comment.
+#
+#
+# WARN-ONLY: every step uses continue-on-error and the final step always
+# exits 0. Failures (missing secret, API errors, missing prompt) surface
+# as a transparent PR comment so reviewers know the automated check did
+# not run — never as silent success.
+
+on:
+  pull_request:
+    # main = promote-to-prod, develop = validate-on-dev. Both get
+    # the same review so dev cycles do not waste time discovering
+    # issues only at the final promotion step.
+    branches: [main, develop]
+    types: [opened, synchronize, reopened]
+    # Path filter scopes the gate to real code worth reviewing.
+    # Excluded by omission: docs (reviewed by humans), pubspec.lock
+    # (auto-generated), assets, build artifacts. The filter is
+    # intentionally broad — Gemini decides what to flag, the workflow
+    # just decides what to send.
+    # CUSTOMIZE per project: scope to your real source paths. Broad is fine —
+    # Gemini decides what to flag; this filter just decides what to send.
+    paths:
+      - "src/**"
+      - "variants/**"
+      - "boards/**"
+      - "lib/**"
+      - "**/*.cpp"
+      - "**/*.h"
+      - "**/*.hpp"
+      - "**/*.ino"
+      - "platformio.ini"
+      - "**/platformio.ini"
+      - ".github/workflows/**"
+      - ".github/gemini-prompts/**"
+
+concurrency:
+  group: gemini-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Collect PR diff
+        id: diff
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -u
+          mkdir -p .gemini-review
+          gh pr diff "${{ github.event.pull_request.number }}" \
+            > .gemini-review/diff.patch || true
+          bytes=$(wc -c < .gemini-review/diff.patch | tr -d ' ')
+          echo "diff_bytes=${bytes}" >> "$GITHUB_OUTPUT"
+          # Cap the diff at ~200KB to stay under Gemini's token limits.
+          head -c 200000 .gemini-review/diff.patch \
+            > .gemini-review/diff.capped.patch
+          if [ "${bytes}" -gt 200000 ]; then
+            echo "TRUNCATED=true" >> "$GITHUB_ENV"
+          else
+            echo "TRUNCATED=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Load review prompt
+        id: prompt
+        continue-on-error: true
+        run: |
+          set -u
+          PROMPT_FILE=".github/gemini-prompts/meshcore-firmware.md"
+          if [ -f "$PROMPT_FILE" ]; then
+            echo "prompt_found=true" >> "$GITHUB_OUTPUT"
+            cp "$PROMPT_FILE" .gemini-review/prompt.md
+          else
+            echo "prompt_found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Call Gemini API
+        id: gemini
+        continue-on-error: true
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          set -u
+          if [ -z "${GEMINI_API_KEY:-}" ]; then
+            echo "status=missing_secret" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ ! -f .gemini-review/prompt.md ]; then
+            echo "status=missing_prompt" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ ! -s .gemini-review/diff.capped.patch ]; then
+            echo "status=empty_diff" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Build the request body: prompt as system-ish context, diff as user content.
+          #
+          # maxOutputTokens=32768 rationale:
+          # Gemini 2.5 Pro is a thinking model. Internal
+          # reasoning tokens come out of maxOutputTokens along
+          # with the visible response. The previous 4096 was
+          # too small for non-trivial diffs: in the first PR
+          # 1167 run, 4093 tokens went to thinking before any
+          # visible output (finishReason MAX_TOKENS, no parts
+          # field). 32768 leaves comfortable headroom while
+          # staying half of the model per-call ceiling of
+          # 65536. Token cost is per-used, not per-budgeted,
+          # so headroom does not bill unless the model uses it.
+          #
+          # NOTE: keep all explanatory comments outside the
+          # single-quoted jq argument below. Apostrophes inside
+          # bash single quotes terminate the quote prematurely
+          # (chore #1175 fixed exactly that regression).
+          jq -n \
+            --rawfile prompt .gemini-review/prompt.md \
+            --rawfile diff   .gemini-review/diff.capped.patch \
+            --arg truncated  "${TRUNCATED:-false}" \
+            '{
+              contents: [{
+                role: "user",
+                parts: [
+                  { text: $prompt },
+                  { text: ("\n\n---\n\nPR diff (truncated=" + $truncated + "):\n\n```diff\n" + $diff + "\n```") }
+                ]
+              }],
+              generationConfig: { temperature: 0.2, maxOutputTokens: 32768 }
+            }' > .gemini-review/request.json
+
+          http_status=$(curl -sS -o .gemini-review/response.json -w '%{http_code}' \
+            -X POST \
+            -H 'Content-Type: application/json' \
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent?key=${GEMINI_API_KEY}" \
+            --data-binary @.gemini-review/request.json || echo "000")
+
+          echo "http_status=${http_status}" >> "$GITHUB_OUTPUT"
+
+          # Always capture a 4KB raw snippet for diagnostics —
+          # truncated so the PR comment never balloons. Used by
+          # both api_error and unparseable_response paths in the
+          # comment step below. Sensitive content from the API
+          # is unlikely (Gemini doesn't echo secrets), and the
+          # snippet is in a collapsed <details> block.
+          head -c 4096 .gemini-review/response.json \
+            > .gemini-review/response.snippet.json 2>/dev/null \
+            || echo "{}" > .gemini-review/response.snippet.json
+
+          if [ "${http_status}" != "200" ]; then
+            echo "status=api_error" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Extract the response text. If structure unexpected,
+          # capture a structured diagnostic object so the PR
+          # comment can show why parsing failed (safety block,
+          # empty candidates, shape change, etc.) instead of a
+          # canned "could not be parsed" message that hides the
+          # real cause.
+          if jq -e '.candidates[0].content.parts[0].text' \
+               .gemini-review/response.json > /dev/null 2>&1; then
+            jq -r '.candidates[0].content.parts[0].text' \
+              .gemini-review/response.json > .gemini-review/review.md
+            echo "status=ok" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=unparseable_response" >> "$GITHUB_OUTPUT"
+            # Build a small diagnostic object capturing the most
+            # informative fields. `// empty` defaults keep the
+            # extractor robust against any missing key.
+            jq -c '{
+              has_candidates: ((.candidates // []) | length > 0),
+              candidate_count: ((.candidates // []) | length),
+              candidate_finish_reasons: [(.candidates // [])[].finishReason // "n/a"],
+              prompt_block_reason: (.promptFeedback.blockReason // null),
+              prompt_safety_ratings: [(.promptFeedback.safetyRatings // [])[] |
+                {category: .category, probability: .probability}],
+              candidate_safety_ratings: [(.candidates // [])[]?.safetyRatings // [] | .[] |
+                {category: .category, probability: .probability}],
+              error_code: (.error.code // null),
+              error_message: (.error.message // null),
+              top_level_keys: ([. | keys[]])
+            }' .gemini-review/response.json \
+              > .gemini-review/diagnostic.json 2>/dev/null \
+              || echo '{"diagnostic_extract_failed": true}' \
+                > .gemini-review/diagnostic.json
+          fi
+
+      - name: Post PR comment
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STATUS: ${{ steps.gemini.outputs.status }}
+          HTTP: ${{ steps.gemini.outputs.http_status }}
+          PROMPT_FOUND: ${{ steps.prompt.outputs.prompt_found }}
+          DIFF_BYTES: ${{ steps.diff.outputs.diff_bytes }}
+        run: |
+          set -u
+          body_file=.gemini-review/comment.md
+          header="### 🤖 Gemini Review (warn-only)"
+
+          case "${STATUS:-unknown}" in
+            ok)
+              {
+                echo "$header"
+                echo ""
+                cat .gemini-review/review.md
+                echo ""
+                echo "<sub>Warn-only — this check never blocks merge. Prompt: \`.github/gemini-prompts/meshcore-firmware.md\`.</sub>"
+              } > "$body_file"
+              ;;
+            missing_secret)
+              {
+                echo "$header"
+                echo ""
+                echo "⚠️ \`GEMINI_API_KEY\` secret is not configured for this repo. Automated review did not run — please review the changes manually."
+              } > "$body_file"
+              ;;
+            missing_prompt)
+              {
+                echo "$header"
+                echo ""
+                echo "⚠️ Prompt file \`.github/gemini-prompts/meshcore-firmware.md\` not found. Automated review did not run — please review changes manually."
+              } > "$body_file"
+              ;;
+            empty_diff)
+              {
+                echo "$header"
+                echo ""
+                echo "_No diff to review (PR contains no changes to reviewed code paths)._"
+              } > "$body_file"
+              ;;
+            api_error)
+              {
+                echo "$header"
+                echo ""
+                echo "⚠️ Gemini API call failed (HTTP ${HTTP:-n/a}). Automated review did not run — please review the changes manually."
+                echo ""
+                if [ -s .gemini-review/response.snippet.json ]; then
+                  echo "<details><summary>Response snippet (first 4KB)</summary>"
+                  echo ""
+                  echo "\`\`\`json"
+                  cat .gemini-review/response.snippet.json
+                  echo ""
+                  echo "\`\`\`"
+                  echo ""
+                  echo "</details>"
+                fi
+              } > "$body_file"
+              ;;
+            unparseable_response)
+              {
+                echo "$header"
+                echo ""
+                echo "⚠️ Gemini returned a response that could not be parsed. Automated review did not run — please review the changes manually."
+                echo ""
+                echo "Common causes — read the diagnostic to know which:"
+                echo "- Safety filter block — \`prompt_block_reason\` or any \`finish_reason: SAFETY\`"
+                echo "- Empty candidates — \`has_candidates: false\` (model returned no completions)"
+                echo "- Shape mismatch — Gemini API envelope changed (\`top_level_keys\` differs from expected)"
+                echo "- Quota / rate limit — \`error_code\` or \`error_message\` populated"
+                echo ""
+                if [ -s .gemini-review/diagnostic.json ]; then
+                  echo "<details><summary>Diagnostic (parsed fields)</summary>"
+                  echo ""
+                  echo "\`\`\`json"
+                  cat .gemini-review/diagnostic.json
+                  echo ""
+                  echo "\`\`\`"
+                  echo ""
+                  echo "</details>"
+                fi
+                if [ -s .gemini-review/response.snippet.json ]; then
+                  echo ""
+                  echo "<details><summary>Raw response snippet (first 4KB)</summary>"
+                  echo ""
+                  echo "\`\`\`json"
+                  cat .gemini-review/response.snippet.json
+                  echo ""
+                  echo "\`\`\`"
+                  echo ""
+                  echo "</details>"
+                fi
+              } > "$body_file"
+              ;;
+            *)
+              {
+                echo "$header"
+                echo ""
+                echo "⚠️ Review step did not complete (status=${STATUS:-unknown}). Please review the changes manually."
+              } > "$body_file"
+              ;;
+          esac
+
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --body-file "$body_file" || true
+
+      - name: Warn-only exit
+        run: exit 0


### PR DESCRIPTION
Ports the canonical warn-only Gemini reviewer (standards#145/#146) to Crosswire — the MeshCore firmware fork that's the prime use case but had none. Closes the gap from the relocation review.

### Added
- **`.github/workflows/gemini-review.yml`** + **`gemini-override.yml`** — canonical warn-only reviewer (every step `continue-on-error`, always `exit 0`; failures post a visible PR comment, never silent). Paths scoped to firmware: `src/`, `variants/`, `boards/`, `*.cpp/*.h/*.hpp/*.ino`, `platformio.ini`.
- **`.github/gemini-prompts/meshcore-firmware.md`** — canonical base + **transferable ESP32/embedded** firmware concerns (NimBLE one-way `deinit`, WiFi/BLE coex power-save trap, NVS 15-char keys, ISR-context discipline, memory safety, build-flag gating, no-silent-failures-via-serial, upstream-friendly commit shape).

### Honest gap (flagged in the prompt, not hidden)
The **MeshCore-specific conventions** section is an explicit `VERIFY/TODO` stub. The prior-art prompt (LoRa `meshtastic-firmware.md`) used **Meshtastic** conventions (`LOG_DEBUG`, `concurrency::OSThread`, `Observable<T>`, `nodeDB->saveToDisk`, `rebootAtMsec`, `meshtastic/protobufs`) — those are **not MeshCore's** and I did not assert them. Someone who knows MeshCore (e.g. RedCreek) should fill that section; until then the reviewer flags only universal + firmware-platform concerns.

### Action needed
Set the **`GEMINI_API_KEY`** repo secret on `Strycher/Crosswire` to enable the API call (warn-only degrades gracefully without it).

Refs: #83
