### PR TITLE
#98: mqtt view + mqtt clear (broker config inspection)

### DIFF
--- a/docs/observer-cli-commands.md
+++ b/docs/observer-cli-commands.md
@@ -43,6 +43,7 @@ device-state verbs like `reboot`/`format`/`erase`/`factory`/`ota.`).
 | `mqtt status` | pool summary + per-slot live state (**configured slots only**) |
 | `mqtt view <N>` | full stored config for slot N, configured or empty (secrets redacted) |
 | `mqtt enable <N>` / `mqtt disable <N>` | enable/disable broker slot N |
+| `mqtt clear <N>` | wipe slot N's stored config back to empty |
 | `set mqtt.broker.<N>.<key> <value>` | set a broker field |
 | `get mqtt.broker.<N>.<key>` | read a broker field (secrets redacted) |
 | `set mqtt.iata <code>` | global IATA / location code |
@@ -55,6 +56,13 @@ Broker fields (`<key>`): `url`, `port`, `transport` (tcp\|tls\|wss),
 
 Setting a field on a **live** (enabled) broker slot auto-disables that slot;
 re-enable explicitly with `mqtt enable <N>` once the config is complete.
+
+`mqtt clear <N>` wipes a slot's stored config back to empty (URL + every field
+blank, disabled) — it clears the *fields*, not the device. A **default** slot
+(0–5) is re-seeded to its default on the next reboot (the boot seed fills empty
+slots — this is the recovery path); a **custom** slot (6–9) stays empty until
+you reconfigure it. Handy for migrating a slot to the current seed: `mqtt clear
+3` then reboot re-seeds slot 3 to the new default (MeshMapper).
 
 **`mqtt status` lists only *configured* slots** — a slot appears only once it
 has a URL. An empty / unconfigured slot is **not** shown, so the highest number

--- a/docs/observer-cli-commands.md
+++ b/docs/observer-cli-commands.md
@@ -40,7 +40,8 @@ device-state verbs like `reboot`/`format`/`erase`/`factory`/`ota.`).
 
 | Command | Effect |
 |---|---|
-| `mqtt status` | pool summary + per-slot state |
+| `mqtt status` | pool summary + per-slot live state |
+| `mqtt view <N>` | full stored config for slot N (all fields, secrets redacted) |
 | `mqtt enable <N>` / `mqtt disable <N>` | enable/disable broker slot N |
 | `set mqtt.broker.<N>.<key> <value>` | set a broker field |
 | `get mqtt.broker.<N>.<key>` | read a broker field (secrets redacted) |
@@ -54,6 +55,13 @@ Broker fields (`<key>`): `url`, `port`, `transport` (tcp\|tls\|wss),
 
 Setting a field on a **live** (enabled) broker slot auto-disables that slot;
 re-enable explicitly with `mqtt enable <N>` once the config is complete.
+
+`mqtt view <N>` (#98) dumps every stored field for one slot in a single reply —
+the fast way to confirm a slot is configured correctly without querying each
+field. Secrets are redacted (`password` / `jwt_token` show only
+`(set, len=N)` / `(cached, len=N)`), and a JWT slot's `username` is reported as
+auto-derived (`v1_<pubkey>` minted at connect). Live state (up / backoff /
+retries) stays in `mqtt status`; `view` is the stored **config**.
 
 ## Broker auth — wss/jwt (the real recipe)
 

--- a/docs/observer-cli-commands.md
+++ b/docs/observer-cli-commands.md
@@ -40,8 +40,8 @@ device-state verbs like `reboot`/`format`/`erase`/`factory`/`ota.`).
 
 | Command | Effect |
 |---|---|
-| `mqtt status` | pool summary + per-slot live state |
-| `mqtt view <N>` | full stored config for slot N (all fields, secrets redacted) |
+| `mqtt status` | pool summary + per-slot live state (**configured slots only**) |
+| `mqtt view <N>` | full stored config for slot N, configured or empty (secrets redacted) |
 | `mqtt enable <N>` / `mqtt disable <N>` | enable/disable broker slot N |
 | `set mqtt.broker.<N>.<key> <value>` | set a broker field |
 | `get mqtt.broker.<N>.<key>` | read a broker field (secrets redacted) |
@@ -56,12 +56,21 @@ Broker fields (`<key>`): `url`, `port`, `transport` (tcp\|tls\|wss),
 Setting a field on a **live** (enabled) broker slot auto-disables that slot;
 re-enable explicitly with `mqtt enable <N>` once the config is complete.
 
-`mqtt view <N>` (#98) dumps every stored field for one slot in a single reply —
-the fast way to confirm a slot is configured correctly without querying each
-field. Secrets are redacted (`password` / `jwt_token` show only
-`(set, len=N)` / `(cached, len=N)`), and a JWT slot's `username` is reported as
-auto-derived (`v1_<pubkey>` minted at connect). Live state (up / backoff /
-retries) stays in `mqtt status`; `view` is the stored **config**.
+**`mqtt status` lists only *configured* slots** — a slot appears only once it
+has a URL. An empty / unconfigured slot is **not** shown, so the highest number
+you see is your last configured slot, not the slot ceiling (currently 10, slots
+0–9). To inspect a specific slot regardless of whether it's configured, use
+`mqtt view <N>`: an empty slot reads `url=(unset)`.
+
+`mqtt view <N>` (#98) dumps every stored field for one slot in a few packed
+lines, in the familiar order: `url, port, transport, auth_type, username,
+jwt_audience, jwt_owner, jwt_email, jwt_refresh, ca_cert, iata`. Secrets are
+never echoed — a basic-auth `password` shows `(set)` / `(unset)`, and the JWT
+bearer token (auto-minted at connect) is omitted entirely. A JWT slot's
+`username` and `jwt_owner` show their auto-derived defaults when unset
+(`auto(v1_+pubkey)` and `auto(device-pubkey)` — the device's own pubkey, #95).
+Live state (up / backoff / retries) stays in `mqtt status`; `view` is the
+stored **config**.
 
 ## Broker auth — wss/jwt (the real recipe)
 

--- a/scripts/test_observer_broker_format.py
+++ b/scripts/test_observer_broker_format.py
@@ -139,6 +139,18 @@ int main() {
     if (!strstr(abuf, "auth_type=none")) return fail("anon: auth_type=none missing", abuf);
     if (strstr(abuf, "mqtt.broker.0:")) return fail("anon: header colon (will mangle)", abuf);
 
+    // 8. clearBrokerConfig wipes a slot's NVS namespace (the `mqtt clear` fix).
+    //    Writing an empty config was not enough on real ESP32 NVS; clearing the
+    //    namespace makes readBrokerConfig return defaults (empty url).
+    BrokerConfig w;
+    strcpy(w.url, "wss://x.example:443/mqtt");
+    if (!writeBrokerConfig(7, w))  { puts("FAIL: clear precond write slot 7"); return 1; }
+    BrokerConfig r1; readBrokerConfig(7, r1);
+    if (r1.url[0] == '\0')         { puts("FAIL: clear precond - write didn't persist"); return 1; }
+    if (!clearBrokerConfig(7))     { puts("FAIL: clearBrokerConfig returned false"); return 1; }
+    BrokerConfig r2; readBrokerConfig(7, r2);
+    if (r2.url[0] != '\0') { printf("FAIL: clearBrokerConfig left url '%s'\n", r2.url); return 1; }
+
     puts("OK");
     return 0;
 }

--- a/scripts/test_observer_broker_format.py
+++ b/scripts/test_observer_broker_format.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+"""
+scripts/test_observer_broker_format.py
+
+Host-runnable test for crosswire::formatBrokerConfig (#98, `mqtt view <N>`).
+Compiles ConfigSchema.cpp against the in-memory Preferences mock and asserts
+that the rendered per-slot view:
+
+  - REDACTS secrets (password + jwt_token values never appear verbatim; only
+    derived "(set, len=N)" / "(cached, len=N)" markers do), per the CLAUDE.md
+    "never echo a secret" rule;
+  - SHOWS the non-secret config values an operator needs to verify a slot
+    (url, transport, auth, audience, ca_cert, jwt_owner, jwt_email);
+  - notes the auto-derived username for JWT slots;
+  - truncates safely into a small buffer (NUL-terminated, return == strlen).
+
+Run with:  python scripts/test_observer_broker_format.py
+
+Reuses the compiler-discovery + build dispatch from
+test_observer_nvs_round_trip.py (same dir) rather than duplicating it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Reuse the proven build harness (PREFS_MOCK + MSVC/g++ dispatch). Importing
+# the module does not run its main() (guarded by __main__).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from test_observer_nvs_round_trip import (  # noqa: E402
+    PREFS_MOCK,
+    _find_msvc_vcvars,
+    _build_with_msvc,
+    _build_with_gcc,
+)
+
+HARNESS = r"""
+#define ARDUINO 1
+#define CROSSWIRE_OBSERVER 1
+#include "prefs_mock.h"
+#include "src/helpers/wifi_observer/ConfigSchema.cpp"
+
+#include <cstdio>
+#include <cstring>
+
+static int fail(const char* why, const char* buf) {
+    printf("FAIL: %s\n--- view ---\n%s\n", why, buf);
+    return 1;
+}
+
+int main() {
+    using namespace crosswire;
+
+    BrokerConfig cfg;
+    cfg.enabled   = false;
+    strcpy(cfg.url, "wss://mqtt.meshmapper.net:443/mqtt");
+    cfg.port      = 443;
+    cfg.transport = BrokerTransport::Wss;
+    cfg.auth_type = BrokerAuthType::Jwt;
+    // Secrets -- must be redacted in the view.
+    strcpy(cfg.password,  "p4ssw0rd-with-symbols!@#");          // len 24
+    strcpy(cfg.jwt_token, "eyJhbGciOiJFZDI1NTE5In0.SECRETPAYLOAD.SIG");
+    // Non-secret config the operator must be able to verify.
+    strcpy(cfg.jwt_audience, "mqtt.meshmapper.net");
+    strcpy(cfg.jwt_owner,    "18315E8B18315E8B18315E8B18315E8B18315E8B18315E8B18315E8B18315E8B");
+    strcpy(cfg.jwt_email,    "strycher@gmail.com");
+    strcpy(cfg.ca_cert_name, "isrg-x2");
+    strcpy(cfg.topic_prefix, "meshcore");
+    cfg.jwt_refresh_sec = 3600;
+    // username left empty -> jwt auto-derive note expected.
+
+    char buf[768];
+    size_t len = formatBrokerConfig(3, cfg, buf, sizeof(buf));
+
+    // 1. Secrets MUST NOT leak verbatim.
+    if (strstr(buf, "p4ssw0rd-with-symbols!@#")) return fail("password value leaked", buf);
+    if (strstr(buf, "SECRETPAYLOAD"))            return fail("jwt_token value leaked", buf);
+
+    // 2. Redaction markers (derived properties only).
+    if (!strstr(buf, "password = (set, len=24)")) return fail("password redaction marker missing", buf);
+    if (!strstr(buf, "jwt_token = (cached"))      return fail("jwt_token redaction marker missing", buf);
+
+    // 3. Non-secret config values ARE shown.
+    if (!strstr(buf, "url = wss://mqtt.meshmapper.net:443/mqtt")) return fail("url missing", buf);
+    if (!strstr(buf, "transport = wss"))                         return fail("transport missing", buf);
+    if (!strstr(buf, "auth_type = jwt"))                         return fail("auth_type missing", buf);
+    if (!strstr(buf, "jwt_audience = mqtt.meshmapper.net"))      return fail("audience missing", buf);
+    if (!strstr(buf, "ca_cert = isrg-x2"))                       return fail("ca_cert missing", buf);
+    if (!strstr(buf, "jwt_owner = 18315E8B"))                    return fail("jwt_owner missing", buf);
+    if (!strstr(buf, "jwt_email = strycher@gmail.com"))          return fail("jwt_email missing", buf);
+
+    // 4. JWT slot w/ empty username -> auto-derive note.
+    if (!strstr(buf, "username = (auto")) return fail("username auto note missing", buf);
+
+    // 5. Return value invariant: len == strlen(buf), non-empty, bounded.
+    if (len == 0 || len != strlen(buf) || len >= sizeof(buf))
+        return fail("bad return length", buf);
+
+    // 6. Truncation safety: tiny buffer must NUL-terminate, never overrun,
+    //    and return the actual (clamped) content length.
+    char tiny[16];
+    size_t tlen = formatBrokerConfig(3, cfg, tiny, sizeof(tiny));
+    if (tlen >= sizeof(tiny))     return fail("tiny: len not clamped", tiny);
+    if (tlen != strlen(tiny))     return fail("tiny: len != strlen", tiny);
+
+    // 7. unset/none fallbacks render for an empty slot.
+    BrokerConfig empty;  // default-constructed: all empty, tcp/none
+    char ebuf[768];
+    formatBrokerConfig(0, empty, ebuf, sizeof(ebuf));
+    if (!strstr(ebuf, "password = (unset)"))   return fail("empty: password unset missing", ebuf);
+    if (!strstr(ebuf, "jwt_token = (none"))    return fail("empty: jwt_token none missing", ebuf);
+    if (!strstr(ebuf, "ca_cert = (none)"))     return fail("empty: ca_cert none missing", ebuf);
+
+    puts("OK");
+    return 0;
+}
+"""
+
+
+def main() -> int:
+    project_root = Path.cwd()
+    vcvars = _find_msvc_vcvars()
+    import shutil
+    gcc_path = shutil.which("g++")
+    if vcvars is not None:
+        print(f"compiler: MSVC ({vcvars})")
+    elif gcc_path is not None:
+        print(f"compiler: g++ ({gcc_path})")
+    else:
+        print("FAIL: no C++ host compiler found (MSVC or g++).")
+        return 1
+
+    with tempfile.TemporaryDirectory() as td_str:
+        td = Path(td_str)
+        (td / "prefs_mock.h").write_text(PREFS_MOCK)
+        (td / "harness.cpp").write_text(HARNESS)
+        (td / "Arduino.h").write_text("#pragma once\n")
+        (td / "Preferences.h").write_text("#pragma once\n")
+
+        if vcvars is not None:
+            rc, build_msg, exe_path = _build_with_msvc(td, project_root, vcvars)
+        else:
+            rc, build_msg, exe_path = _build_with_gcc(td, project_root)
+
+        if rc != 0:
+            print("FAIL compile:")
+            print(build_msg)
+            return 1
+
+        r = subprocess.run([str(exe_path)], capture_output=True, text=True)
+        out = (r.stdout or "").strip()
+        if out.endswith("OK") and r.returncode == 0:
+            print("OK: formatBrokerConfig redaction + field-dump tests pass.")
+            return 0
+        print(f"FAIL (rc={r.returncode}): {out}")
+        if r.stderr:
+            print(f"stderr:\n{r.stderr}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_observer_broker_format.py
+++ b/scripts/test_observer_broker_format.py
@@ -75,27 +75,43 @@ int main() {
     char buf[768];
     size_t len = formatBrokerConfig(3, cfg, buf, sizeof(buf));
 
-    // 1. Secrets MUST NOT leak verbatim.
+    // 1. Secrets MUST NOT leak (jwt view shows neither password nor token).
     if (strstr(buf, "p4ssw0rd-with-symbols!@#")) return fail("password value leaked", buf);
     if (strstr(buf, "SECRETPAYLOAD"))            return fail("jwt_token value leaked", buf);
 
-    // 2. Token redaction: a derived marker only, never the value.
-    if (!strstr(buf, "tok=cached")) return fail("jwt token redaction marker missing", buf);
+    // 2. Header must NOT use a leading "label: " -- the MeshCore companion
+    //    renders "<word>: <text>" as sender:message and mangles it.
+    if (strstr(buf, "mqtt.broker.3:")) return fail("header uses a colon (will mangle in app)", buf);
 
-    // 3. The fields the OLD 16-line dump used to lose (they were the earliest
-    //    lines, dropped by the 8-deep _sys ring buffer) MUST be present now.
-    if (!strstr(buf, "wss/jwt"))                                return fail("transport/auth header missing", buf);
-    if (!strstr(buf, "port=443"))                               return fail("port missing", buf);
+    // 3. All operator-layout fields present (full names).
     if (!strstr(buf, "url=wss://mqtt.meshmapper.net:443/mqtt")) return fail("url missing", buf);
-    if (!strstr(buf, "cert=isrg-x2"))                          return fail("ca_cert missing", buf);
-    if (!strstr(buf, "aud=mqtt.meshmapper.net"))               return fail("audience missing", buf);
-    if (!strstr(buf, "owner=18315E8B"))                        return fail("owner missing", buf);
-    if (!strstr(buf, "strycher@gmail.com"))                    return fail("email missing", buf);
-    if (!strstr(buf, "user=auto(v1_+pubkey)"))                 return fail("username auto note missing", buf);
+    if (!strstr(buf, "port=443"))                       return fail("port missing", buf);
+    if (!strstr(buf, "transport=wss"))                  return fail("transport missing", buf);
+    if (!strstr(buf, "auth_type=jwt"))                  return fail("auth_type missing", buf);
+    if (!strstr(buf, "username=auto(v1_+pubkey)"))      return fail("username missing", buf);
+    if (!strstr(buf, "jwt_audience=mqtt.meshmapper.net")) return fail("jwt_audience missing", buf);
+    if (!strstr(buf, "jwt_owner=18315E8B"))             return fail("jwt_owner missing", buf);
+    if (!strstr(buf, "jwt_email=strycher@gmail.com"))   return fail("jwt_email missing", buf);
+    if (!strstr(buf, "jwt_refresh=3600"))               return fail("jwt_refresh missing", buf);
+    if (!strstr(buf, "ca_cert=isrg-x2"))                return fail("ca_cert missing", buf);
+    if (!strstr(buf, "iata=(global)"))                  return fail("iata missing", buf);
 
-    // 4. Line budget -- the whole point of the repack. The _sys queue is 8 deep
-    //    and drops the OLDEST when full, so a per-slot view must stay well under
-    //    that or its earliest fields vanish in delivery.
+    // 4. Fields appear in the operator's familiar order.
+    {
+        const char* order[] = {"url=","port=","transport=","auth_type=",
+            "username=","jwt_audience=","jwt_owner=","jwt_email=",
+            "jwt_refresh=","ca_cert=","iata="};
+        long prev = -1;
+        for (int i = 0; i < 11; i++) {
+            const char* pos = strstr(buf, order[i]);
+            if (!pos) { printf("FAIL: %s missing (order check)\n%s\n", order[i], buf); return 1; }
+            long off = (long)(pos - buf);
+            if (off < prev) { printf("FAIL: %s out of order\n%s\n", order[i], buf); return 1; }
+            prev = off;
+        }
+    }
+
+    // 5. Line budget -- the _sys queue is 8 deep and drops the OLDEST when full.
     {
         int lines = 0;
         for (const char* q = buf; *q; ++q) if (*q == '\n') lines++;
@@ -105,26 +121,23 @@ int main() {
         }
     }
 
-    // 5. Return value invariant: len == strlen(buf), non-empty, bounded.
-    if (len == 0 || len != strlen(buf) || len >= sizeof(buf))
-        return fail("bad return length", buf);
-
-    // 6. Truncation safety: tiny buffer must NUL-terminate, never overrun.
+    // 6. Return value invariant + truncation safety.
+    if (len == 0 || len != strlen(buf) || len >= sizeof(buf)) return fail("bad return length", buf);
     char tiny[16];
     size_t tlen = formatBrokerConfig(3, cfg, tiny, sizeof(tiny));
-    if (tlen >= sizeof(tiny))     return fail("tiny: len not clamped", tiny);
-    if (tlen != strlen(tiny))     return fail("tiny: len != strlen", tiny);
+    if (tlen >= sizeof(tiny)) return fail("tiny: len not clamped", tiny);
+    if (tlen != strlen(tiny)) return fail("tiny: len != strlen", tiny);
 
     // 7. tcp/anon slot (the slot-0 bug): NO jwt-specific fields or auto-notes.
     BrokerConfig anon;  // default-constructed: tcp / none, all empty
     char abuf[768];
     formatBrokerConfig(0, anon, abuf, sizeof(abuf));
-    if (strstr(abuf, "owner="))     return fail("anon: jwt owner shown on tcp/none", abuf);
-    if (strstr(abuf, "aud="))       return fail("anon: jwt aud shown on tcp/none", abuf);
-    if (strstr(abuf, "tok="))       return fail("anon: jwt token shown on tcp/none", abuf);
-    if (strstr(abuf, "auto("))      return fail("anon: auto note shown on tcp/none", abuf);
-    if (!strstr(abuf, "tcp/none"))  return fail("anon: tcp/none header missing", abuf);
-    if (!strstr(abuf, "url=(unset)")) return fail("anon: url(unset) missing", abuf);
+    if (strstr(abuf, "jwt_owner="))     return fail("anon: jwt_owner shown on tcp/none", abuf);
+    if (strstr(abuf, "jwt_audience="))  return fail("anon: jwt_audience shown on tcp/none", abuf);
+    if (strstr(abuf, "auto("))          return fail("anon: auto note shown on tcp/none", abuf);
+    if (!strstr(abuf, "transport=tcp")) return fail("anon: transport=tcp missing", abuf);
+    if (!strstr(abuf, "auth_type=none")) return fail("anon: auth_type=none missing", abuf);
+    if (strstr(abuf, "mqtt.broker.0:")) return fail("anon: header colon (will mangle)", abuf);
 
     puts("OK");
     return 0;

--- a/scripts/test_observer_broker_format.py
+++ b/scripts/test_observer_broker_format.py
@@ -141,14 +141,16 @@ int main() {
 
     // 8. clearBrokerConfig wipes a slot's NVS namespace (the `mqtt clear` fix).
     //    Writing an empty config was not enough on real ESP32 NVS; clearing the
-    //    namespace makes readBrokerConfig return defaults (empty url).
+    //    namespace makes readBrokerConfig return defaults (empty url). Use the
+    //    LAST valid slot so this holds regardless of CROSSWIRE_MAX_BROKERS.
+    const uint8_t cslot = (uint8_t)(CROSSWIRE_MAX_BROKERS - 1);
     BrokerConfig w;
     strcpy(w.url, "wss://x.example:443/mqtt");
-    if (!writeBrokerConfig(7, w))  { puts("FAIL: clear precond write slot 7"); return 1; }
-    BrokerConfig r1; readBrokerConfig(7, r1);
-    if (r1.url[0] == '\0')         { puts("FAIL: clear precond - write didn't persist"); return 1; }
-    if (!clearBrokerConfig(7))     { puts("FAIL: clearBrokerConfig returned false"); return 1; }
-    BrokerConfig r2; readBrokerConfig(7, r2);
+    if (!writeBrokerConfig(cslot, w)) { puts("FAIL: clear precond write"); return 1; }
+    BrokerConfig r1; readBrokerConfig(cslot, r1);
+    if (r1.url[0] == '\0')            { puts("FAIL: clear precond - write didn't persist"); return 1; }
+    if (!clearBrokerConfig(cslot))    { puts("FAIL: clearBrokerConfig returned false"); return 1; }
+    BrokerConfig r2; readBrokerConfig(cslot, r2);
     if (r2.url[0] != '\0') { printf("FAIL: clearBrokerConfig left url '%s'\n", r2.url); return 1; }
 
     puts("OK");

--- a/scripts/test_observer_broker_format.py
+++ b/scripts/test_observer_broker_format.py
@@ -79,40 +79,52 @@ int main() {
     if (strstr(buf, "p4ssw0rd-with-symbols!@#")) return fail("password value leaked", buf);
     if (strstr(buf, "SECRETPAYLOAD"))            return fail("jwt_token value leaked", buf);
 
-    // 2. Redaction markers (derived properties only).
-    if (!strstr(buf, "password = (set, len=24)")) return fail("password redaction marker missing", buf);
-    if (!strstr(buf, "jwt_token = (cached"))      return fail("jwt_token redaction marker missing", buf);
+    // 2. Token redaction: a derived marker only, never the value.
+    if (!strstr(buf, "tok=cached")) return fail("jwt token redaction marker missing", buf);
 
-    // 3. Non-secret config values ARE shown.
-    if (!strstr(buf, "url = wss://mqtt.meshmapper.net:443/mqtt")) return fail("url missing", buf);
-    if (!strstr(buf, "transport = wss"))                         return fail("transport missing", buf);
-    if (!strstr(buf, "auth_type = jwt"))                         return fail("auth_type missing", buf);
-    if (!strstr(buf, "jwt_audience = mqtt.meshmapper.net"))      return fail("audience missing", buf);
-    if (!strstr(buf, "ca_cert = isrg-x2"))                       return fail("ca_cert missing", buf);
-    if (!strstr(buf, "jwt_owner = 18315E8B"))                    return fail("jwt_owner missing", buf);
-    if (!strstr(buf, "jwt_email = strycher@gmail.com"))          return fail("jwt_email missing", buf);
+    // 3. The fields the OLD 16-line dump used to lose (they were the earliest
+    //    lines, dropped by the 8-deep _sys ring buffer) MUST be present now.
+    if (!strstr(buf, "wss/jwt"))                                return fail("transport/auth header missing", buf);
+    if (!strstr(buf, "port=443"))                               return fail("port missing", buf);
+    if (!strstr(buf, "url=wss://mqtt.meshmapper.net:443/mqtt")) return fail("url missing", buf);
+    if (!strstr(buf, "cert=isrg-x2"))                          return fail("ca_cert missing", buf);
+    if (!strstr(buf, "aud=mqtt.meshmapper.net"))               return fail("audience missing", buf);
+    if (!strstr(buf, "owner=18315E8B"))                        return fail("owner missing", buf);
+    if (!strstr(buf, "strycher@gmail.com"))                    return fail("email missing", buf);
+    if (!strstr(buf, "user=auto(v1_+pubkey)"))                 return fail("username auto note missing", buf);
 
-    // 4. JWT slot w/ empty username -> auto-derive note.
-    if (!strstr(buf, "username = (auto")) return fail("username auto note missing", buf);
+    // 4. Line budget -- the whole point of the repack. The _sys queue is 8 deep
+    //    and drops the OLDEST when full, so a per-slot view must stay well under
+    //    that or its earliest fields vanish in delivery.
+    {
+        int lines = 0;
+        for (const char* q = buf; *q; ++q) if (*q == '\n') lines++;
+        if (lines > 7) {
+            printf("FAIL: too many lines (%d > 7) -- _sys queue is only 8 deep\n%s\n", lines, buf);
+            return 1;
+        }
+    }
 
     // 5. Return value invariant: len == strlen(buf), non-empty, bounded.
     if (len == 0 || len != strlen(buf) || len >= sizeof(buf))
         return fail("bad return length", buf);
 
-    // 6. Truncation safety: tiny buffer must NUL-terminate, never overrun,
-    //    and return the actual (clamped) content length.
+    // 6. Truncation safety: tiny buffer must NUL-terminate, never overrun.
     char tiny[16];
     size_t tlen = formatBrokerConfig(3, cfg, tiny, sizeof(tiny));
     if (tlen >= sizeof(tiny))     return fail("tiny: len not clamped", tiny);
     if (tlen != strlen(tiny))     return fail("tiny: len != strlen", tiny);
 
-    // 7. unset/none fallbacks render for an empty slot.
-    BrokerConfig empty;  // default-constructed: all empty, tcp/none
-    char ebuf[768];
-    formatBrokerConfig(0, empty, ebuf, sizeof(ebuf));
-    if (!strstr(ebuf, "password = (unset)"))   return fail("empty: password unset missing", ebuf);
-    if (!strstr(ebuf, "jwt_token = (none"))    return fail("empty: jwt_token none missing", ebuf);
-    if (!strstr(ebuf, "ca_cert = (none)"))     return fail("empty: ca_cert none missing", ebuf);
+    // 7. tcp/anon slot (the slot-0 bug): NO jwt-specific fields or auto-notes.
+    BrokerConfig anon;  // default-constructed: tcp / none, all empty
+    char abuf[768];
+    formatBrokerConfig(0, anon, abuf, sizeof(abuf));
+    if (strstr(abuf, "owner="))     return fail("anon: jwt owner shown on tcp/none", abuf);
+    if (strstr(abuf, "aud="))       return fail("anon: jwt aud shown on tcp/none", abuf);
+    if (strstr(abuf, "tok="))       return fail("anon: jwt token shown on tcp/none", abuf);
+    if (strstr(abuf, "auto("))      return fail("anon: auto note shown on tcp/none", abuf);
+    if (!strstr(abuf, "tcp/none"))  return fail("anon: tcp/none header missing", abuf);
+    if (!strstr(abuf, "url=(unset)")) return fail("anon: url(unset) missing", abuf);
 
     puts("OK");
     return 0;

--- a/scripts/test_observer_nvs_round_trip.py
+++ b/scripts/test_observer_nvs_round_trip.py
@@ -54,6 +54,7 @@ class Preferences {
  public:
     bool begin(const char* ns, bool /*ro*/) { ns_ = ns; return true; }
     void end() {}
+    bool clear() { kvs_[ns_].clear(); return true; }
     bool   putBool   (const char* k, bool v)        { kvs_[ns_][k] = v ? "1":"0"; return true; }
     bool   getBool   (const char* k, bool def)      { auto& m = kvs_[ns_]; auto it=m.find(k); return it==m.end()?def:(it->second=="1"); }
     size_t putString (const char* k, const char* v) { kvs_[ns_][k] = v; return strlen(v); }

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -262,48 +262,51 @@ size_t formatBrokerConfig(uint8_t slot, const BrokerConfig& cfg,
     out[0] = '\0';
     int n = 0;
 
-    CW_VIEW_APPEND("mqtt.broker.%u:\n", (unsigned)slot);
-    CW_VIEW_APPEND("  enabled = %d\n", cfg.enabled ? 1 : 0);
-    CW_VIEW_APPEND("  url = %s\n", cfg.url[0] ? cfg.url : "(unset)");
-    CW_VIEW_APPEND("  port = %u\n", (unsigned)cfg.port);
-    CW_VIEW_APPEND("  transport = %s\n", brokerTransportName(cfg.transport));
-    CW_VIEW_APPEND("  auth_type = %s\n", brokerAuthName(cfg.auth_type));
-    CW_VIEW_APPEND("  topic_prefix = %s\n",
-                   cfg.topic_prefix[0] ? cfg.topic_prefix : "(unset)");
-    CW_VIEW_APPEND("  iata_override = %s\n",
-                   cfg.iata_override[0] ? cfg.iata_override : "(global)");
-    CW_VIEW_APPEND("  ca_cert = %s\n",
-                   cfg.ca_cert_name[0] ? cfg.ca_cert_name : "(none)");
-    CW_VIEW_APPEND("  jwt_audience = %s\n",
-                   cfg.jwt_audience[0] ? cfg.jwt_audience : "(unset)");
-    CW_VIEW_APPEND("  jwt_refresh = %u\n", (unsigned)cfg.jwt_refresh_sec);
-    CW_VIEW_APPEND("  jwt_owner = %s\n",
-                   cfg.jwt_owner[0] ? cfg.jwt_owner
-                                    : "(auto: device pubkey at connect)");
-    CW_VIEW_APPEND("  jwt_email = %s\n",
-                   cfg.jwt_email[0] ? cfg.jwt_email : "(unset)");
-    // username: for jwt brokers it auto-derives at connect (v1_<pubkey>), so
-    // the stored field is normally empty -- say so rather than show blank.
-    if (cfg.username[0]) {
-        CW_VIEW_APPEND("  username = %s\n", cfg.username);
-    } else if (cfg.auth_type == BrokerAuthType::Jwt) {
-        CW_VIEW_APPEND("  username = (auto: v1_<pubkey> at connect)\n");
-    } else {
-        CW_VIEW_APPEND("  username = (unset)\n");
+    // PACKED layout (multiple fields per line). The observer _sys channel sends
+    // each reply LINE as its own frame through an 8-deep ring buffer
+    // (kSystemChannelQueueDepth, SystemChannelCli.h) that DROPS THE OLDEST when
+    // full -- and interceptMsg enqueues a reply's lines synchronously, so a
+    // reply longer than the queue silently loses its EARLIEST lines before they
+    // flush. A one-field-per-line dump (16 lines) lost url/port/transport/etc.
+    // So pack like `mqtt status` and keep this <= 6 lines: 3 common + up to 3
+    // jwt-only. JWT-specific fields render ONLY for jwt brokers (a tcp/anon
+    // slot has no owner/aud/token).
+    const bool is_jwt = (cfg.auth_type == BrokerAuthType::Jwt);
+
+    CW_VIEW_APPEND("mqtt.broker.%u: %s %s/%s port=%u\n",
+                   (unsigned)slot,
+                   cfg.enabled ? "ENABLED" : "disabled",
+                   brokerTransportName(cfg.transport),
+                   brokerAuthName(cfg.auth_type),
+                   (unsigned)cfg.port);
+    CW_VIEW_APPEND("  url=%s\n", cfg.url[0] ? cfg.url : "(unset)");
+    CW_VIEW_APPEND("  topic=%s iata=%s cert=%s\n",
+                   cfg.topic_prefix[0]  ? cfg.topic_prefix  : "(unset)",
+                   cfg.iata_override[0] ? cfg.iata_override : "(global)",
+                   cfg.ca_cert_name[0]  ? cfg.ca_cert_name  : "(none)");
+
+    if (is_jwt) {
+        CW_VIEW_APPEND("  aud=%s refresh=%us\n",
+                       cfg.jwt_audience[0] ? cfg.jwt_audience : "(unset)",
+                       (unsigned)cfg.jwt_refresh_sec);
+        // owner: explicit jwt_owner, else the connect-time default = this
+        // device's own pubkey (#95). email: operator-optional.
+        CW_VIEW_APPEND("  owner=%s email=%s\n",
+                       cfg.jwt_owner[0] ? cfg.jwt_owner : "auto(device-pubkey)",
+                       cfg.jwt_email[0] ? cfg.jwt_email : "(unset)");
+        // username auto-derives at connect (v1_+pubkey) when unset. The minted
+        // bearer token is the credential (not password); shown only as a
+        // derived property -- never the value (CLAUDE.md never-echo-a-secret).
+        CW_VIEW_APPEND("  user=%s tok=%s\n",
+                       cfg.username[0] ? cfg.username : "auto(v1_+pubkey)",
+                       cfg.jwt_token[0] ? "cached" : "none");
+    } else if (cfg.auth_type == BrokerAuthType::Basic) {
+        // Basic: username + password (password redacted to set/unset).
+        CW_VIEW_APPEND("  user=%s pw=%s\n",
+                       cfg.username[0] ? cfg.username : "(unset)",
+                       cfg.password[0] ? "(set)" : "(unset)");
     }
-    // SECRETS -- never emit the value, only a derived property (CLAUDE.md).
-    if (cfg.password[0]) {
-        CW_VIEW_APPEND("  password = (set, len=%u)\n",
-                       (unsigned)strlen(cfg.password));
-    } else {
-        CW_VIEW_APPEND("  password = (unset)\n");
-    }
-    if (cfg.jwt_token[0]) {
-        CW_VIEW_APPEND("  jwt_token = (cached, len=%u)\n",
-                       (unsigned)strlen(cfg.jwt_token));
-    } else {
-        CW_VIEW_APPEND("  jwt_token = (none; minted live at connect)\n");
-    }
+    // auth==None (anon, e.g. CoreScope): no credential line.
 
     // snprintf returns the would-be length, so on truncation n can exceed
     // out_size; report the ACTUAL bytes written (== strlen(out)), capped.

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -278,7 +278,8 @@ size_t formatBrokerConfig(uint8_t slot, const BrokerConfig& cfg,
                    cfg.jwt_audience[0] ? cfg.jwt_audience : "(unset)");
     CW_VIEW_APPEND("  jwt_refresh = %u\n", (unsigned)cfg.jwt_refresh_sec);
     CW_VIEW_APPEND("  jwt_owner = %s\n",
-                   cfg.jwt_owner[0] ? cfg.jwt_owner : "(unset)");
+                   cfg.jwt_owner[0] ? cfg.jwt_owner
+                                    : "(auto: device pubkey at connect)");
     CW_VIEW_APPEND("  jwt_email = %s\n",
                    cfg.jwt_email[0] ? cfg.jwt_email : "(unset)");
     // username: for jwt brokers it auto-derives at connect (v1_<pubkey>), so

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -220,4 +220,96 @@ void populateDefaultBrokers() {
 
 #endif  // ARDUINO
 
+// ---------------------------------------------------------------------------
+// formatBrokerConfig — #98 (mqtt view <N>) + reusable by #96 (export)
+// ---------------------------------------------------------------------------
+// Pure renderer (no NVS/Arduino deps) so it compiles + host-tests on both the
+// device and the bench harness. Lives outside the ARDUINO guard.
+//
+// Small enum->name helpers are file-local here; ObserverCli.cpp has its own
+// transportStr/authStr for its status line (minor dup, noted for #97).
+namespace {
+const char* brokerTransportName(BrokerTransport t) {
+    switch (t) {
+        case BrokerTransport::Tcp: return "tcp";
+        case BrokerTransport::Tls: return "tls";
+        case BrokerTransport::Wss: return "wss";
+        default:                   return "?";
+    }
+}
+const char* brokerAuthName(BrokerAuthType a) {
+    switch (a) {
+        case BrokerAuthType::None:  return "none";
+        case BrokerAuthType::Basic: return "basic";
+        case BrokerAuthType::Jwt:   return "jwt";
+        default:                    return "?";
+    }
+}
+}  // namespace
+
+// Bounded append: only writes if room remains; a field that would overflow is
+// simply skipped (graceful truncation -- never overruns out_size).
+#define CW_VIEW_APPEND(...) do {                                       \
+    if (n >= 0 && (size_t)n < out_size) {                             \
+        int added = snprintf(out + n, out_size - (size_t)n, __VA_ARGS__); \
+        if (added > 0) n += added;                                    \
+    }                                                                 \
+} while (0)
+
+size_t formatBrokerConfig(uint8_t slot, const BrokerConfig& cfg,
+                          char* out, size_t out_size) {
+    if (out == nullptr || out_size == 0) return 0;
+    out[0] = '\0';
+    int n = 0;
+
+    CW_VIEW_APPEND("mqtt.broker.%u:\n", (unsigned)slot);
+    CW_VIEW_APPEND("  enabled = %d\n", cfg.enabled ? 1 : 0);
+    CW_VIEW_APPEND("  url = %s\n", cfg.url[0] ? cfg.url : "(unset)");
+    CW_VIEW_APPEND("  port = %u\n", (unsigned)cfg.port);
+    CW_VIEW_APPEND("  transport = %s\n", brokerTransportName(cfg.transport));
+    CW_VIEW_APPEND("  auth_type = %s\n", brokerAuthName(cfg.auth_type));
+    CW_VIEW_APPEND("  topic_prefix = %s\n",
+                   cfg.topic_prefix[0] ? cfg.topic_prefix : "(unset)");
+    CW_VIEW_APPEND("  iata_override = %s\n",
+                   cfg.iata_override[0] ? cfg.iata_override : "(global)");
+    CW_VIEW_APPEND("  ca_cert = %s\n",
+                   cfg.ca_cert_name[0] ? cfg.ca_cert_name : "(none)");
+    CW_VIEW_APPEND("  jwt_audience = %s\n",
+                   cfg.jwt_audience[0] ? cfg.jwt_audience : "(unset)");
+    CW_VIEW_APPEND("  jwt_refresh = %u\n", (unsigned)cfg.jwt_refresh_sec);
+    CW_VIEW_APPEND("  jwt_owner = %s\n",
+                   cfg.jwt_owner[0] ? cfg.jwt_owner : "(unset)");
+    CW_VIEW_APPEND("  jwt_email = %s\n",
+                   cfg.jwt_email[0] ? cfg.jwt_email : "(unset)");
+    // username: for jwt brokers it auto-derives at connect (v1_<pubkey>), so
+    // the stored field is normally empty -- say so rather than show blank.
+    if (cfg.username[0]) {
+        CW_VIEW_APPEND("  username = %s\n", cfg.username);
+    } else if (cfg.auth_type == BrokerAuthType::Jwt) {
+        CW_VIEW_APPEND("  username = (auto: v1_<pubkey> at connect)\n");
+    } else {
+        CW_VIEW_APPEND("  username = (unset)\n");
+    }
+    // SECRETS -- never emit the value, only a derived property (CLAUDE.md).
+    if (cfg.password[0]) {
+        CW_VIEW_APPEND("  password = (set, len=%u)\n",
+                       (unsigned)strlen(cfg.password));
+    } else {
+        CW_VIEW_APPEND("  password = (unset)\n");
+    }
+    if (cfg.jwt_token[0]) {
+        CW_VIEW_APPEND("  jwt_token = (cached, len=%u)\n",
+                       (unsigned)strlen(cfg.jwt_token));
+    } else {
+        CW_VIEW_APPEND("  jwt_token = (none; minted live at connect)\n");
+    }
+
+    // snprintf returns the would-be length, so on truncation n can exceed
+    // out_size; report the ACTUAL bytes written (== strlen(out)), capped.
+    if (n < 0) return 0;
+    return ((size_t)n >= out_size) ? (out_size - 1) : (size_t)n;
+}
+
+#undef CW_VIEW_APPEND
+
 }  // namespace crosswire

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -136,6 +136,23 @@ bool writeBrokerConfig(uint8_t slot, const BrokerConfig& cfg) {
     return true;
 }
 
+// #98: clear a broker slot by WIPING its NVS namespace (every key removed), so
+// readBrokerConfig returns defaults (empty url) and populateDefaultBrokers
+// re-seeds a default slot at the next boot. Writing an empty BrokerConfig is
+// NOT sufficient: ESP32 NVS does not reliably clear a key via putString("")
+// (the old value persists), which left `mqtt clear` ineffective -- the slot
+// re-appeared in `mqtt status` and survived a reboot. Wiping is definitive.
+bool clearBrokerConfig(uint8_t slot) {
+    if (slot >= CROSSWIRE_MAX_BROKERS) return false;
+    char ns[16];
+    mqttBrokerNamespace(slot, ns, sizeof(ns));
+    Preferences p;
+    if (!p.begin(ns, /*readOnly=*/false)) return false;
+    bool ok = p.clear();   // remove ALL keys in this broker's namespace
+    p.end();
+    return ok;
+}
+
 // ---------------------------------------------------------------------------
 // populateDefaultBrokers — Plan 2 v2 Task 3 Step 4
 // ---------------------------------------------------------------------------

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -262,51 +262,54 @@ size_t formatBrokerConfig(uint8_t slot, const BrokerConfig& cfg,
     out[0] = '\0';
     int n = 0;
 
-    // PACKED layout (multiple fields per line). The observer _sys channel sends
-    // each reply LINE as its own frame through an 8-deep ring buffer
-    // (kSystemChannelQueueDepth, SystemChannelCli.h) that DROPS THE OLDEST when
-    // full -- and interceptMsg enqueues a reply's lines synchronously, so a
-    // reply longer than the queue silently loses its EARLIEST lines before they
-    // flush. A one-field-per-line dump (16 lines) lost url/port/transport/etc.
-    // So pack like `mqtt status` and keep this <= 6 lines: 3 common + up to 3
-    // jwt-only. JWT-specific fields render ONLY for jwt brokers (a tcp/anon
-    // slot has no owner/aud/token).
+    // Field ORDER matches the operator's familiar layout: url, port, transport,
+    // auth_type, username, jwt_audience, jwt_owner, jwt_email, jwt_refresh,
+    // ca_cert, iata. PACKED so the whole view stays <= 6 lines: the observer
+    // _sys channel sends each reply LINE as its own frame through an 8-deep ring
+    // buffer that DROPS THE OLDEST when full (kSystemChannelQueueDepth,
+    // SystemChannelCli.h), and interceptMsg enqueues a reply's lines
+    // synchronously -- a reply longer than the queue silently loses its EARLIEST
+    // lines. The header avoids a leading "<word>: " because the MeshCore
+    // companion renders "<word>: <text>" as sender:message (which mangled the
+    // old "mqtt.broker.N:" header). JWT fields render only for jwt brokers.
     const bool is_jwt = (cfg.auth_type == BrokerAuthType::Jwt);
 
-    CW_VIEW_APPEND("mqtt.broker.%u: %s %s/%s port=%u\n",
-                   (unsigned)slot,
-                   cfg.enabled ? "ENABLED" : "disabled",
+    CW_VIEW_APPEND("mqtt.broker.%u  %s\n",
+                   (unsigned)slot, cfg.enabled ? "ENABLED" : "disabled");
+    CW_VIEW_APPEND("url=%s\n", cfg.url[0] ? cfg.url : "(unset)");
+    CW_VIEW_APPEND("port=%u transport=%s auth_type=%s\n",
+                   (unsigned)cfg.port,
                    brokerTransportName(cfg.transport),
-                   brokerAuthName(cfg.auth_type),
-                   (unsigned)cfg.port);
-    CW_VIEW_APPEND("  url=%s\n", cfg.url[0] ? cfg.url : "(unset)");
-    CW_VIEW_APPEND("  topic=%s iata=%s cert=%s\n",
-                   cfg.topic_prefix[0]  ? cfg.topic_prefix  : "(unset)",
-                   cfg.iata_override[0] ? cfg.iata_override : "(global)",
-                   cfg.ca_cert_name[0]  ? cfg.ca_cert_name  : "(none)");
+                   brokerAuthName(cfg.auth_type));
 
     if (is_jwt) {
-        CW_VIEW_APPEND("  aud=%s refresh=%us\n",
-                       cfg.jwt_audience[0] ? cfg.jwt_audience : "(unset)",
-                       (unsigned)cfg.jwt_refresh_sec);
-        // owner: explicit jwt_owner, else the connect-time default = this
-        // device's own pubkey (#95). email: operator-optional.
-        CW_VIEW_APPEND("  owner=%s email=%s\n",
-                       cfg.jwt_owner[0] ? cfg.jwt_owner : "auto(device-pubkey)",
-                       cfg.jwt_email[0] ? cfg.jwt_email : "(unset)");
-        // username auto-derives at connect (v1_+pubkey) when unset. The minted
-        // bearer token is the credential (not password); shown only as a
-        // derived property -- never the value (CLAUDE.md never-echo-a-secret).
-        CW_VIEW_APPEND("  user=%s tok=%s\n",
+        // username auto-derives at connect (v1_+pubkey) when unset.
+        CW_VIEW_APPEND("username=%s jwt_audience=%s\n",
                        cfg.username[0] ? cfg.username : "auto(v1_+pubkey)",
-                       cfg.jwt_token[0] ? "cached" : "none");
+                       cfg.jwt_audience[0] ? cfg.jwt_audience : "(unset)");
+        // jwt_owner: explicit value, else the connect-time default = this
+        // device's own pubkey (#95). Own line (64 hex).
+        CW_VIEW_APPEND("jwt_owner=%s\n",
+                       cfg.jwt_owner[0] ? cfg.jwt_owner : "auto(device-pubkey)");
+        CW_VIEW_APPEND("jwt_email=%s jwt_refresh=%u ca_cert=%s iata=%s\n",
+                       cfg.jwt_email[0]     ? cfg.jwt_email     : "(unset)",
+                       (unsigned)cfg.jwt_refresh_sec,
+                       cfg.ca_cert_name[0]  ? cfg.ca_cert_name  : "(none)",
+                       cfg.iata_override[0] ? cfg.iata_override : "(global)");
     } else if (cfg.auth_type == BrokerAuthType::Basic) {
-        // Basic: username + password (password redacted to set/unset).
-        CW_VIEW_APPEND("  user=%s pw=%s\n",
+        // password redacted to set/unset -- never the value (CLAUDE.md).
+        CW_VIEW_APPEND("username=%s password=%s\n",
                        cfg.username[0] ? cfg.username : "(unset)",
                        cfg.password[0] ? "(set)" : "(unset)");
+        CW_VIEW_APPEND("ca_cert=%s iata=%s\n",
+                       cfg.ca_cert_name[0]  ? cfg.ca_cert_name  : "(none)",
+                       cfg.iata_override[0] ? cfg.iata_override : "(global)");
+    } else {
+        // None (anon, e.g. CoreScope): no credentials.
+        CW_VIEW_APPEND("ca_cert=%s iata=%s\n",
+                       cfg.ca_cert_name[0]  ? cfg.ca_cert_name  : "(none)",
+                       cfg.iata_override[0] ? cfg.iata_override : "(global)");
     }
-    // auth==None (anon, e.g. CoreScope): no credential line.
 
     // snprintf returns the would-be length, so on truncation n can exceed
     // out_size; report the ACTUAL bytes written (== strlen(out)), capped.

--- a/src/helpers/wifi_observer/ConfigSchema.h
+++ b/src/helpers/wifi_observer/ConfigSchema.h
@@ -104,6 +104,9 @@ struct BrokerConfig {
 
 bool readBrokerConfig(uint8_t slot, BrokerConfig& out);
 bool writeBrokerConfig(uint8_t slot, const BrokerConfig& cfg);
+// #98: wipe slot N's NVS namespace entirely (definitive clear for
+// `mqtt clear <N>` -- putString("") does NOT reliably clear an ESP32 NVS key).
+bool clearBrokerConfig(uint8_t slot);
 
 // Phase 2 (#48): seed the owner's 6-slot broker registry into empty slots
 // only (cfg.url[0] == '\0'); never overwrites user-set values; idempotent.

--- a/src/helpers/wifi_observer/ConfigSchema.h
+++ b/src/helpers/wifi_observer/ConfigSchema.h
@@ -112,4 +112,15 @@ bool writeBrokerConfig(uint8_t slot, const BrokerConfig& cfg);
 // is left empty for a custom broker.
 void populateDefaultBrokers();
 
+// #98: render a broker slot's stored config to a human-readable, multi-line
+// text block (one "  key = value" per line) for `mqtt view <N>`. SECRETS ARE
+// REDACTED -- password and jwt_token are never emitted; only derived
+// properties ("(set, len=N)" / "(unset)" / "(cached, len=N)") appear, per the
+// CLAUDE.md "never echo a secret" rule. Pure: no NVS/Arduino deps -- the caller
+// passes a cfg already read via readBrokerConfig, so this is host-testable and
+// reusable by #96 (config export). Writes at most out_size-1 bytes + NUL,
+// truncating gracefully; returns bytes written (excluding NUL).
+size_t formatBrokerConfig(uint8_t slot, const BrokerConfig& cfg,
+                          char* out, size_t out_size);
+
 }  // namespace crosswire

--- a/src/helpers/wifi_observer/MqttBroker.cpp
+++ b/src/helpers/wifi_observer/MqttBroker.cpp
@@ -105,6 +105,14 @@ void MqttBroker::shutdown() {
         auth_ = nullptr;
     }
     rt_ = BrokerRuntimeState{};
+    // #98: reset to UNCONFIGURED (slot_ = 0xFF) so isConfigured() goes false and
+    // `mqtt status` drops the slot immediately after a clear/empty reload, rather
+    // than showing its stale cached cfg_ until the next reboot. begin() re-sets
+    // slot_ + cfg_ for any (re)configured slot, so this is safe on the re-init
+    // path. Protected by the reconciling_[] guard (loopTask skips a slot mid-
+    // reconcile), same as the rt_ reset above.
+    slot_ = 0xFF;
+    cfg_  = BrokerConfig{};
 }
 
 #ifdef ARDUINO

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -529,6 +529,22 @@ static bool handleGetBrokerField(char* reply, size_t reply_size,
     return true;
 }
 
+// "mqtt view <N>" -- Strycher/Crosswire#98: dump ALL stored config for one
+// slot in a single reply (secrets redacted), so an operator can verify a slot
+// without querying each field via `get mqtt.broker.<N>.<key>`. The rendering +
+// redaction live in ConfigSchema::formatBrokerConfig (host-tested,
+// test_observer_broker_format.py); this is just the NVS read + glue. Runtime
+// state (state/retries) stays in `mqtt status` -- view is the stored CONFIG.
+static bool handleViewBroker(char* reply, size_t reply_size, int slot) {
+    BrokerConfig cfg;
+    if (!readBrokerConfig((uint8_t)slot, cfg)) {
+        snprintf(reply, reply_size, "ERROR: cannot read slot %d\n", slot);
+        return true;
+    }
+    formatBrokerConfig((uint8_t)slot, cfg, reply, reply_size);
+    return true;
+}
+
 bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
                          MqttBrokerPool& pool) {
     if (cmd == nullptr || reply == nullptr || reply_size == 0) return false;
@@ -560,7 +576,19 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
             }
             return handleEnableSet(reply, reply_size, pool, slot, false);
         }
-        snprintf(reply, reply_size, "ERROR: unknown mqtt subcommand\n");
+        const char* view_rest = skipPrefix(rest, "view");
+        if (view_rest != nullptr) {
+            int slot = parseSlot(view_rest);
+            if (slot < 0) {
+                snprintf(reply, reply_size, "ERROR: usage: mqtt view <0..%d>\n",
+                         CROSSWIRE_MAX_BROKERS - 1);
+                return true;
+            }
+            return handleViewBroker(reply, reply_size, slot);
+        }
+        snprintf(reply, reply_size,
+                 "ERROR: unknown mqtt subcommand "
+                 "(status | view <N> | enable <N> | disable <N>)\n");
         return true;
     }
 

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -545,6 +545,25 @@ static bool handleViewBroker(char* reply, size_t reply_size, int slot) {
     return true;
 }
 
+// "mqtt clear <N>" -- Strycher/Crosswire#98: wipe one slot's stored config back
+// to empty (url + every field blank, disabled), tearing down any live client.
+// It clears the FIELDS, not the device. RECOVERY: a default slot (0-5) is
+// re-seeded to its default on the NEXT reboot (populateDefaultBrokers fills
+// empty slots); a custom slot (6-9) stays empty until reconfigured.
+static bool handleClearBroker(char* reply, size_t reply_size,
+                              MqttBrokerPool& pool, int slot) {
+    BrokerConfig empty;  // default-constructed: url + all fields blank, disabled
+    if (!writeBrokerConfig((uint8_t)slot, empty)) {
+        snprintf(reply, reply_size, "ERROR: cannot clear slot %d\n", slot);
+        return true;
+    }
+    pool.reloadSlot((uint8_t)slot);  // empty url -> worker tears down any client
+    snprintf(reply, reply_size,
+             "mqtt slot %d cleared. Default slots re-seed at next reboot; "
+             "custom slots stay empty.\n", slot);
+    return true;
+}
+
 bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
                          MqttBrokerPool& pool) {
     if (cmd == nullptr || reply == nullptr || reply_size == 0) return false;
@@ -586,9 +605,19 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
             }
             return handleViewBroker(reply, reply_size, slot);
         }
+        const char* clr_rest = skipPrefix(rest, "clear");
+        if (clr_rest != nullptr) {
+            int slot = parseSlot(clr_rest);
+            if (slot < 0) {
+                snprintf(reply, reply_size, "ERROR: usage: mqtt clear <0..%d>\n",
+                         CROSSWIRE_MAX_BROKERS - 1);
+                return true;
+            }
+            return handleClearBroker(reply, reply_size, pool, slot);
+        }
         snprintf(reply, reply_size,
                  "ERROR: unknown mqtt subcommand "
-                 "(status | view <N> | enable <N> | disable <N>)\n");
+                 "(status | view <N> | enable <N> | disable <N> | clear <N>)\n");
         return true;
     }
 

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -552,8 +552,7 @@ static bool handleViewBroker(char* reply, size_t reply_size, int slot) {
 // empty slots); a custom slot (6-9) stays empty until reconfigured.
 static bool handleClearBroker(char* reply, size_t reply_size,
                               MqttBrokerPool& pool, int slot) {
-    BrokerConfig empty;  // default-constructed: url + all fields blank, disabled
-    if (!writeBrokerConfig((uint8_t)slot, empty)) {
+    if (!clearBrokerConfig((uint8_t)slot)) {
         snprintf(reply, reply_size, "ERROR: cannot clear slot %d\n", slot);
         return true;
     }

--- a/src/helpers/wifi_observer/ObserverCli.h
+++ b/src/helpers/wifi_observer/ObserverCli.h
@@ -15,9 +15,11 @@ namespace crosswire {
 // observer command (caller falls through to its own unknown-command path).
 //
 // Commands handled:
-//   mqtt status                                  -- pool summary
+//   mqtt status                                  -- pool summary (live state)
+//   mqtt view <N>                                -- full stored config for slot N (secrets redacted)
 //   mqtt enable <N>                              -- slot N: enabled=true + reload
 //   mqtt disable <N>                             -- slot N: enabled=false + reload
+//   get mqtt.broker.<N>.<key>                    -- read one stored field (#45; password write-only)
 //   set mqtt.iata <code>                         -- global IATA
 //   set mqtt.status_interval <sec>               -- 10..3600
 //   set mqtt.broker.<N>.url <uri>

--- a/src/helpers/wifi_observer/ObserverCli.h
+++ b/src/helpers/wifi_observer/ObserverCli.h
@@ -19,6 +19,7 @@ namespace crosswire {
 //   mqtt view <N>                                -- full stored config for slot N (secrets redacted)
 //   mqtt enable <N>                              -- slot N: enabled=true + reload
 //   mqtt disable <N>                             -- slot N: enabled=false + reload
+//   mqtt clear <N>                               -- wipe slot N to empty (default slots re-seed at reboot)
 //   get mqtt.broker.<N>.<key>                    -- read one stored field (#45; password write-only)
 //   set mqtt.iata <code>                         -- global IATA
 //   set mqtt.status_interval <sec>               -- 10..3600


### PR DESCRIPTION
## #98 — `mqtt view <N>` + `mqtt clear <N>` (non-destructive broker inspection)

> **Depends on #95 — merge that first.** This branch is off `firmware-base`; it relies on #95's 10-slot ceiling + Phase B owner default for full accuracy, and the firmware-base NVS round-trip test it inherits is fixed by #95.

### What's in it
- **`mqtt view <N>`** — full per-slot stored config in the operator's field order (`url, port, transport, auth_type, username, jwt_audience, jwt_owner, jwt_email, jwt_refresh, ca_cert, iata`). Secrets redacted; JWT fields render only for JWT brokers; empty slots are visible (`url=(unset)`). Packed to ≤6 lines to fit the observer's 8-deep `_sys` ring buffer (a one-field-per-line dump silently dropped the earliest fields); header de-coloned (the companion app renders a leading `word: text` as sender:message). `formatBrokerConfig` is a pure, host-tested serializer (reusable by #96 export).
- **`mqtt clear <N>`** — wipes a slot's NVS namespace via `Preferences.clear()` (`putString("")` does NOT reliably clear an ESP32 NVS key, which left an earlier attempt ineffective). Default slots re-seed on reboot (recovery + slot-by-slot migration to the new layout); custom slots stay empty. The cleared slot drops from `mqtt status` immediately (`shutdown()` resets the broker to unconfigured).
- Docs: clarify that `mqtt status` lists only *configured* slots; document view + clear.

### Verification
- Host test (`test_observer_broker_format.py`): secret redaction, field order, line budget (≤ the 8-deep queue), tcp/anon conditional, clear-empties-slot. Passes under MSVC.
- Device-verified on ST-P: view renders correctly in the field order; `mqtt clear 3` + reboot → re-seeds MeshMapper. Gemini adversarial pre-PR review: no real defects.

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)
