### PR TITLE
chore(#107): finish OffbandMesh local cutover (preflight, CLAUDE.md, board #1)

### DIFF
--- a/.claude/hooks/preflight.sh
+++ b/.claude/hooks/preflight.sh
@@ -19,7 +19,7 @@
 set -euo pipefail
 
 # ─── Project-specific overrides (edit these) ──────────────────────────────
-PROJECT_DIR="/c/Dev/Crosswire"
+PROJECT_DIR="/c/Dev/meshcore-firmware"
 # ──────────────────────────────────────────────────────────────────────────
 
 CITADEL_HEALTH="https://getunfocused.app/citadel/health"

--- a/.github/workflows/sync-labels-to-board.yml
+++ b/.github/workflows/sync-labels-to-board.yml
@@ -5,8 +5,8 @@ name: Sync Labels to Project Board
 # This Action translates those labels into board field updates.
 #
 # Requires repo secret PROJECT_PAT: a PAT with `project` + `repo` scope that can
-# write to the user-level Crosswire Project Board (#14). The default GITHUB_TOKEN
-# is repo-scoped and CANNOT mutate a user-owned Projects v2 board.
+# write to the OffbandMesh org-level Project Board (#1). The default GITHUB_TOKEN
+# is repo-scoped and CANNOT mutate an org-owned Projects v2 board.
 on:
   issues:
     types: [labeled, closed]
@@ -40,26 +40,26 @@ jobs:
         with:
           github-token: ${{ secrets.PROJECT_PAT }}
           script: |
-            // ── Project field IDs (Crosswire Project Board, project #14) ──
-            const PROJECT_ID = 'PVT_kwHODGcOBc4BZuj8';
+            // ── Project field IDs (OffbandMesh org board, project #1) ──
+            const PROJECT_ID = 'PVT_kwDOEXsS3c4BaleW';
 
-            const STATUS_FIELD_ID = 'PVTSSF_lAHODGcOBc4BZuj8zhUrOWo';
+            const STATUS_FIELD_ID = 'PVTSSF_lADOEXsS3c4BaleWzhVcBL8';
             const STATUS_OPTIONS = {
-              'board:backlog':     '21424ffd',  // Backlog
-              'board:todo':        'e440428b',  // Todo
-              'board:ready':       '1bbb2e8b',  // Ready
-              'board:in-progress': '7f81218e',  // In Progress
-              'board:testing':     '8275aca6',  // Testing
-              'board:deferred':    'c6ce415d',  // Deferred
-              'board:done':        'da0f8be7',  // Done
+              'board:backlog':     '91d35710',  // Backlog
+              'board:todo':        '7bf7b9ef',  // Todo
+              'board:ready':       'ec816a33',  // Ready
+              'board:in-progress': 'ee71a6e3',  // In Progress
+              'board:testing':     '3dc70fe4',  // Testing
+              'board:deferred':    'fc4959bc',  // Deferred
+              'board:done':        '4a67db65',  // Done
             };
 
-            const PRIORITY_FIELD_ID = 'PVTSSF_lAHODGcOBc4BZuj8zhUrPDQ';
+            const PRIORITY_FIELD_ID = 'PVTSSF_lADOEXsS3c4BaleWzhVcBMs';
             const PRIORITY_OPTIONS = {
-              'priority:P0': '4c4b0f45',
-              'priority:P1': '48f7b50e',
-              'priority:P2': '1a66b940',
-              'priority:P3': 'a5ffd218',
+              'priority:P0': '43b5c396',
+              'priority:P1': '40c7b471',
+              'priority:P2': '3ed2b368',
+              'priority:P3': '2406bdd1',
             };
 
             // ── Determine what triggered us ─────────────────────────

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ hardware-devices.yaml
 # per-host flash audit log + full-flash backups (device MACs/DeviceIDs) -- never commit
 flash-history.jsonl
 flash-backups/
+
+# local scratch working dir -- untracked for now (#107)
+weather/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Crosswire -- Project CLAUDE.md
+# Offband (meshcore-firmware) -- Project CLAUDE.md
 
 > **Read and follow [`C:\Dev\DifferentWire\standards\SAFELANE.md`](../../DifferentWire/standards/SAFELANE.md). No exceptions.**
 > **Read and follow [`C:\Dev\DifferentWire\standards\CLAUDE-BASE.md`](../../DifferentWire/standards/CLAUDE-BASE.md). No exceptions.**
@@ -7,52 +7,55 @@ These two documents are the canonical inheritance for this project. Anything bel
 
 ---
 
-## What Crosswire is
+## What Offband is
 
-A standalone MIT fork of [MeshCore](https://github.com/meshcore-dev/MeshCore) for cross-role firmware enhancements and optimization (companion/observer + repeater active; room/bridge not yet). See `README.md`.
+Offband is a standalone MIT fork of [MeshCore](https://github.com/meshcore-dev/MeshCore) for cross-role firmware enhancements and optimization (companion/observer + repeater active; room/bridge not yet). Firmware repo: **`OffbandMesh/meshcore-firmware`**. See `README.md`.
 
-## Project identity (READ FIRST -- do NOT conflate with LoRa)
+> Formerly **Crosswire** — the product was rebranded to **Offband** (#100) and the repo moved `Strycher/Crosswire` → `OffbandMesh/meshcore-firmware` (#107, 2026-06-13). The **Citadel project and Agent-Mail key intentionally keep the legacy `Crosswire` name** (Citadel has no project-rename/batch-move — DifferentWire/citadel#81; renaming would strand 80+ tasks and the `Crosswire-xxx` short-ids). The name mismatch is cosmetic.
 
-Crosswire is its **own** project. `Strycher/LoRa` is the **separate personal origin** repo; the Crosswire fork is no longer part of LoRa. For ALL work in `C:\Dev\Crosswire` (including worktrees under `.worktrees/*`):
+## Project identity (READ FIRST)
+
+This firmware is **Offband**, repo **`OffbandMesh/meshcore-firmware`**, working dir **`C:\Dev\meshcore-firmware`**. For ALL work here (including worktrees):
 
 | Channel | Value |
 |---|---|
-| Citadel | `DW_PROJECT=Crosswire` (Strycher/Crosswire). **Never** `LoRa`. |
-| GitHub issues/PRs | `Strycher/Crosswire` |
-| Agent Mail `project_key` | **`app-c-dev-crosswire`** (path slug of `C:\Dev\Crosswire`). Register + send + read HERE. NOT `app-c-dev-lora` (the LoRa workspace), NOT `app-crosswire` (stray), NOT `app-c-dev-lora-crosswire` (RETIRED 2026-06-10 — pitched in the relocation). |
-| Active agents (2026-06-10) | RedCreek (active). DustyFox archived after its 1.16.0 base-update assessment merged. HazyForest is on the separate `Strycher/meshcore-open` client fork, not this project. |
+| Citadel | **`DW_PROJECT=Crosswire` — MANDATORY to export.** The git hooks default the project to the repo basename (`meshcore-firmware`), which is NOT a Citadel project, so commits/pushes fail unless `DW_PROJECT=Crosswire` is set. **Never** `LoRa`. (worktree project-resolution bug: #22.) |
+| GitHub issues/PRs | `OffbandMesh/meshcore-firmware` |
+| GitHub Project board | OffbandMesh org board **#1** (`PVT_kwDOEXsS3c4BaleW`) |
+| Agent Mail `project_key` | **`app-c-dev-crosswire`** — register + send + read HERE. Register with `register_agent(project_key="app-c-dev-crosswire", ...)` directly; do **NOT** `ensure_project` on the path (would mint a stray `app-c-dev-meshcore-firmware` and break coordination). NOT `app-c-dev-lora`, NOT `app-crosswire`. |
+| Do NOT conflate | `Strycher/LoRa` (separate personal origin repo) and `Strycher/meshcore-open` (separate client fork — not this project). |
 
-Worktrees coordinate in the SAME `app-c-dev-crosswire` (resolve from the repo common dir, not the worktree path). The stale "in-flight firmware work tracked under the LoRa Citadel project" note in Migration status below is RETIRED: net-new Crosswire work is tracked under Crosswire (Citadel) + Strycher/Crosswire (issues) + `app-c-dev-crosswire` (Agent Mail).
+Worktrees coordinate in the SAME `app-c-dev-crosswire` (resolve from the repo common dir, not the worktree path).
 
 ## Project Parameters
 
 | Parameter | Value |
 |-----------|-------|
-| `PROJECT_NAME` | Crosswire |
-| `PROJECT_DIR` | `C:\Dev\Crosswire` (standalone repo; relocated out of the LoRa workspace 2026-06-10) |
+| `PROJECT_NAME` | Offband (Citadel project + `DW_PROJECT` = `Crosswire`; see Project identity) |
+| `PROJECT_DIR` | `C:\Dev\meshcore-firmware` (renamed from `C:\Dev\Crosswire` 2026-06-13, #107) |
 | `INFRA_PROFILE` | Maker |
-| `BUILD_COMMAND` | `pio run -e <env>` (run from this repo's working tree at `C:\Dev\Crosswire`) |
+| `BUILD_COMMAND` | `pio run -e <env>` (run from this repo's working tree at `C:\Dev\meshcore-firmware`) |
 | `DEPLOY_TARGET` | Device flash over USB / OTA (no SCP deploy; firmware is flashed, not server-deployed) |
-| `CITADEL_PROJECT` | `Crosswire` (Strycher/Crosswire) |
-| `GITHUB_PROJECT_ID` | `PVT_kwHODGcOBc4BZuj8` (Project #14, "Crosswire Project Board") |
+| `CITADEL_PROJECT` | `Crosswire` (now → `OffbandMesh/meshcore-firmware`; name kept, citadel#81). Always `DW_PROJECT=Crosswire`. |
+| `GITHUB_PROJECT_ID` | `PVT_kwDOEXsS3c4BaleW` (OffbandMesh org board #1) |
 | `AGENT_MAIL_STATUS` | Canonical git hooks installed (preflight, pre-commit, post-commit, pre-push, commit-msg, block-direct-citadel-db). Firmware flash/OTA/agent-mail PreToolUse hooks PORTED (P5.2): block-raw-flash, block-raw-curl-ota, require-agent-mail-check (registered in `.claude/settings.json`). |
 
-## Project board field IDs (project #14)
+## Project board field IDs (OffbandMesh org board #1)
 
 Recorded per REPOCONFIG (board field IDs captured in project CLAUDE.md). Consumed by `.github/workflows/sync-labels-to-board.yml`.
 
-- `PROJECT_ID` = `PVT_kwHODGcOBc4BZuj8`
-- Status field `PVTSSF_lAHODGcOBc4BZuj8zhUrOWo`: backlog `21424ffd`, todo `e440428b`, ready `1bbb2e8b`, in-progress `7f81218e`, testing `8275aca6`, deferred `c6ce415d`, done `da0f8be7`
-- Priority field `PVTSSF_lAHODGcOBc4BZuj8zhUrPDQ`: P0 `4c4b0f45`, P1 `48f7b50e`, P2 `1a66b940`, P3 `a5ffd218`
+- `PROJECT_ID` = `PVT_kwDOEXsS3c4BaleW`
+- Status field `PVTSSF_lADOEXsS3c4BaleWzhVcBL8`: backlog `91d35710`, todo `7bf7b9ef`, ready `ec816a33`, in-progress `ee71a6e3`, testing `3dc70fe4`, deferred `fc4959bc`, done `4a67db65`
+- Priority field `PVTSSF_lADOEXsS3c4BaleWzhVcBMs`: P0 `43b5c396`, P1 `40c7b471`, P2 `3ed2b368`, P3 `2406bdd1`
 
-**Required secret:** the sync workflow needs repo secret `PROJECT_PAT` (PAT with `project` + `repo` scope) — the default `GITHUB_TOKEN` cannot mutate a user-owned Projects v2 board. Not yet set as of board creation (2026-06-04).
+**Required secret:** the sync workflow needs repo secret `PROJECT_PAT` (PAT with `project` + `repo` scope) — the default `GITHUB_TOKEN` cannot mutate an org-owned Projects v2 board. Set it on `OffbandMesh/meshcore-firmware`; the existing `GITHUB_PERSONAL_ACCESS_TOKEN` (classic; `project`+`repo`) already covers it. **Not yet set** as of 2026-06-13 — workflow inert until then.
 
 ## Migration status (IMPORTANT for agents)
 
-**Firmware has migrated here.** `firmware-base` (this repo's default branch) is the canonical Crosswire firmware tree. The old `crosswire` branch of `Strycher/MeshCore` is retired and that **fork is archived** (2026-06-04, read-only; reversible via `gh repo unarchive`). Full history is preserved in this repo: branches (patch-id verified), all `crosswire-v*` release tags + `archive/*` tags, and Plan 3 (see Preserved artifacts). Design-of-record: `docs/architecture/2026-06-01-observer-architecture-review.md`.
+**Firmware has migrated here.** `firmware-base` (this repo's default branch) is the canonical Offband (meshcore-firmware) firmware tree. The old `crosswire` branch of `Strycher/MeshCore` is retired and that **fork is archived** (2026-06-04, read-only; reversible via `gh repo unarchive`). Full history is preserved in this repo: branches (patch-id verified), all `crosswire-v*` release tags + `archive/*` tags, and Plan 3 (see Preserved artifacts). Design-of-record: `docs/architecture/2026-06-01-observer-architecture-review.md`.
 
-Working-tree cutover COMPLETE (Strycher/Crosswire#10, 2026-06-10) -- the legacy `meshcore-firmware` clone is **retired/deleted**:
-- **Build/flash run from THIS repo's working tree** (`C:\Dev\Crosswire`). Upstream MeshCore remotes live here: `upstream` = meshcore-dev/MeshCore and `iotthinks`, both **fetch-only** (`no-push`); `origin` = Strycher/Crosswire (push). `firmware-base` is a self-contained MeshCore fork (full `src/` tree), so future upstream merges (e.g. the deferred 1.16.0 base-update) fetch + merge directly here. Firmware work is tracked under the **Crosswire** Citadel project + Strycher/Crosswire issues (legacy Strycher/LoRa firmware issues are being migrated).
+Working-tree cutover COMPLETE (OffbandMesh/meshcore-firmware#10, 2026-06-10) -- the legacy pre-relocation clone is **retired/deleted** (distinct from the current `C:\Dev\meshcore-firmware` working dir, which was `C:\Dev\Crosswire` until the 2026-06-13 rename):
+- **Build/flash run from THIS repo's working tree** (`C:\Dev\meshcore-firmware`). Upstream MeshCore remotes live here: `upstream` = meshcore-dev/MeshCore and `iotthinks`, both **fetch-only** (`no-push`); `origin` = OffbandMesh/meshcore-firmware (push). `firmware-base` is a self-contained MeshCore fork (full `src/` tree), so future upstream merges (e.g. the deferred 1.16.0 base-update) fetch + merge directly here. Firmware work is tracked under the **Crosswire** Citadel project + OffbandMesh/meshcore-firmware issues.
 - **Net-new Crosswire requests / bugs / design-of-record are filed here** under the **Crosswire** Citadel project.
 - **Flash discipline PORTED (P5.2):** `scripts/pio-flash` (+`.py`), `scripts/ota-push.py`, and the `block-raw-flash` / `block-raw-curl-ota` / `require-agent-mail-check` PreToolUse hooks live in this repo. The device registry `hardware-devices.yaml` is **gitignored** (per-host; holds LAN IPs/MACs) — copy `hardware-devices.example.yaml` to `hardware-devices.yaml` and populate it before flashing from this repo.
 
@@ -64,7 +67,7 @@ Intentionally-kept tags/branches that are **NOT on the build line** and must **N
 |---|---|---|---|
 | `archive/plan3-web-ui-crash-fixture` | tag (→ `447cf206`) | Plan 3 observer web UI / HTTPS / web auth / AP setup — 7 file-pairs (WebServer, WebApi, WebUiAssets, WebAuth, WebSession, WebCertStore, ApSetupForm) + the `Strycher/LoRa#282` heap fix. Deferred dead-path (heap/TLS instability, `Strycher/LoRa#281/#282/#312`). Kept for salvageable code **and** as a deliberate crash/boot-cycle fixture for SafeBoot / rapid-reboot recovery testing (`Strycher/LoRa#264/#265/#267`). | `git checkout -b plan3-revive archive/plan3-web-ui-crash-fixture` |
 
-Decision record: **Strycher/Crosswire#5** (closed, preserved-by-design). Do not casually merge any of these into `firmware-base`.
+Decision record: **OffbandMesh/meshcore-firmware#5** (closed, preserved-by-design). Do not casually merge any of these into `firmware-base`.
 
 ## Security
 
@@ -75,9 +78,9 @@ Decision record: **Strycher/Crosswire#5** (closed, preserved-by-design). Do not 
 ## Follow-ups (bootstrap gaps to close)
 
 - `/work` slash command + `session-state.py` compaction-recovery hook: **now published canonically** (standards @27b3ec7 — `/work` #112, `session-state.py` #107). `/work` auto-syncs into `.claude/commands/` via preflight; `session-state.py` is a hook copy-in (not auto-synced). Port deferred by owner — do when picked up.
-- Projects-v2 board + `sync-labels-to-board.yml` workflow: **DONE (2026-06-04)** — board #14 created, `board:*`/`priority:*` labels created, workflow committed + validated. Remaining: set repo secret `PROJECT_PAT` (workflow inert until then); board-view column grouping is a one-click UI step.
+- Projects-v2 board + `sync-labels-to-board.yml` workflow: re-pointed to **OffbandMesh org board #1** (2026-06-13, #107; was Strycher board #14). Remaining: set repo secret `PROJECT_PAT` on `OffbandMesh/meshcore-firmware` (workflow inert until then); board-view column grouping is a one-click UI step.
 - `ci.yml`: **DONE (2026-06-04)** — matrix CI added + green (6 envs). Firmware flash/OTA hooks: **PORTED (P5.2).**
 
 ---
 
-**Last updated:** 2026-06-10 (active-agents roster corrected post-relocation: RedCreek active in `app-c-dev-crosswire`, DustyFox archived, HazyForest on the separate meshcore-open fork).
+**Last updated:** 2026-06-13 (#107 OffbandMesh cutover: repo → `OffbandMesh/meshcore-firmware`, working dir → `C:\Dev\meshcore-firmware`, board → OffbandMesh org #1, preflight path fixed; Citadel project + Agent-Mail key intentionally remain `Crosswire` / `app-c-dev-crosswire` — citadel#81).


### PR DESCRIPTION
Local-repo half of the Offband Phase 4-5 cutover (#107). The infra side (repo transfer → `OffbandMesh/meshcore-firmware`, Citadel re-point, OffbandMesh org board #1) was already done by the standards/governance session; this finishes the in-repo references.

## Changes
- **`.claude/hooks/preflight.sh`** — `PROJECT_DIR` `/c/Dev/Crosswire` → `/c/Dev/meshcore-firmware`. Fixes the SessionStart `fatal: not in a git directory`; preflight now exits 0.
- **`CLAUDE.md`** — identity/params → `OffbandMesh/meshcore-firmware`, working dir → `C:\Dev\meshcore-firmware`, board section → OffbandMesh org board **#1** field IDs; refreshed migration notes + last-updated.
- **`.github/workflows/sync-labels-to-board.yml`** — `PROJECT_ID` + Status/Priority field & option IDs re-pointed to board #1.
- **`.gitignore`** — add `weather/` scratch dir.

## Intentionally kept (not a miss)
- **Citadel project stays `Crosswire`**, short-ids stay `Crosswire-xxx` — Citadel has no rename/batch-move (`DifferentWire/citadel#81`). `DW_PROJECT=Crosswire` stays mandatory (hooks default to repo basename `meshcore-firmware`, which is not a Citadel project — see #22).
- **Agent-Mail key stays `app-c-dev-crosswire`** — coordination history lives there; CLAUDE.md documents registering via the slug directly.

## Action required (human)
- Set repo secret **`PROJECT_PAT`** on `OffbandMesh/meshcore-firmware` so the sync workflow can write to the org board. Existing `GITHUB_PERSONAL_ACCESS_TOKEN` (classic; `project`+`repo`) already covers it — no new PAT needed. Workflow is inert until set.

## Out of scope (follow-up)
- Several `docs/**` + `VERSIONING.md` files still reference `Strycher/Crosswire` (rebrand session left repo URLs for GitHub's redirect). Worth a later cleanup pass; untouched here.

## Verification
- `bash .claude/hooks/preflight.sh` → all checks pass, exit 0.
- `git diff` = exactly the 4 files above.

Closes #107