### PR TITLE
docs(#113): finish rebrand — Strycher/Crosswire refs + CLAUDE.md PROJECT_PAT note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Recorded per REPOCONFIG (board field IDs captured in project CLAUDE.md). Consume
 - Status field `PVTSSF_lADOEXsS3c4BaleWzhVcBL8`: backlog `91d35710`, todo `7bf7b9ef`, ready `ec816a33`, in-progress `ee71a6e3`, testing `3dc70fe4`, deferred `fc4959bc`, done `4a67db65`
 - Priority field `PVTSSF_lADOEXsS3c4BaleWzhVcBMs`: P0 `43b5c396`, P1 `40c7b471`, P2 `3ed2b368`, P3 `2406bdd1`
 
-**Required secret:** the sync workflow needs repo secret `PROJECT_PAT` (PAT with `project` + `repo` scope) — the default `GITHUB_TOKEN` cannot mutate an org-owned Projects v2 board. Set it on `OffbandMesh/meshcore-firmware`; the existing `GITHUB_PERSONAL_ACCESS_TOKEN` (classic; `project`+`repo`) already covers it. **Not yet set** as of 2026-06-13 — workflow inert until then.
+**Required secret:** the sync workflow needs repo secret `PROJECT_PAT` — a **classic** PAT with `project` + `repo` scope (the default `GITHUB_TOKEN` cannot mutate an org-owned Projects v2 board). ⚠ **Must be classic, not fine-grained:** OffbandMesh rejects fine-grained PATs with >366-day lifetime for org-Projects access, so `GITHUB_PERSONAL_ACCESS_TOKEN` (fine-grained) does **not** work (DifferentWire/standards#148). **Set + verified** 2026-06-14 (board sync confirmed live).
 
 ## Migration status (IMPORTANT for agents)
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -45,7 +45,7 @@ Between version tags, commits accumulate as `+N` dev builds (e.g.
 `offband-v0.16.0-4-gABCDEF` = 4 commits past the tag); each epic landing cuts a
 new tag. **Every landing updates `CHANGELOG.md`.**
 
-Tags are pushed to the **`origin` remote** (`Strycher/Crosswire`; moves to the
+Tags are pushed to the **`origin` remote** (`OffbandMesh/meshcore-firmware`; moves to the
 Offband org repo after the rename) and are accessible to all working trees of the
 fork.
 

--- a/docs/architecture/2026-06-08-position-to-map-pipeline-draft.md
+++ b/docs/architecture/2026-06-08-position-to-map-pipeline-draft.md
@@ -1,9 +1,9 @@
-<!-- DRAFT for owner review. Task Strycher/Crosswire#32, Epic #31, Feature #30. Author: CyanGate (claude-code). First pass: research + draft. Not a committed design-of-record until human sign-off (Epic #31 acceptance gate). -->
+<!-- DRAFT for owner review. Task #32, Epic #31, Feature #30. Author: CyanGate (claude-code). First pass: research + draft. Not a committed design-of-record until human sign-off (Epic #31 acceptance gate). -->
 
 # Position-to-Map Telemetry Pipeline -- Draft Architecture
 
 **Status:** DRAFT, first pass. Not yet design-of-record.
-**Feature:** Strycher/Crosswire#30 -- **Epic:** #31 -- **Task:** #32
+**Feature:** #30 -- **Epic:** #31 -- **Task:** #32
 **Scope:** Evaluate architecture and means. Hardware selection (antennas, enclosures, exact boards) is explicitly out of scope.
 
 ---

--- a/docs/assessments/2026-06-10-meshcore-1.16.0-base-update-impact.md
+++ b/docs/assessments/2026-06-10-meshcore-1.16.0-base-update-impact.md
@@ -4,7 +4,7 @@
 |---|---|
 | **Date** | 2026-06-10 |
 | **Author** | DustyFox (claude-opus-4-8) |
-| **Tracking** | Strycher/Crosswire#54 / Citadel `Crosswire-qzp` |
+| **Tracking** | #54 / Citadel `Crosswire-qzp` |
 | **Type** | Spike (read-only assessment; no migration performed) |
 | **Status** | For review |
 
@@ -50,7 +50,7 @@ All findings are commit-to-commit diffs against fetched upstream objects. **The 
 - **Current base:** `companion-v1.15.0` + 14 commits. Crosswire builds companion/observer + repeater (room/bridge not active), so the relevant upstream lines are `companion-v1.16.0` and `repeater-v1.16.0`.
 - **Target:** the 1.16.0 release line, currently == `upstream/main` tip.
 - **Delta to absorb:** **257 upstream commits.**
-- **Remotes available in the repo:** `origin` = Strycher/Crosswire (push), `upstream` = meshcore-dev (fetch), `iotthinks` = IoTThinks/MeshCore (fetch). "MeshCore 1.16.0" here = meshcore-dev's tags. (Open question 8.3 re: IoTThinks.)
+- **Remotes available in the repo:** `origin` = OffbandMesh/meshcore-firmware (push), `upstream` = meshcore-dev (fetch), `iotthinks` = IoTThinks/MeshCore (fetch). "MeshCore 1.16.0" here = meshcore-dev's tags. (Open question 8.3 re: IoTThinks.)
 
 ---
 

--- a/docs/handoffs/2026-06-10-observer-mqtt-session-handoff.md
+++ b/docs/handoffs/2026-06-10-observer-mqtt-session-handoff.md
@@ -17,11 +17,11 @@
 
 | Channel | Value |
 |---|---|
-| Firmware repo | `C:\Dev\LoRa\Crosswire` -- GitHub `Strycher/Crosswire`, default branch **`firmware-base`** |
+| Firmware repo | `C:\Dev\meshcore-firmware` -- GitHub `OffbandMesh/meshcore-firmware`, default branch **`firmware-base`** |
 | Citadel | `DW_PROJECT=Crosswire` (prefix every `dw` and `git commit` from a worktree). **Never** `LoRa`. |
 | Agent Mail | project_key **`app-c-dev-lora-crosswire`** (path slug). NOT `app-c-dev-lora`, NOT `app-crosswire`. |
 | Other agents | **DustyFox** (owns the deferred MeshCore 1.16.0 base-update), HazyForest (meshcore-open client fork -- separate). I was **RedCreek**. |
-| Upstream remotes on the repo | `upstream` = meshcore-dev/MeshCore, `iotthinks` -- both fetch-only (`no-push`). `origin` = Strycher/Crosswire (push). |
+| Upstream remotes on the repo | `upstream` = meshcore-dev/MeshCore, `iotthinks` -- both fetch-only (`no-push`). `origin` = OffbandMesh/meshcore-firmware (push). |
 
 `Strycher/LoRa` is the **separate personal origin** repo -- the Crosswire fork is no longer part of it. Bash sandbox blocks network; use `dangerouslyDisableSandbox: true` for git fetch/push/pull and any broker/Pi5 network call.
 
@@ -123,7 +123,7 @@ The owner explicitly flagged multiple SAFELANE failures this session. They were 
 
 1. `/refresh-context` (date, preflight, standards, Citadel, the 5 canonical docs) -- and actually read all 5.
 2. Register in Agent Mail `app-c-dev-lora-crosswire`, `fetch_inbox`, and reply to DustyFox if there's a pending thread.
-3. Confirm the `crosswire-v0.14.0` / `v0.15.0` GitHub Releases published (`gh release list -R Strycher/Crosswire`).
+3. Confirm the `crosswire-v0.14.0` / `v0.15.0` GitHub Releases published (`gh release list -R OffbandMesh/meshcore-firmware`).
 4. Pick from section 5 -- the natural next is the **#66/#67/#70 cosmetic-display fix** (one small PR, same `ObserverCli` status path) and/or pinging DustyFox to start the 1.16.0 merge.
 5. If returning to broker work: re-read section 4 and use the empirical-probe method, not guesses.
 

--- a/docs/observer-cli-commands.md
+++ b/docs/observer-cli-commands.md
@@ -5,7 +5,7 @@ MeshCore companion app (BLE) — type these as channel messages. The observer
 build has **no USB-serial text console**; the `_sys` channel is the management
 surface.
 
-## Grammar (Strycher/Crosswire#45)
+## Grammar (#45)
 
 Two shapes, consistently:
 

--- a/docs/plans/2026-06-03-observer-onto-safeboot-base-migration.md
+++ b/docs/plans/2026-06-03-observer-onto-safeboot-base-migration.md
@@ -6,7 +6,7 @@
 
 **Why this direction:** both branches are MeshCore **v1.15.0** (verified, identical `FIRMWARE_VERSION`). `crosswire` is a *shallow* clone (history truncated at the graft); `feature/safeboot` has full history + the rebrand + SafeBoot + the variant matrix. The observer feature set is smaller and largely additive, so moving it onto the richer base is less work and lands on the better base. No meaningful history loss (cherry-pick preserves content/message/author; only SHAs change; the GitHub PR/issue trail is independent; full upstream history is *gained*).
 
-**Architectural decision this forces (OWNER SIGN-OFF REQUIRED — see S6):** SafeBoot edits MeshCore core (`Mesh.cpp`, `NRF52Board.cpp`) + variant inis, so **Crosswire is a true MeshCore fork, not a "compose MeshCore as a dependency" consumer.** This *supersedes* the compose-not-inherit conclusion of the 2026-06-01 architecture review for the firmware-as-a-whole. The observer's decoupling (Session isolation, command bus, transport router) becomes an **internal refactor within the fork**, not a repo-boundary mechanism. The new `Strycher/Crosswire` repo therefore eventually holds the **full fork tree** (this unified base), not a thin consumer.
+**Architectural decision this forces (OWNER SIGN-OFF REQUIRED — see S6):** SafeBoot edits MeshCore core (`Mesh.cpp`, `NRF52Board.cpp`) + variant inis, so **Crosswire is a true MeshCore fork, not a "compose MeshCore as a dependency" consumer.** This *supersedes* the compose-not-inherit conclusion of the 2026-06-01 architecture review for the firmware-as-a-whole. The observer's decoupling (Session isolation, command bus, transport router) becomes an **internal refactor within the fork**, not a repo-boundary mechanism. The new `OffbandMesh/meshcore-firmware` repo therefore eventually holds the **full fork tree** (this unified base), not a thin consumer.
 
 **Overlap analysis (verified):** `feature/safeboot` has NO `wifi_observer`, NO `wifi_telemetry`, and a Bluedroid BLE stack. So: `wifi_observer`/`wifi_telemetry` port purely additively (new files, zero conflict); the NimBLE migration (#288) replays onto the same Bluedroid starting point it originally migrated from; the only real conflict hotspot is `examples/companion_radio/main.cpp` (SafeBoot's `setup()` hook vs observer init wiring).
 
@@ -61,7 +61,7 @@
 
 ## Phase 5 — Land as the canonical Crosswire firmware (Tier 2 — explicit approval) [GATE]
 
-- [ ] **5.1** Decide the canonical branch + how the unified tree becomes `Strycher/Crosswire`'s content (push as the repo's firmware = the "code migration" endpoint finally executed, now as a fork tree). See S6.
+- [ ] **5.1** Decide the canonical branch + how the unified tree becomes `OffbandMesh/meshcore-firmware`'s content (push as the repo's firmware = the "code migration" endpoint finally executed, now as a fork tree). See S6.
 - [ ] **5.2** Port the LoRa flash-discipline (`hardware-devices.yaml`, `pio-flash`, `block-raw-flash`/`block-raw-curl-ota`/`require-agent-mail-check` hooks) into Crosswire BEFORE any flash happens from it.
 - [ ] **5.3** On-hardware smoke test (ST-P V4 observer + an hv3 repeater) before declaring the base canonical. NO PR/merge without the owner's hands-on test.
 
@@ -69,7 +69,7 @@
 
 1. **Fork vs compose (load-bearing):** confirm Crosswire is a full MeshCore fork (SafeBoot requires it), superseding the compose-not-inherit firmware framing. The observer decoupling becomes internal.
 2. **Granular cherry-pick (recommended) vs squash-port** the observer delta.
-3. **When the unified base populates `Strycher/Crosswire`** (now, vs after build+hardware verify).
+3. **When the unified base populates `OffbandMesh/meshcore-firmware`** (now, vs after build+hardware verify).
 4. **#325/#327 disposition** — fold into the port, or keep as follow-on PRs against the new base.
 
 ## Rollback (whole migration)


### PR DESCRIPTION
Finishes the repo-rename doc cleanup (repo is now OffbandMesh/meshcore-firmware).

- 6 docs (VERSIONING.md + docs/architecture, assessments, handoffs, observer-cli-commands, plans): `Strycher/Crosswire` → `OffbandMesh/meshcore-firmware`; issue refs → bare `#N`; stale `C:\Dev\LoRa\Crosswire` → `C:\Dev\meshcore-firmware`.
- CLAUDE.md: corrects the `PROJECT_PAT` note — must be a **classic** PAT (org blocks fine-grained >366d; `GITHUB_PERSONAL_ACCESS_TOKEN` is fine-grained, rejected). Now set + verified.

Excluded: `docs/llm-consultations/*.log` (captured artifact). Code-comment `Strycher/Crosswire#` refs tracked in #114.

Closes #113