### PR TITLE
chore(#114): update stale Strycher/Crosswire# refs in code comments -> #N

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -383,7 +383,7 @@ void MyMesh::onContactOverwrite(const uint8_t* pub_key) {
     _store->deleteBlobByKey(pub_key, PUB_KEY_SIZE); // delete from storage
   // _serial is NULL during boot-time loadContacts (transport not set up yet);
   // guard it so the overwrite-oldest path during a populated-store load -- e.g.
-  // after MAX_CONTACTS is reduced (Strycher/Crosswire#42) -- does not NULL-deref.
+  // after MAX_CONTACTS is reduced (#42) -- does not NULL-deref.
   if (_serial && _serial->isConnected()) {
     out_frame[0] = PUSH_CODE_CONTACT_DELETED;
     memcpy(&out_frame[1], pub_key, PUB_KEY_SIZE);

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -76,7 +76,7 @@ public:
     // The commits-since suffix is identified by git's "-g<sha>" marker, NOT the
     // first dash. Splitting on the first dash (prior behavior) mis-read a
     // pre-release tag's "-rcN" as the commits field -> it dropped "-rcN" and
-    // showed a spurious "+0" (Strycher/Crosswire#33).
+    // showed a spurious "+0" (#33).
     const char *cw = OFFBAND_VERSION;
     static const char *cw_prefix = "offband-";
     if (strncmp(cw, cw_prefix, 8) == 0) cw += 8;
@@ -500,7 +500,7 @@ public:
 #if defined(ESP32) || defined(ESP_PLATFORM)
     // Heap readout was added for the ESP32 V3/V4 heap crisis; ESP.* is
     // ESP32-only, so guard it -- nRF52 companions otherwise fail to compile
-    // ('ESP' not declared). Strycher/Crosswire#8.
+    // ('ESP' not declared). #8.
     char heap_tmp[24];
     snprintf(heap_tmp, sizeof(heap_tmp), "Heap:%u", (unsigned)ESP.getFreeHeap());
     display.setTextSize(1);

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -5,7 +5,7 @@
 #include "MyMesh.h"
 
 #ifdef PIN_STATUS_LED
-  // Repeater heartbeat status LED (Strycher/Crosswire#9). Active-high default;
+  // Repeater heartbeat status LED (#9). Active-high default;
   // variants override LED_STATE_ON for active-low boards.
   #ifndef LED_STATE_ON
     #define LED_STATE_ON HIGH
@@ -959,7 +959,7 @@ void setup() {
 
 void loop() {
 #ifdef PIN_STATUS_LED
-  // Heartbeat: brief blip = alive (Strycher/Crosswire#9). No unread-message
+  // Heartbeat: brief blip = alive (#9). No unread-message
   // logic (repeaters carry none). Cadence follows the loop rate; under nRF52
   // powersave it blips on each wake.
   {

--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -78,13 +78,13 @@ FIRMWARE_DIR = Path(os.environ.get(
 # ESP32 OTA partition offsets. Universal across this repo's ESP32 partition
 # tables (default*.csv / min_spiffs.csv / max_app_*.csv place the low region
 # identically; only the high-region app/spiffs sizes vary). Verified against
-# the partition table embedded in CI -merged.bin images (Strycher/Crosswire#29):
+# the partition table embedded in CI -merged.bin images (#29):
 # nvs@0x9000, otadata@0xe000, app0(ota_0)@0x10000.
 ESP32_APP0_OFFSET = 0x10000      # ota_0 (app) partition start
 ESP32_OTADATA_OFFSET = 0xe000    # boot selector
 ESP32_OTADATA_SIZE = 0x2000
 
-# Bootloader-discovery (Strycher/Crosswire#34): native-USB boards change USB
+# Bootloader-discovery (#34): native-USB boards change USB
 # identity + COM number entering bootloader (ESP32-S3 303A:0002->303A:1001;
 # nRF52/Adafruit 239A:8029->239A:00xx). After triggering bootloader entry on the
 # verified running port, the wrapper re-enumerates and discovers the new port by
@@ -379,7 +379,7 @@ def cmd_list(args, registry):
 
 
 # ---------------------------------------------------------------------------
-# Artifact-flash (Strycher/Crosswire#29): flash a downloaded CI release
+# Artifact-flash (#29): flash a downloaded CI release
 # artifact through the SAME resolve_device identity gate as an env flash.
 # ESP32 default = NVS-preserving app-slot update (write app0 + reset otadata);
 # --erase = full factory write of the -merged.bin at 0x0. nRF52 = serial DFU
@@ -534,7 +534,7 @@ def env_with_auth() -> dict:
 
 
 # esptool / adafruit-nrfutil output markers for output-parsed verification
-# (Strycher/Crosswire#34). Markers are matched case-insensitively.
+# (#34). Markers are matched case-insensitively.
 _ESPTOOL_WRITE_OK = ["hash of data verified"]
 _ESPTOOL_ERASE_OK = ["erased successfully", "erased in"]
 _ESPTOOL_FAIL = ["a fatal error", "serial exception", "failed", "traceback (most recent call"]
@@ -547,7 +547,7 @@ def _run_flasher(cmd: list, env_d: dict, success_markers: list,
     """Run a flasher subprocess, capture + print its output, and decide success
     by PARSING that output - never by exit code alone.
 
-    Rationale (Strycher/Crosswire#34): adafruit-nrfutil exits 0 even on a fatal
+    Rationale (#34): adafruit-nrfutil exits 0 even on a fatal
     "Failed to upgrade target", which reported false success (the OTA-incident
     class of bug). A flash is "ok" only when exit code 0 AND a positive success
     marker is present AND no failure marker is present. Conservative by design:
@@ -644,7 +644,7 @@ def _discover_bootloader_port(before: list, vendor: str, running_pid: str,
 def _enter_bootloader_and_discover(running_port: dict, platform: str) -> dict:
     """Trigger bootloader entry on the verified running port, then discover the
     device on its new (bootloader) COM. Unified for both chip families - they
-    all change identity + COM entering bootloader (Strycher/Crosswire#34)."""
+    all change identity + COM entering bootloader (#34)."""
     vendor = NRF52_VENDOR if platform == "nrf52" else ESP32S3_VENDOR
     running_pid = running_port["vid_pid"].split(":")[1]
     out(f"Triggering bootloader entry on {running_port['com']} "
@@ -700,7 +700,7 @@ def _flash_esp32_merged_full(artifact: Path, bl_com: str, env_d: dict) -> bool:
 def _flash_nrf52_dfu(artifact: Path, bl_com: str, env_d: dict) -> bool:
     """nRF52 serial DFU of the .zip on the DISCOVERED DFU port (no --touch - the
     device is already in the bootloader). Success is decided by PARSING output:
-    adafruit-nrfutil exits 0 even when it fails (Strycher/Crosswire#34). A normal
+    adafruit-nrfutil exits 0 even when it fails (#34). A normal
     app DFU preserves the internal config filesystem."""
     out(f"[1/1] adafruit-nrfutil dfu serial {artifact.name} -> {bl_com}")
     _, ok = _run_flasher(

--- a/scripts/test_observer_env_matrix.py
+++ b/scripts/test_observer_env_matrix.py
@@ -37,7 +37,7 @@ REQUIRED_FLAGS_ALL = [
 ]
 REQUIRED_SRC_FILTER = "+<helpers/wifi_observer/*.cpp>"
 
-# Phase-1 strip (Strycher/Crosswire#42): observer envs override the inherited
+# Phase-1 strip (#42): observer envs override the inherited
 # companion defaults down to observer minima to free static .bss. The strings
 # below must match the platformio.ini byte-for-byte -- MAX_GROUP_CHANNELS uses
 # the no-space second-D form; MAX_CONTACTS / OFFLINE_QUEUE_SIZE use the spaced

--- a/scripts/test_offband_version_splash.py
+++ b/scripts/test_offband_version_splash.py
@@ -5,7 +5,7 @@
 # the same pure parse in Python and testing against known-good fixtures.
 #
 # The C++ implementation is a direct translation of this algorithm; this test
-# is the executable specification (Strycher/Crosswire#33). Portable: no g++.
+# is the executable specification (#33). Portable: no g++.
 #
 # Run with:  python scripts/test_offband_version_splash.py
 

--- a/src/helpers/wifi_observer/CliPassthrough.cpp
+++ b/src/helpers/wifi_observer/CliPassthrough.cpp
@@ -106,7 +106,7 @@ bool cliPassthroughIsAllowed(const char* line) {
     // (Strycher/LoRa#313 phone auto-capitalize fix). "mqtt " covers the
     // status/enable/disable subcommands documented in ObserverCli.h; "wifi "
     // covers the aligned "wifi status/enable/disable" grammar
-    // (Strycher/Crosswire#45) -- without it, "wifi status" was denied here
+    // (#45) -- without it, "wifi status" was denied here
     // before ever reaching dispatchObserverCli.
     size_t skip = 0;
     if      (strncmp(p, "get ", 4) == 0)  skip = 4;

--- a/src/helpers/wifi_observer/MqttBroker.cpp
+++ b/src/helpers/wifi_observer/MqttBroker.cpp
@@ -18,7 +18,7 @@ namespace offband {
 namespace {
 // RAII guard for the per-broker recursive client mutex. Take on
 // construction, give on destruction -- covers all early-return paths
-// (Strycher/Crosswire#53).
+// (#53).
 struct ClientLockGuard {
     SemaphoreHandle_t m_;
     explicit ClientLockGuard(SemaphoreHandle_t m) : m_(m) {

--- a/src/helpers/wifi_observer/MqttBroker.h
+++ b/src/helpers/wifi_observer/MqttBroker.h
@@ -70,7 +70,7 @@ public:
     void shutdown();
 
     // Create the per-broker client mutex. Call ONCE from the pool on
-    // loopTask, before the lifecycle worker task starts (Strycher/Crosswire#53),
+    // loopTask, before the lifecycle worker task starts (#53),
     // so worker create/destroy and loopTask publish/connect serialize on the
     // same handle. Idempotent; no-op on host builds.
     void initLock();
@@ -112,7 +112,7 @@ private:
     esp_mqtt_client_handle_t client_ = nullptr;
     // Serializes ALL client_ ops (publish/start/stop/destroy) so the lifecycle
     // worker's blocking stop/destroy never races a loopTask publish/connect on
-    // the same handle (Strycher/Crosswire#53). Recursive: begin() -> shutdown().
+    // the same handle (#53). Recursive: begin() -> shutdown().
     SemaphoreHandle_t        client_lock_ = nullptr;
     // LoRa#327: tracks whether esp_mqtt_client_start() has been called since the
     // last stop/destroy, so tryConnect() can pair a stop() before each re-start.

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -60,7 +60,7 @@ void MqttBrokerPool::begin(const mesh::LocalIdentity& identity,
 #if defined(ARDUINO) && defined(ESP_PLATFORM)
     // Start the lifecycle worker. It owns ALL blocking esp_mqtt ops --
     // create/destroy AND the connect/retry loop -- so loopTask never stalls
-    // on MQTT for any reason (Strycher/Crosswire#53). Created once; lives for
+    // on MQTT for any reason (#53). Created once; lives for
     // the device's life (pool.begin() is one-shot, guarded upstream).
     worker_run_  = true;
     reconcile_q_ = xQueueCreate(OFFBAND_MAX_BROKERS * 2, sizeof(uint8_t));

--- a/src/helpers/wifi_observer/MqttBrokerPool.h
+++ b/src/helpers/wifi_observer/MqttBrokerPool.h
@@ -94,7 +94,7 @@ public:
     // NON-BLOCKING: marks the slot "reconciling" + posts it to the lifecycle
     // worker task, which performs the (possibly multi-second) esp_mqtt client
     // create/destroy OFF loopTask so the BLE command channel never stalls
-    // (Strycher/Crosswire#53). Returns false if the pool/worker isn't up or
+    // (#53). Returns false if the pool/worker isn't up or
     // the request couldn't be queued; true if the reload was queued.
     bool reloadSlot(uint8_t slot);
 

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -471,7 +471,7 @@ static bool handleSetWebAllowInitial(char* reply, size_t reply_size,
 // Top-level dispatch
 // ---------------------------------------------------------------------------
 
-// "wifi enable" / "wifi disable" -- Strycher/Crosswire#45. Persists an NVS
+// "wifi enable" / "wifi disable" -- #45. Persists an NVS
 // policy flag in namespace "wifi" (key "enabled", default true) that
 // WifiBootstrap::begin() honors at boot. Reboot-to-apply by design: we do
 // NOT tear down a live STA here, because the observer's MQTT uplink and this
@@ -492,7 +492,7 @@ static bool handleSetWifiEnabled(char* reply, size_t reply_size, bool enabled) {
     return true;
 }
 
-// "get mqtt.broker.<N>.<key>" -- Strycher/Crosswire#45: symmetric read for the
+// "get mqtt.broker.<N>.<key>" -- #45: symmetric read for the
 // existing "set mqtt.broker.<N>.<key>". Key vocabulary mirrors
 // handleSetBrokerField. Secret fields (password) are write-only and refused
 // here, per the wifi.pwd policy + the CLAUDE.md "never echo a secret" rule.
@@ -529,7 +529,7 @@ static bool handleGetBrokerField(char* reply, size_t reply_size,
     return true;
 }
 
-// "mqtt view <N>" -- Strycher/Crosswire#98: dump ALL stored config for one
+// "mqtt view <N>" -- #98: dump ALL stored config for one
 // slot in a single reply (secrets redacted), so an operator can verify a slot
 // without querying each field via `get mqtt.broker.<N>.<key>`. The rendering +
 // redaction live in ConfigSchema::formatBrokerConfig (host-tested,
@@ -545,7 +545,7 @@ static bool handleViewBroker(char* reply, size_t reply_size, int slot) {
     return true;
 }
 
-// "mqtt clear <N>" -- Strycher/Crosswire#98: wipe one slot's stored config back
+// "mqtt clear <N>" -- #98: wipe one slot's stored config back
 // to empty (url + every field blank, disabled), tearing down any live client.
 // It clears the FIELDS, not the device. RECOVERY: a default slot (0-5) is
 // re-seeded to its default on the NEXT reboot (populateDefaultBrokers fills
@@ -620,7 +620,7 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
         return true;
     }
 
-    // "wifi ..." commands -- Strycher/Crosswire#45: namespace-subcommand
+    // "wifi ..." commands -- #45: namespace-subcommand
     // grammar aligned with "mqtt status/enable/disable". `status` moves from
     // the verb-first "get wifi.status" to "wifi status"; the dotted form is
     // kept as a backward-compat alias in the `get` branch below.

--- a/src/helpers/wifi_observer/ObserverPipeline.h
+++ b/src/helpers/wifi_observer/ObserverPipeline.h
@@ -1,6 +1,6 @@
 // src/helpers/wifi_observer/ObserverPipeline.h
 //
-// Plan 2 v2 Task 9 (ring removed in Strycher/Crosswire#42): LoRa RX hooks
+// Plan 2 v2 Task 9 (ring removed in #42): LoRa RX hooks
 // -> broker-pool publish. Hooks MyMesh::logRxRaw (every raw RX, rssi+snr)
 // and MyMesh::logRx (parsed), fanning each out to the pool via /raw + /packets.
 //

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -418,7 +418,7 @@ extends = env:Heltec_v3_companion_radio_ble
 monitor_rts = 0
 monitor_dtr = 0
 ; MAX_GROUP_CHANNELS reserves the LAST slot for the locked system CLI
-; channel. Phase-1 strip (Strycher/Crosswire#42): 41 -> 11 (user slots
+; channel. Phase-1 strip (#42): 41 -> 11 (user slots
 ; 0-9 + system slot 10; was 0-39 + slot 40 pre-strip), plus the inherited
 ; companion defaults are overridden down to observer minima to free
 ; static .bss: MAX_CONTACTS 350->50, OFFLINE_QUEUE_SIZE 256->16.

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -536,7 +536,7 @@ extends = env:heltec_v4_companion_radio_ble
 monitor_rts = 0
 monitor_dtr = 0
 ; MAX_GROUP_CHANNELS reserves the LAST slot for the locked system CLI
-; channel. Phase-1 strip (Strycher/Crosswire#42): 41 -> 11 (user slots
+; channel. Phase-1 strip (#42): 41 -> 11 (user slots
 ; 0-9 + system slot 10), plus the inherited companion defaults overridden
 ; to observer minima to free static .bss: MAX_CONTACTS 350->50,
 ; OFFLINE_QUEUE_SIZE 256->16. The MAX_GROUP_CHANNELS redefinition lands

--- a/variants/rak3401/platformio.ini
+++ b/variants/rak3401/platformio.ini
@@ -41,7 +41,7 @@ build_flags =
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
   -D MAX_NEIGHBOURS=50
-  ; green LED1 (P1.03) as repeater heartbeat status LED -- Strycher/Crosswire#9
+  ; green LED1 (P1.03) as repeater heartbeat status LED -- #9
   -D PIN_STATUS_LED=LED_BUILTIN
   ;-D MESH_PACKET_LOGGING=1
   ;-D MESH_DEBUG=1

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -164,7 +164,7 @@ build_flags =
   -D BLE_PIN_CODE=123456
   -D BLE_DEBUG_LOGGING=1
   -D OFFLINE_QUEUE_SIZE=256
-  ; green LED1 (P1.03) as heartbeat / unread-message status LED -- Strycher/Crosswire#7
+  ; green LED1 (P1.03) as heartbeat / unread-message status LED -- #7
   -D PIN_STATUS_LED=LED_BUILTIN
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1

--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -250,7 +250,7 @@ extends = env:Xiao_S3_WIO_companion_radio_ble
 monitor_rts = 0
 monitor_dtr = 0
 ; MAX_GROUP_CHANNELS reserves the LAST slot for the locked system CLI
-; channel. Phase-1 strip (Strycher/Crosswire#42): 41 -> 11 (user slots
+; channel. Phase-1 strip (#42): 41 -> 11 (user slots
 ; 0-9 + system slot 10), plus the inherited companion defaults overridden
 ; to observer minima to free static .bss: MAX_CONTACTS 350->50,
 ; OFFLINE_QUEUE_SIZE 256->16. The MAX_GROUP_CHANNELS redefinition lands


### PR DESCRIPTION
Comment-only cleanup: stale `Strycher/Crosswire#NN` issue-refs in code comments -> bare `#NN` (repo is now OffbandMesh/meshcore-firmware).

- 18 files across `src/helpers/wifi_observer/`, `examples/`, `scripts/`, `variants/*/platformio.ini`.
- **No functional change** (comments only). Preserved: `crosswire-v*` release tags, `crosswire-sysch-v1` PSK, `CROSSWIRE_`/observer identifiers.

CI builds all 6 envs to confirm no accidental breakage.

Closes #114