### PR TITLE
Offband rebrand: Crosswire -> Offband (code + docs)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Report a defect in Crosswire firmware (any role)
+about: Report a defect in Offband firmware (any role)
 title: "bug: "
 labels: ["type:bug", "board:backlog"]
 ---
@@ -11,7 +11,7 @@ A clear description of the misbehavior.
 ## Affected role / variant
 - Role: companion / observer / repeater / other
 - Board: Heltec V3 / Heltec V4 / XIAO ESP32-S3 / RAK / other
-- Crosswire version (from the OLED splash or serial banner, e.g. `crosswire-v0.12.0-N-gXXXXXXX`):
+- Offband version (from the OLED splash or serial banner, e.g. `offband-v0.12.0-N-gXXXXXXX`):
 
 ## Steps to reproduce
 1.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Request an enhancement or optimization for Crosswire (any MeshCore role)
+about: Request an enhancement or optimization for Offband (any MeshCore role)
 title: "feat: "
 labels: ["type:feature", "board:backlog"]
 ---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
-# Crosswire firmware build verification. Builds a curated representative env
+# Offband firmware build verification. Builds a curated representative env
 # set on every push to the canonical branch + PRs. NOT the full 407-env matrix
-# (that is a publish concern); this proves the Crosswire differentiators
+# (that is a publish concern); this proves the Offband differentiators
 # (observer, repeater-telemetry) and SafeBoot (ESP32 + nRF52) compile.
 #
 # This repo's platformio.ini requires PIO_SECRETS_FILE (LoRa#209). Real secrets
@@ -61,7 +61,7 @@ jobs:
       - name: Upload firmware artifact (dev channel)
         uses: actions/upload-artifact@v4
         with:
-          name: crosswire-dev-${{ matrix.env }}
+          name: offband-dev-${{ matrix.env }}
           path: |
             .pio/build/${{ matrix.env }}/firmware.bin
             .pio/build/${{ matrix.env }}/firmware.elf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 # Builds the curated community board set (.github/release-envs.txt) and publishes
-# a GitHub Release. Triggers on crosswire-v* tags (stable + -rc pre-releases) and
+# a GitHub Release. Triggers on offband-v* (and legacy crosswire-v*) tags (stable + -rc pre-releases) and
 # workflow_dispatch (build-only test run; no Release published on dispatch).
 # Public binaries carry placeholder secrets, configured at runtime.
 # Design of record: docs/architecture/2026-06-06-ci-release-pipeline.md (epic #14 / T3 / #17).
@@ -9,7 +9,8 @@ name: Release
 on:
   push:
     tags:
-      - 'crosswire-v*'
+      - 'offband-v*'
+      - 'crosswire-v*'   # legacy fork tags (pre-rebrand; kept for historical re-pushes)
   workflow_dispatch:
     inputs:
       version:
@@ -52,7 +53,8 @@ jobs:
         id: ver
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
-            echo "version=${GITHUB_REF_NAME#crosswire-}" >> "$GITHUB_OUTPUT"
+            ref="${GITHUB_REF_NAME#offband-}"; ref="${ref#crosswire-}"
+            echo "version=${ref}" >> "$GITHUB_OUTPUT"
           else
             echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
           fi
@@ -97,7 +99,7 @@ jobs:
 
       - name: Extract CHANGELOG section for release body
         run: |
-          ver="${GITHUB_REF_NAME#crosswire-}"   # e.g. v0.14.0
+          ver="${GITHUB_REF_NAME#offband-}"; ver="${ver#crosswire-}"   # e.g. v0.16.0
           num="${ver#v}"                         # e.g. 0.14.0
           awk -v v="$num" '
             $0 ~ "^## \\[" v "\\]" { grab=1; next }
@@ -111,7 +113,7 @@ jobs:
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: Crosswire ${{ github.ref_name }}
+          name: Offband ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
           prerelease: ${{ contains(github.ref_name, '-rc') }}
           make_latest: ${{ !contains(github.ref_name, '-rc') }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ compile_commands.json
 venv/
 platformio.local.ini
 
-# --- Crosswire repo additions (folded in from bootstrap) ---
+# --- Offband repo additions (folded in from bootstrap) ---
 # PlatformIO / Arduino build
 .pio/
 .pioenvs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-All notable changes to Crosswire are documented here.
+All notable changes to Offband are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This
 project uses **Pattern B fork versioning** -- an independent
-`crosswire-vMAJOR.MINOR.PATCH` line with the upstream MeshCore baseline tracked
+`offband-vMAJOR.MINOR.PATCH` line (historically `crosswire-v*`) with the upstream MeshCore baseline tracked
 separately. See [VERSIONING.md](VERSIONING.md) for the cadence (commit per task /
 compile, PR per epic, tag per landing), the `+N` dev-build suffix, and the
 dev / `-rc` / stable release channels.
@@ -16,7 +16,15 @@ Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
 ## [Unreleased]
 
-_Nothing yet._
+### Changed
+- **Rebranded the fork from Crosswire to Offband** (GitHub org `OffbandMesh`):
+  the C++ namespace, build macros, embedded identity blob, version prefix
+  (`offband-v*`), MQTT / flash-audit identity fields (`offband_*`), brand
+  strings (serial banner, `version` command, OLED splash, Home Assistant
+  manufacturer), and the WiFi setup-AP SSID (`Offband-Observer-`). Historical
+  `crosswire-v*` release tags are preserved; the `_sys` PSK domain separator
+  and the MeshCore interop topic namespace are intentionally unchanged.
+  Repo / board / working-dir moves to follow. (#100)
 
 ## [0.16.0] - 2026-06-12
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Crosswire
+# Offband
 
-A [MeshCore](https://github.com/meshcore-dev/MeshCore) fork for **cross-role firmware enhancements and optimization** -- not a single-role project. Crosswire adds capabilities and tuning across MeshCore firmware roles, maintained as a standalone fork (several of these enhancements were originally intended as upstream contributions).
+A [MeshCore](https://github.com/meshcore-dev/MeshCore) fork for **cross-role firmware enhancements and optimization** -- not a single-role project. Offband adds capabilities and tuning across MeshCore firmware roles, maintained as a standalone fork (several of these enhancements were originally intended as upstream contributions).
 
 ## Roles
 
-| Role | Status | What Crosswire adds |
+| Role | Status | What Offband adds |
 |------|--------|---------------------|
 | **Companion / Observer** | Active | WiFi + MQTT publishing of LoRa-mesh observations to public brokers (CoreScope, eastme.sh, LetsMesh), NimBLE BLE stack, multi-broker pool with TLS + JWT auth, a GPS&nbsp;>&nbsp;NTP phone-free wall clock for unattended JWT auth, position in the MQTT `/status`, and a `_sys`-channel CLI for WiFi/broker config |
 | **Repeater** | Active | MQTT telemetry bridging (to Mosquitto and other brokers), burst-WiFi telemetry, heap and power tuning |
@@ -15,19 +15,19 @@ Cross-cutting work used by multiple roles: a NimBLE migration off Bluedroid, a C
 
 ## Status
 
-The firmware lives here: **`firmware-base`** is the canonical Crosswire tree (the old `Strycher/MeshCore` fork is archived). Design-of-record for the observer architecture is in [`docs/architecture/`](docs/architecture/). Operator setup for the observer is in [`docs/observer-cli-commands.md`](docs/observer-cli-commands.md) (the `_sys` CLI) and [`docs/observer-gps-location-config.md`](docs/observer-gps-location-config.md) (GPS / location).
+The firmware lives here: **`firmware-base`** is the canonical Offband tree (the old `Strycher/MeshCore` fork is archived). Design-of-record for the observer architecture is in [`docs/architecture/`](docs/architecture/). Operator setup for the observer is in [`docs/observer-cli-commands.md`](docs/observer-cli-commands.md) (the `_sys` CLI) and [`docs/observer-gps-location-config.md`](docs/observer-gps-location-config.md) (GPS / location).
 
 ## Filing requests
 
-Requests and bug reports are welcome now -- use the issue templates (Bug report / Feature request). When reporting a bug, include the role, board, and the Crosswire version from the OLED splash or serial banner, and **never paste WiFi/MQTT credentials**.
+Requests and bug reports are welcome now -- use the issue templates (Bug report / Feature request). When reporting a bug, include the role, board, and the Offband version from the OLED splash or serial banner, and **never paste WiFi/MQTT credentials**.
 
 ## Releases & versioning
 
-Crosswire uses an independent `crosswire-vMAJOR.MINOR.PATCH` version (see [VERSIONING.md](VERSIONING.md)); every build self-identifies on the OLED splash + serial banner. Changes are tracked in [CHANGELOG.md](CHANGELOG.md). Releases come in three channels: **dev** (CI artifacts, untested on hardware), **`-rc` pre-releases** (community testing), and **stable** (the "Latest" GitHub Release). The release gate is hardware validation, not just a green build.
+Offband uses an independent `offband-vMAJOR.MINOR.PATCH` version (see [VERSIONING.md](VERSIONING.md)); every build self-identifies on the OLED splash + serial banner. Changes are tracked in [CHANGELOG.md](CHANGELOG.md). Releases come in three channels: **dev** (CI artifacts, untested on hardware), **`-rc` pre-releases** (community testing), and **stable** (the "Latest" GitHub Release). The release gate is hardware validation, not just a green build.
 
 ## License
 
-MIT, inherited from upstream MeshCore (Copyright (c) 2025 Scott Powell / rippleradios.com). See [`license.txt`](license.txt). Crosswire's additions are released under the same terms.
+MIT, inherited from upstream MeshCore (Copyright (c) 2025 Scott Powell / rippleradios.com). See [`license.txt`](license.txt). Offband's additions are released under the same terms.
 
 ## Hardware
 

--- a/README.upstream.md
+++ b/README.upstream.md
@@ -1,6 +1,6 @@
-# Crosswire — Strycher's MeshCore fork
+# Offband — Strycher's MeshCore fork
 
-Crosswire is a community fork of [MeshCore](https://github.com/meshcore-dev/MeshCore)
+Offband is a community fork of [MeshCore](https://github.com/meshcore-dev/MeshCore)
 that carries feature branches not (yet) in upstream:
 
 - **SafeBoot** — pre-init power guard for solar/battery-powered LoRa nodes

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,7 +1,13 @@
-# Crosswire Versioning
+# Offband Versioning
 
 This fork uses **Pattern B** versioning: an independent fork version, with the
 upstream MeshCore version captured as a separate baseline field.
+
+> **Brand note (2026-06-13):** the fork was previously named **Crosswire** and
+> tagged `crosswire-v*` (`crosswire-v0.5.0` through `crosswire-v0.16.0`). Those
+> historical tags are preserved as-is. Going forward the fork is **Offband** and
+> tags `offband-v*`; the build matches both patterns (preferring `offband-v*`),
+> so existing release history stays intact.
 
 ## Why Pattern B (vs. upstream-suffix)
 
@@ -15,9 +21,9 @@ firmware identifiers. Neither one alone identifies a build; both together do.
 
 ## Tag schemes
 
-### Fork dev versioning (Crosswire as a whole)
+### Fork dev versioning (Offband as a whole)
 
-Tag format: `crosswire-vMAJOR.MINOR.PATCH`
+Tag format: `offband-vMAJOR.MINOR.PATCH`
 
 Increments per CLAUDE-BASE §Versioning:
 
@@ -33,14 +39,15 @@ Increments per CLAUDE-BASE §Versioning:
 |---|---|---|
 | **Commit** | Each completed task, **and after every successful compile** | granular history + clean rollback; shows as the `+N` suffix in `git describe` |
 | **PR** | A confirmed-working iteration of a **closed epic** | review surface + merge to `firmware-base` |
-| **Version bump (tag)** | Each landing on `firmware-base` (the epic PR) | a `crosswire-vX.Y.Z` tag; `CHANGELOG.md` `[Unreleased]` rolls into the new version section |
+| **Version bump (tag)** | Each landing on `firmware-base` (the epic PR) | an `offband-vX.Y.Z` tag; `CHANGELOG.md` `[Unreleased]` rolls into the new version section |
 
 Between version tags, commits accumulate as `+N` dev builds (e.g.
-`crosswire-v0.13.1-4-gABCDEF` = 4 commits past the tag); each epic landing cuts a
+`offband-v0.16.0-4-gABCDEF` = 4 commits past the tag); each epic landing cuts a
 new tag. **Every landing updates `CHANGELOG.md`.**
 
-Tags are pushed to the **`crosswire` remote** (`Strycher/Crosswire`) and are
-accessible to all working trees of the fork.
+Tags are pushed to the **`origin` remote** (`Strycher/Crosswire`; moves to the
+Offband org repo after the rename) and are accessible to all working trees of the
+fork.
 
 ### Feature-scoped release tags
 
@@ -50,15 +57,15 @@ For specific shippable feature artifacts that produce per-variant binaries via C
 |---|---|---|
 | SafeBoot | `safeboot-<example>-vX.Y.Z[-rcN]` | `safeboot-simple-repeater-v1.15.0-rc2` |
 
-Feature-scoped tags use **upstream's** version number, not Crosswire's. This is
+Feature-scoped tags use **upstream's** version number, not Offband's. This is
 intentional: SafeBoot may be accepted into upstream MeshCore via PR; if so,
-the SafeBoot release tags travel cleanly without Crosswire-specific branding.
+the SafeBoot release tags travel cleanly without Offband-specific branding.
 
 ### Future consideration
 
-A `crosswire-<feature>-vX.Y.Z` form (e.g., `crosswire-safeboot-v0.1.0`) is on
-the table for feature-specific Crosswire releases that are intentionally NOT
-upstream-bound -- i.e., features that only make sense under Crosswire branding
+An `offband-<feature>-vX.Y.Z` form (e.g., `offband-safeboot-v0.1.0`) is on
+the table for feature-specific Offband releases that are intentionally NOT
+upstream-bound -- i.e., features that only make sense under Offband branding
 (deployment-config, MQTT topic conventions tied to SWOH infrastructure, etc.).
 Not used yet; will be defined when the first such release ships.
 
@@ -71,8 +78,8 @@ labels:
 | Channel | Mechanism | Audience |
 |---|---|---|
 | **dev** | CI build **artifact** only (downloadable from the Actions run); no GitHub Release | maintainer only |
-| **pre-release (`-rcN`)** | tag `crosswire-vX.Y.Z-rc1` → GitHub Release with the **pre-release** flag set | community testers; shown as "Pre-release", not "Latest" |
-| **stable** | tag `crosswire-vX.Y.Z` → GitHub Release marked **"Latest"** | everyone; the recommended download |
+| **pre-release (`-rcN`)** | tag `offband-vX.Y.Z-rc1` → GitHub Release with the **pre-release** flag set | community testers; shown as "Pre-release", not "Latest" |
+| **stable** | tag `offband-vX.Y.Z` → GitHub Release marked **"Latest"** | everyone; the recommended download |
 
 Publishing a GitHub Release is the deliberate "make this available to the
 community" action. The **release gate is hardware validation** (the maintainer's
@@ -83,30 +90,32 @@ if a rougher tier below `-rc` is ever needed.
 
 ## Upstream baseline tracking
 
-The upstream MeshCore version that a given Crosswire build rides on is
+The upstream MeshCore version that a given Offband build rides on is
 captured separately at build time as `UPSTREAM_VERSION` (see FF2 / #179).
-The fork version `crosswire-vX.Y.Z` does NOT need to match upstream's
+The fork version `offband-vX.Y.Z` does NOT need to match upstream's
 version -- they are independent counters.
 
-Example: Crosswire v0.5.0 riding on upstream MeshCore v1.15.0 is reported by
+Example: Offband v0.5.0 riding on upstream MeshCore v1.15.0 is reported by
 firmware as:
 
 | Field | Value |
 |---|---|
-| `sw_version` (MQTT/HA) | `MC v1.15.0 / Crosswire v0.5.0` |
-| `crosswire_version` (MQTT state) | `v0.5.0` |
+| `sw_version` (MQTT/HA) | `MC v1.15.0 / Offband v0.5.0` |
+| `offband_version` (MQTT state) | `v0.5.0` |
 | `upstream_version` (MQTT state) | `v1.15.0` |
-| `manufacturer` (MQTT/HA `dev.mf`) | `Crosswire` |
+| `manufacturer` (MQTT/HA `dev.mf`) | `Offband` |
 
-When upstream releases v1.16.0 and we rebase, the Crosswire version increments
+When upstream releases v1.16.0 and we rebase, the Offband version increments
 independently based on what NEW fork-side work landed during/around the
 rebase -- not because of the upstream change itself.
 
-## Initial backfill (2026-05-21)
+## Version history (initial backfill, 2026-05-21)
 
-The first Crosswire version tag is **`crosswire-v0.5.0`**, applied to
-`crosswire` (the fork's active integration branch -- renamed from
-`deploy/issues-84-86-87-combined` 2026-05-23 per LoRa#212) as of 2026-05-21.
+The fork's first version tag was **`crosswire-v0.5.0`** (under the prior
+Crosswire brand), applied to the `crosswire` integration branch -- renamed from
+`deploy/issues-84-86-87-combined` 2026-05-23 per LoRa#212 -- as of 2026-05-21.
+The `crosswire-v*` line ran `crosswire-v0.5.0` … `crosswire-v0.16.0`; all those
+tags are preserved, and the `offband-v*` line continues from there.
 
 ### Why v0.5.0 (not v0.1.0 or v1.0.0)
 
@@ -114,10 +123,10 @@ The first Crosswire version tag is **`crosswire-v0.5.0`**, applied to
   OTA discipline + safety log + rollback infrastructure, partial MQTT command
   queue (#86)
 - **Pre-1.0 maturity**: SafeBoot pre-bench-validation; MQTT command queue
-  partial; no field-deployment soak under Crosswire branding yet
+  partial; no field-deployment soak yet
 - **Room to grow**: v1.0.0 is reserved for the first major milestone
   (bench-validated SafeBoot in production + full MQTT command queue shipped +
-  patio operational under Crosswire identity for at least a 7-day soak)
+  patio operational under the fork's identity for at least a 7-day soak)
 
 ### Retroactive tagging
 
@@ -125,28 +134,28 @@ Earlier branch states (e.g., the `feat/wifi-telemetry-stock` state deployed to
 patio on 2026-05-15) MAY be tagged retroactively if the historical value
 exceeds the tagging cost. Not done by default; case-by-case.
 
-## How to increment the Crosswire version
+## How to increment the Offband version
 
 After an epic lands on `firmware-base` (and `CHANGELOG.md` `[Unreleased]` has been
 rolled into the new version section):
 
 ```bash
 # PATCH (small fix / docs / non-feature landing)
-git tag -a crosswire-v0.13.2 -m "PATCH: <one-line description>"
-git push crosswire crosswire-v0.13.2
+git tag -a offband-v0.16.1 -m "PATCH: <one-line description>"
+git push origin offband-v0.16.1
 
 # MINOR (a feature lands)
-git tag -a crosswire-v0.14.0 -m "MINOR: <feature> landed"
-git push crosswire crosswire-v0.14.0
+git tag -a offband-v0.17.0 -m "MINOR: <feature> landed"
+git push origin offband-v0.17.0
 
 # Pre-release for community testers (then publish a GitHub Release, pre-release flag)
-git tag -a crosswire-v0.14.0-rc1 -m "RC1: <feature> -- community test"
-git push crosswire crosswire-v0.14.0-rc1
+git tag -a offband-v0.17.0-rc1 -m "RC1: <feature> -- community test"
+git push origin offband-v0.17.0-rc1
 ```
 
 The firmware build picks up the latest matching tag via
-`git describe --tags --match 'crosswire-v*'` (configured in `platformio.ini`,
-see FF2 / #179).
+`git describe --tags --match 'offband-v*'` (configured in `platformio.ini`,
+see FF2 / #179); the release workflow also accepts legacy `crosswire-v*` tags.
 
 ## Related references
 

--- a/docs/cli-and-mqtt-commands.md
+++ b/docs/cli-and-mqtt-commands.md
@@ -1,6 +1,6 @@
-# Crosswire CLI + MQTT Command Reference
+# Offband CLI + MQTT Command Reference
 
-Catalog of commands exposed by Crosswire firmware over (a) serial CLI and
+Catalog of commands exposed by Offband firmware over (a) serial CLI and
 (b) MQTT command channel. Source-of-truth references in parentheses point
 at the actual handlers; this doc summarizes behavior.
 
@@ -41,7 +41,7 @@ reads the response for ~5s, prints it.)
 
 | Command | Behavior | Reply | Source |
 |---|---|---|---|
-| `version` | Print upstream + Crosswire identity | `Upstream MeshCore: vX.Y.Z (date)\nCrosswire fork: crosswire-vA.B.C (sha, branch, date)` | CommonCLI.cpp:237 (FF3 / #180) |
+| `version` | Print upstream + Offband identity | `Upstream MeshCore: vX.Y.Z (date)\nOffband fork: offband-vA.B.C (sha, branch, date)` | CommonCLI.cpp:237 (FF3 / #180) |
 | `reboot` | Reboot device | does not return | CommonCLI.cpp:235 |
 | `poweroff` / `shutdown` | Power off (deep sleep) | does not return | CommonCLI.cpp:233 |
 | `clkreboot` | Reset RTC to 2024-05-15 + reboot | does not return | CommonCLI.cpp:237 |
@@ -330,7 +330,7 @@ Verify via MQTT after boot:
 ssh pi5 "mosquitto_sub -h localhost -t 'meshcore/<node_id>/state' -C 1 -v"
 ```
 
-Look for `crosswire_version` field + low `uptime_seconds` + `reset_reason: Power-on reset` indicating a clean boot.
+Look for `offband_version` field + low `uptime_seconds` + `reset_reason: Power-on reset` indicating a clean boot.
 
 ### Verify device identity post-flash
 

--- a/docs/observer-cli-commands.md
+++ b/docs/observer-cli-commands.md
@@ -1,6 +1,6 @@
 # Observer `_sys` CLI command reference
 
-The Crosswire observer is configured over the **`_sys` system channel** in the
+The Offband observer is configured over the **`_sys` system channel** in the
 MeshCore companion app (BLE) — type these as channel messages. The observer
 build has **no USB-serial text console**; the `_sys` channel is the management
 surface.

--- a/docs/observer-gps-location-config.md
+++ b/docs/observer-gps-location-config.md
@@ -1,6 +1,6 @@
 # Observer GPS, Location, and Time Configuration
 
-This doc is for operators deploying a Crosswire observer node — the WiFi+MQTT gateway that listens on
+This doc is for operators deploying a Offband observer node — the WiFi+MQTT gateway that listens on
 LoRa and forwards traffic to a broker. It covers what position and time the observer can report, how to
 configure it, and which hardware it applies to.
 
@@ -8,7 +8,7 @@ configure it, and which hardware it applies to.
 
 ## What an observer can report
 
-A Crosswire observer reports position in two places simultaneously, using the same data and the same
+A Offband observer reports position in two places simultaneously, using the same data and the same
 policy:
 
 - **LoRa advert** — broadcast to the mesh on the advertise interval.

--- a/docs/safeboot-maintenance.md
+++ b/docs/safeboot-maintenance.md
@@ -14,7 +14,7 @@ need to be updated, in order.
 | `main` | `Strycher/MeshCore` (fork) | Tracks upstream `meshcore-dev/MeshCore:main` exactly. No local modifications. |
 | `feature/safeboot` | `Strycher/MeshCore` (fork) | Long-lived feature branch carrying the SafeBoot port. Always rebased onto (or merged with) the latest upstream release. **Never squash, never delete.** This is the branch the upstream PR is filed from. |
 | `safeboot-vX.Y.Z` | `Strycher/MeshCore` tags | Release tags applied to `feature/safeboot` at each upstream-aligned build distributed to the community. |
-| `crosswire` | `meshcore-firmware/` working clone (origin = `meshcore-dev/MeshCore`) | Our fleet-deployment branch (renamed from `deploy/issues-84-86-87-combined` 2026-05-23 per LoRa#212). Contains custom Crosswire features. SafeBoot is **merged or cherry-picked INTO** this branch — it does NOT live on this branch as a separate concern. Per LoRa#210, this branch is itself interim until the fork's `main` becomes the Crosswire main. |
+| `crosswire` | `meshcore-firmware/` working clone (origin = `meshcore-dev/MeshCore`) | Our fleet-deployment branch (renamed from `deploy/issues-84-86-87-combined` 2026-05-23 per LoRa#212). Contains custom Offband features. SafeBoot is **merged or cherry-picked INTO** this branch — it does NOT live on this branch as a separate concern. Per LoRa#210, this branch is itself interim until the fork's `main` becomes the Offband main. |
 
 ## Remotes
 

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -3,7 +3,7 @@
 #include <Arduino.h> // needed for PlatformIO
 #include <Mesh.h>
 
-#ifdef CROSSWIRE_OBSERVER_BLE_COMPANION
+#ifdef OFFBAND_OBSERVER_BLE_COMPANION
 // Plan 3 Task 10 (Strycher/LoRa#272): reserved-slot CLI intercepts +
 // system-channel status posting. Build-flag-gated so the upstream
 // MyMesh translation unit is unchanged when the observer is not
@@ -11,13 +11,13 @@
 #include "helpers/wifi_observer/SystemChannelCli.h"
 #endif
 
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
 // Strycher/LoRa#325: the observer config CLI must be reachable over
 // ANY connection type, not just the BLE _sys channel. cliPassthrough
 // is the same allowlist+dispatch surface the _sys channel uses; here
 // we feed it plain-text lines typed into the USB serial console so a
 // USB-cabled observer can be configured without a phone. Gated on the
-// broad CROSSWIRE_OBSERVER flag (not the BLE-companion flag) so it is
+// broad OFFBAND_OBSERVER flag (not the BLE-companion flag) so it is
 // present on every observer build, including future BLE-disabled ones.
 #include "helpers/wifi_observer/CliPassthrough.h"
 #endif
@@ -298,7 +298,7 @@ uint8_t MyMesh::getExtraAckTransmitCount() const {
   return _prefs.multi_acks;
 }
 
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
   #include "helpers/wifi_observer/ObserverPipeline.h"
 #endif
 
@@ -314,15 +314,15 @@ void MyMesh::logRxRaw(float snr, float rssi, const uint8_t raw[], int len) {
     _serial->writeFrame(out_frame, i);
   }
 
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
   // Plan 2 v2 Task 9: tee every raw RX into the observer pipeline.
   // Non-blocking: trampoline -> ring-buffer copy + pool.publishRaw.
   // Pool publishes are MQTT enqueue (non-blocking even if broker is Down).
-  crosswire::observerLogRxTrampoline(snr, rssi, raw, len);
+  offband::observerLogRxTrampoline(snr, rssi, raw, len);
 #endif
 }
 
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
 // Strycher/LoRa#335: tee every PARSED RX packet into the observer pipeline's
 // /packets path. Dispatcher::checkRecv calls logRx (Dispatcher.cpp:237) for
 // every successfully-parsed packet BEFORE routing, so it is promiscuous (sees
@@ -337,7 +337,7 @@ void MyMesh::logRx(mesh::Packet* pkt, int len, float score) {
   float snr         = _radio->getLastSNR();
   int   score_milli = (int)(score * 1000.0f);
   int   duration    = (int)_radio->getEstAirtimeFor(len);
-  crosswire::observerLogRxParsedTrampoline(*pkt, rssi, snr, score_milli, duration);
+  offband::observerLogRxParsedTrampoline(*pkt, rssi, snr, score_milli, duration);
 }
 #endif
 
@@ -629,7 +629,7 @@ void MyMesh::onChannelMessageRecv(const mesh::GroupChannel &channel, mesh::Packe
 #endif
 }
 
-#ifdef CROSSWIRE_OBSERVER_BLE_COMPANION
+#ifdef OFFBAND_OBSERVER_BLE_COMPANION
 // Plan 3 Task 10 (Strycher/LoRa#272): post a status / CLI-reply
 // message onto the locked system channel slot. Same frame layout
 // as onChannelMessageRecv() so the MeshCore app renders it as a
@@ -661,7 +661,7 @@ void MyMesh::postSystemChannelText(const char* text, size_t text_len) {
   } else {
     out_frame[i++] = RESP_CODE_CHANNEL_MSG_RECV;
   }
-  out_frame[i++] = crosswire::kSystemChannelSlot;
+  out_frame[i++] = offband::kSystemChannelSlot;
   out_frame[i++] = 0xFF;             // path_len: 0xFF = direct
   out_frame[i++] = TXT_TYPE_PLAIN;
   uint32_t ts = (uint32_t)getRTCClock()->getCurrentTime();
@@ -954,7 +954,7 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
       _serial(NULL), telemetry(MAX_PACKET_PAYLOAD - 4), _store(&store), _ui(ui) {
   _iter_started = false;
   _cli_rescue = false;
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
   // Strycher/LoRa#325: init the USB-serial observer-CLI accumulator here
   // (matching this constructor's body-init convention) so _obs_cli_len is
   // guaranteed zero before the first checkObserverSerialCli() call.
@@ -1065,12 +1065,12 @@ void MyMesh::begin(bool has_display) {
   addChannel("Public", PUBLIC_GROUP_PSK); // pre-configure Andy's public channel
   _store->loadChannels(this);
 
-#ifdef CROSSWIRE_OBSERVER_BLE_COMPANION
+#ifdef OFFBAND_OBSERVER_BLE_COMPANION
   // Plan 3 Task 10 (Strycher/LoRa#272): provision the locked
   // system CLI channel at slot 40. Idempotent: only persists
   // when the slot actually changed (returns true), to avoid
   // flash wear on every boot.
-  if (crosswire::systemChannelInit(self_id)) {
+  if (offband::systemChannelInit(self_id)) {
     saveChannels();
   }
 #endif
@@ -1114,13 +1114,13 @@ void MyMesh::startInterface(BaseSerialInterface &serial) {
   _serial = &serial;
   serial.enable();
 
-#ifdef CROSSWIRE_OBSERVER_BLE_COMPANION
+#ifdef OFFBAND_OBSERVER_BLE_COMPANION
   // Plan 3 Task 10 (Strycher/LoRa#272): wire the system-channel
   // post callback so SystemChannelCli can push messages into the
   // BLE offline queue without #include'ing MyMesh.h itself. The
   // trampoline keeps SystemChannelCli ignorant of MyMesh's type;
   // the_mesh is the file-scope singleton declared above.
-  crosswire::systemChannelSetPostFunction(
+  offband::systemChannelSetPostFunction(
       [](const char* text, size_t text_len) {
         the_mesh.postSystemChannelText(text, text_len);
       });
@@ -1245,16 +1245,16 @@ void MyMesh::handleCmdFrame(size_t len) {
     i += 4;
     const char *text = (char *)&cmd_frame[i];
 
-#ifdef CROSSWIRE_OBSERVER_BLE_COMPANION
+#ifdef OFFBAND_OBSERVER_BLE_COMPANION
     // Plan 3 Task 10 intercept (Strycher/LoRa#272): slot 40 is
     // the system CLI channel. Route the message into the local
     // CLI passthrough instead of broadcasting it over LoRa.
     // Reply is enqueued and posted back on the same slot via
     // RESP_CODE_CHANNEL_MSG_RECV_V3 from systemChannelDrain().
-    if (channel_idx == crosswire::kSystemChannelSlot &&
+    if (channel_idx == offband::kSystemChannelSlot &&
         txt_type == TXT_TYPE_PLAIN) {
       size_t text_len = (len > (size_t)i) ? (len - (size_t)i) : 0;
-      if (crosswire::systemChannelInterceptMsg(text, text_len)) {
+      if (offband::systemChannelInterceptMsg(text, text_len)) {
         writeOKFrame();
       } else {
         writeErrFrame(ERR_CODE_BAD_STATE);
@@ -1827,11 +1827,11 @@ void MyMesh::handleCmdFrame(size_t len) {
       writeErrFrame(ERR_CODE_NOT_FOUND);
     }
   } else if (cmd_frame[0] == CMD_SET_CHANNEL && len >= 2 + 32 + 32) {
-#ifdef CROSSWIRE_OBSERVER_BLE_COMPANION
+#ifdef OFFBAND_OBSERVER_BLE_COMPANION
     // Plan 3 Task 10 intercept: slot 40 is locked even for the
     // (currently unsupported) 256-bit-key variant.
-    if (cmd_frame[1] == crosswire::kSystemChannelSlot &&
-        !crosswire::systemChannelAllowSet()) {
+    if (cmd_frame[1] == offband::kSystemChannelSlot &&
+        !offband::systemChannelAllowSet()) {
       writeErrFrame(ERR_CODE_UNSUPPORTED_CMD);
       return;
     }
@@ -1839,12 +1839,12 @@ void MyMesh::handleCmdFrame(size_t len) {
     writeErrFrame(ERR_CODE_UNSUPPORTED_CMD); // not supported (yet)
   } else if (cmd_frame[0] == CMD_SET_CHANNEL && len >= 2 + 32 + 16) {
     uint8_t channel_idx = cmd_frame[1];
-#ifdef CROSSWIRE_OBSERVER_BLE_COMPANION
+#ifdef OFFBAND_OBSERVER_BLE_COMPANION
     // Plan 3 Task 10 intercept: slot 40 is the locked system
     // channel; refuse SET so the user cannot overwrite or
     // accidentally delete it from their MeshCore app.
-    if (channel_idx == crosswire::kSystemChannelSlot &&
-        !crosswire::systemChannelAllowSet()) {
+    if (channel_idx == offband::kSystemChannelSlot &&
+        !offband::systemChannelAllowSet()) {
       writeErrFrame(ERR_CODE_UNSUPPORTED_CMD);
       return;
     }
@@ -2330,11 +2330,11 @@ void MyMesh::checkSerialInterface() {
   }
 }
 
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
 // Strycher/LoRa#325: USB-serial path to the observer config CLI.
 // Accumulates a line from the USB Serial console and dispatches it
 // through cliPassthroughExecute -- the SAME allowlist + dispatch the
-// BLE _sys channel uses (crosswire::cliPassthroughExecute), so the
+// BLE _sys channel uses (offband::cliPassthroughExecute), so the
 // command set, allowlist, and security are identical regardless of
 // transport. The reply is echoed back to Serial. Non-blocking: reads
 // only what is already buffered each call.
@@ -2378,7 +2378,7 @@ void MyMesh::checkObserverSerialCli() {
       _obs_cli_buf[_obs_cli_len] = 0;
       Serial.println();                          // finish the echoed line
       char reply[256];
-      crosswire::cliPassthroughExecute(_obs_cli_buf, reply, sizeof(reply));
+      offband::cliPassthroughExecute(_obs_cli_buf, reply, sizeof(reply));
       Serial.println(reply);
       _obs_cli_len = 0;
       _obs_cli_redact = false;
@@ -2408,7 +2408,7 @@ void MyMesh::loop() {
     checkCLIRescueCmd();
   } else {
     checkSerialInterface();
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
     // Strycher/LoRa#325: also accept observer config commands typed on
     // the USB serial console (independent of the compiled transport, so
     // a USB-cabled observer is configurable without a phone). Only runs
@@ -2417,12 +2417,12 @@ void MyMesh::loop() {
 #endif
   }
 
-#ifdef CROSSWIRE_OBSERVER_BLE_COMPANION
+#ifdef OFFBAND_OBSERVER_BLE_COMPANION
   // Plan 3 Task 10 (Strycher/LoRa#272): drain any pending
   // system-channel status / CLI-reply messages enqueued by
   // SystemChannelCli (from WifiBootstrap, intercept dispatch,
   // etc.). Cheap when the queue is empty (single load + branch).
-  crosswire::systemChannelDrain();
+  offband::systemChannelDrain();
 #endif
 
   // is there are pending dirty contacts write needed?

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -102,7 +102,7 @@ public:
 
   int  getRecentlyHeard(AdvertPath dest[], int max_num);
 
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
   // #31 Task C: live Dispatcher stats for the /status snapshot. Observer-only,
   // so guarded to keep this shared-lineage header's diff minimal against
   // upstream MeshCore (the only callers are observer-gated in main.cpp).
@@ -114,7 +114,7 @@ public:
   int      getOutboundQueueLen() const { return _mgr->getOutboundTotal(); }
 #endif
 
-#ifdef CROSSWIRE_OBSERVER_BLE_COMPANION
+#ifdef OFFBAND_OBSERVER_BLE_COMPANION
   // Plan 3 Task 10 (Strycher/LoRa#272): post a status message
   // onto the locked system channel slot. Builds a
   // RESP_CODE_CHANNEL_MSG_RECV_V3 frame (or the pre-v3
@@ -143,7 +143,7 @@ protected:
   void sendFloodScoped(const mesh::GroupChannel& channel, mesh::Packet* pkt, uint32_t delay_millis=0) override;
 
   void logRxRaw(float snr, float rssi, const uint8_t raw[], int len) override;
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
   void logRx(mesh::Packet* pkt, int len, float score) override;   // Strycher/LoRa#335: /packets path
 #endif
   bool isAutoAddEnabled() const override;
@@ -223,7 +223,7 @@ private:
 
   void checkCLIRescueCmd();
   void checkSerialInterface();
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
   void checkObserverSerialCli();   // Strycher/LoRa#325: USB-serial -> observer CLI
 #endif
   bool isValidClientRepeatFreq(uint32_t f) const;
@@ -248,7 +248,7 @@ private:
   bool _iter_started;
   bool _cli_rescue;
   char cli_command[80];
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
   // Strycher/LoRa#325: USB-serial observer-CLI line accumulator.
   // Initialized in the MyMesh constructor body (matching the convention
   // of the other members here), NOT via in-class initializers.

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -3,13 +3,13 @@
 #include <SafeBoot.h>
 #include "MyMesh.h"
 
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
   #include "helpers/wifi_observer/WifiObserver.h"
   #include "helpers/wifi_observer/CrashLog.h"
   // CW_PHASE: tracing macro for setup() crash localization. With
   // CrashLog v2's ESP_LOG hook + shutdown handler, the last phase
   // line surviving in the ring buffer pinpoints where setup() died.
-  #define CW_PHASE(name) crosswire::crashLogf("[setup] phase: %s", name)
+  #define CW_PHASE(name) offband::crashLogf("[setup] phase: %s", name)
 #else
   #define CW_PHASE(name) ((void)0)
 #endif
@@ -122,8 +122,8 @@ void setup() {
 
   // SafeBoot: pre-init power guard. See src/SafeBoot.h.
   SafeBoot::checkAndMaybeSleep();
-#ifdef CROSSWIRE_OBSERVER
-  crosswire::wifiObserverBegin();
+#ifdef OFFBAND_OBSERVER
+  offband::wifiObserverBegin();
 #endif
   CW_PHASE("post:wifiObserverBegin");
 
@@ -134,12 +134,12 @@ void setup() {
   DisplayDriver* disp = NULL;
   bool display_begin_ok = display.begin();
   CW_PHASE(display_begin_ok ? "post:display.begin(OK)" : "post:display.begin(FAILED)");
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
   // I2C bus scan: report ALL addresses that ACK on the bus that
   // display.begin() initialized. If OLED at expected DISPLAY_ADDRESS
   // (0x3C) doesn't appear, our pin/address assumptions are wrong for
   // this V3 sub-variant. Run AFTER display.begin() so bus is alive.
-  crosswire::i2cScan(-1, -1, "board-bus-default-pins");
+  offband::i2cScan(-1, -1, "board-bus-default-pins");
 #endif
   if (display_begin_ok) {
     disp = &display;
@@ -148,13 +148,13 @@ void setup() {
     disp->setTextSize(2);
   #endif
     disp->drawTextCentered(disp->width() / 2, 28, "Loading...");
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
     // Boot counter on top-left corner. User can directly observe whether
     // it increments without any interaction = positive proof of (or
     // against) chip rebooting. Persists via RTC_NOINIT across soft
     // resets; resets only on power-on / esptool reset.
     char bootbuf[16];
-    snprintf(bootbuf, sizeof(bootbuf), "B#%u", (unsigned)crosswire::bootCounterValue());
+    snprintf(bootbuf, sizeof(bootbuf), "B#%u", (unsigned)offband::bootCounterValue());
     disp->setTextSize(1);
     disp->drawTextLeftAlign(0, 0, bootbuf);
 #endif
@@ -259,7 +259,7 @@ void setup() {
   the_mesh.startInterface(serial_interface);
   CW_PHASE("ESP32:post the_mesh.startInterface");
 
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
   // Plan 2 v2 Task 12: wire observer mesh context AFTER the_mesh.begin()
   // populates self_id. Strings cached as borrowed pointers in WifiObserver;
   // backing storage here must outlive the observer (static buffer +
@@ -270,9 +270,9 @@ void setup() {
   // firmware_version and client_version fields until a project-specific
   // CLIENT_VERSION is established (filed as follow-up).
   static char observer_device_id[65];
-  crosswire::bytesToHexUpper(the_mesh.self_id.pub_key, PUB_KEY_SIZE,
+  offband::bytesToHexUpper(the_mesh.self_id.pub_key, PUB_KEY_SIZE,
                              observer_device_id, sizeof(observer_device_id));
-  crosswire::wifiObserverSetMeshContext(
+  offband::wifiObserverSetMeshContext(
       the_mesh.self_id,
       observer_device_id,
       the_mesh.getNodeName(),
@@ -301,23 +301,23 @@ void setup() {
 }
 
 void loop() {
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
   // CrashLog v6: per-sub-loop visit marking + heartbeat. Each sub-loop
   // sets its bit on entry; heartbeat reads + resets every ~1s. Lets us
   // PROVE that each sub-loop actually ran in the past 1s window.
-  crosswire::loopIterTick();
-  crosswire::subloopMark(crosswire::SUBLOOP_WIFI);
-  crosswire::wifiObserverLoop();
-  crosswire::subloopMark(crosswire::SUBLOOP_MESH);
+  offband::loopIterTick();
+  offband::subloopMark(offband::SUBLOOP_WIFI);
+  offband::wifiObserverLoop();
+  offband::subloopMark(offband::SUBLOOP_MESH);
 #endif
   the_mesh.loop();
 
-#ifdef CROSSWIRE_OBSERVER
-  crosswire::subloopMark(crosswire::SUBLOOP_SENSORS);
+#ifdef OFFBAND_OBSERVER
+  offband::subloopMark(offband::SUBLOOP_SENSORS);
 #endif
   sensors.loop();
 
-#if defined(CROSSWIRE_OBSERVER) && ENV_INCLUDE_GPS == 1
+#if defined(OFFBAND_OBSERVER) && ENV_INCLUDE_GPS == 1
   // #69 Task A: push GPS time-state to observer ~1 Hz so the SNTP arbiter
   // (next task) can see whether GPS currently owns the clock.
   {
@@ -325,14 +325,14 @@ void loop() {
     uint32_t _now = millis();
     if (_now - s_gps_state_ms >= 1000) {
       s_gps_state_ms = _now;
-      crosswire::wifiObserverSetGpsTimeState(
+      offband::wifiObserverSetGpsTimeState(
           the_mesh.getNodePrefs()->gps_enabled != 0,
           sensors.gpsHasFix());
     }
   }
 #endif
 
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
   // #31 Task C: push status snapshot to observer so the pool's
   // publishStatusIfDue() can emit /status.  Throttled to
   // kMinStatusIntervalSec (10 s = min legal status_interval; keeps the
@@ -353,9 +353,9 @@ void loop() {
   {
     static uint32_t s_status_snap_ms = 0;
     uint32_t _now = millis();
-    if (_now - s_status_snap_ms >= crosswire::kMinStatusIntervalSec * 1000U) {
+    if (_now - s_status_snap_ms >= offband::kMinStatusIntervalSec * 1000U) {
       s_status_snap_ms = _now;
-      crosswire::MqttStatusSnapshot snap = {};
+      offband::MqttStatusSnapshot snap = {};
       snap.battery_mv     = static_cast<int>(board.getBattMilliVolts());
       snap.uptime_secs    = static_cast<uint32_t>(_now / 1000UL);
       snap.error_flags    = the_mesh.getErrFlags();
@@ -397,21 +397,21 @@ void loop() {
         snap.node_lon  = sensors.node_lon;
         snap.loc_valid = (sensors.node_lat != 0.0 || sensors.node_lon != 0.0);
       }
-      crosswire::wifiObserverSetStatusSnapshot(snap);
+      offband::wifiObserverSetStatusSnapshot(snap);
     }
   }
 #endif
 
 #ifdef DISPLAY_CLASS
-#ifdef CROSSWIRE_OBSERVER
-  crosswire::subloopMark(crosswire::SUBLOOP_UI);
+#ifdef OFFBAND_OBSERVER
+  offband::subloopMark(offband::SUBLOOP_UI);
 #endif
   ui_task.loop();
 #endif
 
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
   // Emit heartbeat if 1s elapsed since last. Cheap timestamp check.
-  crosswire::heartbeatTick(millis());
+  offband::heartbeatTick(millis());
 #endif
   rtc_clock.tick();
 }

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -5,7 +5,7 @@
 #ifdef WIFI_SSID
   #include <WiFi.h>
 #endif
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
   #include <helpers/wifi_observer/CrashLog.h>
 #endif
 
@@ -38,13 +38,13 @@ class SplashScreen : public UIScreen {
   UITask* _task;
   unsigned long dismiss_after;
   char _mc_version[12];
-#ifdef CROSSWIRE_VERSION
-  // Crosswire fork version short form (CROSSWIRE_VERSION with the
-  // "crosswire-" prefix and any commits-since-tag suffix stripped).
+#ifdef OFFBAND_VERSION
+  // Offband fork version short form (OFFBAND_VERSION with the
+  // "offband-" prefix and any commits-since-tag suffix stripped).
   // Per VERSIONING.md Pattern B the splash exposes BOTH the upstream
-  // MeshCore version AND the Crosswire fork version so a glance at
+  // MeshCore version AND the Offband fork version so a glance at
   // the device unambiguously identifies what firmware is running.
-  char _crosswire_short[24];
+  char _offband_short[24];
 #endif
 
 public:
@@ -58,28 +58,28 @@ public:
     memcpy(_mc_version, ver, len);
     _mc_version[len] = 0;
 
-#ifdef CROSSWIRE_VERSION
-    // Crosswire version: strip leading "crosswire-" tag prefix, then render
+#ifdef OFFBAND_VERSION
+    // Offband version: strip leading "offband-" tag prefix, then render
     // a COMPACT build-identity that distinguishes test builds from the
     // tagged release (Strycher/LoRa#319). git describe form is
     // "<tag>[-<N>-g<sha>][-dirty]", where <tag> may ITSELF contain dashes for
     // a pre-release (e.g. v0.14.0-rc1). We render:
-    //   crosswire-v0.14.0                  -> v0.14.0        (clean release)
-    //   crosswire-v0.14.0-rc1              -> v0.14.0-rc1    (clean pre-release)
-    //   crosswire-v0.14.0-rc1-4-g369714e   -> v0.14.0-rc1+4  (4 past pre-release)
-    //   crosswire-v0.14.0-4-g369714e       -> v0.14.0+4      (4 past release)
+    //   offband-v0.14.0                  -> v0.14.0        (clean release)
+    //   offband-v0.14.0-rc1              -> v0.14.0-rc1    (clean pre-release)
+    //   offband-v0.14.0-rc1-4-g369714e   -> v0.14.0-rc1+4  (4 past pre-release)
+    //   offband-v0.14.0-4-g369714e       -> v0.14.0+4      (4 past release)
     //   ...-dirty                          -> ...*           (dirty work tree)
     // Full identity (SHA included) stays in the `ver` CLI + the
-    // CROSSWIRE_IDENTITY_BLOB in .rodata; this is just the at-a-glance form.
-    // Spec + fixtures: scripts/test_crosswire_version_splash.py.
+    // OFFBAND_IDENTITY_BLOB in .rodata; this is just the at-a-glance form.
+    // Spec + fixtures: scripts/test_offband_version_splash.py.
     //
     // The commits-since suffix is identified by git's "-g<sha>" marker, NOT the
     // first dash. Splitting on the first dash (prior behavior) mis-read a
     // pre-release tag's "-rcN" as the commits field -> it dropped "-rcN" and
     // showed a spurious "+0" (Strycher/Crosswire#33).
-    const char *cw = CROSSWIRE_VERSION;
-    static const char *cw_prefix = "crosswire-";
-    if (strncmp(cw, cw_prefix, 10) == 0) cw += 10;
+    const char *cw = OFFBAND_VERSION;
+    static const char *cw_prefix = "offband-";
+    if (strncmp(cw, cw_prefix, 8) == 0) cw += 8;
     bool        cw_dirty = (strstr(cw, "-dirty") != nullptr);
     const char *gmark    = strstr(cw, "-g");   // start of "-g<sha>" iff commits>0
     int commits = 0;
@@ -98,12 +98,12 @@ public:
       const char *d = strstr(cw, "-dirty");
       taglen = d ? (int)(d - cw) : (int)strlen(cw);
     }
-    if (taglen >= (int)sizeof(_crosswire_short)) taglen = (int)sizeof(_crosswire_short) - 1;
+    if (taglen >= (int)sizeof(_offband_short)) taglen = (int)sizeof(_offband_short) - 1;
     if (commits > 0) {
-      snprintf(_crosswire_short, sizeof(_crosswire_short), "%.*s+%d%s",
+      snprintf(_offband_short, sizeof(_offband_short), "%.*s+%d%s",
                taglen, cw, commits, cw_dirty ? "*" : "");
     } else {
-      snprintf(_crosswire_short, sizeof(_crosswire_short), "%.*s%s",
+      snprintf(_offband_short, sizeof(_offband_short), "%.*s%s",
                taglen, cw, cw_dirty ? "*" : "");
     }
 #endif
@@ -112,24 +112,24 @@ public:
   }
 
   int render(DisplayDriver& display) override {
-#ifdef CROSSWIRE_OBSERVER
-    crosswire::crashLogf("[ui] SplashScreen.render() at %lu", (unsigned long)millis());
+#ifdef OFFBAND_OBSERVER
+    offband::crashLogf("[ui] SplashScreen.render() at %lu", (unsigned long)millis());
 #endif
     // meshcore logo
     display.setColor(DisplayDriver::BLUE);
     int logoWidth = 128;
     display.drawXbm((display.width() - logoWidth) / 2, 3, meshcore_logo, logoWidth, 13);
 
-#ifdef CROSSWIRE_VERSION
+#ifdef OFFBAND_VERSION
     // Pattern B per VERSIONING.md: BOTH fork + baseline versions visible
     // and FULLY LABELED with brand names so a glance at the splash is
-    // unambiguous. Size 2 won't fit the literal "Crosswire" word at our
-    // 128-px width, so we use 3 size-1 lines with the Crosswire line
+    // unambiguous. Size 2 won't fit the literal "Offband" word at our
+    // 128-px width, so we use 3 size-1 lines with the Offband line
     // first (visual prominence via line order, not font size).
     display.setColor(DisplayDriver::LIGHT);
     display.setTextSize(1);
     char cw_line[32];
-    snprintf(cw_line, sizeof(cw_line), "Crosswire %s", _crosswire_short);
+    snprintf(cw_line, sizeof(cw_line), "Offband %s", _offband_short);
     // drawTextCentered does NOT wrap or clip: a line wider than the panel
     // spills off both edges invisibly. Clamp to the chars that fit at size-1
     // (~6px/char) so the version can never run off-screen (Strycher/LoRa#319).
@@ -144,7 +144,7 @@ public:
     display.drawTextCentered(display.width()/2, 35, mc_line);
     display.drawTextCentered(display.width()/2, 53, FIRMWARE_BUILD_DATE);
 #else
-    // Upstream MeshCore build (no Crosswire identity injected): original layout.
+    // Upstream MeshCore build (no Offband identity injected): original layout.
     display.setColor(DisplayDriver::LIGHT);
     display.setTextSize(2);
     display.drawTextCentered(display.width()/2, 22, _mc_version);
@@ -738,8 +738,8 @@ void UITask::newMsg(uint8_t path_len, const char* from_name, const char* text, i
 
   if (_display != NULL) {
     if (!_display->isOn() && !hasConnection()) {
-#ifdef CROSSWIRE_OBSERVER
-      crosswire::crashLogf("[ui] newMsg: display off + no conn -> turnOn");
+#ifdef OFFBAND_OBSERVER
+      offband::crashLogf("[ui] newMsg: display off + no conn -> turnOn");
 #endif
       _display->turnOn();
     }
@@ -772,7 +772,7 @@ void UITask::userLedHandler() {
 }
 
 void UITask::setCurrScreen(UIScreen* c) {
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
   // Screen transition tracing: log every change so we can see if the
   // SplashScreen ↔ HomeScreen oscillation observed on hv3-bench is
   // a real state-machine bug.
@@ -786,7 +786,7 @@ void UITask::setCurrScreen(UIScreen* c) {
   else if (c == home)           to   = "HOME";
   else if (c == msg_preview)    to   = "MSG_PREVIEW";
   else if (c == nullptr)        to   = "NULL";
-  crosswire::crashLogf("[ui] setCurrScreen %s -> %s", from, to);
+  offband::crashLogf("[ui] setCurrScreen %s -> %s", from, to);
 #endif
   curr = c;
   _next_refresh = 100;
@@ -892,8 +892,8 @@ void UITask::loop() {
 #endif
 
   if (c != 0 && curr) {
-#ifdef CROSSWIRE_OBSERVER
-    crosswire::crashLogf("[ui] button event c=0x%x dispatched to curr screen", (int)c);
+#ifdef OFFBAND_OBSERVER
+    offband::crashLogf("[ui] button event c=0x%x dispatched to curr screen", (int)c);
 #endif
     curr->handleInput(c);
     _auto_off = millis() + AUTO_OFF_MILLIS;   // extend auto-off timer

--- a/platformio.ini
+++ b/platformio.ini
@@ -76,7 +76,7 @@ extends = arduino_base
 platform = platformio/espressif32@6.11.0
 monitor_filters = esp32_exception_decoder
 extra_scripts =
-  pre:scripts/inject_crosswire_version.py
+  pre:scripts/inject_offband_version.py
   merge-bin.py
 build_flags = ${arduino_base.build_flags}
   -D ESP32_PLATFORM
@@ -102,7 +102,7 @@ platform = nordicnrf52
 platform_packages =
   framework-arduinoadafruitnrf52 @ 1.10700.0
 extra_scripts =
-  pre:scripts/inject_crosswire_version.py
+  pre:scripts/inject_offband_version.py
   create-uf2.py
   arch/nrf52/extra_scripts/patch_bluefruit.py
 build_flags = ${arduino_base.build_flags}
@@ -119,7 +119,7 @@ extends = arduino_base
 upload_protocol = picotool
 board_build.core = earlephilhower
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
-extra_scripts = pre:scripts/inject_crosswire_version.py
+extra_scripts = pre:scripts/inject_offband_version.py
 build_flags = ${arduino_base.build_flags}
   -D RP2040_PLATFORM
 
@@ -130,7 +130,7 @@ extends = arduino_base
 platform = platformio/ststm32@19.1.0
 platform_packages = platformio/framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/2.10.1.zip
 extra_scripts =
-  pre:scripts/inject_crosswire_version.py
+  pre:scripts/inject_offband_version.py
   post:arch/stm32/build_hex.py
 build_flags = ${arduino_base.build_flags}
   -D STM32_PLATFORM

--- a/scripts/firmware_identity.py
+++ b/scripts/firmware_identity.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-scripts/firmware_identity.py - Extract Crosswire identity from firmware .bin
+scripts/firmware_identity.py - Extract Offband identity from firmware .bin
 
 #200 / LoRa-wek: closes the audit-log integrity bug where
 get_firmware_identity() in scripts/pio-flash.py + scripts/ota-push.py
@@ -9,20 +9,20 @@ snapshotting newer HEAD instead of the commit that produced the .bin sitting
 on disk. The .bin can sit for hours or days between build and push; the
 working tree advances; the audit log records the wrong commit.
 
-Fix: at build time, scripts/inject_crosswire_version.py embeds a marker-
+Fix: at build time, scripts/inject_offband_version.py embeds a marker-
 wrapped identity blob in the firmware binary's .rodata via a
-CROSSWIRE_IDENTITY_BLOB CPPDEFINE consumed by an __attribute__((used))
+OFFBAND_IDENTITY_BLOB CPPDEFINE consumed by an __attribute__((used))
 static in helpers/CommonCLI.cpp. At flash time, this parser scans the .bin
 for those markers and recovers the BUILD-time identity. The previous git-
 derived behavior is kept as a fallback for pre-#200 builds, but tagged
 with firmware_identity_source="git-fallback" in the audit log so stale-
 format entries are visible.
 
-Marker format (ON-WIRE ABI, see inject_crosswire_version.py docstring):
+Marker format (ON-WIRE ABI, see inject_offband_version.py docstring):
 
-  XWIRE_BEGIN|XWIRE_VER=<ver>|XWIRE_SHA=<sha>|XWIRE_BD=<date>|XWIRE_BR=<branch>|XWIRE_END
+  OBND_BEGIN|OBND_VER=<ver>|OBND_SHA=<sha>|OBND_BD=<date>|OBND_BR=<branch>|OBND_END
 
-Field order is fixed; XWIRE_BR is last so a branch containing | cannot
+Field order is fixed; OBND_BR is last so a branch containing | cannot
 break boundary detection.
 """
 from __future__ import annotations
@@ -33,22 +33,22 @@ from typing import Optional
 
 
 # ---------------------------------------------------------------------------
-# Marker constants - must match scripts/inject_crosswire_version.py
+# Marker constants - must match scripts/inject_offband_version.py
 # ---------------------------------------------------------------------------
-_BEGIN = b"XWIRE_BEGIN"
-_END = b"XWIRE_END"
+_BEGIN = b"OBND_BEGIN"
+_END = b"OBND_END"
 
 # Field prefixes in their fixed order. Each prefix appears EXACTLY ONCE in a
 # valid blob. The parser uses these as boundaries (looking for the *next*
 # prefix to find where the current field's value ends), which is what lets a
 # branch name like "feat/foo|bar" still parse correctly: the | inside the
-# value is bounded by the literal `|XWIRE_<next>=` marker, not by a naive
+# value is bounded by the literal `|OBND_<next>=` marker, not by a naive
 # split on `|`.
 _FIELDS_IN_ORDER = [
-    ("crosswire_version", b"|XWIRE_VER="),
-    ("crosswire_git_sha", b"|XWIRE_SHA="),
-    ("crosswire_build_date", b"|XWIRE_BD="),
-    ("crosswire_branch", b"|XWIRE_BR="),
+    ("offband_version", b"|OBND_VER="),
+    ("offband_git_sha", b"|OBND_SHA="),
+    ("offband_build_date", b"|OBND_BD="),
+    ("offband_branch", b"|OBND_BR="),
 ]
 
 
@@ -57,10 +57,10 @@ _FIELDS_IN_ORDER = [
 # ---------------------------------------------------------------------------
 def parse_identity_from_binary(firmware_path: Path) -> Optional[dict]:
     """
-    Scan firmware .bin for the Crosswire identity blob.
+    Scan firmware .bin for the Offband identity blob.
 
-    Returns a dict with crosswire_version / crosswire_git_sha /
-    crosswire_branch / crosswire_build_date on success, or None if the
+    Returns a dict with offband_version / offband_git_sha /
+    offband_branch / offband_build_date on success, or None if the
     file exists and is readable but contains no marker / a malformed
     marker (pre-#200 build, or corruption).
 
@@ -103,7 +103,7 @@ def parse_identity_from_binary(firmware_path: Path) -> Optional[dict]:
 
     # Slice the blob exclusive of BEGIN/END markers themselves. Each field
     # value runs from end-of-its-prefix to start-of-next-prefix (or to the
-    # final | before XWIRE_END for the last field).
+    # final | before OBND_END for the last field).
     blob = data[begin + len(_BEGIN):end]
 
     fields: dict[str, str] = {}
@@ -120,7 +120,7 @@ def parse_identity_from_binary(firmware_path: Path) -> Optional[dict]:
             if value_end < 0:
                 return None
         else:
-            # Last field: value runs to the trailing | (right before XWIRE_END,
+            # Last field: value runs to the trailing | (right before OBND_END,
             # which we sliced out above). If no trailing | found, fall back to
             # end-of-blob.
             value_end = blob.rfind(b"|", value_start)
@@ -159,14 +159,14 @@ def git_fallback_identity(firmware_dir: Path) -> dict:
         return default
 
     return {
-        "crosswire_version": _git(
-            "describe", "--tags", "--match", "crosswire-v*",
+        "offband_version": _git(
+            "describe", "--tags", "--match", "offband-v*",
             "--abbrev=7", "--dirty",
-            default="crosswire-untagged",
+            default="offband-untagged",
         ),
-        "crosswire_git_sha": _git("rev-parse", "--short=7", "HEAD"),
-        "crosswire_branch": _git("rev-parse", "--abbrev-ref", "HEAD"),
-        "crosswire_build_date": _git(
+        "offband_git_sha": _git("rev-parse", "--short=7", "HEAD"),
+        "offband_branch": _git("rev-parse", "--abbrev-ref", "HEAD"),
+        "offband_build_date": _git(
             "log", "-1", "--format=%cd", "--date=format:%Y-%m-%d",
             default="unknown",
         ),
@@ -176,7 +176,7 @@ def git_fallback_identity(firmware_dir: Path) -> dict:
 # ---------------------------------------------------------------------------
 # Orchestrator - what the wrappers actually call
 # ---------------------------------------------------------------------------
-_WEAK_FIELD_VALUES = frozenset({"", "unknown", "crosswire-untagged"})
+_WEAK_FIELD_VALUES = frozenset({"", "unknown", "offband-untagged"})
 
 
 def _is_binary_parse_trustworthy(parsed: dict) -> bool:
@@ -184,8 +184,8 @@ def _is_binary_parse_trustworthy(parsed: dict) -> bool:
     Validity gate for a non-None parse_identity_from_binary() result.
 
     Defends against the realistic threat: a build host where git is missing
-    or has no history, causing inject_crosswire_version.py to silently emit
-    its fallback strings ("unknown" / "crosswire-untagged") into all four
+    or has no history, causing inject_offband_version.py to silently emit
+    its fallback strings ("unknown" / "offband-untagged") into all four
     fields. Without this gate, those bogus values would be recorded in the
     audit log as firmware_identity_source="binary-markers" - structurally
     valid but semantically useless for post-incident reconstruction.
@@ -195,8 +195,8 @@ def _is_binary_parse_trustworthy(parsed: dict) -> bool:
     working tree (the pre-#200 behavior we're replacing) instead of a row
     of "unknown"s.
     """
-    for key in ("crosswire_version", "crosswire_git_sha",
-                "crosswire_branch", "crosswire_build_date"):
+    for key in ("offband_version", "offband_git_sha",
+                "offband_branch", "offband_build_date"):
         if parsed.get(key, "") in _WEAK_FIELD_VALUES:
             return False
     return True
@@ -208,10 +208,10 @@ def get_firmware_identity(firmware_path: Path, firmware_dir: Path) -> dict:
 
     Returns a dict shaped:
       {
-        "crosswire_version":        str,
-        "crosswire_git_sha":        str,
-        "crosswire_branch":         str,
-        "crosswire_build_date":     str,
+        "offband_version":        str,
+        "offband_git_sha":        str,
+        "offband_branch":         str,
+        "offband_build_date":     str,
         "firmware_identity_source": "binary-markers" | "git-fallback",
       }
 

--- a/scripts/inject_offband_version.py
+++ b/scripts/inject_offband_version.py
@@ -1,37 +1,37 @@
 #!/usr/bin/env python
 """
-Inject Crosswire identity into the build as preprocessor defines.
+Inject Offband identity into the build as preprocessor defines.
 
 Called from platformio.ini per-platform `extra_scripts`. Sets:
 
-  CROSSWIRE_VERSION         - from `git describe --tags --match 'crosswire-v*'`
-  CROSSWIRE_GIT_SHA         - from `git rev-parse --short HEAD`
-  CROSSWIRE_BRANCH          - from `git rev-parse --abbrev-ref HEAD`
-  CROSSWIRE_BUILD_DATE      - current UTC date (YYYY-MM-DD)
-  CROSSWIRE_IDENTITY_BLOB   - combined marker-wrapped form for binary scanners
+  OFFBAND_VERSION         - from `git describe --tags --match 'offband-v*'`
+  OFFBAND_GIT_SHA         - from `git rev-parse --short HEAD`
+  OFFBAND_BRANCH          - from `git rev-parse --abbrev-ref HEAD`
+  OFFBAND_BUILD_DATE      - current UTC date (YYYY-MM-DD)
+  OFFBAND_IDENTITY_BLOB   - combined marker-wrapped form for binary scanners
 
 The upstream baseline is already exposed by MeshCore's existing
 FIRMWARE_VERSION / FIRMWARE_BUILD_DATE macros (set per-example in
-MyMesh.h with `#ifndef` guards). Crosswire-aware code combines the two
+MyMesh.h with `#ifndef` guards). Offband-aware code combines the two
 via the format defined in VERSIONING.md:
 
-  "MC <FIRMWARE_VERSION> / Crosswire <CROSSWIRE_VERSION>"
+  "MC <FIRMWARE_VERSION> / Offband <OFFBAND_VERSION>"
 
 See VERSIONING.md for the full scheme. Epic #176 / LoRa-edl; FF2 #179.
 
 ================================================================
-CROSSWIRE_IDENTITY_BLOB FORMAT  --  ON-WIRE ABI WARNING (#200)
+OFFBAND_IDENTITY_BLOB FORMAT  --  ON-WIRE ABI WARNING (#200)
 ================================================================
 The blob is embedded in the firmware binary's .rodata and parsed back
 out by scripts/firmware_identity.py at flash time. The parser is
 deployed separately from the firmware image, so the format is an
 on-wire ABI between the build and the flash wrappers.
 
-  XWIRE_BEGIN|XWIRE_VER=<ver>|XWIRE_SHA=<sha>|XWIRE_BD=<date>|XWIRE_BR=<branch>|XWIRE_END
+  OBND_BEGIN|OBND_VER=<ver>|OBND_SHA=<sha>|OBND_BD=<date>|OBND_BR=<branch>|OBND_END
 
 Rules:
   * Field order is fixed (parsers may rely on it for boundary detection).
-  * XWIRE_BR is intentionally LAST before XWIRE_END so a branch name
+  * OBND_BR is intentionally LAST before OBND_END so a branch name
     containing the (theoretically-legal) | character cannot break the
     parser by being confused for a field boundary.
   * Do not change the begin / end markers, field prefixes, or delimiter
@@ -67,37 +67,37 @@ def _build_date_utc():
     return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
 
 
-crosswire_version = _git(
+offband_version = _git(
     "describe", "--tags",
-    "--match", "crosswire-v*",
+    "--match", "offband-v*",
     "--abbrev=7", "--dirty",
-    # --always: when no crosswire-v* tag is reachable (e.g. the unified
+    # --always: when no offband-v* tag is reachable (e.g. the unified
     # firmware-base line before its first release tag), fall back to the
     # abbreviated commit SHA instead of a non-distinguishing "untagged"
     # string, so every build self-identifies on the OLED splash + CLI
     # (Strycher/LoRa#319). `default` only fires if git itself is unavailable.
     "--always",
-    default="crosswire-untagged",
+    default="offband-untagged",
 )
-crosswire_git_sha = _git("rev-parse", "--short=7", "HEAD")
-crosswire_branch = _git("rev-parse", "--abbrev-ref", "HEAD")
-crosswire_build_date = _build_date_utc()
+offband_git_sha = _git("rev-parse", "--short=7", "HEAD")
+offband_branch = _git("rev-parse", "--abbrev-ref", "HEAD")
+offband_build_date = _build_date_utc()
 
 
 # Combined marker-wrapped blob for binary scanners. See "ON-WIRE ABI WARNING"
 # block in the module docstring above before changing format. Field order is
 # fixed: branch is last because branch names can contain `|`.
-crosswire_identity_blob = (
-    "XWIRE_BEGIN"
-    f"|XWIRE_VER={crosswire_version}"
-    f"|XWIRE_SHA={crosswire_git_sha}"
-    f"|XWIRE_BD={crosswire_build_date}"
-    f"|XWIRE_BR={crosswire_branch}"
-    "|XWIRE_END"
+offband_identity_blob = (
+    "OBND_BEGIN"
+    f"|OBND_VER={offband_version}"
+    f"|OBND_SHA={offband_git_sha}"
+    f"|OBND_BD={offband_build_date}"
+    f"|OBND_BR={offband_branch}"
+    "|OBND_END"
 )
 
 # Emit the version macros via a GENERATED HEADER that we force-include (-include),
-# rather than command-line -D macros. CROSSWIRE_IDENTITY_BLOB contains '|'
+# rather than command-line -D macros. OFFBAND_IDENTITY_BLOB contains '|'
 # delimiters; as a -D value those are word-split by POSIX sh on Linux CI and
 # break the compile (xtensa/arm g++ "no input files", Error 127). Inside a header
 # the pipes are ordinary string-literal bytes -> portable on Windows + Linux.
@@ -109,21 +109,21 @@ def _cstr(s):  # minimal C string-literal escape
 import os
 _build_dir = env.subst("$BUILD_DIR")  # type: ignore[name-defined]  # noqa: F821
 os.makedirs(_build_dir, exist_ok=True)
-_hdr = os.path.join(_build_dir, "crosswire_version.h")
+_hdr = os.path.join(_build_dir, "offband_version.h")
 with open(_hdr, "w", encoding="utf-8") as _f:
     _f.write(
         "#pragma once\n"
-        f"#define CROSSWIRE_VERSION {_cstr(crosswire_version)}\n"
-        f"#define CROSSWIRE_GIT_SHA {_cstr(crosswire_git_sha)}\n"
-        f"#define CROSSWIRE_BRANCH {_cstr(crosswire_branch)}\n"
-        f"#define CROSSWIRE_BUILD_DATE {_cstr(crosswire_build_date)}\n"
-        f"#define CROSSWIRE_IDENTITY_BLOB {_cstr(crosswire_identity_blob)}\n"
+        f"#define OFFBAND_VERSION {_cstr(offband_version)}\n"
+        f"#define OFFBAND_GIT_SHA {_cstr(offband_git_sha)}\n"
+        f"#define OFFBAND_BRANCH {_cstr(offband_branch)}\n"
+        f"#define OFFBAND_BUILD_DATE {_cstr(offband_build_date)}\n"
+        f"#define OFFBAND_IDENTITY_BLOB {_cstr(offband_identity_blob)}\n"
     )
 env.Append(CCFLAGS=["-include", _hdr])  # type: ignore[name-defined]  # noqa: F821
 
-print("[crosswire] embedded identity:")
-print(f"[crosswire]   CROSSWIRE_VERSION    = {crosswire_version}")
-print(f"[crosswire]   CROSSWIRE_GIT_SHA    = {crosswire_git_sha}")
-print(f"[crosswire]   CROSSWIRE_BRANCH     = {crosswire_branch}")
-print(f"[crosswire]   CROSSWIRE_BUILD_DATE = {crosswire_build_date}")
-print(f"[crosswire]   CROSSWIRE_IDENTITY_BLOB embedded ({len(crosswire_identity_blob)} bytes)")
+print("[offband] embedded identity:")
+print(f"[offband]   OFFBAND_VERSION    = {offband_version}")
+print(f"[offband]   OFFBAND_GIT_SHA    = {offband_git_sha}")
+print(f"[offband]   OFFBAND_BRANCH     = {offband_branch}")
+print(f"[offband]   OFFBAND_BUILD_DATE = {offband_build_date}")
+print(f"[offband]   OFFBAND_IDENTITY_BLOB embedded ({len(offband_identity_blob)} bytes)")

--- a/scripts/ota-push.py
+++ b/scripts/ota-push.py
@@ -767,7 +767,7 @@ def run_push(args) -> int:
     # #200 (LoRa-wek): identity is read from the firmware binary's embedded
     # XWIRE marker blob, NOT re-derived from git. The .bin was built at one
     # point in time; the working tree may have advanced since. firmware_sha256
-    # is still the authoritative artifact ID; the crosswire_* fields are the
+    # is still the authoritative artifact ID; the offband_* fields are the
     # human-readable label. firmware_identity_source records which path won.
     fw_identity = get_firmware_identity(firmware_path, FIRMWARE_DIR)
 
@@ -782,10 +782,10 @@ def run_push(args) -> int:
         "firmware_sha256": upload_result["firmware_sha256"],
         "firmware_md5": upload_result["firmware_md5"],
         "firmware_size": upload_result["firmware_size"],
-        "crosswire_version": fw_identity["crosswire_version"],
-        "crosswire_git_sha": fw_identity["crosswire_git_sha"],
-        "crosswire_branch": fw_identity["crosswire_branch"],
-        "crosswire_build_date": fw_identity["crosswire_build_date"],
+        "offband_version": fw_identity["offband_version"],
+        "offband_git_sha": fw_identity["offband_git_sha"],
+        "offband_branch": fw_identity["offband_branch"],
+        "offband_build_date": fw_identity["offband_build_date"],
         "firmware_identity_source": fw_identity["firmware_identity_source"],
         "upload_status_code": upload_result["status_code"],
         "upload_exception": upload_result["exception_class"],

--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -66,7 +66,7 @@ FLASH_HISTORY_PATH = PROJECT_ROOT / "flash-history.jsonl"
 TOKEN_TTL_SEC = 300   # 5 min per Standards design note #1
 
 # Directory holding the firmware tree (platformio.ini + variants/) for build +
-# upload + monitor invocations. Post-migration the Crosswire repo root IS the
+# upload + monitor invocations. Post-migration the Offband repo root IS the
 # firmware tree, so the default is PROJECT_ROOT. Override per-host via the
 # PIO_FLASH_FIRMWARE_DIR env var, or per-invocation via --firmware-dir.
 # Precedence: --firmware-dir > PIO_FLASH_FIRMWARE_DIR > default. See #27.
@@ -400,17 +400,17 @@ def _artifact_identity(artifact: Path) -> dict:
     m = ARTIFACT_RE.search(artifact.name)
     if m:
         return {
-            "crosswire_version": m.group(1),
-            "crosswire_git_sha": m.group(2),
-            "crosswire_branch": "unknown",
-            "crosswire_build_date": "unknown",
+            "offband_version": m.group(1),
+            "offband_git_sha": m.group(2),
+            "offband_branch": "unknown",
+            "offband_build_date": "unknown",
             "firmware_identity_source": "ci-artifact-filename",
         }
     return {
-        "crosswire_version": "unknown",
-        "crosswire_git_sha": "unknown",
-        "crosswire_branch": "unknown",
-        "crosswire_build_date": "unknown",
+        "offband_version": "unknown",
+        "offband_git_sha": "unknown",
+        "offband_branch": "unknown",
+        "offband_build_date": "unknown",
         "firmware_identity_source": "artifact-filename-unparsed",
     }
 
@@ -491,8 +491,8 @@ def _preview_artifact(args, port: dict, entry: dict) -> int:
     out(f"Platform      : {platform}")
     out(f"Flash method  : {method}")
     out(f"Mode          : {mode_desc}")
-    out(f"Crosswire ver : {ident['crosswire_version']}")
-    out(f"Crosswire SHA : {ident['crosswire_git_sha']}")
+    out(f"Offband ver : {ident['offband_version']}")
+    out(f"Offband SHA : {ident['offband_git_sha']}")
     out(f"Identity src  : {ident['firmware_identity_source']}")
     out("------------------------------------------------------------")
     out("To proceed, get explicit user GO in chat naming the device, then run:")
@@ -514,10 +514,10 @@ def _preview_artifact(args, port: dict, entry: dict) -> int:
         "artifact_path": str(artifact),
         "firmware_sha256": sha,
         "firmware_size": size,
-        "crosswire_version": ident["crosswire_version"],
-        "crosswire_git_sha": ident["crosswire_git_sha"],
-        "crosswire_branch": ident["crosswire_branch"],
-        "crosswire_build_date": ident["crosswire_build_date"],
+        "offband_version": ident["offband_version"],
+        "offband_git_sha": ident["offband_git_sha"],
+        "offband_branch": ident["offband_branch"],
+        "offband_build_date": ident["offband_build_date"],
         "firmware_identity_source": ident["firmware_identity_source"],
     }
     p = write_token(args.device, payload)
@@ -763,8 +763,8 @@ def _confirm_artifact(args, token: dict, port: dict) -> int:
         "artifact_path": token.get("artifact_path"),
         "firmware_sha256": token.get("firmware_sha256"),
         "firmware_size": token.get("firmware_size"),
-        "crosswire_version": token.get("crosswire_version", "unknown"),
-        "crosswire_git_sha": token.get("crosswire_git_sha", "unknown"),
+        "offband_version": token.get("offband_version", "unknown"),
+        "offband_git_sha": token.get("offband_git_sha", "unknown"),
         "firmware_identity_source": token.get("firmware_identity_source", "unknown"),
         "verified_ok": ok,
         "exit_code": 0 if ok else 1,
@@ -830,9 +830,9 @@ def cmd_preview(args, registry):
     # cmd_confirm logs the same identity it previewed - no second source of
     # truth between preview and confirm.
     fw_identity = get_firmware_identity(firmware_bin, FIRMWARE_DIR)
-    out(f"Crosswire version : {fw_identity['crosswire_version']}")
-    out(f"Crosswire SHA     : {fw_identity['crosswire_git_sha']}")
-    out(f"Crosswire branch  : {fw_identity['crosswire_branch']}")
+    out(f"Offband version : {fw_identity['offband_version']}")
+    out(f"Offband SHA     : {fw_identity['offband_git_sha']}")
+    out(f"Offband branch  : {fw_identity['offband_branch']}")
     out(f"Identity source   : {fw_identity['firmware_identity_source']}")
     out("------------------------------------------------------------")
 
@@ -847,10 +847,10 @@ def cmd_preview(args, registry):
         "firmware_size": size,
         "pio_env": env,
         "firmware_dir": str(FIRMWARE_DIR),
-        "crosswire_version": fw_identity["crosswire_version"],
-        "crosswire_git_sha": fw_identity["crosswire_git_sha"],
-        "crosswire_branch": fw_identity["crosswire_branch"],
-        "crosswire_build_date": fw_identity["crosswire_build_date"],
+        "offband_version": fw_identity["offband_version"],
+        "offband_git_sha": fw_identity["offband_git_sha"],
+        "offband_branch": fw_identity["offband_branch"],
+        "offband_build_date": fw_identity["offband_build_date"],
         "firmware_identity_source": fw_identity["firmware_identity_source"],
     }
     p = write_token(args.device, payload)
@@ -926,10 +926,10 @@ def cmd_confirm(args, registry):
         "pio_env": token["pio_env"],
         "firmware_sha256": token["firmware_sha256"],
         "firmware_size": token["firmware_size"],
-        "crosswire_version": token.get("crosswire_version", "unknown"),
-        "crosswire_git_sha": token.get("crosswire_git_sha", "unknown"),
-        "crosswire_branch": token.get("crosswire_branch", "unknown"),
-        "crosswire_build_date": token.get("crosswire_build_date", "unknown"),
+        "offband_version": token.get("offband_version", "unknown"),
+        "offband_git_sha": token.get("offband_git_sha", "unknown"),
+        "offband_branch": token.get("offband_branch", "unknown"),
+        "offband_build_date": token.get("offband_build_date", "unknown"),
         "firmware_identity_source": token.get("firmware_identity_source", "git-fallback"),
         "exit_code": rc,
         "user_confirmation": args.device,
@@ -1507,7 +1507,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="override the firmware tree (platformio.ini location) for this "
              "invocation; must precede the subcommand. Precedence: "
              "--firmware-dir > PIO_FLASH_FIRMWARE_DIR env > default "
-             "(Crosswire repo root). See #27.",
+             "(Offband repo root). See #27.",
     )
     sub = p.add_subparsers(dest="cmd", required=True)
 

--- a/scripts/test_observer_broker_format.py
+++ b/scripts/test_observer_broker_format.py
@@ -2,7 +2,7 @@
 """
 scripts/test_observer_broker_format.py
 
-Host-runnable test for crosswire::formatBrokerConfig (#98, `mqtt view <N>`).
+Host-runnable test for offband::formatBrokerConfig (#98, `mqtt view <N>`).
 Compiles ConfigSchema.cpp against the in-memory Preferences mock and asserts
 that the rendered per-slot view:
 
@@ -39,7 +39,7 @@ from test_observer_nvs_round_trip import (  # noqa: E402
 
 HARNESS = r"""
 #define ARDUINO 1
-#define CROSSWIRE_OBSERVER 1
+#define OFFBAND_OBSERVER 1
 #include "prefs_mock.h"
 #include "src/helpers/wifi_observer/ConfigSchema.cpp"
 
@@ -52,7 +52,7 @@ static int fail(const char* why, const char* buf) {
 }
 
 int main() {
-    using namespace crosswire;
+    using namespace offband;
 
     BrokerConfig cfg;
     cfg.enabled   = false;
@@ -142,8 +142,8 @@ int main() {
     // 8. clearBrokerConfig wipes a slot's NVS namespace (the `mqtt clear` fix).
     //    Writing an empty config was not enough on real ESP32 NVS; clearing the
     //    namespace makes readBrokerConfig return defaults (empty url). Use the
-    //    LAST valid slot so this holds regardless of CROSSWIRE_MAX_BROKERS.
-    const uint8_t cslot = (uint8_t)(CROSSWIRE_MAX_BROKERS - 1);
+    //    LAST valid slot so this holds regardless of OFFBAND_MAX_BROKERS.
+    const uint8_t cslot = (uint8_t)(OFFBAND_MAX_BROKERS - 1);
     BrokerConfig w;
     strcpy(w.url, "wss://x.example:443/mqtt");
     if (!writeBrokerConfig(cslot, w)) { puts("FAIL: clear precond write"); return 1; }

--- a/scripts/test_observer_cli_allowlist.py
+++ b/scripts/test_observer_cli_allowlist.py
@@ -55,7 +55,7 @@ from pathlib import Path
 # returns false -> result is CliResult::Unknown.
 STUB_DEFS_CPP = r"""
 #include <cstddef>
-namespace crosswire {
+namespace offband {
 class MqttBrokerPool {};
 bool dispatchObserverCli(const char* cmd, char* /*reply*/,
                          std::size_t /*reply_size*/,
@@ -69,7 +69,7 @@ MqttBrokerPool& wifiObserverPool() {
     static MqttBrokerPool inst;
     return inst;
 }
-}  // namespace crosswire
+}  // namespace offband
 """
 
 # Driver: 16 allowlist-gate cases + 2 end-to-end execute cases.
@@ -113,20 +113,20 @@ static const GateCase kGateCases[] = {
 //     returns true -> CliResult::Ok (baseline; passes pre + post fix).
 struct ExecCase {
     const char* line;
-    crosswire::CliResult expect;
+    offband::CliResult expect;
 };
 
 static const ExecCase kExecCases[] = {
-    {"  set mqtt.iata CMH", crosswire::CliResult::Ok},  // I1 regression
-    {"get mqtt.iata",       crosswire::CliResult::Ok},  // baseline
-    {"  Wifi status",       crosswire::CliResult::Ok},  // #45: trim+lowercase+allow (screenshot)
+    {"  set mqtt.iata CMH", offband::CliResult::Ok},  // I1 regression
+    {"get mqtt.iata",       offband::CliResult::Ok},  // baseline
+    {"  Wifi status",       offband::CliResult::Ok},  // #45: trim+lowercase+allow (screenshot)
 };
 
-static const char* resultName(crosswire::CliResult r) {
+static const char* resultName(offband::CliResult r) {
     switch (r) {
-        case crosswire::CliResult::Ok:      return "Ok";
-        case crosswire::CliResult::Denied:  return "Denied";
-        case crosswire::CliResult::Unknown: return "Unknown";
+        case offband::CliResult::Ok:      return "Ok";
+        case offband::CliResult::Denied:  return "Denied";
+        case offband::CliResult::Unknown: return "Unknown";
     }
     return "?";
 }
@@ -137,7 +137,7 @@ int main() {
 
     int n_gate = (int)(sizeof(kGateCases)/sizeof(kGateCases[0]));
     for (int i = 0; i < n_gate; ++i) {
-        bool got = crosswire::cliPassthroughIsAllowed(kGateCases[i].line);
+        bool got = offband::cliPassthroughIsAllowed(kGateCases[i].line);
         const char* tag = (got == kGateCases[i].expect_allowed) ? "PASS" : "FAIL";
         if (got != kGateCases[i].expect_allowed) ++fails;
         ++total;
@@ -150,7 +150,7 @@ int main() {
     int n_exec = (int)(sizeof(kExecCases)/sizeof(kExecCases[0]));
     for (int i = 0; i < n_exec; ++i) {
         char buf[128] = {0};
-        crosswire::CliResult got = crosswire::cliPassthroughExecute(
+        offband::CliResult got = offband::cliPassthroughExecute(
             kExecCases[i].line, buf, sizeof(buf));
         const char* tag = (got == kExecCases[i].expect) ? "PASS" : "FAIL";
         if (got != kExecCases[i].expect) ++fails;

--- a/scripts/test_observer_env_matrix.py
+++ b/scripts/test_observer_env_matrix.py
@@ -28,12 +28,12 @@ EXPECTED = [
 ]
 
 # Every Plan-1 env MUST set both flags (Plan 1 = companion-only,
-# so CROSSWIRE_OBSERVER_BLE_COMPANION is always on). When a repeater
-# variant lands later, only CROSSWIRE_OBSERVER will be required and
+# so OFFBAND_OBSERVER_BLE_COMPANION is always on). When a repeater
+# variant lands later, only OFFBAND_OBSERVER will be required and
 # this assertion splits.
 REQUIRED_FLAGS_ALL = [
-    "-D CROSSWIRE_OBSERVER",
-    "-D CROSSWIRE_OBSERVER_BLE_COMPANION",
+    "-D OFFBAND_OBSERVER",
+    "-D OFFBAND_OBSERVER_BLE_COMPANION",
 ]
 REQUIRED_SRC_FILTER = "+<helpers/wifi_observer/*.cpp>"
 

--- a/scripts/test_observer_nvs_round_trip.py
+++ b/scripts/test_observer_nvs_round_trip.py
@@ -73,11 +73,11 @@ class Preferences {
 
 HARNESS = r"""
 // Define BOTH ARDUINO (so ConfigSchema.cpp picks the real branch) AND
-// CROSSWIRE_OBSERVER (so the transitive include of WifiObserverConfig.h
+// OFFBAND_OBSERVER (so the transitive include of WifiObserverConfig.h
 // doesn't trip its "missing define" #error guard). Both defines must
 // precede every include.
 #define ARDUINO 1
-#define CROSSWIRE_OBSERVER 1
+#define OFFBAND_OBSERVER 1
 #include "prefs_mock.h"
 #include "src/helpers/wifi_observer/ConfigSchema.cpp"
 
@@ -85,7 +85,7 @@ HARNESS = r"""
 #include <cstring>
 
 int main() {
-    using namespace crosswire;
+    using namespace offband;
 
     // Fixture: realistic broker config in slot 2 (incl Plan 2 v2 fields).
     BrokerConfig wrote;

--- a/scripts/test_observer_status_payload.py
+++ b/scripts/test_observer_status_payload.py
@@ -2,7 +2,7 @@
 """
 scripts/test_observer_status_payload.py
 
-Plan 2 v2 Task 5: golden-JSON contract test for crosswire::buildStatusJson.
+Plan 2 v2 Task 5: golden-JSON contract test for offband::buildStatusJson.
 
 Compiles MqttPayload.cpp on the host (MSVC or g++), runs the status
 builder with a deterministic snapshot + ctx, captures the output, and
@@ -49,17 +49,17 @@ from pathlib import Path
 # Mirrors the snapshot fields used by the vendored MqttUplink in production.
 # Values chosen to be obvious in the JSON output for human review.
 HARNESS = r"""
-// Host-side test harness for crosswire::buildStatusJson.
+// Host-side test harness for offband::buildStatusJson.
 // We do NOT #define ARDUINO -- this exercises the host-portable branch
-// of MqttPayload.cpp. CROSSWIRE_OBSERVER is required by WifiObserverConfig.h.
-#define CROSSWIRE_OBSERVER 1
+// of MqttPayload.cpp. OFFBAND_OBSERVER is required by WifiObserverConfig.h.
+#define OFFBAND_OBSERVER 1
 #include "src/helpers/wifi_observer/MqttPayload.cpp"
 
 #include <cstdio>
 #include <cstring>
 
 int main() {
-    using namespace crosswire;
+    using namespace offband;
 
     MqttStatusSnapshot snap;
     snap.battery_mv     = 4100;

--- a/scripts/test_observer_system_channel.py
+++ b/scripts/test_observer_system_channel.py
@@ -192,7 +192,7 @@ static void sha256(const uint8_t* msg, size_t len, uint8_t out[32]) {
 // be unresolved. To fix: the .cpp's forward declaration is
 // `static void sysch_sha256(...)` -- "static" means internal
 // linkage, so we can supply the body inside the SAME TU after the
-// declaration. The trick: include the .cpp INSIDE the crosswire
+// declaration. The trick: include the .cpp INSIDE the offband
 // namespace so we can then add the host body right after.
 
 #include "src/helpers/wifi_observer/SystemChannelCli.cpp"
@@ -202,7 +202,7 @@ static void sha256(const uint8_t* msg, size_t len, uint8_t out[32]) {
 // scope, so we extend with a definition in the same translation
 // unit. The #ifdef ARDUINO body is compiled out for this host
 // build, so this is the only definition.
-namespace crosswire {
+namespace offband {
 static void sysch_sha256(uint8_t* out_hash, size_t out_len,
                          const uint8_t* msg, size_t msg_len) {
   uint8_t full[32];
@@ -210,20 +210,20 @@ static void sysch_sha256(uint8_t* out_hash, size_t out_len,
   if (out_len > 32) out_len = 32;
   memcpy(out_hash, full, out_len);
 }
-}  // namespace crosswire
+}  // namespace offband
 
 // Stub for cliPassthroughExecute since SystemChannelCli.cpp links
 // against it. Not exercised by any of the 5 pure-logic tests, but
 // the symbol must resolve. The .cpp's ARDUINO-only call site is
 // compiled out, but the include of CliPassthrough.h still
 // declares it.
-namespace crosswire {
+namespace offband {
 CliResult cliPassthroughExecute(const char* /*line*/,
                                 char* out, size_t out_len) {
   if (out && out_len) out[0] = '\0';
   return CliResult::Unknown;
 }
-}  // namespace crosswire
+}  // namespace offband
 
 // ---------------------------------------------------------------------------
 // Test harness.
@@ -273,7 +273,7 @@ static int hamming_bits(const uint8_t* a, const uint8_t* b, size_t n) {
 }
 
 int main() {
-  using namespace crosswire;
+  using namespace offband;
 
   // -------------------------------------------------------------
   // Case 1: golden vector for all-zero pubkey.

--- a/scripts/test_offband_version_splash.py
+++ b/scripts/test_offband_version_splash.py
@@ -1,4 +1,4 @@
-# scripts/test_crosswire_version_splash.py
+# scripts/test_offband_version_splash.py
 #
 # Verifies the companion OLED splash compact-version derivation
 # (SplashScreen in examples/companion_radio/ui-new/UITask.cpp) by implementing
@@ -7,17 +7,17 @@
 # The C++ implementation is a direct translation of this algorithm; this test
 # is the executable specification (Strycher/Crosswire#33). Portable: no g++.
 #
-# Run with:  python scripts/test_crosswire_version_splash.py
+# Run with:  python scripts/test_offband_version_splash.py
 
 import sys
 
-CW_PREFIX = "crosswire-"
+CW_PREFIX = "offband-"
 
 
-def compact_crosswire_version(cw: str) -> str:
-    """Python equivalent of the SplashScreen _crosswire_short derivation.
+def compact_offband_version(cw: str) -> str:
+    """Python equivalent of the SplashScreen _offband_short derivation.
 
-    CROSSWIRE_VERSION is `git describe` output: "<tag>[-<N>-g<sha>][-dirty]"
+    OFFBAND_VERSION is `git describe` output: "<tag>[-<N>-g<sha>][-dirty]"
     where <tag> may itself contain dashes for a pre-release (e.g. v0.14.0-rc1).
     The commits-since suffix is identified by git's "-g<sha>" marker, NOT the
     first dash (which on a pre-release tag is the "-rcN" separator).
@@ -45,20 +45,20 @@ def compact_crosswire_version(cw: str) -> str:
 
 
 FIXTURES = [
-    # (label, CROSSWIRE_VERSION, expected compact form)
-    ("exact release tag",        "crosswire-v0.14.0",                  "v0.14.0"),
-    ("exact pre-release tag",    "crosswire-v0.14.0-rc1",              "v0.14.0-rc1"),
-    ("rc2 exact pre-release",    "crosswire-v1.2.3-rc2",              "v1.2.3-rc2"),
-    ("commits past release",     "crosswire-v0.14.0-4-g369714e",       "v0.14.0+4"),
-    ("commits past pre-release", "crosswire-v0.14.0-rc1-4-g369714e",   "v0.14.0-rc1+4"),
-    ("dirty exact pre-release",  "crosswire-v0.14.0-rc1-dirty",        "v0.14.0-rc1*"),
-    ("dirty commits past tag",   "crosswire-v0.14.0-4-g369714e-dirty", "v0.14.0+4*"),
+    # (label, OFFBAND_VERSION, expected compact form)
+    ("exact release tag",        "offband-v0.14.0",                  "v0.14.0"),
+    ("exact pre-release tag",    "offband-v0.14.0-rc1",              "v0.14.0-rc1"),
+    ("rc2 exact pre-release",    "offband-v1.2.3-rc2",              "v1.2.3-rc2"),
+    ("commits past release",     "offband-v0.14.0-4-g369714e",       "v0.14.0+4"),
+    ("commits past pre-release", "offband-v0.14.0-rc1-4-g369714e",   "v0.14.0-rc1+4"),
+    ("dirty exact pre-release",  "offband-v0.14.0-rc1-dirty",        "v0.14.0-rc1*"),
+    ("dirty commits past tag",   "offband-v0.14.0-4-g369714e-dirty", "v0.14.0+4*"),
     ("untagged SHA fallback",    "369714e",                            "369714e"),
 ]
 
 failures = []
 for label, cw, expected in FIXTURES:
-    got = compact_crosswire_version(cw)
+    got = compact_offband_version(cw)
     if got == expected:
         print(f"OK: '{cw}' -> '{got}' ({label})")
     else:
@@ -67,7 +67,7 @@ for label, cw, expected in FIXTURES:
 
 # Explicit regression guard for the #33 bug: a clean pre-release tag must NOT
 # collapse to "v0.14.0+0".
-if compact_crosswire_version("crosswire-v0.14.0-rc1") == "v0.14.0+0":
+if compact_offband_version("offband-v0.14.0-rc1") == "v0.14.0+0":
     print("FAIL: regression -- pre-release tag still renders the spurious '+0'")
     failures.append("rc1-plus0-regression")
 

--- a/scripts/test_wifi_bootstrap_ssid.py
+++ b/scripts/test_wifi_bootstrap_ssid.py
@@ -13,14 +13,14 @@
 
 import sys
 
-AP_SSID_PREFIX = "Crosswire-Observer-"
+AP_SSID_PREFIX = "Offband-Observer-"
 
 
 def derive_ap_ssid(mac_bytes: bytes) -> str:
     """
     Python equivalent of WifiBootstrap::deriveApSsid().
 
-    Format: "Crosswire-Observer-XXXXXX" where XXXXXX = last 6 hex chars
+    Format: "Offband-Observer-XXXXXX" where XXXXXX = last 6 hex chars
     of MAC (last 3 bytes, upper-case). Mirrors the C++ bit-shift logic:
 
         hex[i*2]     = H[(tail[i] >> 4) & 0x0F];
@@ -46,22 +46,22 @@ FIXTURES = [
     (
         "ST-P MAC (88:56:A6:96:0D:0C)",
         bytes([0x88, 0x56, 0xA6, 0x96, 0x0D, 0x0C]),
-        "Crosswire-Observer-960D0C",
+        "Offband-Observer-960D0C",
     ),
     (
         "all-zeros MAC",
         bytes([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
-        "Crosswire-Observer-000000",
+        "Offband-Observer-000000",
     ),
     (
         "all-0xFF MAC",
         bytes([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
-        "Crosswire-Observer-FFFFFF",
+        "Offband-Observer-FFFFFF",
     ),
     (
         "mixed-nibble MAC (AB:CD:EF:12:34:56)",
         bytes([0xAB, 0xCD, 0xEF, 0x12, 0x34, 0x56]),
-        "Crosswire-Observer-123456",
+        "Offband-Observer-123456",
     ),
 ]
 

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -5,14 +5,14 @@
 #include <RTClib.h>
 
 // Plan 2 v2 Task 11: ObserverCli dispatcher hooked into handleCommand's
-// fall-through. Compiles in only when CROSSWIRE_OBSERVER is defined
+// fall-through. Compiles in only when OFFBAND_OBSERVER is defined
 // (observer envs); other envs have zero impact.
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
   #include "wifi_observer/ObserverCli.h"
   #include "wifi_observer/WifiObserver.h"  // wifiObserverPool() accessor
 #endif
 
-// #200 / LoRa-wek: embed the Crosswire identity blob in .rodata so the
+// #200 / LoRa-wek: embed the Offband identity blob in .rodata so the
 // flash-history parser (scripts/firmware_identity.py) can recover BUILD-time
 // identity by scanning the firmware binary, rather than re-running git at
 // flash time against a working tree that may have advanced past the build.
@@ -40,9 +40,9 @@
 //   so the marker section becomes reachable from the kept .init_array
 //   entry and survives --gc-sections on every platform.
 //
-// See scripts/inject_crosswire_version.py "ON-WIRE ABI WARNING" for format.
+// See scripts/inject_offband_version.py "ON-WIRE ABI WARNING" for format.
 __attribute__((used))
-static const char _xwire_identity_blob[] = CROSSWIRE_IDENTITY_BLOB;
+static const char _xwire_identity_blob[] = OFFBAND_IDENTITY_BLOB;
 
 // Volatile pointer the constructor writes to. volatile prevents the optimizer
 // from concluding the constructor body has no observable effect and elising
@@ -297,13 +297,13 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
     } else if (memcmp(command, "reboot", 6) == 0) {
       _board->reboot();  // doesn't return
     } else if (memcmp(command, "version", 7) == 0 && (command[7] == 0 || command[7] == ' ')) {
-      // Crosswire identity (FF3 / #180). Reports both upstream MeshCore version
+      // Offband identity (FF3 / #180). Reports both upstream MeshCore version
       // (via callback into example's MyMesh which #defines FIRMWARE_VERSION) and
-      // the Crosswire-injected build identity from scripts/inject_crosswire_version.py
+      // the Offband-injected build identity from scripts/inject_offband_version.py
       // (FF2 / #179). See VERSIONING.md for the dual-version scheme rationale.
-      sprintf(reply, "Upstream MeshCore: %s (%s)\nCrosswire fork: %s (sha %s, %s, built %s)",
+      sprintf(reply, "Upstream MeshCore: %s (%s)\nOffband fork: %s (sha %s, %s, built %s)",
               _callbacks->getFirmwareVer(), _callbacks->getBuildDate(),
-              CROSSWIRE_VERSION, CROSSWIRE_GIT_SHA, CROSSWIRE_BRANCH, CROSSWIRE_BUILD_DATE);
+              OFFBAND_VERSION, OFFBAND_GIT_SHA, OFFBAND_BRANCH, OFFBAND_BUILD_DATE);
       // #213: the in-handler keepalive moved to a file-scope constructor
       // (_xwire_keepalive_ctor near top of this file). The constructor
       // approach works on every platform; the in-handler line was
@@ -1226,9 +1226,9 @@ void CommonCLI::handleRegionCmd(char* command, char* reply) {
     if (len == 0) {
       strcpy(reply, "-none-");
     }
-#ifdef CROSSWIRE_OBSERVER
-  } else if (crosswire::dispatchObserverCli(command, reply, /*reply_size=*/1024,
-                                            crosswire::wifiObserverPool())) {
+#ifdef OFFBAND_OBSERVER
+  } else if (offband::dispatchObserverCli(command, reply, /*reply_size=*/1024,
+                                            offband::wifiObserverPool())) {
     // handled by Plan 2 v2 observer CLI (mqtt status / enable / disable /
     // set mqtt.iata / set mqtt.status_interval / set mqtt.broker.<N>.*).
 #endif

--- a/src/helpers/ui/SSD1306Display.cpp
+++ b/src/helpers/ui/SSD1306Display.cpp
@@ -1,6 +1,6 @@
 #include "SSD1306Display.h"
 
-#ifdef CROSSWIRE_OBSERVER
+#ifdef OFFBAND_OBSERVER
   #include <helpers/wifi_observer/CrashLog.h>
 #endif
 
@@ -22,8 +22,8 @@ bool SSD1306Display::begin() {
 }
 
 void SSD1306Display::turnOn() {
-#ifdef CROSSWIRE_OBSERVER
-  crosswire::crashLogf("[oled] turnOn() called; was_on=%d", (int)_isOn);
+#ifdef OFFBAND_OBSERVER
+  offband::crashLogf("[oled] turnOn() called; was_on=%d", (int)_isOn);
 #endif
   if (!_isOn) {
     if (_peripher_power) _peripher_power->claim();
@@ -34,8 +34,8 @@ void SSD1306Display::turnOn() {
 }
 
 void SSD1306Display::turnOff() {
-#ifdef CROSSWIRE_OBSERVER
-  crosswire::crashLogf("[oled] turnOff() called; was_on=%d", (int)_isOn);
+#ifdef OFFBAND_OBSERVER
+  offband::crashLogf("[oled] turnOff() called; was_on=%d", (int)_isOn);
 #endif
   display.ssd1306_command(SSD1306_DISPLAYOFF);
   if (_isOn) {

--- a/src/helpers/wifi_observer/CliPassthrough.cpp
+++ b/src/helpers/wifi_observer/CliPassthrough.cpp
@@ -17,7 +17,7 @@
 #include <cstdio>
 #include <cstring>
 
-namespace crosswire {
+namespace offband {
 
 // Forward declarations. These MUST stay byte-identical to:
 //   - dispatchObserverCli: declared in ObserverCli.h
@@ -162,4 +162,4 @@ CliResult cliPassthroughExecute(const char* line, char* out_response,
     return CliResult::Unknown;
 }
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/CliPassthrough.h
+++ b/src/helpers/wifi_observer/CliPassthrough.h
@@ -21,7 +21,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-namespace crosswire {
+namespace offband {
 
 enum class CliResult : uint8_t {
     Ok      = 0,
@@ -47,4 +47,4 @@ CliResult cliPassthroughExecute(const char* line,
 // accepted by the allowlist (without executing).
 bool cliPassthroughIsAllowed(const char* line);
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -11,11 +11,11 @@
   #include <cstring>
 #endif
 
-namespace crosswire {
+namespace offband {
 
 void mqttBrokerNamespace(uint8_t broker_index, char* out, size_t out_len) {
     // "mqtt_b0".."mqtt_b5" -- 7 chars, well under 15-char NVS limit.
-    if (broker_index >= CROSSWIRE_MAX_BROKERS || out_len < 8) {
+    if (broker_index >= OFFBAND_MAX_BROKERS || out_len < 8) {
         if (out_len > 0) out[0] = '\0';
         return;
     }
@@ -66,7 +66,7 @@ void writeStatusIntervalSec(uint16_t seconds) {
 }
 
 bool readBrokerConfig(uint8_t slot, BrokerConfig& out) {
-    if (slot >= CROSSWIRE_MAX_BROKERS) return false;
+    if (slot >= OFFBAND_MAX_BROKERS) return false;
     char ns[16];
     mqttBrokerNamespace(slot, ns, sizeof(ns));
     Preferences p;
@@ -110,7 +110,7 @@ bool readBrokerConfig(uint8_t slot, BrokerConfig& out) {
 }
 
 bool writeBrokerConfig(uint8_t slot, const BrokerConfig& cfg) {
-    if (slot >= CROSSWIRE_MAX_BROKERS) return false;
+    if (slot >= OFFBAND_MAX_BROKERS) return false;
     char ns[16];
     mqttBrokerNamespace(slot, ns, sizeof(ns));
     Preferences p;
@@ -143,7 +143,7 @@ bool writeBrokerConfig(uint8_t slot, const BrokerConfig& cfg) {
 // (the old value persists), which left `mqtt clear` ineffective -- the slot
 // re-appeared in `mqtt status` and survived a reboot. Wiping is definitive.
 bool clearBrokerConfig(uint8_t slot) {
-    if (slot >= CROSSWIRE_MAX_BROKERS) return false;
+    if (slot >= OFFBAND_MAX_BROKERS) return false;
     char ns[16];
     mqttBrokerNamespace(slot, ns, sizeof(ns));
     Preferences p;
@@ -232,7 +232,7 @@ void populateDefaultBrokers() {
     }
 
     for (uint8_t slot = 0;
-         slot < kNumDefaultBrokers && slot < CROSSWIRE_MAX_BROKERS; ++slot) {
+         slot < kNumDefaultBrokers && slot < OFFBAND_MAX_BROKERS; ++slot) {
         BrokerConfig cur;
         readBrokerConfig(slot, cur);
         if (cur.url[0] != '\0') {
@@ -360,4 +360,4 @@ size_t formatBrokerConfig(uint8_t slot, const BrokerConfig& cfg,
 
 #undef CW_VIEW_APPEND
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/ConfigSchema.h
+++ b/src/helpers/wifi_observer/ConfigSchema.h
@@ -1,6 +1,6 @@
 // src/helpers/wifi_observer/ConfigSchema.h
 //
-// Single source of truth for Crosswire observer NVS keys. All
+// Single source of truth for Offband observer NVS keys. All
 // observer-subsystem reads/writes flow through the typed accessors
 // below; raw Preferences calls are forbidden in observer code so
 // typos in key names cannot drift across files.
@@ -13,7 +13,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-namespace crosswire {
+namespace offband {
 
 // ---------------------------------------------------------------------------
 // Namespaces
@@ -75,7 +75,7 @@ void writeGlobalIata(const char* iata);
 uint16_t readStatusIntervalSec();
 void     writeStatusIntervalSec(uint16_t seconds);
 
-// Broker-slot accessors. Slot range [0, CROSSWIRE_MAX_BROKERS).
+// Broker-slot accessors. Slot range [0, OFFBAND_MAX_BROKERS).
 // Returns sensible defaults on read-miss (e.g., empty url, enabled=false,
 // transport=Tcp, port=1883).
 //
@@ -127,4 +127,4 @@ void populateDefaultBrokers();
 size_t formatBrokerConfig(uint8_t slot, const BrokerConfig& cfg,
                           char* out, size_t out_size);
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/CrashLog.cpp
+++ b/src/helpers/wifi_observer/CrashLog.cpp
@@ -21,7 +21,7 @@
   #include <freertos/task.h> // uxTaskGetStackHighWaterMark()
 #endif
 
-namespace crosswire {
+namespace offband {
 
 // ---------------------------------------------------------------------------
 // Reset-reason mapping
@@ -535,4 +535,4 @@ uint32_t bootCounterValue() { return 0; }
 
 #endif
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/CrashLog.h
+++ b/src/helpers/wifi_observer/CrashLog.h
@@ -28,7 +28,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-namespace crosswire {
+namespace offband {
 
 // ---------------------------------------------------------------------------
 // Reset-reason string mapping (Stage A)
@@ -162,4 +162,4 @@ void heartbeatTick(uint32_t now_ms);
 // deep-sleep wake / esptool hard reset.
 uint32_t bootCounterValue();
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/MqttAuth.cpp
+++ b/src/helpers/wifi_observer/MqttAuth.cpp
@@ -10,7 +10,7 @@
   #include <ctime>
 #endif
 
-namespace crosswire {
+namespace offband {
 
 // ---------------------------------------------------------------------------
 // MqttAuthNone -- no credentials, no refresh.
@@ -179,4 +179,4 @@ MqttAuth* makeAuth(const BrokerConfig& cfg
     }
 }
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/MqttAuth.h
+++ b/src/helpers/wifi_observer/MqttAuth.h
@@ -17,7 +17,7 @@
   #include <mqtt_client.h>       // esp_mqtt_client_config_t
 #endif
 
-namespace crosswire {
+namespace offband {
 
 // Abstract auth strategy. Two methods:
 //   apply() -- mutate the esp_mqtt config to install credentials.
@@ -104,4 +104,4 @@ MqttAuth* makeAuth(const BrokerConfig& cfg
 #endif
                   );
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/MqttBroker.cpp
+++ b/src/helpers/wifi_observer/MqttBroker.cpp
@@ -12,7 +12,7 @@
   #include "MqttCaCerts.h"  // embedded CA PEMs (Plan 1 vendored, retained)
 #endif
 
-namespace crosswire {
+namespace offband {
 
 #if defined(ARDUINO) && defined(ESP_PLATFORM)
 namespace {
@@ -453,4 +453,4 @@ void MqttBroker::onError(uint32_t now_ms, BrokerErrorClass err) {
 
 #endif  // ARDUINO && ESP_PLATFORM
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/MqttBroker.h
+++ b/src/helpers/wifi_observer/MqttBroker.h
@@ -18,7 +18,7 @@
   #include "freertos/semphr.h"
 #endif
 
-namespace crosswire {
+namespace offband {
 
 enum class BrokerState : uint8_t {
     Down        = 0,  // disabled OR not yet attempted
@@ -145,4 +145,4 @@ uint32_t brokerBackoffMs(uint32_t retry_count);
 // uses system trust store or skips TLS verify).
 const char* lookupCaCertPem(const char* name);
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -11,7 +11,7 @@
   #include <Arduino.h>
 #endif
 
-namespace crosswire {
+namespace offband {
 
 // ---------------------------------------------------------------------------
 // begin
@@ -42,7 +42,7 @@ void MqttBrokerPool::begin(const mesh::LocalIdentity& identity,
 
     // Create per-broker client locks + clear reconcile flags BEFORE the
     // worker task starts -- runs single-threaded on loopTask here (#53).
-    for (uint8_t slot = 0; slot < CROSSWIRE_MAX_BROKERS; ++slot) {
+    for (uint8_t slot = 0; slot < OFFBAND_MAX_BROKERS; ++slot) {
         brokers_[slot].initLock();
         reconciling_[slot] = false;
     }
@@ -50,7 +50,7 @@ void MqttBrokerPool::begin(const mesh::LocalIdentity& identity,
     // Initialize each configured slot. begin() stores config always and
     // creates a live client ONLY if the slot is enabled (#53); disabled or
     // url-empty slots stay client-less.
-    for (uint8_t slot = 0; slot < CROSSWIRE_MAX_BROKERS; ++slot) {
+    for (uint8_t slot = 0; slot < OFFBAND_MAX_BROKERS; ++slot) {
         BrokerConfig cfg;
         if (!readBrokerConfig(slot, cfg)) continue;
         if (cfg.url[0] == '\0') continue;  // skip unused slots
@@ -63,7 +63,7 @@ void MqttBrokerPool::begin(const mesh::LocalIdentity& identity,
     // on MQTT for any reason (Strycher/Crosswire#53). Created once; lives for
     // the device's life (pool.begin() is one-shot, guarded upstream).
     worker_run_  = true;
-    reconcile_q_ = xQueueCreate(CROSSWIRE_MAX_BROKERS * 2, sizeof(uint8_t));
+    reconcile_q_ = xQueueCreate(OFFBAND_MAX_BROKERS * 2, sizeof(uint8_t));
     if (reconcile_q_ != nullptr) {
         xTaskCreatePinnedToCore(&MqttBrokerPool::workerTrampoline, "mqtt_worker",
                                 6144, this, 5, &worker_task_, tskNO_AFFINITY);
@@ -86,7 +86,7 @@ void MqttBrokerPool::shutdown() {
         xQueueSend(reconcile_q_, &sentinel, 0);  // wake worker so it can exit
     }
 #endif
-    for (uint8_t slot = 0; slot < CROSSWIRE_MAX_BROKERS; ++slot) {
+    for (uint8_t slot = 0; slot < OFFBAND_MAX_BROKERS; ++slot) {
         brokers_[slot].shutdown();
     }
 }
@@ -121,7 +121,7 @@ void MqttBrokerPool::setStatusSnapshot(const MqttStatusSnapshot& snap) {
 uint8_t MqttBrokerPool::publishPacket(const uint8_t* payload, size_t payload_len) {
     if (payload == nullptr || payload_len == 0) return 0;
     uint8_t accepted = 0;
-    for (uint8_t slot = 0; slot < CROSSWIRE_MAX_BROKERS; ++slot) {
+    for (uint8_t slot = 0; slot < OFFBAND_MAX_BROKERS; ++slot) {
         if (reconciling_[slot]) continue;  // #53: skip slots mid-reconcile
         MqttBroker& b = brokers_[slot];
         if (!b.isConfigured() || b.runtime().state != BrokerState::Up) continue;
@@ -181,7 +181,7 @@ uint8_t MqttBrokerPool::publishRawFromBytes(const uint8_t* raw, size_t raw_len,
 
     // Fan-out per broker with their own iata + topic_prefix.
     uint8_t accepted = 0;
-    for (uint8_t slot = 0; slot < CROSSWIRE_MAX_BROKERS; ++slot) {
+    for (uint8_t slot = 0; slot < OFFBAND_MAX_BROKERS; ++slot) {
         if (reconciling_[slot]) continue;  // #53: skip slots mid-reconcile
         MqttBroker& b = brokers_[slot];
         if (!b.isConfigured() || b.runtime().state != BrokerState::Up) continue;
@@ -259,7 +259,7 @@ void MqttBrokerPool::publishStatusIfDue(uint32_t now_ms) {
     }
 
     char status_buf[1024];
-    for (uint8_t slot = 0; slot < CROSSWIRE_MAX_BROKERS; ++slot) {
+    for (uint8_t slot = 0; slot < OFFBAND_MAX_BROKERS; ++slot) {
         if (reconciling_[slot]) continue;  // #53: skip slots mid-reconcile
         MqttBroker& b = brokers_[slot];
         if (!b.isConfigured() || b.runtime().state != BrokerState::Up) continue;
@@ -287,7 +287,7 @@ void MqttBrokerPool::publishStatusIfDue(uint32_t now_ms) {
 // reloadSlot -- uses cached identity_ from begin()
 // ---------------------------------------------------------------------------
 bool MqttBrokerPool::reloadSlot(uint8_t slot) {
-    if (slot >= CROSSWIRE_MAX_BROKERS) return false;
+    if (slot >= OFFBAND_MAX_BROKERS) return false;
 #if defined(ARDUINO) && defined(ESP_PLATFORM)
     // #53: NON-BLOCKING. Mark the slot reconciling (loopTask skips it from
     // here on) and hand it to the worker, which does the actual begin/shutdown
@@ -318,7 +318,7 @@ void MqttBrokerPool::workerTrampoline(void* arg) {
 // (begin() may stop+destroy+recreate the esp_mqtt client); runs ONLY on the
 // worker task. begin() creates a client only if the slot is enabled.
 void MqttBrokerPool::reconcileSlot(uint8_t slot) {
-    if (slot >= CROSSWIRE_MAX_BROKERS || identity_ == nullptr) return;
+    if (slot >= OFFBAND_MAX_BROKERS || identity_ == nullptr) return;
     BrokerConfig cfg;
     if (!readBrokerConfig(slot, cfg) || cfg.url[0] == '\0') {
         brokers_[slot].shutdown();   // no/empty config -> ensure no client
@@ -336,7 +336,7 @@ void MqttBrokerPool::workerLoop() {
         bool got = (xQueueReceive(reconcile_q_, &slot, pdMS_TO_TICKS(500)) == pdTRUE);
         if (!worker_run_) break;
 
-        if (got && slot < CROSSWIRE_MAX_BROKERS) {
+        if (got && slot < OFFBAND_MAX_BROKERS) {
             reconcileSlot(slot);
             reconciling_[slot] = false;  // hand the slot back to loopTask
         }
@@ -347,7 +347,7 @@ void MqttBrokerPool::workerLoop() {
         // the same slot serializes safely (and loopTask only publishes to Up
         // slots, never one the worker is connect-blocking on).
         uint32_t now = millis();
-        for (uint8_t s = 0; s < CROSSWIRE_MAX_BROKERS; ++s) {
+        for (uint8_t s = 0; s < OFFBAND_MAX_BROKERS; ++s) {
             if (reconciling_[s]) continue;
             MqttBroker& b = brokers_[s];
             if (!b.isConfigured()) continue;
@@ -370,7 +370,7 @@ void MqttBrokerPool::workerLoop() {
 // ---------------------------------------------------------------------------
 uint8_t MqttBrokerPool::configuredCount() const {
     uint8_t n = 0;
-    for (uint8_t i = 0; i < CROSSWIRE_MAX_BROKERS; ++i) {
+    for (uint8_t i = 0; i < OFFBAND_MAX_BROKERS; ++i) {
         if (brokers_[i].isConfigured()) n++;
     }
     return n;
@@ -378,7 +378,7 @@ uint8_t MqttBrokerPool::configuredCount() const {
 
 uint8_t MqttBrokerPool::enabledCount() const {
     uint8_t n = 0;
-    for (uint8_t i = 0; i < CROSSWIRE_MAX_BROKERS; ++i) {
+    for (uint8_t i = 0; i < OFFBAND_MAX_BROKERS; ++i) {
         if (brokers_[i].isConfigured() && brokers_[i].config().enabled) n++;
     }
     return n;
@@ -386,10 +386,10 @@ uint8_t MqttBrokerPool::enabledCount() const {
 
 uint8_t MqttBrokerPool::upCount() const {
     uint8_t n = 0;
-    for (uint8_t i = 0; i < CROSSWIRE_MAX_BROKERS; ++i) {
+    for (uint8_t i = 0; i < OFFBAND_MAX_BROKERS; ++i) {
         if (brokers_[i].runtime().state == BrokerState::Up) n++;
     }
     return n;
 }
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/MqttBrokerPool.h
+++ b/src/helpers/wifi_observer/MqttBrokerPool.h
@@ -1,6 +1,6 @@
 // src/helpers/wifi_observer/MqttBrokerPool.h
 //
-// Plan 2 v2 Task 8: owns up to CROSSWIRE_MAX_BROKERS MqttBroker instances.
+// Plan 2 v2 Task 8: owns up to OFFBAND_MAX_BROKERS MqttBroker instances.
 // Loads each from NVS via ConfigSchema. Schedules connect attempts
 // (staggered by slot index). Fan-out publish + periodic /status.
 
@@ -23,7 +23,7 @@
 // buildPacketJson, so the forward declaration is sufficient here.
 namespace mesh { class Packet; }
 
-namespace crosswire {
+namespace offband {
 
 class MqttBrokerPool {
 public:
@@ -108,12 +108,12 @@ private:
 #ifdef ARDUINO
     const mesh::LocalIdentity* identity_ = nullptr;
 #endif
-    MqttBroker brokers_[CROSSWIRE_MAX_BROKERS];
+    MqttBroker brokers_[OFFBAND_MAX_BROKERS];
 
     // Per-slot guard: true while the lifecycle worker is creating/destroying
     // that slot's client. loopTask publish/status paths SKIP reconciling slots
     // so they never wait on the worker's blocking teardown (#53).
-    volatile bool reconciling_[CROSSWIRE_MAX_BROKERS] = {false};
+    volatile bool reconciling_[OFFBAND_MAX_BROKERS] = {false};
 
 #if defined(ARDUINO) && defined(ESP_PLATFORM)
     // Lifecycle worker: owns ALL blocking esp_mqtt ops so loopTask never
@@ -148,4 +148,4 @@ private:
     void publishStatusIfDue(uint32_t now_ms);
 };
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/MqttPayload.cpp
+++ b/src/helpers/wifi_observer/MqttPayload.cpp
@@ -20,7 +20,7 @@
   #include <target.h>        // `board` global (getManufacturerName())
 #endif
 
-namespace crosswire {
+namespace offband {
 
 // ---------------------------------------------------------------------------
 // Helpers — ported verbatim from MqttUplink.cpp:371-456
@@ -346,4 +346,4 @@ int buildRawJson(char* buf, size_t buf_size,
 
 #endif  // ARDUINO
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/MqttPayload.h
+++ b/src/helpers/wifi_observer/MqttPayload.h
@@ -1,6 +1,6 @@
 // src/helpers/wifi_observer/MqttPayload.h
 //
-// Shared payload + topic builders for the Crosswire observer broker pool.
+// Shared payload + topic builders for the Offband observer broker pool.
 // All brokers (vendored + custom) call these same functions; per-broker
 // variation is via the MqttPayloadCtx argument, not via class state.
 //
@@ -22,7 +22,7 @@ namespace mesh {
     class Packet;
 }
 
-namespace crosswire {
+namespace offband {
 
 // Re-export the same status snapshot shape the vendored MqttUplink used,
 // to keep MeshCore main.cpp's snapshot-build code unchanged when Task 11
@@ -117,4 +117,4 @@ void escapeJsonString(const char* input, char* output, size_t output_size);
 // Used for the "model" field in status JSON.
 void makeSafeToken(const char* input, char* output, size_t output_size);
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -16,7 +16,7 @@
   #include <WiFi.h>          // WiFi.localIP() for get wifi.status
 #endif
 
-namespace crosswire {
+namespace offband {
 
 // ---------------------------------------------------------------------------
 // Small utilities
@@ -44,7 +44,7 @@ static const char* skipPrefix(const char* s, const char* prefix) {
 static int parseSlot(const char* s) {
     if (s == nullptr || *s < '0' || *s > '9') return -1;
     int v = (int)strtol(s, nullptr, 10);
-    if (v < 0 || v >= CROSSWIRE_MAX_BROKERS) return -1;
+    if (v < 0 || v >= OFFBAND_MAX_BROKERS) return -1;
     return v;
 }
 
@@ -100,7 +100,7 @@ static const char* stateStr(BrokerState s) {
 static bool handleStatus(char* reply, size_t reply_size, MqttBrokerPool& pool) {
     int n = snprintf(reply, reply_size, "mqtt: configured=%u enabled=%u up=%u\n",
                      pool.configuredCount(), pool.enabledCount(), pool.upCount());
-    for (uint8_t slot = 0; slot < CROSSWIRE_MAX_BROKERS; ++slot) {
+    for (uint8_t slot = 0; slot < OFFBAND_MAX_BROKERS; ++slot) {
         const MqttBroker& b = pool.broker(slot);
         if (!b.isConfigured()) continue;
         if (n < 0 || (size_t)n >= reply_size) break;
@@ -579,7 +579,7 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
             int slot = parseSlot(en_rest);
             if (slot < 0) {
                 snprintf(reply, reply_size, "ERROR: usage: mqtt enable <0..%d>\n",
-                         CROSSWIRE_MAX_BROKERS - 1);
+                         OFFBAND_MAX_BROKERS - 1);
                 return true;
             }
             return handleEnableSet(reply, reply_size, pool, slot, true);
@@ -589,7 +589,7 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
             int slot = parseSlot(dis_rest);
             if (slot < 0) {
                 snprintf(reply, reply_size, "ERROR: usage: mqtt disable <0..%d>\n",
-                         CROSSWIRE_MAX_BROKERS - 1);
+                         OFFBAND_MAX_BROKERS - 1);
                 return true;
             }
             return handleEnableSet(reply, reply_size, pool, slot, false);
@@ -599,7 +599,7 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
             int slot = parseSlot(view_rest);
             if (slot < 0) {
                 snprintf(reply, reply_size, "ERROR: usage: mqtt view <0..%d>\n",
-                         CROSSWIRE_MAX_BROKERS - 1);
+                         OFFBAND_MAX_BROKERS - 1);
                 return true;
             }
             return handleViewBroker(reply, reply_size, slot);
@@ -609,7 +609,7 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
             int slot = parseSlot(clr_rest);
             if (slot < 0) {
                 snprintf(reply, reply_size, "ERROR: usage: mqtt clear <0..%d>\n",
-                         CROSSWIRE_MAX_BROKERS - 1);
+                         OFFBAND_MAX_BROKERS - 1);
                 return true;
             }
             return handleClearBroker(reply, reply_size, pool, slot);
@@ -665,7 +665,7 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
             if (slot < 0) {
                 snprintf(reply, reply_size,
                          "ERROR: usage: get mqtt.broker.<0..%d>.<key>\n",
-                         CROSSWIRE_MAX_BROKERS - 1);
+                         OFFBAND_MAX_BROKERS - 1);
                 return true;
             }
             while (*p >= '0' && *p <= '9') p++;  // past slot digit(s)
@@ -725,7 +725,7 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
         int slot = parseSlot(p);
         if (slot < 0) {
             snprintf(reply, reply_size, "ERROR: usage: set mqtt.broker.<0..%d>.<key> <value>\n",
-                     CROSSWIRE_MAX_BROKERS - 1);
+                     OFFBAND_MAX_BROKERS - 1);
             return true;
         }
         // Skip past the slot digit(s)
@@ -748,4 +748,4 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
     return false;
 }
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/ObserverCli.h
+++ b/src/helpers/wifi_observer/ObserverCli.h
@@ -2,13 +2,13 @@
 //
 // Plan 2 v2 Task 10: serial CLI commands for mqtt config.
 // Single entry point dispatchObserverCli(); CommonCLI calls it from its
-// fall-through under #ifdef CROSSWIRE_OBSERVER.
+// fall-through under #ifdef OFFBAND_OBSERVER.
 
 #pragma once
 #include "MqttBrokerPool.h"
 #include <stddef.h>
 
-namespace crosswire {
+namespace offband {
 
 // Parses + dispatches "mqtt"-prefixed commands. Returns true if handled
 // (reply populated with result/error), false if the command wasn't an
@@ -39,8 +39,8 @@ namespace crosswire {
 //
 // All "set" commands write to NVS via ConfigSchema and call
 // pool.reloadSlot(N) if a per-slot field changed. Slot range [0,
-// CROSSWIRE_MAX_BROKERS).
+// OFFBAND_MAX_BROKERS).
 bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
                          MqttBrokerPool& pool);
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/ObserverPipeline.cpp
+++ b/src/helpers/wifi_observer/ObserverPipeline.cpp
@@ -9,7 +9,7 @@
   #include <Arduino.h>
 #endif
 
-namespace crosswire {
+namespace offband {
 
 void ObserverPipeline::begin(MqttBrokerPool* pool) {
     pool_  = pool;
@@ -55,4 +55,4 @@ void observerLogRxParsedTrampoline(const mesh::Packet& packet, int rssi,
     observerPipeline().onParsedReceived(packet, rssi, snr, score, duration);
 }
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/ObserverPipeline.h
+++ b/src/helpers/wifi_observer/ObserverPipeline.h
@@ -9,8 +9,8 @@
 //     raw RX, BEFORE Packet construction. Already virtual on Dispatcher
 //     (declared empty default) -- MyMesh overrides at MyMesh.cpp:282 to
 //     forward to the serial interface.
-//   * We extend MyMesh::logRxRaw to ALSO invoke crosswire's trampoline
-//     when CROSSWIRE_OBSERVER is defined. Non-observer builds unaffected.
+//   * We extend MyMesh::logRxRaw to ALSO invoke offband's trampoline
+//     when OFFBAND_OBSERVER is defined. Non-observer builds unaffected.
 //   * Hook point gives us raw bytes + rssi + snr cleanly. Does NOT give
 //     us a parsed mesh::Packet -- the Dispatcher constructs Packet AFTER
 //     logRxRaw. So Plan 2 v2 publishes via /raw topic only (buildRawJson
@@ -23,7 +23,7 @@
 #include "WifiObserverConfig.h"
 #include "MqttBrokerPool.h"
 
-namespace crosswire {
+namespace offband {
 
 class ObserverPipeline {
 public:
@@ -50,15 +50,15 @@ private:
 ObserverPipeline& observerPipeline();
 
 // C-style trampoline that MyMesh::logRxRaw calls under
-// #ifdef CROSSWIRE_OBSERVER. Delegates to observerPipeline().onRawReceived.
+// #ifdef OFFBAND_OBSERVER. Delegates to observerPipeline().onRawReceived.
 // Signature deliberately matches the logRxRaw shape so the wiring at the
 // call site is a one-liner.
 void observerLogRxTrampoline(float snr, float rssi, const uint8_t* raw, int len);
 
-// C-style trampoline that MyMesh::logRx calls under #ifdef CROSSWIRE_OBSERVER
+// C-style trampoline that MyMesh::logRx calls under #ifdef OFFBAND_OBSERVER
 // (Strycher/LoRa#335). Delegates to observerPipeline().onParsedReceived for
 // the /packets publish path.
 void observerLogRxParsedTrampoline(const mesh::Packet& packet, int rssi,
                                    float snr, int score, int duration);
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/README.md
+++ b/src/helpers/wifi_observer/README.md
@@ -1,7 +1,7 @@
 # src/helpers/wifi_observer/
 
-This subsystem implements the Crosswire WiFi+MQTT observer stack. It is
-gated behind the `CROSSWIRE_OBSERVER` preprocessor flag and compiled into
+This subsystem implements the Offband WiFi+MQTT observer stack. It is
+gated behind the `OFFBAND_OBSERVER` preprocessor flag and compiled into
 the `*_companion_observer_wifi` env variants (V3/V4/XIAO).
 
 ## Vendored origin
@@ -14,16 +14,16 @@ The files `MqttUplink.{cpp,h}`, `MqttPrefs.{cpp,h}`, `MqttCaCerts.h`, and
 - Commit: `374d6aa87a0123514d05b607310266a0c6a86b6a`
 - Date:   `2026-05-23 20:44:45 +1000`
 
-Renamed at vendoring time to match Crosswire's mixed-case header
+Renamed at vendoring time to match Offband's mixed-case header
 convention (`MqttUplink` instead of `MQTTUplink`, etc.). The actual
 file copy + rename happens in Plan 1 Task 3; the C++ class-name rename
 happens in Plan 1 Task 4 as an isolated diff.
 
 EastMesh is itself a fork of upstream <https://github.com/meshcore-dev/MeshCore>,
-which is the same upstream Crosswire forks from. License inheritance is
+which is the same upstream Offband forks from. License inheritance is
 identical (see `meshcore-firmware/license.txt`).
 
-## Native to Crosswire (not vendored)
+## Native to Offband (not vendored)
 
 - `WifiObserverConfig.h` -- compile-time constants (Plan 1 Task 6)
 - `WifiBootstrap.{cpp,h}` -- AP-mode + STA + serial CLI rescue (Plan 1 Task 9)
@@ -34,6 +34,6 @@ identical (see `meshcore-firmware/license.txt`).
 Per #210 (Crosswire fork architectural restructure) and the
 WiFi+BLE Observer design spec (2026-05-24), the vendored EastMesh code
 is a starting point. Future iterations will progressively rewrite these
-files for Crosswire-native idioms and remove the EastMesh dependency
-entirely. New code added in Plan 1+ MUST be Crosswire-native, even when
+files for Offband-native idioms and remove the EastMesh dependency
+entirely. New code added in Plan 1+ MUST be Offband-native, even when
 it sits next to vendored files.

--- a/src/helpers/wifi_observer/SystemChannelCli.cpp
+++ b/src/helpers/wifi_observer/SystemChannelCli.cpp
@@ -42,7 +42,7 @@
   #include <helpers/ChannelDetails.h>
 #endif
 
-namespace crosswire {
+namespace offband {
 
 // ---------------------------------------------------------------------------
 // Pure logic. Always compiled.
@@ -198,7 +198,7 @@ void systemChannelDrain() {
 
 #ifdef ARDUINO
 
-}  // namespace crosswire
+}  // namespace offband
 
 // External reference to the global MyMesh instance defined in
 // examples/companion_radio/MyMesh.cpp at translation-unit scope
@@ -208,7 +208,7 @@ void systemChannelDrain() {
 // channel API which the cast below reaches through.
 extern class MyMesh the_mesh;
 
-namespace crosswire {
+namespace offband {
 
 bool systemChannelInit(const mesh::Identity& self_id) {
     // Derive what we WANT slot 40 to look like.
@@ -342,4 +342,4 @@ void systemChannelPostStatus(const char* /*fmt*/, ...) {}
 
 #endif  // ARDUINO
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/SystemChannelCli.h
+++ b/src/helpers/wifi_observer/SystemChannelCli.h
@@ -44,7 +44,7 @@ namespace mesh {
 class Identity;
 }  // namespace mesh
 
-namespace crosswire {
+namespace offband {
 
 // Reserved _sys slot = the LAST channel slot (MAX_GROUP_CHANNELS - 1).
 // Observer envs set MAX_GROUP_CHANNELS via -D (Phase-1 strip #42: =11 ->
@@ -118,7 +118,7 @@ void systemChannelDrain();
 
 // ---------------------------------------------------------------------------
 // Intercepts (called from MyMesh::handleCmdFrame() under
-// CROSSWIRE_OBSERVER_BLE_COMPANION).
+// OFFBAND_OBSERVER_BLE_COMPANION).
 // ---------------------------------------------------------------------------
 
 // Handle a CMD_SEND_CHANNEL_TXT_MSG whose channel_idx is
@@ -195,4 +195,4 @@ void deriveSystemChannelName(const uint8_t pubkey[32], char* out_name,
 bool systemChannelRateAllows(uint32_t last_post_ms, uint32_t now_ms,
                              uint32_t min_interval_ms);
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/WifiBootstrap.cpp
+++ b/src/helpers/wifi_observer/WifiBootstrap.cpp
@@ -2,7 +2,7 @@
 #include "WifiBootstrap.h"
 #include "WifiObserverConfig.h"
 
-#ifdef CROSSWIRE_OBSERVER_BLE_COMPANION
+#ifdef OFFBAND_OBSERVER_BLE_COMPANION
 // Plan 3 Task 10 (Strycher/LoRa#272): system channel for first-
 // contact WiFi setup (welcome message on no-creds, IP + mDNS
 // hostname on STA connect). Only compiled in for BLE-companion
@@ -23,14 +23,14 @@
   #include <esp_wifi.h>      // esp_wifi_set_ps() -- companion to coex tuning
 #endif
 
-namespace crosswire {
+namespace offband {
 
 // -------------------------------------------------------------------------
 // SSID derivation -- pure function, host-testable.
 // -------------------------------------------------------------------------
 void WifiBootstrap::deriveApSsid(const uint8_t* mac_bytes, char* out,
                                  size_t out_len) {
-    // Format: "Crosswire-Observer-XXXXXX" where XXXXXX = last 6 hex
+    // Format: "Offband-Observer-XXXXXX" where XXXXXX = last 6 hex
     // chars of MAC. Total: 19 (prefix) + 6 (hex) + 1 (NUL) = 26 bytes.
     const size_t needed = 26;
     if (out_len < needed) {
@@ -46,7 +46,7 @@ void WifiBootstrap::deriveApSsid(const uint8_t* mac_bytes, char* out,
         hex[i * 2 + 1] = H[tail[i] & 0x0F];
     }
     hex[6] = '\0';
-    snprintf(out, out_len, "%s%s", CROSSWIRE_AP_SSID_PREFIX, hex);
+    snprintf(out, out_len, "%s%s", OFFBAND_AP_SSID_PREFIX, hex);
 }
 
 // -------------------------------------------------------------------------
@@ -86,7 +86,7 @@ void WifiBootstrap::begin() {
                        "system-channel CLI commands "
                        "(set wifi.ssid + set wifi.pwd).");
         state_ = WifiBootstrapState::ApMode;  // semantic kept; no softAP started
-#ifdef CROSSWIRE_OBSERVER_BLE_COMPANION
+#ifdef OFFBAND_OBSERVER_BLE_COMPANION
         // Plan 3 Task 10 replaces the originally-planned softAP +
         // captive form path. The welcome message is enqueued and
         // posted as soon as MyMesh::loop() runs systemChannelDrain,
@@ -94,7 +94,7 @@ void WifiBootstrap::begin() {
         // no captive portal, no Wi-Fi switching on the user's
         // phone -- they type commands in the channel that's
         // already paired with their MeshCore app.
-        crosswire::systemChannelPostStatus(
+        offband::systemChannelPostStatus(
             "Welcome! To set WiFi: send 'set wifi.ssid YourSSID' "
             "then 'set wifi.pwd YourPSK' as messages in this channel. "
             "Use 'wifi status' to check.");
@@ -134,7 +134,7 @@ void WifiBootstrap::loop() {
                 state_ = WifiBootstrapState::StaConnected;
                 Serial.printf("[WifiBootstrap] STA connected; IP=%s\n",
                               WiFi.localIP().toString().c_str());
-#ifdef CROSSWIRE_OBSERVER_BLE_COMPANION
+#ifdef OFFBAND_OBSERVER_BLE_COMPANION
                 // Plan 3 Task 10 (Strycher/LoRa#272): post the IP +
                 // mDNS hostname so the user immediately sees how to
                 // reach the web UI without having to dig through
@@ -172,7 +172,7 @@ bool WifiBootstrap::isStaConnected() const {
     return state_ == WifiBootstrapState::StaConnected;
 }
 
-#ifdef CROSSWIRE_OBSERVER_BLE_COMPANION
+#ifdef OFFBAND_OBSERVER_BLE_COMPANION
 // Borrowed from WifiObserver -- the cached identity pubkey, set
 // by wifiObserverSetMeshContext (called from main.cpp after
 // the_mesh.begin). May be nullptr if STA happens to come up
@@ -196,16 +196,16 @@ void WifiBootstrap::postStaConnectedStatus() {
             hex[i * 2 + 1] = H[pk[i] & 0x0F];
         }
         hex[8] = '\0';
-        crosswire::systemChannelPostStatus(
+        offband::systemChannelPostStatus(
             "WiFi connected. IP %s -- https://meshcore-%s.local/",
             WiFi.localIP().toString().c_str(), hex);
     } else {
-        crosswire::systemChannelPostStatus(
+        offband::systemChannelPostStatus(
             "WiFi connected. IP %s",
             WiFi.localIP().toString().c_str());
     }
 }
-#endif  // CROSSWIRE_OBSERVER_BLE_COMPANION
+#endif  // OFFBAND_OBSERVER_BLE_COMPANION
 
 WifiBootstrap& wifiBootstrap() {
     static WifiBootstrap inst;
@@ -224,4 +224,4 @@ WifiBootstrap& wifiBootstrap() {
 
 #endif  // ARDUINO
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/WifiBootstrap.h
+++ b/src/helpers/wifi_observer/WifiBootstrap.h
@@ -1,6 +1,6 @@
 // src/helpers/wifi_observer/WifiBootstrap.h
 //
-// Boot-time WiFi bootstrap for the Crosswire observer. Owns the
+// Boot-time WiFi bootstrap for the Offband observer. Owns the
 // AP-mode-vs-STA-vs-CLI-rescue decision and the AP-mode HTTP setup
 // form. Once WiFi is up, signals readiness via isStaConnected().
 
@@ -9,7 +9,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-namespace crosswire {
+namespace offband {
 
 enum class WifiBootstrapState : uint8_t {
     Boot,           // before begin() called
@@ -32,7 +32,7 @@ public:
     // True once STA is connected and the MQTT subsystem may start.
     bool isStaConnected() const;
 
-    // Returns "Crosswire-Observer-XXXXXX" using the last 6 hex chars
+    // Returns "Offband-Observer-XXXXXX" using the last 6 hex chars
     // of the device MAC. Static so it can be unit-tested without WiFi.
     // mac_bytes must point to 6 bytes (BSSID / WiFi.macAddress() raw).
     static void deriveApSsid(const uint8_t* mac_bytes, char* out, size_t out_len);
@@ -44,7 +44,7 @@ private:
     uint32_t sta_retry_count_ = 0;
     uint32_t last_attempt_ms_ = 0;
 
-#ifdef CROSSWIRE_OBSERVER_BLE_COMPANION
+#ifdef OFFBAND_OBSERVER_BLE_COMPANION
     // Plan 3 Task 10 (Strycher/LoRa#272): post the IP + mDNS
     // hostname onto the system channel on STA-connect transition.
     // Pulls the pubkey from wifiObserverPubKey() so the mDNS hex
@@ -61,4 +61,4 @@ private:
 // Singleton accessor. The whole subsystem assumes one instance.
 WifiBootstrap& wifiBootstrap();
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/WifiObserver.cpp
+++ b/src/helpers/wifi_observer/WifiObserver.cpp
@@ -17,7 +17,7 @@
   #include <esp_sntp.h>     // #87: esp_sntp_stop() once GPS owns the clock
 #endif
 
-namespace crosswire {
+namespace offband {
 
 // Singleton pool. ObserverCli + main.cpp's status snapshot updater
 // access via wifiObserverPool().
@@ -67,10 +67,10 @@ void wifiObserverBegin() {
     crashLogf("[WifiObserver] boot; reset_reason=%d (%s) version=%s",
               (int)esp_reset_reason(),
               resetReasonString((int)esp_reset_reason()),
-              CROSSWIRE_VERSION);
+              OFFBAND_VERSION);
 #else
     crashLogf("[WifiObserver] boot (host build) version=%s",
-              CROSSWIRE_VERSION);
+              OFFBAND_VERSION);
 #endif
 
     crashLogf("[WifiObserver] subsystem starting");
@@ -218,4 +218,4 @@ const uint8_t* wifiObserverPubKey() {
 #endif
 }
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/WifiObserver.h
+++ b/src/helpers/wifi_observer/WifiObserver.h
@@ -1,9 +1,9 @@
 // src/helpers/wifi_observer/WifiObserver.h
 //
-// Top-level entry point for the Crosswire observer subsystem. Owns
+// Top-level entry point for the Offband observer subsystem. Owns
 // the WifiBootstrap state machine and (Plan 2 v2) the MqttBrokerPool +
 // ObserverPipeline that publish observed LoRa traffic to up to
-// CROSSWIRE_MAX_BROKERS configured brokers.
+// OFFBAND_MAX_BROKERS configured brokers.
 //
 // Lifecycle on companion_radio/main.cpp:
 //   1. wifiObserverBegin()           -- from setup(), after Serial.begin().
@@ -25,7 +25,7 @@
   #include <Identity.h>          // mesh::LocalIdentity
 #endif
 
-namespace crosswire {
+namespace offband {
 
 // Call from setup(), after Serial.begin() but before any user-facing
 // operation. Does NOT block.
@@ -56,7 +56,7 @@ void wifiObserverSetStatusSnapshot(const MqttStatusSnapshot& snap);
 // (next task) can defer to GPS when the fix is locked.
 // enabled: true when GPS is configured on (prefs.gps_enabled).
 // locked:  true when the GPS provider reports a valid fix.
-// Call from loop() at ~1 Hz inside ENV_INCLUDE_GPS + CROSSWIRE_OBSERVER guards.
+// Call from loop() at ~1 Hz inside ENV_INCLUDE_GPS + OFFBAND_OBSERVER guards.
 void wifiObserverSetGpsTimeState(bool enabled, bool locked);
 
 // Singleton accessors -- exposed for ObserverCli + future Plan 3 web UI.
@@ -70,4 +70,4 @@ MqttBrokerPool& wifiObserverPool();
 // caller and consistent with how WebAuth borrows the same bytes.
 const uint8_t* wifiObserverPubKey();
 
-}  // namespace crosswire
+}  // namespace offband

--- a/src/helpers/wifi_observer/WifiObserverConfig.h
+++ b/src/helpers/wifi_observer/WifiObserverConfig.h
@@ -1,24 +1,24 @@
 // src/helpers/wifi_observer/WifiObserverConfig.h
 //
-// Compile-time configuration for the Crosswire WiFi+MQTT observer
+// Compile-time configuration for the Offband WiFi+MQTT observer
 // subsystem. Included by every translation unit under
 // src/helpers/wifi_observer/ to centralize tunables.
 //
-// Gated by CROSSWIRE_OBSERVER -- if undefined, the whole subsystem is
+// Gated by OFFBAND_OBSERVER -- if undefined, the whole subsystem is
 // compiled out. The flag is defined by env variants in
 // variants/<board>/platformio.ini under [env:<board>_*_observer_wifi].
 
 #pragma once
 
-#ifndef CROSSWIRE_OBSERVER
-  #error "WifiObserverConfig.h included without CROSSWIRE_OBSERVER defined. \
+#ifndef OFFBAND_OBSERVER
+  #error "WifiObserverConfig.h included without OFFBAND_OBSERVER defined. \
           Check env build_flags or remove the include."
 #endif
 
 // ---------------------------------------------------------------------------
 // Variant gate (companion vs. repeater)
 // ---------------------------------------------------------------------------
-// CROSSWIRE_OBSERVER_BLE_COMPANION is defined ONLY in companion variants.
+// OFFBAND_OBSERVER_BLE_COMPANION is defined ONLY in companion variants.
 // Plan 1 is companion-only so every Plan-1 env defines it; future repeater
 // observer envs (post-v1) will leave it undefined. The wifi_observer
 // subsystem itself is identical for both -- this flag is consumed by
@@ -34,7 +34,7 @@
 // MeshMapper + Eastmesh.au = 6 slots, slots 0-5) leave four free slots (6-9)
 // for operator-custom brokers.
 //
-// Static cost: MqttBrokerPool holds brokers_[CROSSWIRE_MAX_BROKERS], and
+// Static cost: MqttBrokerPool holds brokers_[OFFBAND_MAX_BROKERS], and
 // BrokerConfig is ~1.2 KB/slot (jwt_token[512] dominates), so 10 slots is
 // ~12 KB static. MEASURED fine even on no-PSRAM HV3: the Heltec_v3 observer
 // build uses 27.4% RAM (89.7 KB / 327 KB internal SRAM) with this at 10 --
@@ -48,16 +48,16 @@
 // The 6-broker default set already sits near that ceiling, so configuring the
 // custom slots 6-9 can truncate the tail of `mqtt status` on the _sys surface
 // until that buffer is paged/enlarged (tracked in #98).
-#ifndef CROSSWIRE_MAX_BROKERS
-  #define CROSSWIRE_MAX_BROKERS 10
+#ifndef OFFBAND_MAX_BROKERS
+  #define OFFBAND_MAX_BROKERS 10
 #endif
 
 // ---------------------------------------------------------------------------
 // AP-mode SSID prefix
 // ---------------------------------------------------------------------------
 // SSID broadcast in first-boot AP mode: <prefix>-<MAC last 6 hex chars>.
-// Per spec: "Crosswire-Observer-XXXXXX".
-#define CROSSWIRE_AP_SSID_PREFIX  "Crosswire-Observer-"
+// Per spec: "Offband-Observer-XXXXXX".
+#define OFFBAND_AP_SSID_PREFIX  "Offband-Observer-"
 
 // ---------------------------------------------------------------------------
 // Serial CLI rescue
@@ -65,21 +65,21 @@
 // Per spec: hold a designated button for 8 seconds during boot to enter
 // CLI Rescue mode. Boot window in milliseconds during which the button
 // press is sampled.
-#define CROSSWIRE_CLI_RESCUE_BOOT_WINDOW_MS  8000
+#define OFFBAND_CLI_RESCUE_BOOT_WINDOW_MS  8000
 
 // ---------------------------------------------------------------------------
-// Crosswire fork version (per VERSIONING.md Pattern B)
+// Offband fork version (per VERSIONING.md Pattern B)
 // ---------------------------------------------------------------------------
-// CROSSWIRE_VERSION is injected at build time by scripts/inject_crosswire_version.py
-// from `git describe --tags --match 'crosswire-v*' --abbrev=7 --dirty`. The
+// OFFBAND_VERSION is injected at build time by scripts/inject_offband_version.py
+// from `git describe --tags --match 'offband-v*' --abbrev=7 --dirty`. The
 // upstream baseline lives in MeshCore's FIRMWARE_VERSION (set per-example in
-// MyMesh.h). Every Crosswire-aware log line / banner / UI surface should
+// MyMesh.h). Every Offband-aware log line / banner / UI surface should
 // expose BOTH identifiers per VERSIONING.md Pattern B:
-//   "MC <FIRMWARE_VERSION> / Crosswire <CROSSWIRE_VERSION>"
+//   "MC <FIRMWARE_VERSION> / Offband <OFFBAND_VERSION>"
 //
 // Host test builds don't invoke the PIO extra_script, so provide a sentinel
 // fallback here. Real device builds always have the macro injected and this
 // branch is never taken.
-#ifndef CROSSWIRE_VERSION
-  #define CROSSWIRE_VERSION  "host-untagged"
+#ifndef OFFBAND_VERSION
+  #define OFFBAND_VERSION  "host-untagged"
 #endif

--- a/src/helpers/wifi_telemetry/WifiTelemetry.cpp
+++ b/src/helpers/wifi_telemetry/WifiTelemetry.cpp
@@ -254,9 +254,9 @@ size_t WifiTelemetry::buildStatePayload(char* buf, size_t buflen, const Telemetr
         snprintf(last_snr_str, sizeof(last_snr_str), "%.2f", d.last_snr_db);
     }
 
-    // FF4 (#181 / LoRa-8wv): state payload includes upstream + Crosswire
-    // identity fields. CROSSWIRE_* defines come from build-time injection
-    // by scripts/inject_crosswire_version.py (FF2 / #179). _fw_version and
+    // FF4 (#181 / LoRa-8wv): state payload includes upstream + Offband
+    // identity fields. OFFBAND_* defines come from build-time injection
+    // by scripts/inject_offband_version.py (FF2 / #179). _fw_version and
     // _fw_build_date were already constructor-supplied per upstream design.
     int n = snprintf(buf, buflen,
         "{\"battery_mv\":%u,"
@@ -276,10 +276,10 @@ size_t WifiTelemetry::buildStatePayload(char* buf, size_t buflen, const Telemetr
         "\"timestamp\":%lu,"
         "\"upstream_version\":\"%s\","
         "\"upstream_build_date\":\"%s\","
-        "\"crosswire_version\":\"%s\","
-        "\"crosswire_git_sha\":\"%s\","
-        "\"crosswire_branch\":\"%s\","
-        "\"crosswire_build_date\":\"%s\","
+        "\"offband_version\":\"%s\","
+        "\"offband_git_sha\":\"%s\","
+        "\"offband_branch\":\"%s\","
+        "\"offband_build_date\":\"%s\","
         "\"wifi_on_pct_24h\":%u.%02u}",
         (unsigned)d.battery_mv,
         (unsigned)d.battery_pct,
@@ -298,10 +298,10 @@ size_t WifiTelemetry::buildStatePayload(char* buf, size_t buflen, const Telemetr
         (unsigned long)d.timestamp,
         _fw_version ? _fw_version : "unknown",
         _fw_build_date ? _fw_build_date : "unknown",
-        CROSSWIRE_VERSION,
-        CROSSWIRE_GIT_SHA,
-        CROSSWIRE_BRANCH,
-        CROSSWIRE_BUILD_DATE,
+        OFFBAND_VERSION,
+        OFFBAND_GIT_SHA,
+        OFFBAND_BRANCH,
+        OFFBAND_BUILD_DATE,
         (unsigned)(d.wifi_on_pct_24h_x100 / 100),
         (unsigned)(d.wifi_on_pct_24h_x100 % 100));
 
@@ -364,18 +364,18 @@ size_t WifiTelemetry::buildScalarDiscoveryPayload(char* buf, size_t buflen,
     // Compose sw_version string: "v1.15.0 (12 May 2026)" if both supplied, else
     // just the version.
     // FF4 (#181 / LoRa-8wv): compose sw_version with both upstream MeshCore
-    // baseline AND Crosswire fork identity. CROSSWIRE_VERSION is injected as
-    // a build-time -D macro by scripts/inject_crosswire_version.py (FF2 / #179).
+    // baseline AND Offband fork identity. OFFBAND_VERSION is injected as
+    // a build-time -D macro by scripts/inject_offband_version.py (FF2 / #179).
     // See VERSIONING.md for the dual-version scheme rationale.
     char sw_version[96];
     if (_fw_version && _fw_build_date) {
-        snprintf(sw_version, sizeof(sw_version), "MC %s (%s) / Crosswire %s",
-                 _fw_version, _fw_build_date, CROSSWIRE_VERSION);
+        snprintf(sw_version, sizeof(sw_version), "MC %s (%s) / Offband %s",
+                 _fw_version, _fw_build_date, OFFBAND_VERSION);
     } else if (_fw_version) {
-        snprintf(sw_version, sizeof(sw_version), "MC %s / Crosswire %s",
-                 _fw_version, CROSSWIRE_VERSION);
+        snprintf(sw_version, sizeof(sw_version), "MC %s / Offband %s",
+                 _fw_version, OFFBAND_VERSION);
     } else {
-        snprintf(sw_version, sizeof(sw_version), "Crosswire %s", CROSSWIRE_VERSION);
+        snprintf(sw_version, sizeof(sw_version), "Offband %s", OFFBAND_VERSION);
     }
 
     // Entity name is JUST the sensor's short name (e.g. "Battery Voltage").
@@ -390,7 +390,7 @@ size_t WifiTelemetry::buildScalarDiscoveryPayload(char* buf, size_t buflen,
         "%s%s%s"
         "%s%s%s"
         "%s%s%s"
-        "\"dev\":{\"ids\":[\"%s\"],\"name\":\"%s\",\"mf\":\"Crosswire\",\"mdl\":\"Repeater\",\"sw_version\":\"%s\",\"hw_version\":\"%s\",\"cu\":\"https://github.com/Strycher/MeshCore\"}}",
+        "\"dev\":{\"ids\":[\"%s\"],\"name\":\"%s\",\"mf\":\"Offband\",\"mdl\":\"Repeater\",\"sw_version\":\"%s\",\"hw_version\":\"%s\",\"cu\":\"https://github.com/Strycher/MeshCore\"}}",
         name,
         _node_id, sensor_id,
         state_topic,
@@ -436,18 +436,18 @@ size_t WifiTelemetry::buildNeighborsSummaryDiscoveryPayload(char* buf, size_t bu
     buildNeighborsTopic(state_topic, sizeof(state_topic));
 
     // FF4 (#181 / LoRa-8wv): compose sw_version with both upstream MeshCore
-    // baseline AND Crosswire fork identity. CROSSWIRE_VERSION is injected as
-    // a build-time -D macro by scripts/inject_crosswire_version.py (FF2 / #179).
+    // baseline AND Offband fork identity. OFFBAND_VERSION is injected as
+    // a build-time -D macro by scripts/inject_offband_version.py (FF2 / #179).
     // See VERSIONING.md for the dual-version scheme rationale.
     char sw_version[96];
     if (_fw_version && _fw_build_date) {
-        snprintf(sw_version, sizeof(sw_version), "MC %s (%s) / Crosswire %s",
-                 _fw_version, _fw_build_date, CROSSWIRE_VERSION);
+        snprintf(sw_version, sizeof(sw_version), "MC %s (%s) / Offband %s",
+                 _fw_version, _fw_build_date, OFFBAND_VERSION);
     } else if (_fw_version) {
-        snprintf(sw_version, sizeof(sw_version), "MC %s / Crosswire %s",
-                 _fw_version, CROSSWIRE_VERSION);
+        snprintf(sw_version, sizeof(sw_version), "MC %s / Offband %s",
+                 _fw_version, OFFBAND_VERSION);
     } else {
-        snprintf(sw_version, sizeof(sw_version), "Crosswire %s", CROSSWIRE_VERSION);
+        snprintf(sw_version, sizeof(sw_version), "Offband %s", OFFBAND_VERSION);
     }
 
     // Text-state sensor, no stat_cla (so no graph). Default entity category
@@ -458,7 +458,7 @@ size_t WifiTelemetry::buildNeighborsSummaryDiscoveryPayload(char* buf, size_t bu
         "\"uniq_id\":\"%s_neighbors_summary\","
         "\"stat_t\":\"%s\","
         "\"val_tpl\":\"{{ value_json.summary }}\","
-        "\"dev\":{\"ids\":[\"%s\"],\"name\":\"%s\",\"mf\":\"Crosswire\",\"mdl\":\"Repeater\",\"sw_version\":\"%s\",\"hw_version\":\"%s\",\"cu\":\"https://github.com/Strycher/MeshCore\"}}",
+        "\"dev\":{\"ids\":[\"%s\"],\"name\":\"%s\",\"mf\":\"Offband\",\"mdl\":\"Repeater\",\"sw_version\":\"%s\",\"hw_version\":\"%s\",\"cu\":\"https://github.com/Strycher/MeshCore\"}}",
         _node_id,
         state_topic,
         _node_id,

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -394,7 +394,7 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
 ; ---------------------------------------------------------------------------
-; Crosswire WiFi+MQTT Observer env (Plan 1, companion-only)
+; Offband WiFi+MQTT Observer env (Plan 1, companion-only)
 ; ---------------------------------------------------------------------------
 ; Extends Heltec_v3_companion_radio_ble (BLE peripheral companion variant)
 ; and layers the wifi_observer subsystem on top. WiFi is owned by our
@@ -430,8 +430,8 @@ build_flags =
   ${env:Heltec_v3_companion_radio_ble.build_flags}
   -DMAX_GROUP_CHANNELS=11
   -Wno-builtin-macro-redefined
-  -D CROSSWIRE_OBSERVER
-  -D CROSSWIRE_OBSERVER_BLE_COMPANION
+  -D OFFBAND_OBSERVER
+  -D OFFBAND_OBSERVER_BLE_COMPANION
   -D WITH_MQTT_UPLINK
   -D MAX_CONTACTS=50
   -D OFFLINE_QUEUE_SIZE=16

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -525,7 +525,7 @@ lib_deps =
   ${esp32_ota.lib_deps}
 
 ; ---------------------------------------------------------------------------
-; Crosswire WiFi+MQTT Observer env (Plan 1, companion-only)
+; Offband WiFi+MQTT Observer env (Plan 1, companion-only)
 ; ---------------------------------------------------------------------------
 ; See variants/heltec_v3/platformio.ini for the rationale block on why we
 ; extend _ble (BLE peripheral) rather than _wifi (WiFi-transport companion)
@@ -547,8 +547,8 @@ build_flags =
   ${env:heltec_v4_companion_radio_ble.build_flags}
   -DMAX_GROUP_CHANNELS=11
   -Wno-builtin-macro-redefined
-  -D CROSSWIRE_OBSERVER
-  -D CROSSWIRE_OBSERVER_BLE_COMPANION
+  -D OFFBAND_OBSERVER
+  -D OFFBAND_OBSERVER_BLE_COMPANION
   -D WITH_MQTT_UPLINK
   -D MAX_CONTACTS=50
   -D OFFLINE_QUEUE_SIZE=16

--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -239,7 +239,7 @@ lib_deps =
   ${esp32_ota.lib_deps}
 
 ; ---------------------------------------------------------------------------
-; Crosswire WiFi+MQTT Observer env (Plan 1, companion-only)
+; Offband WiFi+MQTT Observer env (Plan 1, companion-only)
 ; ---------------------------------------------------------------------------
 ; See variants/heltec_v3/platformio.ini for the rationale block on why we
 ; extend _ble (BLE peripheral) rather than _wifi (WiFi-transport companion)
@@ -261,8 +261,8 @@ build_flags =
   ${env:Xiao_S3_WIO_companion_radio_ble.build_flags}
   -DMAX_GROUP_CHANNELS=11
   -Wno-builtin-macro-redefined
-  -D CROSSWIRE_OBSERVER
-  -D CROSSWIRE_OBSERVER_BLE_COMPANION
+  -D OFFBAND_OBSERVER
+  -D OFFBAND_OBSERVER_BLE_COMPANION
   -D WITH_MQTT_UPLINK
   -D MAX_CONTACTS=50
   -D OFFLINE_QUEUE_SIZE=16


### PR DESCRIPTION
Rebrands the firmware fork from Crosswire to Offband (GitHub org OffbandMesh) -- code + docs. Implements the firmware portion of #100 (now closed); the owner-side infra cutover (org/repo/board/Citadel/Agent-Mail/working-dir + CLAUDE.md/governance docs) is tracked in #107.

## Commits
- b1c57229 Phase 2 -- code, version/identity, CI
- efa83ed0 Phase 3 -- product docs

## What changed
- Identifiers: crosswire:: -> offband::, CROSSWIRE_* -> OFFBAND_*, XWIRE_* -> OBND_* (build-checked).
- Identity fields: crosswire_* -> offband_* across producer (firmware_identity.py) + all consumers (pio-flash, ota-push, WifiTelemetry MQTT payload), in lockstep.
- Version: git describe --match offband-v* (release.yml keeps legacy crosswire-v* too); fallback offband-untagged; OLED splash prefix offband-.
- Brand display: serial banner, version command, OLED splash, Home Assistant manufacturer; WiFi setup-AP SSID Crosswire-Observer- -> Offband-Observer-.
- Renamed scripts inject_offband_version.py + test_offband_version_splash.py; CI release.yml dual-prefix + ci.yml offband-dev- artifact.
- Docs: README, CHANGELOG (+ [Unreleased] entry), VERSIONING (rewritten: offband-v go-forward, crosswire-v0.5.0..0.16.0 history preserved), operator guides, observer README, issue templates.

## Intentionally preserved (NOT renamed)
- crosswire-sysch-v1 (_sys PSK domain separator -- renaming de-pairs devices)
- the meshcore MQTT topic prefix + meshcore-<hex> device name (upstream/interop namespace)
- Strycher/Crosswire#NN issue refs + repo URLs (GitHub redirects after the rename)
- historical crosswire-v* release tags; NVS namespaces

## Verification
- 6/6 CI envs build locally (ESP32 + nRF52)
- OBND_ on-wire identity blob round-trips to offband_* keys on real binaries
- host specs pass (splash + SSID derivation)
- Gemini reviewed twice (code 0 blocker/major; docs review caught + fixed bare Crosswire#NN refs)
- gitleaks clean on the staged diff

Generated with Claude Code