### PR TITLE
epic(#117): Offband release-readiness — docs, observer reference, CHANGELOG prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-06-14
+
+First release under **OffbandMesh/meshcore-firmware**. Bundles the 0.16.0 observer
+work below (which landed on `firmware-base` but was never separately tagged) with
+the Crosswire→Offband rebrand and the OffbandMesh org cutover. *(Version pending
+owner confirmation; the tag is hardware-gated per VERSIONING.md.)*
+
 ### Changed
 - **Rebranded the fork from Crosswire to Offband** (GitHub org `OffbandMesh`):
   the C++ namespace, build macros, embedded identity blob, version prefix
@@ -23,8 +30,17 @@ Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
   strings (serial banner, `version` command, OLED splash, Home Assistant
   manufacturer), and the WiFi setup-AP SSID (`Offband-Observer-`). Historical
   `crosswire-v*` release tags are preserved; the `_sys` PSK domain separator
-  and the MeshCore interop topic namespace are intentionally unchanged.
-  Repo / board / working-dir moves to follow. (#100)
+  and the MeshCore interop topic namespace are intentionally unchanged. (#100)
+- **Repo / board / working-dir cutover to OffbandMesh** — repo
+  `OffbandMesh/meshcore-firmware`, OffbandMesh org Projects board, and the
+  preflight / CLAUDE.md / label-sync workflow re-pointed; removed the stale
+  upstream `CNAME`. (#107, #111)
+
+### Docs
+- Finished the rebrand reference cleanup across docs + code comments. (#113, #114)
+- Release-readiness pass: README getting-started + multi-role positioning, the
+  docs index surfaces the observer guides, and observer `_sys` CLI reference
+  corrections. (#117)
 
 ## [0.16.0] - 2026-06-12
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ Cross-cutting work used by multiple roles: a NimBLE migration off Bluedroid, a C
 
 The firmware lives here: **`firmware-base`** is the canonical Offband tree (the old `Strycher/MeshCore` fork is archived). Design-of-record for the observer architecture is in [`docs/architecture/`](docs/architecture/). Operator setup for the observer is in [`docs/observer-cli-commands.md`](docs/observer-cli-commands.md) (the `_sys` CLI) and [`docs/observer-gps-location-config.md`](docs/observer-gps-location-config.md) (GPS / location).
 
+## Getting started
+
+**Pre-built firmware** — grab a `.bin` from the [Releases page](../../releases) and flash it (web flasher, `esptool`, or `pio run -e <env> -t upload`). Each release's notes carry per-board flashing details.
+
+**Build from source** — install [PlatformIO](https://platformio.org/), then build the env that matches your board + role:
+
+```bash
+pio run -e heltec_v4_companion_observer_wifi     # observer — Heltec V4
+pio run -e Heltec_v3_companion_observer_wifi     # observer — Heltec V3
+pio run -e Xiao_S3_WIO_companion_observer_wifi   # observer — XIAO S3 WIO
+pio run -e heltec_v4_repeater_telemetry          # repeater telemetry — Heltec V4
+```
+
+The full env list lives in [`platformio.ini`](platformio.ini). Build artifacts land in `.pio/build/<env>/`; flash with `pio run -e <env> -t upload`.
+
 ## Filing requests
 
 Requests and bug reports are welcome now -- use the issue templates (Bug report / Feature request). When reporting a bug, include the role, board, and the Offband version from the OLED splash or serial banner, and **never paste WiFi/MQTT credentials**.

--- a/README.upstream.md
+++ b/README.upstream.md
@@ -1,69 +1,10 @@
-# Offband — Strycher's MeshCore fork
+# Offband — upstream MeshCore README
 
-Offband is a community fork of [MeshCore](https://github.com/meshcore-dev/MeshCore)
-that carries feature branches not (yet) in upstream:
-
-- **SafeBoot** — pre-init power guard for solar/battery-powered LoRa nodes
-  (ported from [Meshtastic PR #10391](https://github.com/meshtastic/firmware/pull/10391)
-  by Mickyleitor, commit `4c7e1ee8`; filed for upstream submission)
-- **WiFi/MQTT telemetry** — Home Assistant-native telemetry from Repeater nodes
-- **MQTT command queue** — remote OTA trigger and other commands over MQTT
-- **OTA discipline** — pre-flight verification, audit log, rollback safety
-
-The currently-shipping feature is **SafeBoot**. The rest are at various stages
-of integration on internal feature branches. See **[`docs/safeboot.md`](docs/safeboot.md)**
-for the SafeBoot user guide (when to use, how it works, hardware support matrix,
-flashing, configuration, troubleshooting).
-
-## What SafeBoot adds
-
-Without SafeBoot, a depleted solar/battery node boot-loops at marginal
-voltage — each failed boot burns ~100-300 mWs and risks LittleFS corruption
-during brownout. SafeBoot intercepts that very early: it reads battery
-voltage before any high-current peripheral comes up, and either continues
-boot (voltage above threshold) or sleeps with exponential backoff until
-solar recharges (LPCOMP wake on nRF52) or the user intervenes.
-
-See **[`docs/safeboot.md`](docs/safeboot.md)** for the full user guide
-(when to use, how it works, hardware support matrix, flashing, configuration,
-troubleshooting).
-
-## Quick start
-
-| Hardware | env | Status |
-|---|---|---|
-| Heltec V4 OLED | `heltec_v4_repeater` | Compile-tested; bench-validation pending |
-| Heltec V3 (≤3.2 and >3.2 revisions) | `Heltec_v3_repeater` | Compile-tested; includes runtime polarity auto-detect |
-| RAK4631 | `RAK_4631_repeater` | Compile-tested; ADC multiplier derivation pending bench validation |
-| Seeed XIAO nRF52840 (incl. Plus) | `Xiao_nrf52_repeater` | Compile-tested |
-| Seeed T1000-E | `t1000e_repeater` | Compile-tested; LPCOMP solar-wake deferred (manual button wake only) |
-
-**Pre-built firmware**: see the [Releases page](../../releases) once tagged
-SafeBoot releases are available. Each release artifact includes `.sha256`
-sidecars and per-platform flashing instructions in the release notes.
-
-**Build from source**: `git checkout feature/safeboot && pio run -e <env>`
-for the env above that matches your hardware.
-
-## Status (honest disclosure)
-
-SafeBoot is **code-complete on this branch but not yet bench-validated on
-real hardware**. Compile-testing covers all 5 supported variants; runtime
-validation is pending.
-
-**Do not deploy this firmware to production solar nodes** until the SafeBoot
-epic's bench-test sub-tasks complete. For experimental use, USB-cabled bench
-testing only.
-
-If you want to help: bench-test on hardware we don't have direct access to
-(RAK4631, XIAO nRF52840, T1000-E) and report results. The SafeBoot tracking
-epic is [Strycher/LoRa#96](https://github.com/Strycher/LoRa/issues/96).
-
-## Maintainer docs
-
-If you're contributing to the SafeBoot port (rebasing onto new upstream
-MeshCore releases, deploy-merging into a downstream branch), see
-[`docs/safeboot-maintenance.md`](docs/safeboot-maintenance.md).
+> **Offband-specific documentation lives in [`README.md`](README.md)** — what Offband is, the roles it covers (companion/observer + repeater), getting started, releases, and versioning.
+>
+> SafeBoot — an early Offband feature (a pre-init power guard for solar/battery LoRa nodes) — has its own guide at [`docs/safeboot.md`](docs/safeboot.md).
+>
+> The text below is the **upstream MeshCore** README, preserved for reference.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,18 @@
-# Introduction
+# Offband Documentation
 
-Welcome to the MeshCore documentation.
+Offband is a [MeshCore](https://github.com/meshcore-dev/MeshCore) fork for cross-role firmware (companion/observer + repeater). See the [project README](https://github.com/OffbandMesh/meshcore-firmware#readme) for what Offband is, the roles it covers, and how to get started.
 
-Below are a few quick start guides.
+## Offband guides
+
+- [Observer CLI (`_sys` channel)](./observer-cli-commands.md) — WiFi / MQTT broker config for the observer
+- [Observer GPS & location](./observer-gps-location-config.md) — GPS / time-source / privacy configuration
+- [Serial CLI & MQTT commands](./cli-and-mqtt-commands.md) — serial CLI plus the MQTT command / OTA reference
+- [SafeBoot](./safeboot.md) — pre-init power guard for solar / battery nodes
+- [Observer architecture](./architecture/2026-06-01-observer-architecture-review.md) — design of record
+
+## Inherited MeshCore docs
+
+These are upstream MeshCore references, kept unmodified:
 
 - [Frequently Asked Questions](./faq.md)
 - [CLI Commands](./cli_commands.md)
@@ -10,6 +20,4 @@ Below are a few quick start guides.
 - [Packet Format](./packet_format.md)
 - [QR Codes](./qr_codes.md)
 
-If you find a mistake in any of our documentation, or find something is missing, please feel free to open a pull request for us to review.
-
-- [Documentation Source](https://github.com/meshcore-dev/MeshCore/tree/main/docs)
+If you find a mistake in the inherited docs, the upstream source is the place to fix it: [MeshCore docs](https://github.com/meshcore-dev/MeshCore/tree/main/docs).

--- a/docs/observer-cli-commands.md
+++ b/docs/observer-cli-commands.md
@@ -19,8 +19,9 @@ The verb + field are case-insensitive (phone auto-capitalize is tolerated, so
 **write-only** — never echoed back.
 
 Commands reach the dispatcher through a `_sys` allowlist that permits the
-`get`, `set`, `mqtt`, and `wifi` verbs (and rejects shell metacharacters and
-device-state verbs like `reboot`/`format`/`erase`/`factory`/`ota.`).
+`get`, `set`, `mqtt`, and `wifi` verbs and rejects shell metacharacters (`$(`,
+backtick, `!`) plus device/filesystem verbs
+(`reboot`/`format`/`erase`/`factory`/`ota.`/`fs.`/`flash.`/`rm`/`cat`/`exit`/`quit`).
 
 ## WiFi
 
@@ -52,7 +53,18 @@ device-state verbs like `reboot`/`format`/`erase`/`factory`/`ota.`).
 Broker fields (`<key>`): `url`, `port`, `transport` (tcp\|tls\|wss),
 `auth_type` (none\|basic\|jwt), `username`, `password` (write-only),
 `topic_prefix`, `iata_override`, `ca_cert`, `jwt_audience`, `jwt_refresh`,
-`jwt_owner`, `jwt_email`, `enabled`.
+`jwt_owner`, `jwt_email`.
+
+`enabled` is **read-only** (via `get`) — there is no `set …enabled`; toggle a
+slot with `mqtt enable <N>` / `mqtt disable <N>`.
+
+**Field constraints:** `port` `1..65535` (per-transport defaults
+`1883`/`8883`/`9001` for tcp/tls/wss); `jwt_owner` = exactly **64 hex chars**;
+`jwt_refresh` `60..86400` s; `status_interval` `10..3600` s (**default 30**).
+
+**Recovery:** `set web.allow_initial <on|off>` is a recovery override for the web
+UI's initial-password gate (writes NVS `web/allow_initial`); leave `off` in
+normal operation.
 
 Setting a field on a **live** (enabled) broker slot auto-disables that slot;
 re-enable explicitly with `mqtt enable <N>` once the config is complete.
@@ -104,7 +116,7 @@ mqtt status
   internally, so the input case doesn't matter.
 - **The exact `username` form is broker-dependent.** A **bare pubkey** works on
   eastme.sh; some brokers expect a `v1_<pubkey>` prefix. If a wss slot won't
-  authenticate, try the other form. (Defaulting this per broker is Crosswire#95.)
+  authenticate, try the other form. (Defaulting this per broker is #95.)
 
 ### Known broker values
 | Broker | url | ca_cert | jwt_audience |
@@ -113,11 +125,15 @@ mqtt status
 | LetsMesh-US | `wss://mqtt-us-v1.letsmesh.net:443/mqtt` | `gts-r4` | `mqtt-us-v1.letsmesh.net` (bare) |
 | eastme.sh | `wss://mqtt.eastme.sh:443/mqtt` | `letsencrypt` | `mqtt.eastme.sh` |
 
+The firmware also seeds **MeshMapper** (slot 3), **LetsMesh-EU** (slot 4), and
+**Eastmesh.au** (slot 5) as defaults — run `mqtt view 3` / `4` / `5` for their
+exact `url` / `ca_cert` / `jwt_audience`.
+
 ## Gotchas
 
 - **A `set` on a *disabled* slot may not apply immediately, and `mqtt status`
   shows the broker's *cached* config, not NVS** — so a slot can look
-  mis-configured right after a `set` (Crosswire#67). Do your `set`s, then
+  mis-configured right after a `set` (#67). Do your `set`s, then
   `mqtt enable <N>` (which reloads), or reboot. If a field looks wrong, re-apply
   it while the slot is enabled.
 - **wss/TLS brokers need a valid wall clock** (cert validity + JWT `exp`). Until

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
-site_name: MeshCore Docs
-site_url: https://meshcore-dev.github.io/meshcore/
-site_description: Documentation for the open source MeshCore firmware
+site_name: Offband Docs
+site_url: https://github.com/OffbandMesh/meshcore-firmware
+site_description: Documentation for Offband, a cross-role MeshCore firmware fork
 
-repo_name: meshcore-dev/meshcore
-repo_url: https://github.com/meshcore-dev/meshcore/
-edit_uri: edit/main/docs/
+repo_name: OffbandMesh/meshcore-firmware
+repo_url: https://github.com/OffbandMesh/meshcore-firmware/
+edit_uri: edit/firmware-base/docs/
 
 theme:
   name: material
@@ -17,3 +17,13 @@ theme:
 
 extra_css:
   - _stylesheets/extra.css
+
+# Internal session artifacts — kept in-repo for history, excluded from the built
+# docs site so they never ship as public pages.
+exclude_docs: |
+  handoffs/
+  assessments/
+  plans/
+  superpowers/
+  llm-consultations/
+  llm-consult-prompts/


### PR DESCRIPTION
Release-readiness pass for the Observer firmware (epic #117). Docs + reference + CHANGELOG prep — **no source changes**.

- **#118** README.upstream.md: stale single-feature SafeBoot preamble → pointer to the multi-role README.md.
- **#119** README.md: added **Getting started** (build envs + flash/Releases).
- **#120** CHANGELOG: prepped a `[0.17.0]` section for the first `offband-v*` (version pending owner confirm; tag is hardware-gated).
- **#121/#124** docs/index.md: rebranded to Offband + surfaces the observer guides (was 100% upstream).
- **#122** observer-cli-commands.md: fixed the `enabled` accuracy bug, added field constraints, documented `set web.allow_initial`, completed the deny-list, noted seeded brokers.
- **#123/#124** mkdocs.yml: `exclude_docs` gates session artifacts + rebranded the site config.

Closes #118
Closes #119
Closes #120
Closes #121
Closes #122
Closes #123
Closes #124

Part of #117 — the epic stays open for human sign-off per the Epic Completion Protocol.