### PR TITLE
#95: observer MQTT broker pre-config + per-device auth

### DIFF
--- a/scripts/test_observer_nvs_round_trip.py
+++ b/scripts/test_observer_nvs_round_trip.py
@@ -144,44 +144,78 @@ int main() {
     // populateDefaultBrokers — Plan 2 v2 Task 3 Step 5
     // -----------------------------------------------------------------------
     // Slot 2 was just written above with a custom URL ("mqtt.example.org").
-    // Slots 0 + 1 are still virgin. populateDefaultBrokers should:
-    //   - fill slot 0 with EastMesh wss URL
-    //   - fill slot 1 with LetsMesh-EU wss URL
+    // Slots 0 + 1 + 3 are still virgin. populateDefaultBrokers should (#95):
+    //   - fill slot 0 with CoreScope (tcp/anon, the only default-ENABLED slot)
+    //   - fill slot 1 with LetsMesh-US (wss/jwt, disabled, BARE audience)
+    //   - fill slot 3 with MeshMapper (wss/jwt, disabled, isrg-x2 CA)
     //   - LEAVE slot 2 alone (already has user-set URL)
 
     populateDefaultBrokers();
 
-    BrokerConfig slot0, slot1, slot2;
+    BrokerConfig slot0, slot1, slot2, slot3;
     if (!readBrokerConfig(0, slot0)) { puts("FAIL read slot 0"); return 1; }
     if (!readBrokerConfig(1, slot1)) { puts("FAIL read slot 1"); return 1; }
     if (!readBrokerConfig(2, slot2)) { puts("FAIL read slot 2"); return 1; }
+    if (!readBrokerConfig(3, slot3)) { puts("FAIL read slot 3"); return 1; }
 
-    if (strcmp(slot0.url, "wss://mqtt2.eastmesh.au:443/mqtt") != 0) {
+    // Slot 0 = CoreScope: plaintext + anonymous, the ONLY default-enabled slot.
+    if (strcmp(slot0.url, "mqtt://mqtt.w8oof.net:1883") != 0) {
         printf("FAIL slot 0 url after populate: '%s'\n", slot0.url);
         return 1;
     }
-    if (strcmp(slot0.jwt_audience, "https://mqtt2.eastmesh.au") != 0) {
-        printf("FAIL slot 0 jwt_audience: '%s'\n", slot0.jwt_audience);
-        return 1;
-    }
-    if (slot0.transport != BrokerTransport::Wss) {
+    if (slot0.transport != BrokerTransport::Tcp) {
         printf("FAIL slot 0 transport: %d\n", (int)slot0.transport);
         return 1;
     }
-    if (slot0.auth_type != BrokerAuthType::Jwt) {
+    if (slot0.auth_type != BrokerAuthType::None) {
         printf("FAIL slot 0 auth_type: %d\n", (int)slot0.auth_type);
         return 1;
     }
-    if (slot0.enabled) {
-        // Defaults must ship DISABLED so user explicitly opts in after
-        // configuring owner identity for the JWT claim.
-        printf("FAIL slot 0 should default to disabled\n");
+    if (!slot0.enabled) {
+        printf("FAIL slot 0 (CoreScope) should default to ENABLED\n");
         return 1;
     }
-    if (strcmp(slot1.url, "wss://mqtt-eu-v1.letsmesh.net:443/mqtt") != 0) {
+
+    // Slot 1 = LetsMesh-US (wss/jwt). Ships disabled; audience is the BARE
+    // host (#95 -- LetsMesh rejects the scheme-qualified "https://" form).
+    if (strcmp(slot1.url, "wss://mqtt-us-v1.letsmesh.net:443/mqtt") != 0) {
         printf("FAIL slot 1 url after populate: '%s'\n", slot1.url);
         return 1;
     }
+    if (strcmp(slot1.jwt_audience, "mqtt-us-v1.letsmesh.net") != 0) {
+        printf("FAIL slot 1 jwt_audience (want bare host): '%s'\n", slot1.jwt_audience);
+        return 1;
+    }
+    if (slot1.transport != BrokerTransport::Wss || slot1.auth_type != BrokerAuthType::Jwt) {
+        printf("FAIL slot 1 transport/auth: %d/%d\n", (int)slot1.transport, (int)slot1.auth_type);
+        return 1;
+    }
+    if (slot1.enabled) {
+        printf("FAIL slot 1 (wss/jwt) should default to disabled\n");
+        return 1;
+    }
+    // #95: JWT identity claims are NOT seeded -- username auto-derives at
+    // connect, and jwt_owner/jwt_email are the operator's claims.
+    if (slot1.jwt_owner[0] != '\0' || slot1.jwt_email[0] != '\0' || slot1.username[0] != '\0') {
+        printf("FAIL slot 1 identity claims should be empty: own='%s' eml='%s' usr='%s'\n",
+               slot1.jwt_owner, slot1.jwt_email, slot1.username);
+        return 1;
+    }
+
+    // Slot 3 = MeshMapper (#95 new slot): wss/jwt, isrg-x2 CA, bare audience.
+    if (strcmp(slot3.url, "wss://mqtt.meshmapper.net:443/mqtt") != 0) {
+        printf("FAIL slot 3 url after populate: '%s'\n", slot3.url);
+        return 1;
+    }
+    if (strcmp(slot3.jwt_audience, "mqtt.meshmapper.net") != 0) {
+        printf("FAIL slot 3 jwt_audience (want bare host): '%s'\n", slot3.jwt_audience);
+        return 1;
+    }
+    if (strcmp(slot3.ca_cert_name, "isrg-x2") != 0) {
+        printf("FAIL slot 3 ca_cert_name: '%s'\n", slot3.ca_cert_name);
+        return 1;
+    }
+
     // Idempotency / no-overwrite: slot 2 STILL has the user-set URL.
     if (strcmp(slot2.url, "mqtt.example.org") != 0) {
         printf("FAIL slot 2 was overwritten by populateDefaultBrokers: '%s'\n", slot2.url);

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -161,18 +161,18 @@ bool writeBrokerConfig(uint8_t slot, const BrokerConfig& cfg) {
 // lookupCaCertPem(), and while disabled they never connect anyway.
 //
 // JWT identity (#95 / #63 / #68) -- the seed deliberately leaves username,
-// jwt_owner, jwt_email EMPTY because none of them is device-derivable here:
-//   * The MQTT CONNECT username is auto-built at connect time as
+// jwt_owner, jwt_email EMPTY; the connect-time auth layer fills what it can:
+//   * The MQTT CONNECT username is auto-built at connect as
 //     "v1_<UPPERCASE hex(device pubkey)>" (MqttAuth.cpp); it is NOT read from
 //     the config for JWT brokers, so seeding it would be dead config.
-//   * jwt_owner / jwt_email are the OPERATOR's identity claims (their broker
-//     account pubkey + email), distinct from the device's own pubkey -- which
-//     is already carried as the JWT "publicKey" claim (JwtHelper.cpp). The
-//     device cannot synthesize the operator's account, so the operator sets
-//     these once via `set mqtt.broker.<N>.jwt_owner|jwt_email` (#63). Whether
-//     jwt_owner may simply equal the device's own pubkey for self-owned nodes
-//     is a per-broker policy question -- do NOT auto-fill it speculatively
-//     (tracked in #95; owner decision pending).
+//   * jwt_owner -- RESOLVED in #95: defaults to THIS device's own pubkey
+//     (owner==device, the verified-working convention) at connect, in
+//     MqttAuthJwt::apply(). Applied at connect (not seeded) so it covers every
+//     JWT slot on every device, fresh NVS or not. The seed leaves it empty so
+//     that default takes effect; `set mqtt.broker.<N>.jwt_owner <64-hex>` still
+//     overrides per slot if a broker ever needs a different owner.
+//   * jwt_email is the operator's email claim -- optional, not device-derivable;
+//     set via `set mqtt.broker.<N>.jwt_email` only if a broker requires it.
 //
 // Audiences are the BARE host (e.g. "mqtt-us-v1.letsmesh.net"), NOT the
 // scheme-qualified "https://..." form: LetsMesh validates the "aud" claim

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -137,27 +137,47 @@ bool writeBrokerConfig(uint8_t slot, const BrokerConfig& cfg) {
 }
 
 // ---------------------------------------------------------------------------
-// populateDefaultBrokers — Plan 2 v2 Task 3 Step 4
+// populateDefaultBrokers — Plan 2 v2 Task 3 Step 4 (layout revised in #95)
 // ---------------------------------------------------------------------------
-// Seeds the owner's intended 6-slot broker registry, but ONLY into slots
-// whose url is currently empty (cfg.url[0] == '\0'). User-set or
-// previously-defaulted values are never overwritten -- so the new defaults
-// only affect fresh-NVS devices, and the function is idempotent across boots.
+// Seeds the public-broker registry, but ONLY into slots whose url is currently
+// empty (cfg.url[0] == '\0'). User-set or previously-defaulted values are
+// never overwritten -- so the new defaults only affect fresh-NVS devices, and
+// the function is idempotent across boots. (Because seeding is skip-if-present,
+// changing this layout does NOT re-shuffle slots on a device already seeded
+// under an older layout; it takes effect only on a fresh NVS.)
 //
-//   slot 0  CoreScope Dayton   mqtt://mqtt.w8oof.net:1883   tcp / anon   ENABLED
-//   slot 1  LetsMesh-US        wss ... :443 /mqtt           wss / jwt    disabled
-//   slot 2  Eastme.sh          wss ... :443 /mqtt           wss / jwt    disabled
-//   slot 3  LetsMesh-EU        wss ... :443 /mqtt           wss / jwt    disabled
-//   slot 4  Eastmesh.au        wss ... :443 /mqtt           wss / jwt    disabled
-//   slot 5  (MQTT Custom)      left empty for the owner to fill
+//   slot 0  CoreScope Dayton   mqtt://mqtt.w8oof.net:1883       tcp / anon   ENABLED
+//   slot 1  LetsMesh-US        wss://mqtt-us-v1.letsmesh.net    wss / jwt    disabled
+//   slot 2  Eastme.sh          wss://mqtt.eastme.sh             wss / jwt    disabled
+//   slot 3  MeshMapper         wss://mqtt.meshmapper.net        wss / jwt    disabled
+//   slot 4  LetsMesh-EU        wss://mqtt-eu-v1.letsmesh.net    wss / jwt    disabled
+//   slot 5  Eastmesh.au        wss://mqtt2.eastmesh.au          wss / jwt    disabled
+//   slots 6-9  (MQTT Custom)   left empty for the operator to fill
 //
 // CoreScope is plaintext + anonymous, so it is the only slot enabled by
 // default: no TLS cert, no JWT identity (validated live on HV3 -- #42/#48).
-// The wss brokers stay disabled until the owner configures JWT identity AND
-// the GTS WE1 cert lands (Item 2). They reference ca_cert "gts-we1", whose
-// PEM is added + mapped in Item 2 after openssl-verifying each broker's
-// actual chain; while disabled they never connect, so the forward-referenced
-// cert name is harmless.
+// The wss brokers stay disabled until the operator opts in; their ca_cert
+// names ("gts-r4", "letsencrypt", "isrg-x2") all resolve in MqttBroker.cpp's
+// lookupCaCertPem(), and while disabled they never connect anyway.
+//
+// JWT identity (#95 / #63 / #68) -- the seed deliberately leaves username,
+// jwt_owner, jwt_email EMPTY because none of them is device-derivable here:
+//   * The MQTT CONNECT username is auto-built at connect time as
+//     "v1_<UPPERCASE hex(device pubkey)>" (MqttAuth.cpp); it is NOT read from
+//     the config for JWT brokers, so seeding it would be dead config.
+//   * jwt_owner / jwt_email are the OPERATOR's identity claims (their broker
+//     account pubkey + email), distinct from the device's own pubkey -- which
+//     is already carried as the JWT "publicKey" claim (JwtHelper.cpp). The
+//     device cannot synthesize the operator's account, so the operator sets
+//     these once via `set mqtt.broker.<N>.jwt_owner|jwt_email` (#63). Whether
+//     jwt_owner may simply equal the device's own pubkey for self-owned nodes
+//     is a per-broker policy question -- do NOT auto-fill it speculatively
+//     (tracked in #95; owner decision pending).
+//
+// Audiences are the BARE host (e.g. "mqtt-us-v1.letsmesh.net"), NOT the
+// scheme-qualified "https://..." form: LetsMesh validates the "aud" claim
+// strictly and rejects the scheme form; Eastme.sh is lenient (#95, verified
+// live 2026-06-11).
 //
 // Invoke once at WifiObserver::begin() before MqttBrokerPool::begin().
 
@@ -172,13 +192,15 @@ struct DefaultBrokerSpec {
     const char*      ca_cert_name;   // "" when no TLS cert (tcp)
 };
 
-// Slots 0-4. Slot 5 (MQTT Custom) is intentionally absent so it stays empty.
+// Slots 0-5. Slots 6-9 (MQTT Custom) are intentionally absent so they stay empty.
+// jwt_audience is the BARE host (#95); ca_cert names resolve in MqttBroker.cpp.
 constexpr DefaultBrokerSpec kDefaultBrokerSpecs[] = {
-    {true,  "mqtt://mqtt.w8oof.net:1883",            BrokerTransport::Tcp, 1883, BrokerAuthType::None, "",                                ""},
-    {false, "wss://mqtt-us-v1.letsmesh.net:443/mqtt", BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "https://mqtt-us-v1.letsmesh.net", "gts-r4"},
-    {false, "wss://mqtt.eastme.sh:443/mqtt",          BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "https://mqtt.eastme.sh",          "letsencrypt"},
-    {false, "wss://mqtt-eu-v1.letsmesh.net:443/mqtt", BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "https://mqtt-eu-v1.letsmesh.net", "gts-r4"},
-    {false, "wss://mqtt2.eastmesh.au:443/mqtt",       BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "https://mqtt2.eastmesh.au",       "letsencrypt"},
+    {true,  "mqtt://mqtt.w8oof.net:1883",             BrokerTransport::Tcp, 1883, BrokerAuthType::None, "",                        ""},
+    {false, "wss://mqtt-us-v1.letsmesh.net:443/mqtt", BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt-us-v1.letsmesh.net", "gts-r4"},
+    {false, "wss://mqtt.eastme.sh:443/mqtt",          BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt.eastme.sh",          "letsencrypt"},
+    {false, "wss://mqtt.meshmapper.net:443/mqtt",     BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt.meshmapper.net",     "isrg-x2"},
+    {false, "wss://mqtt-eu-v1.letsmesh.net:443/mqtt", BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt-eu-v1.letsmesh.net", "gts-r4"},
+    {false, "wss://mqtt2.eastmesh.au:443/mqtt",       BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt2.eastmesh.au",       "letsencrypt"},
 };
 constexpr uint8_t kNumDefaultBrokers =
     sizeof(kDefaultBrokerSpecs) / sizeof(kDefaultBrokerSpecs[0]);
@@ -212,8 +234,10 @@ void populateDefaultBrokers() {
         strncpy(def.ca_cert_name, spec.ca_cert_name, sizeof(def.ca_cert_name)); def.ca_cert_name[sizeof(def.ca_cert_name)-1] = '\0';
         strncpy(def.topic_prefix, kDefaultTopicPrefix, sizeof(def.topic_prefix)); def.topic_prefix[sizeof(def.topic_prefix)-1] = '\0';
         // username + password + jwt_token + jwt_owner + jwt_email +
-        // iata_override stay empty -- owner fills in (jwt_owner/jwt_email
-        // via `set mqtt.broker.<N>.jwt_owner|jwt_email`, #63)
+        // iata_override stay empty by design (see header): the CONNECT username
+        // is auto-built at connect, and jwt_owner/jwt_email are the operator's
+        // identity claims, set via `set mqtt.broker.<N>.jwt_owner|jwt_email`
+        // (#63). NOT device-derivable here -- see header comment (#95).
         writeBrokerConfig(slot, def);
     }
 }

--- a/src/helpers/wifi_observer/ConfigSchema.h
+++ b/src/helpers/wifi_observer/ConfigSchema.h
@@ -105,11 +105,12 @@ struct BrokerConfig {
 bool readBrokerConfig(uint8_t slot, BrokerConfig& out);
 bool writeBrokerConfig(uint8_t slot, const BrokerConfig& cfg);
 
-// Phase 2 (#48): seed the owner's 6-slot broker registry into empty slots
-// only (cfg.url[0] == '\0'); never overwrites user-set values; idempotent.
-// Slot 0 = CoreScope (tcp/anon) ships ENABLED; slots 1-4 (wss/jwt) ship
-// disabled pending owner JWT identity + the GTS WE1 cert (Item 2); slot 5
-// is left empty for a custom broker.
+// Phase 2 (#48; layout revised in #95): seed the public-broker registry into
+// empty slots only (cfg.url[0] == '\0'); never overwrites user-set values;
+// idempotent. Slot 0 = CoreScope (tcp/anon) ships ENABLED; slots 1-5 (wss/jwt:
+// LetsMesh-US, Eastme.sh, MeshMapper, LetsMesh-EU, Eastmesh.au) ship disabled
+// pending operator opt-in + JWT identity claims; slots 6-9 are left empty for
+// operator-custom brokers.
 void populateDefaultBrokers();
 
 }  // namespace crosswire

--- a/src/helpers/wifi_observer/MqttAuth.cpp
+++ b/src/helpers/wifi_observer/MqttAuth.cpp
@@ -86,6 +86,19 @@ MqttAuthJwt::MqttAuthJwt(const mesh::LocalIdentity& identity,
 bool MqttAuthJwt::apply(esp_mqtt_client_config_t& cfg, uint32_t now_ms) {
     if (identity_ == nullptr || audience_[0] == '\0') return false;
 
+    // #95: default the JWT "owner" claim to THIS device's own pubkey (UPPERCASE
+    // hex -- the same form as the token's publicKey claim) when no jwt_owner was
+    // configured. owner==device-pubkey is the verified-working convention across
+    // every target broker (eastme.sh / LetsMesh), so this makes wss zero-touch:
+    // no per-slot jwt_owner entry needed. An explicit jwt_owner still overrides.
+    // Built once (pubkey is constant); owner_[65] holds exactly 64 hex + NUL.
+    if (owner_[0] == '\0') {
+        for (size_t i = 0; i < PUB_KEY_SIZE; ++i) {
+            snprintf(&owner_[i * 2], 3, "%02X", identity_->pub_key[i]);
+        }
+        owner_[2 * PUB_KEY_SIZE] = '\0';
+    }
+
     // Mint if never minted OR refresh window elapsed.
     bool need_mint = (last_mint_ms_ == 0) || needsRefresh(now_ms);
     if (need_mint) {
@@ -96,7 +109,7 @@ bool MqttAuthJwt::apply(esp_mqtt_client_config_t& cfg, uint32_t now_ms) {
             audience_,
             issued, expires,
             token_, sizeof(token_),
-            owner_[0] ? owner_ : nullptr,
+            owner_,  // #95: always set -- configured jwt_owner, else device pubkey (above)
             email_[0] ? email_ : nullptr);
         if (!ok) return false;
         last_mint_ms_ = now_ms;
@@ -150,13 +163,13 @@ MqttAuth* makeAuth(const BrokerConfig& cfg
         case BrokerAuthType::Jwt:
 #ifdef ARDUINO
             if (cfg.jwt_audience[0] == '\0') return nullptr;
-            // #63: owner claim prefers the dedicated jwt_owner field; falls
-            // back to username for configs predating it (username[64] cannot
-            // hold a full 64-hex owner key -- the fallback is best-effort
-            // legacy compat, not the supported path).
+            // #95/#63: the "owner" claim is the dedicated jwt_owner field when
+            // set; otherwise MqttAuthJwt::apply() defaults it to this device's
+            // own pubkey (owner==device, the verified-working convention). The
+            // old username fallback is dropped -- username[64] can't hold a
+            // 64-hex key and the device-pubkey default supersedes it.
             return new MqttAuthJwt(identity, cfg.jwt_audience, cfg.jwt_refresh_sec,
-                                   cfg.jwt_owner[0] ? cfg.jwt_owner
-                                                    : (cfg.username[0] ? cfg.username : nullptr),
+                                   cfg.jwt_owner[0] ? cfg.jwt_owner : nullptr,
                                    cfg.jwt_email[0] ? cfg.jwt_email : nullptr);
 #else
             return nullptr;

--- a/src/helpers/wifi_observer/MqttAuth.h
+++ b/src/helpers/wifi_observer/MqttAuth.h
@@ -82,7 +82,7 @@ private:
     const mesh::LocalIdentity* identity_ = nullptr;
 #endif
     char     audience_[96] = {0};
-    char     owner_[65]    = {0};
+    char     owner_[65]    = {0};  // JWT "owner"; #95: defaults to device pubkey at apply() if unset
     char     email_[96]    = {0};
     uint32_t refresh_sec_  = 3600;
     uint32_t last_mint_ms_ = 0;

--- a/src/helpers/wifi_observer/WifiObserverConfig.h
+++ b/src/helpers/wifi_observer/WifiObserverConfig.h
@@ -28,12 +28,25 @@
 // ---------------------------------------------------------------------------
 // Broker pool sizing
 // ---------------------------------------------------------------------------
-// Hard ceiling on configurable brokers. Plan 1 uses the EastMesh-vendored
-// static 3-entry registry with letsmesh-us as the single default-enabled
-// broker; Plan 2 introduces the configurable NVS-backed list up to this
-// ceiling.
+// Hard ceiling on configurable broker slots. Plan 2 introduced the
+// configurable NVS-backed list; #95 raised the ceiling from 6 to 10 so the
+// pre-seeded public brokers (CoreScope + LetsMesh US/EU + Eastme.sh +
+// MeshMapper + Eastmesh.au = 6 slots, slots 0-5) leave four free slots (6-9)
+// for operator-custom brokers.
+//
+// Static cost: MqttBrokerPool holds brokers_[CROSSWIRE_MAX_BROKERS], and
+// BrokerConfig is ~1.2 KB/slot (jwt_token[512] dominates), so 10 slots is
+// ~12 KB static -- fine even on HV3. This is the CONFIGURABLE ceiling, NOT a
+// concurrency target: simultaneously *enabling* many wss/TLS brokers is
+// heap-bound by mbedTLS (~3-5 on HV3), independent of this number.
+//
+// Caveat (#95/#98): `mqtt status` assembles every configured slot into one
+// kSystemChannelReplyBufLen (768 B) buffer before splitting to _sys frames.
+// The 6-broker default set already sits near that ceiling, so configuring the
+// custom slots 6-9 can truncate the tail of `mqtt status` on the _sys surface
+// until that buffer is paged/enlarged (tracked in #98).
 #ifndef CROSSWIRE_MAX_BROKERS
-  #define CROSSWIRE_MAX_BROKERS 6
+  #define CROSSWIRE_MAX_BROKERS 10
 #endif
 
 // ---------------------------------------------------------------------------

--- a/src/helpers/wifi_observer/WifiObserverConfig.h
+++ b/src/helpers/wifi_observer/WifiObserverConfig.h
@@ -36,9 +36,12 @@
 //
 // Static cost: MqttBrokerPool holds brokers_[CROSSWIRE_MAX_BROKERS], and
 // BrokerConfig is ~1.2 KB/slot (jwt_token[512] dominates), so 10 slots is
-// ~12 KB static -- fine even on HV3. This is the CONFIGURABLE ceiling, NOT a
-// concurrency target: simultaneously *enabling* many wss/TLS brokers is
-// heap-bound by mbedTLS (~3-5 on HV3), independent of this number.
+// ~12 KB static. MEASURED fine even on no-PSRAM HV3: the Heltec_v3 observer
+// build uses 27.4% RAM (89.7 KB / 327 KB internal SRAM) with this at 10 --
+// ~238 KB free, the +4.7 KB of the 6->10 bump is ~1.4% of SRAM. This is the
+// CONFIGURABLE ceiling, NOT a concurrency target: simultaneously *enabling*
+// many wss/TLS brokers is heap-bound by mbedTLS (~3-5 on HV3), independent of
+// this number.
 //
 // Caveat (#95/#98): `mqtt status` assembles every configured slot into one
 // kSystemChannelReplyBufLen (768 B) buffer before splitting to _sys frames.


### PR DESCRIPTION
## #95 — Observer MQTT broker pre-config + per-device auth

Pre-seeds the public MeshCore broker pool and auto-supplies per-device JWT identity, so a fresh observer connects with minimal hand-entry.

### What's in it
- **Seed corrections** (`ConfigSchema.cpp`): JWT audiences are the BARE host (LetsMesh validates the `aud` claim strictly and rejects `https://`); added **MeshMapper** (slot 3, `ca_cert isrg-x2`); owner-ordered 6-broker layout — CoreScope / LetsMesh-US / Eastme.sh / MeshMapper / LetsMesh-EU / Eastmesh.au.
- **`CROSSWIRE_MAX_BROKERS` 6 → 10** — six pre-seeded public brokers (slots 0–5) leave four operator-custom slots (6–9). Memory verified on the constrained **no-PSRAM HV3** target: observer build = **27.4% RAM (89.7 KB / 327 KB internal SRAM), ~238 KB free**.
- **Phase B — per-device auth** (`MqttAuth.cpp`): the JWT `owner` claim defaults to **this device's own pubkey** (uppercase hex) at connect when `jwt_owner` isn't configured, so wss brokers are zero-touch. An explicit `jwt_owner` still overrides. (The CONNECT username already auto-derives as `v1_<pubkey>`; the seed leaves identity claims empty by design.)

### Verification
- Host NVS round-trip test updated to the new layout (passes under MSVC).
- Device-verified on ST-P (Heltec V4): 3 brokers at 0 retries, valid clock, correct radio params.
- HV3 + HV4 observer builds: SUCCESS. Gemini adversarial pre-PR review: no real defects (the memory BLOCKER was disproven by the HV3 build above).

> Not exercised on-device: a *full* 10 configured slots, and HV3 on hardware (HV3 build verified). Proceeding to merge by owner decision.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)
