### PR TITLE
docs: README/CHANGELOG 0.16.0 (#93) + observer instructions (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,38 @@ Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
 _Nothing yet._
 
+## [0.16.0] - 2026-06-12
+
+Observer time/clock + `_sys` CLI + reporting hardening. Hardware-validated on
+ST-P (Heltec V4): three brokers connected, a valid phone-free wall clock, and
+correct radio + position reporting on CoreScope.
+
+### Added
+- Observer `_sys` CLI grammar standardization: `wifi status` / `wifi enable` /
+  `wifi disable` (namespace-subcommand, aligned with `mqtt status/enable/disable`)
+  and symmetric `get mqtt.broker.<N>.<key>` (read mirror of `set`, secrets
+  redacted). `get wifi.status` kept as a backward-compat alias. (#45)
+- Observer time-source arbiter, GPS > NTP > BLE: SNTP provides a fast clock and
+  GPS takes over on lock (SNTP stopped once GPS owns the clock) -- a JWT-grade
+  wall clock with no phone dependency. (#69)
+- Position in the observer MQTT `/status` payload, selected by `advert_loc_policy`
+  exactly as the LoRa advert (0,0 null-island suppressed). (#31)
+- `mqtt status` broker state `held(no-clock)`: a wss/TLS slot deferred pending a
+  sane wall clock now reads as *held* (no retry burn) instead of looking like a
+  failure, and releases automatically once the clock syncs. (#87)
+
+### Changed
+- Observer MQTT pool no longer blocks on GPS acquisition: SNTP starts immediately
+  on STA-connect and the pool comes up regardless, so tcp brokers publish at once
+  while wss/TLS brokers self-defer to `held(no-clock)`. (#87)
+- `/status` radio fields (`freq/bw/sf/cr`) now report the **runtime** radio config
+  (`NodePrefs`, set via the companion API) instead of the compile-time `LORA_*`
+  build macros. (#88)
+
+### Docs
+- `docs/observer-cli-commands.md` -- `_sys` CLI command reference. (#45)
+- `docs/observer-gps-location-config.md` -- GPS / location operator guide. (#31/#69)
+
 ## [0.15.0] - 2026-06-10
 
 Observer MQTT connectivity -- hardware-validated against three brokers

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A [MeshCore](https://github.com/meshcore-dev/MeshCore) fork for **cross-role fir
 
 | Role | Status | What Crosswire adds |
 |------|--------|---------------------|
-| **Companion / Observer** | Active | WiFi + MQTT publishing of LoRa-mesh observations to public brokers, NimBLE BLE stack, configurable multi-broker pool with TLS + JWT auth (validated against CoreScope, eastme.sh, LetsMesh) |
+| **Companion / Observer** | Active | WiFi + MQTT publishing of LoRa-mesh observations to public brokers (CoreScope, eastme.sh, LetsMesh), NimBLE BLE stack, multi-broker pool with TLS + JWT auth, a GPS&nbsp;>&nbsp;NTP phone-free wall clock for unattended JWT auth, position in the MQTT `/status`, and a `_sys`-channel CLI for WiFi/broker config |
 | **Repeater** | Active | MQTT telemetry bridging (to Mosquitto and other brokers), burst-WiFi telemetry, heap and power tuning |
 | **Room server** | Not yet | -- |
 | **Bridge** | Not yet | -- |
@@ -15,7 +15,7 @@ Cross-cutting work used by multiple roles: a NimBLE migration off Bluedroid, a C
 
 ## Status
 
-The firmware lives here: **`firmware-base`** is the canonical Crosswire tree (the old `Strycher/MeshCore` fork is archived). Design-of-record for the observer architecture is in [`docs/architecture/`](docs/architecture/).
+The firmware lives here: **`firmware-base`** is the canonical Crosswire tree (the old `Strycher/MeshCore` fork is archived). Design-of-record for the observer architecture is in [`docs/architecture/`](docs/architecture/). Operator setup for the observer is in [`docs/observer-cli-commands.md`](docs/observer-cli-commands.md) (the `_sys` CLI) and [`docs/observer-gps-location-config.md`](docs/observer-gps-location-config.md) (GPS / location).
 
 ## Filing requests
 

--- a/docs/observer-cli-commands.md
+++ b/docs/observer-cli-commands.md
@@ -55,17 +55,57 @@ Broker fields (`<key>`): `url`, `port`, `transport` (tcp\|tls\|wss),
 Setting a field on a **live** (enabled) broker slot auto-disables that slot;
 re-enable explicitly with `mqtt enable <N>` once the config is complete.
 
-## First-time bring-up
+## Broker auth — wss/jwt (the real recipe)
+
+The public MeshCore brokers (LetsMesh, eastme.sh) use `wss` + JWT. The credential
+is your node's **own Ed25519 public key** — the firmware mints the token; there's
+no separate registration. Configure a wss/jwt slot like this:
+
+```
+set mqtt.broker.1.url           wss://mqtt-us-v1.letsmesh.net:443/mqtt
+set mqtt.broker.1.transport     wss
+set mqtt.broker.1.auth_type     jwt
+set mqtt.broker.1.ca_cert       gts-r4
+set mqtt.broker.1.jwt_audience  mqtt-us-v1.letsmesh.net
+set mqtt.broker.1.username      <your node pubkey>
+set mqtt.broker.1.jwt_owner     <your node pubkey>
+set mqtt.broker.1.jwt_email     you@example.com
+mqtt enable 1
+mqtt status
+```
+
+- **`username` + `jwt_owner` = your node's pubkey.** The firmware mints the JWT
+  (the password — you do **not** set it) and normalizes `jwt_owner` case
+  internally, so the input case doesn't matter.
+- **The exact `username` form is broker-dependent.** A **bare pubkey** works on
+  eastme.sh; some brokers expect a `v1_<pubkey>` prefix. If a wss slot won't
+  authenticate, try the other form. (Defaulting this per broker is Crosswire#95.)
+
+### Known broker values
+| Broker | url | ca_cert | jwt_audience |
+|---|---|---|---|
+| CoreScope | `mqtt://mqtt.w8oof.net:1883` | — (tcp / anon) | — |
+| LetsMesh-US | `wss://mqtt-us-v1.letsmesh.net:443/mqtt` | `gts-r4` | `mqtt-us-v1.letsmesh.net` (bare) |
+| eastme.sh | `wss://mqtt.eastme.sh:443/mqtt` | `letsencrypt` | `mqtt.eastme.sh` |
+
+## Gotchas
+
+- **A `set` on a *disabled* slot may not apply immediately, and `mqtt status`
+  shows the broker's *cached* config, not NVS** — so a slot can look
+  mis-configured right after a `set` (Crosswire#67). Do your `set`s, then
+  `mqtt enable <N>` (which reloads), or reboot. If a field looks wrong, re-apply
+  it while the slot is enabled.
+- **wss/TLS brokers need a valid wall clock** (cert validity + JWT `exp`). Until
+  the clock syncs (NTP, or a GPS fix), such a slot reads `state=held(no-clock)`
+  in `mqtt status` — that's *deferred, not failing*; it connects on its own once
+  the clock is sane. tcp brokers (CoreScope) never wait on the clock.
+
+## First-time bring-up (minimal)
 
 ```
 set wifi.ssid YourSSID
 set wifi.pwd  YourPSK
 wifi status                       # confirm StaConnected + IP
-set mqtt.broker.0.url  mqtts://broker.example:8883
-set mqtt.broker.0.transport tls
-set mqtt.broker.0.auth_type basic
-set mqtt.broker.0.username obs-node
-set mqtt.broker.0.password ******
-mqtt enable 0
-mqtt status                       # confirm the slot is up
+# ...configure a broker slot (see "Broker auth — wss/jwt" above)...
+mqtt status                       # wss reads held(no-clock) until the clock syncs, then up
 ```

--- a/docs/observer-gps-location-config.md
+++ b/docs/observer-gps-location-config.md
@@ -45,8 +45,11 @@ Time priority is: **GPS > NTP > BLE**.
   faster warm).
 - **BLE (app):** Lowest priority. Only accepted before GPS or NTP have set the clock.
 
-A valid clock is required for TLS connections (`wss://`, JWT brokers). If your broker rejects the
-connection, check that the node has time (NTP needs WiFi; GPS needs to be enabled and have a fix).
+A valid clock is required for TLS connections (`wss://`, JWT brokers). The observer never blocks MQTT
+waiting for GPS — SNTP syncs immediately on WiFi connect, and a wss broker still waiting on the clock
+shows `state=held(no-clock)` in `mqtt status` (deferred, **not** failing — it connects on its own once
+the clock is sane). tcp brokers don't wait on time at all. See
+[`observer-cli-commands.md`](observer-cli-commands.md) for broker setup + the `mqtt status` reference.
 
 ---
 


### PR DESCRIPTION
Documentation for the observer work shipped in **0.16.0** (#91/#92). **Docs-only — no code changes.**

## #93 — README + CHANGELOG
- **CHANGELOG**: `[0.16.0]` entry for #45 (`_sys` CLI grammar), #69 (time arbiter), #31 (position in `/status`), #87 (arbiter decouple + `held(no-clock)`), #88 (runtime radio reporting).
- **README**: refreshed the Companion/Observer capabilities row + added observer operator-doc pointers.

## #94 — observer instructions
- **`observer-cli-commands.md`**: real wss/jwt broker recipe (`username`/`jwt_owner` = node pubkey; username form **broker-dependent**; password auto-minted), a known-broker-values table (CoreScope / LetsMesh / eastme.sh), and the gotchas we hit live — the #67 set-on-disabled / cached-cfg trap, and wss `held(no-clock)` until the clock syncs.
- **`observer-gps-location-config.md`**: reflect the #87 immediate-SNTP + `held(no-clock)` behavior; cross-link the CLI doc.

Closes #93, #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
