### PR TITLE
Observer follow-ups: arbiter decouple + held-state (#87) + /status radio from runtime prefs (#88)

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -348,7 +348,7 @@ void loop() {
   //   tx_air_secs    -- the_mesh.getTotalAirTime() / 1000
   //   rx_air_secs    -- the_mesh.getReceiveAirTime() / 1000
   //   recv_errors    -- radio_driver.getPacketsRecvErrors()
-  //   radio_freq/bw/sf/cr -- compile-time LORA_* macros (runtime prefs TODO)
+  //   radio_freq/bw/sf/cr -- runtime NodePrefs freq/bw/sf/cr (#88)
   //   repeat_enabled -- getNodePrefs()->client_repeat != 0
   {
     static uint32_t s_status_snap_ms = 0;
@@ -364,10 +364,14 @@ void loop() {
       snap.tx_air_secs    = static_cast<uint32_t>(the_mesh.getTotalAirTime() / 1000UL);
       snap.rx_air_secs    = static_cast<uint32_t>(the_mesh.getReceiveAirTime() / 1000UL);
       snap.recv_errors    = static_cast<uint32_t>(radio_driver.getPacketsRecvErrors());
-      snap.radio_freq     = static_cast<float>(LORA_FREQ);
-      snap.radio_bw       = static_cast<float>(LORA_BW);
-      snap.radio_sf       = static_cast<uint8_t>(LORA_SF);
-      snap.radio_cr       = static_cast<uint8_t>(LORA_CR);
+      // #88: report the ACTUAL runtime radio config from NodePrefs (set via
+      // companion-API CMD_SET_RADIO_PARAMS, surfaced to HA/HACS through
+      // SELF_INFO) -- NOT the compile-time LORA_* macros, which on the observer
+      // env default to esp32_base 869.618/SF8 and never reflect a runtime re-tune.
+      snap.radio_freq     = the_mesh.getNodePrefs()->freq;
+      snap.radio_bw       = the_mesh.getNodePrefs()->bw;
+      snap.radio_sf       = the_mesh.getNodePrefs()->sf;
+      snap.radio_cr       = the_mesh.getNodePrefs()->cr;
       snap.repeat_enabled = (the_mesh.getNodePrefs()->client_repeat != 0);
       // #31 Task D: publish position in /status, selected EXACTLY as the
       // companion advert path selects its location, so the MQTT position always

--- a/src/helpers/wifi_observer/MqttBroker.cpp
+++ b/src/helpers/wifi_observer/MqttBroker.cpp
@@ -214,6 +214,12 @@ bool MqttBroker::tryConnect(uint32_t now_ms) {
     // clock; we retry on the next drive tick. tcp brokers are unaffected.
     if ((cfg_.transport == BrokerTransport::Tls ||
          cfg_.transport == BrokerTransport::Wss) && !wallClockSane()) {
+        // #87: surface the clock-hold as a distinct state so `mqtt status` reads
+        // "held(no-clock)" instead of "down"/"backoff" (which look like a failure).
+        // No retry_count bump -- nothing was attempted. The pool keeps driving
+        // tryConnect for HeldNoClock slots, so this releases on the first tick
+        // after wallClockSane() becomes true (NTP sync or GPS lock).
+        rt_.state = BrokerState::HeldNoClock;
         return false;
     }
 

--- a/src/helpers/wifi_observer/MqttBroker.h
+++ b/src/helpers/wifi_observer/MqttBroker.h
@@ -21,10 +21,13 @@
 namespace crosswire {
 
 enum class BrokerState : uint8_t {
-    Down       = 0,  // disabled OR not yet attempted
-    Connecting = 1,  // tcp connect / TLS handshake in progress
-    Up         = 2,  // healthy
-    Backoff    = 3,  // failed; waiting for backoff window
+    Down        = 0,  // disabled OR not yet attempted
+    Connecting  = 1,  // tcp connect / TLS handshake in progress
+    Up          = 2,  // healthy
+    Backoff     = 3,  // failed; waiting for backoff window
+    HeldNoClock = 4,  // #87: wss/TLS deferred pending a sane wall clock (NTP/GPS).
+                      // NOT a failure -- no retry burned; released automatically on
+                      // the next drive tick once wallClockSane() becomes true.
 };
 
 enum class BrokerErrorClass : uint8_t {

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -353,7 +353,8 @@ void MqttBrokerPool::workerLoop() {
             if (!b.isConfigured()) continue;
             b.loop(now);
             if (b.runtime().state == BrokerState::Down ||
-                b.runtime().state == BrokerState::Backoff) {
+                b.runtime().state == BrokerState::Backoff ||
+                b.runtime().state == BrokerState::HeldNoClock) {  // #87: re-check the clock gate each tick so held wss slots release the moment the clock is sane
                 uint32_t biased = now + static_cast<uint32_t>(s) * 1000U;
                 (void)b.tryConnect(biased);
             }

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -83,11 +83,12 @@ static const char* authStr(BrokerAuthType a) {
 
 static const char* stateStr(BrokerState s) {
     switch (s) {
-        case BrokerState::Down:       return "down";
-        case BrokerState::Connecting: return "connecting";
-        case BrokerState::Up:         return "up";
-        case BrokerState::Backoff:    return "backoff";
-        default:                      return "?";
+        case BrokerState::Down:        return "down";
+        case BrokerState::Connecting:  return "connecting";
+        case BrokerState::Up:          return "up";
+        case BrokerState::Backoff:     return "backoff";
+        case BrokerState::HeldNoClock: return "held(no-clock)";
+        default:                       return "?";
     }
 }
 

--- a/src/helpers/wifi_observer/WifiObserver.cpp
+++ b/src/helpers/wifi_observer/WifiObserver.cpp
@@ -14,6 +14,7 @@
   #include <Arduino.h>
   #include <esp_system.h>   // esp_reset_reason()
   #include <time.h>         // #69: configTime() + time() for the SNTP wall clock
+  #include <esp_sntp.h>     // #87: esp_sntp_stop() once GPS owns the clock
 #endif
 
 namespace crosswire {
@@ -44,9 +45,9 @@ static bool        s_gps_time_locked  = false;
 // iat/exp are garbage, so the pool waits for it before enabling brokers.
 static bool        s_sntp_started     = false;
 static uint32_t    s_sntp_started_ms  = 0;
-// #69 Task B: STA-up timestamp used by the GPS grace-window calculation.
-// Set once on the first loop iteration where STA becomes connected.
-static uint32_t    s_sta_up_ms        = 0;
+// #87: one-shot guard -- stop SNTP once GPS has locked (GPS > NTP) so a later
+// NTP poll cannot overwrite GPS-accurate time.
+static bool        s_sntp_stopped_for_gps = false;
 static bool wallClockSane() { return time(nullptr) > 1735689600; }
 #endif
 
@@ -116,53 +117,40 @@ void wifiObserverLoop() {
     // Bring pool + pipeline up on the STA-connected transition (with
     // mesh context). One-shot guarded by s_pool_started.
 
-    // #69 Task B: Phase 1 -- time-source arbiter. Record STA-up timestamp once
-    // (for the GPS grace window), then start SNTP only when GPS will NOT serve
-    // the clock.
-    //
-    // Decision tree (D1/D3 -- GPS > NTP > BLE):
-    //   - GPS locked:         GPS owns the clock; do NOT start SNTP.
-    //   - GPS enabled+unlocked, within cold-fix budget: wait for GPS first.
-    //   - GPS enabled+unlocked, grace expired: fall back to NTP.
-    //   - GPS disabled:       start NTP immediately (existing behavior).
-    //
-    // GPS sets the RTC directly via MicroNMEA on each fix, so wallClockSane()
-    // is satisfied by either source -- Phase 2 remains source-agnostic.
-    constexpr uint32_t kGpsGraceMs = 60000;  // GPS cold-fix budget before NTP fallback
-    if (wifiBootstrap().isStaConnected() && s_sta_up_ms == 0) {
-        s_sta_up_ms = now;  // record once; used for grace-window math below
-    }
-    {
-        bool gps_will_serve = s_gps_time_enabled &&
-                              (s_gps_time_locked ||
-                               (s_sta_up_ms != 0 && (now - s_sta_up_ms) < kGpsGraceMs));
-        if (!s_sntp_started && s_context_set &&
-            wifiBootstrap().isStaConnected() && !gps_will_serve) {
-            configTime(0, 0, "pool.ntp.org", "time.nist.gov", "time.google.com");
-            s_sntp_started    = true;
-            s_sntp_started_ms = now;
-            crashLogf("[WifiObserver] SNTP started (gps_en=%d gps_lock=%d pre-sync wall=%lu)",
-                      (int)s_gps_time_enabled, (int)s_gps_time_locked,
-                      (unsigned long)time(nullptr));
-        }
+    // #69/#87 Task B: time-source arbiter. GPS > NTP > BLE for *accuracy*, but
+    // we never block MQTT on GPS acquisition (#87). SNTP starts immediately on
+    // STA-connect; the pool comes up as soon as SNTP is kicked off. GPS runs in
+    // parallel (it writes the RTC directly via MicroNMEA on each fix) and, once
+    // it locks, takes over the clock -- we then stop SNTP so a later NTP poll
+    // cannot overwrite GPS-accurate time. wss/TLS brokers self-defer
+    // (BrokerState::HeldNoClock) until wallClockSane(); tcp brokers publish now.
+
+    // Phase 1 -- start SNTP immediately (no GPS pre-grace).
+    if (!s_sntp_started && s_context_set && wifiBootstrap().isStaConnected()) {
+        configTime(0, 0, "pool.ntp.org", "time.nist.gov", "time.google.com");
+        s_sntp_started    = true;
+        s_sntp_started_ms = now;
+        crashLogf("[WifiObserver] SNTP started immediately (gps_en=%d gps_lock=%d pre-sync wall=%lu)",
+                  (int)s_gps_time_enabled, (int)s_gps_time_locked,
+                  (unsigned long)time(nullptr));
     }
 
-    // #69: Phase 2 -- bring up the MQTT pool once we have a real wall clock, so
-    // wss/jwt brokers connect on their first attempt instead of failing TLS into
-    // backoff. Source-agnostic: wallClockSane() is true whether GPS or NTP set
-    // the clock. Bounded wait (NTP path only): if NTP is blocked and GPS has
-    // not locked, the tcp brokers still come up rather than MQTT never starting.
-    constexpr uint32_t kClockWaitMs = 30000;
-    bool clock_wait_expired = s_sntp_started &&
-                              (now - s_sntp_started_ms >= kClockWaitMs);
+    // #87: GPS > NTP after the fact -- once GPS owns the clock, stop SNTP so a
+    // later poll cannot overwrite GPS-accurate time. One-shot.
+    if (s_gps_time_locked && s_sntp_started && !s_sntp_stopped_for_gps) {
+        esp_sntp_stop();
+        s_sntp_stopped_for_gps = true;
+        crashLogf("[WifiObserver] GPS locked -- SNTP stopped (GPS>NTP)");
+    }
+
+    // Phase 2 -- bring the pool up as soon as SNTP is running (or GPS locked).
+    // No clock gate here (#87): tcp brokers publish immediately; wss/TLS brokers
+    // self-defer to HeldNoClock until wallClockSane() and release the instant the
+    // clock arrives. A clockless start no longer blocks the tcp feed.
     if (!s_pool_started && s_identity != nullptr &&
-        (s_gps_time_locked || s_sntp_started) &&
-        (wallClockSane() || clock_wait_expired)) {
-        if (!wallClockSane()) {
-            crashLogf("[WifiObserver] clock not synced after %us -- pool up anyway "
-                      "(wss brokers will wait)", (unsigned)(kClockWaitMs / 1000));
-        }
-        crashLogf("[WifiObserver] clock ready -- bringing up MqttBrokerPool (wall=%lu)",
+        wifiBootstrap().isStaConnected() &&
+        (s_gps_time_locked || s_sntp_started)) {
+        crashLogf("[WifiObserver] bringing up MqttBrokerPool (tcp now; wss held until clock; wall=%lu)",
                   (unsigned long)time(nullptr));
         s_pool.begin(*s_identity, s_device_id, s_node_name,
                      s_client_version, s_firmware_version, s_model);


### PR DESCRIPTION
Two observer follow-ups, both flashed to ST-P and **device-verified**; both issues (#87, #88) closed. Builds on #69/#31/#45 (PR #91, merged).

## #87 — decouple MQTT pool from GPS acquisition + `held(no-clock)` state
- SNTP starts **immediately** on STA-connect (drops the 60s GPS pre-grace). The pool comes up as soon as SNTP is kicked off, so **tcp brokers publish immediately** and **wss/TLS brokers self-defer** to the new `BrokerState::HeldNoClock` until `wallClockSane()`, releasing on the next drive tick.
- `mqtt status` renders `held(no-clock)` (no retry burn) so a clock-deferred broker reads as *held*, not *failing*.
- GPS > NTP after the fact: `esp_sntp_stop()` once GPS locks, so a later poll can't overwrite GPS-accurate time.

## #88 — `/status` radio params from runtime config
- `snap.radio_freq/bw/sf/cr` now read `the_mesh.getNodePrefs()->{freq,bw,sf,cr}` (runtime config, set via companion-API `CMD_SET_RADIO_PARAMS`, the same source HA/HACS reads via `SELF_INFO`) instead of the compile-time `LORA_*` macros — which on the observer env defaulted to esp32_base `869.618/SF8` and never reflected a runtime re-tune.

## Verification
- 3-env observer build green (HV3 / HV4 / XIAO) at each increment.
- Gemini adversarial review → adjudicated: 2 "BLOCKERs" were **false positives on pre-existing code** (verified — XIAO build green; struct fully initialized); 1 minor (`wallClockSane()` de-dup) noted.
- **Flashed ST-P (`45bdfa8`) + device-verified:** all 3 brokers at 0 retries, `held(no-clock)` worked, CoreScope `/status` reports radio **`910.525/SF7`** (was 869.6/SF8) + a current/valid clock timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
