### PR TITLE
chore(#111): remove stale upstream CNAME (docs.meshcore.nz)

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-docs.meshcore.nz


### PR DESCRIPTION
Removes the repo-root `CNAME` (`docs.meshcore.nz`) inherited from the MeshCore fork — it pointed GitHub Pages at **upstream's** domain.

- Pages is disabled on this repo, so this was latent (no active publishing).
- No per-repo docs Pages planned; repo discoverability will be a links page on offband.org.

Closes #111