### PR TITLE
fix(#89): exclude SerialBLEInterface.cpp from Xiao_S3_WIO_companion_radio_usb

### DIFF
--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -141,6 +141,7 @@ build_flags =
 build_src_filter = ${Xiao_S3_WIO.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<helpers/esp32/*.cpp>
+  -<helpers/esp32/SerialBLEInterface.cpp>   ; #89: USB companion has no BLE (gated on BLE_PIN_CODE); drop NimBLE-only file
   +<helpers/ui/MomentaryButton.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>


### PR DESCRIPTION
## Summary
Fixes the #288 NimBLE-migration build regression for the **`Xiao_S3_WIO_companion_radio_usb`** env. The greedy `+<helpers/esp32/*.cpp>` filter pulled `SerialBLEInterface.cpp` (which `#include <NimBLEDevice.h>`) into the USB build, but NimBLE is only a `lib_dep` of the `_ble` env → `fatal error: NimBLEDevice.h: No such file or directory`.

The USB companion never uses BLE — `examples/companion_radio/main.cpp` only instantiates `SerialBLEInterface` under `defined(BLE_PIN_CODE)`, which the `_usb` env does not define. So excluding that one file from this env's `build_src_filter` is safe.

## Change
One line in the `_usb` env's per-env `build_src_filter`:
```
-<helpers/esp32/SerialBLEInterface.cpp>
```

## Validation
- ✅ `pio run -e Xiao_S3_WIO_companion_radio_usb` builds green (Flash 18.5%).
- ✅ **End-to-end verified:** this firmware was flashed to a device (WSMJ898 KETT) and is fully operational — companion-API + LoRa radio confirmed (closed #86).
- ✅ `pio run -e Xiao_S3_WIO_companion_radio_ble` still builds green (Flash 25%) — proves the exclusion is **per-env scoped** and does not affect the BLE build.

## Adversarial review (Gemini 2.5 Pro)
Ran the binding pre-PR review. It raised a BLOCKER claiming the exclusion sits in a "shared section" and would leak to `_ble`. **Adjudicated as a false positive:** the exclusion is at line 144, inside `[env:Xiao_S3_WIO_companion_radio_usb]` (130–152); the `_ble` env has its own filter; the base `[Xiao_S3_WIO]` filter is untouched. Confirmed structurally **and empirically** (green `_ble` build above). Gemini only had the diff, not the full `.ini`.

## Scope
This env only. The same regression on `heltec_v3`/`v4` + the `_serial`/`_wifi` companion envs is tracked separately in #90 ("fix properly later").

Closes #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
