### PR TITLE
docs(#127): MeshCore 1.16.0 base-update merge plan

### DIFF
--- a/docs/plans/2026-06-14-meshcore-1.16.0-merge-plan.md
+++ b/docs/plans/2026-06-14-meshcore-1.16.0-merge-plan.md
@@ -1,0 +1,128 @@
+# MeshCore 1.16.0 Base-Update — Merge Plan (Offband `firmware-base`)
+
+| | |
+|---|---|
+| **Date** | 2026-06-14 |
+| **Author** | CloudyFalcon (claude-opus-4-8), from a 3-agent per-file conflict analysis |
+| **Tracking** | Epic #126 / Citadel `Crosswire-zbt` |
+| **Supersedes (sizing)** | 2026-06-10 spike `docs/assessments/2026-06-10-meshcore-1.16.0-base-update-impact.md` (#54) |
+| **Type** | Migration plan / working spec (resolution-level; the spike only sized the surface) |
+
+This plan resolves what the 2026-06-10 spike deliberately deferred: the per-file 3-way reconciliation. It is the working spec for the migration epic (#126).
+
+---
+
+## 0. Locked decisions (owner, 2026-06-14)
+
+1. **Pin target = `companion-v1.16.0` tag** (`24fe7d4b`), not `upstream/main`. `1.16.0` is the latest release (no `1.16.1+` tag); `main` is only 8 commits past it and they're housekeeping (CLI-docs, stale-bot, `SECURITY.md`). A fixed released target keeps the goalpost still during a multi-session merge; future 1.16.1/1.17 absorbs are then cheap increments.
+2. **`iotthinks` remote dropped.** 1.16.0 carries its own power-saving improvements; we are not re-pulling the IoTThinks power-save line. (Remote removed locally; CLAUDE.md line to follow — #130.)
+3. **Scope = companion/observer + repeater.** Room-server/bridge are out (we add no new role). The 4 non-repeater example mains we *touched* are reconciled only because we touched them (a SafeBoot one-liner), not added scope.
+
+## 1. Refs (re-pin at execution time)
+
+| Ref | SHA | Meaning |
+|---|---|---|
+| **BASE** | `c940ea5f` | merge-base (`room-server-v1.15.0-14-gc940ea5f`). The fork never advanced past 1.15+14, so this is a clean "absorb 1.16.0," not a tangle. |
+| **FORK** | `0ec4fd1d` | `firmware-base` tip at plan time. **Re-pin to the then-current tip at merge time.** |
+| **TARGET** | `companion-v1.16.0` (`24fe7d4b`) | The 1.16.0 line. |
+
+**Delta:** 257 upstream commits to absorb; fork is 227 commits ahead (overwhelmingly additive). `git merge-tree --write-tree firmware-base companion-v1.16.0` = exit 1, **18 files with real textual conflicts**; the rest of the ~76-file overlap auto-merges.
+
+## 2. Approach
+
+**Option 1 — one controlled merge** into a fresh integration branch off `firmware-base`. All conflicts visible in one pass; the additive 92 new files arrive clean; single revert if it goes wrong. (Rebase/curated-replay rejected per the spike.)
+
+> ⚠️ `git merge-tree` / `git merge` trips the `require-agent-mail-check` PreToolUse hook (regex matches `git merge`). It is read-only when using `merge-tree`; satisfy the hook via the prescribed AM-check + ack refresh, **not** a bypass.
+
+---
+
+## 3. Textual conflicts — per-file resolution
+
+### 3.1 🔴 `src/helpers/CommonCLI.cpp` + `CommonCLI.h` — prefs serializer (the hard one; do FIRST)
+Both sides append a new persisted-prefs field at **the same on-flash offset 291** — a **binary-layout collision**, not just text:
+- Ours: `radio_fem_rxgain` (1 byte)
+- Upstream: `flood_max_unscoped` + `flood_max_advert` (2 bytes)
+
+**Resolution:** linearize to unique offsets — e.g. upstream `flood_max_unscoped`@291, `flood_max_advert`@292, ours `radio_fem_rxgain`@293, update the `// next: 294` comment. Keep **both** `constrain()` sanitizers. The `NodePrefs` struct order in `CommonCLI.h` must stay internally consistent with the explicit byte offsets in `load/savePrefs` (struct order ≠ flash order, but both must be self-consistent). No version byte in the format → pre-1.16 (shorter) blobs rely on `file.read` leaving in-memory defaults; **preserve that behavior** (bench-test, §5).
+- Also in CommonCLI.cpp (auto-merged, verify): take upstream's `password`/`config`/`owner.info` buffer-safety, `powersaving` replies, `USE_LR1110` rxgain ifdef, `flood.max.*` set/get, and the new `region def` parser. Re-confirm our observer-dispatcher fall-through in `handleRegionCmd` and upstream's new `region def` early-return don't shadow each other.
+
+### 3.2 🟡 `examples/companion_radio/MyMesh.cpp` — 1 hunk in `begin()`
+Our `#ifdef OFFBAND_OBSERVER_BLE_COMPANION systemChannelInit()` block sits directly above the radio config. **Keep the observer block; take upstream's `radio_driver.setParams/setTxPower`** (drop the old `radio_set_*`). Adopt upstream's `CMD_DEVICE_QUERY` spelling (the other rename + `handleCmdFrame` radio sites already auto-resolved to the new API — we never customized those lines).
+
+### 3.3 🟡 `examples/companion_radio/main.cpp` — 2 hunks
+- `fast_rng.begin(...)`: take `radio_driver.getRngSeed()`, keep our `CW_PHASE("post:fast_rng.begin")`.
+- end of `setup()`: keep our `CW_PHASE("setup:DONE")` **and** take upstream's `board.onBootComplete()` (additive). Take upstream's power-save / `loop()`-tail additions (auto-merge).
+- **Semantic flag (no conflict):** upstream's new ESP32 WiFi auto-reconnect overlaps our `offband::wifiObserverLoop()` — verify they don't both drive reconnect on WiFi+observer builds (§5).
+
+### 3.4 🟡 `examples/companion_radio/ui-new/UITask.cpp` — 3 hunks (boot splash, brand-only)
+Keep our `#ifdef OFFBAND_VERSION` dual-brand splash branch verbatim. In the upstream `#else` branch, take upstream's new `https://meshcore.io` line + repositioned version/date coordinates so non-Offband builds match 1.16.0. No logic risk.
+
+### 3.5 🟡 `examples/simple_repeater/main.cpp` — 1 hunk
+End of `setup()`: keep **both** — emit `board.onBootComplete();` first, then our `#ifdef ENABLE_WIFI_TELEMETRY wifi_telemetry_setup();#endif`. Take upstream's power-save rewrite + `getRngSeed()` (auto-merge elsewhere).
+
+### 3.6 🟡 `variants/heltec_v4/HeltecV4Board.h` — mechanical
+Union our 3 FEM-override decls with upstream's `ADC_MULTIPLIER` macro + `adc_mult` member + `setAdcMultiplier`/`getAdcMultiplier`. Single canonical `getManufacturerName` decl.
+
+### 3.7 ⚙️ `variants/*/platformio.ini` (~48) + 5 deleted CI workflows
+- `.ini`: mechanical — re-apply our per-variant build flags/defines on top of upstream's variant edits. Scriptable, reviewable per-file.
+- CI workflows (`build-companion/repeater/room-server-firmwares.yml`, `github-pages.yml`, `pr-build-check.yml`): **keep deleted** (modify/delete conflicts; Offband runs its own `ci.yml`). Resolve toward deletion deliberately or upstream CI resurrects.
+
+### Auto-merge-clean (accept union; verify only)
+`companion_radio/MyMesh.h`, `simple_repeater/MyMesh.h`, `src/MeshCore.h`, `src/helpers/ESP32Board.h`, `src/helpers/NRF52Board.cpp`, `src/helpers/sensors/EnvironmentSensorManager.h`, and the 4 non-repeater mains (`kiss_modem`, `simple_room_server`, `simple_secure_chat`, `simple_sensor` — our edit is a `#include <SafeBoot.h>` + `SafeBoot::checkAndMaybeSleep()` one-liner, disjoint from upstream).
+
+---
+
+## 4. ⚠️ The silent link break — radio free-fns → `radio_driver.*` methods (#129)
+
+Upstream commit `0a8a0a49` (radio de-dup) **removed** the per-variant free functions and centralized them on the driver:
+
+| Old (1.15 free fn) | New (1.16 method) |
+|---|---|
+| `radio_set_params(freq, bw, sf, cr)` | `radio_driver.setParams(freq, bw, sf, cr)` |
+| `radio_set_tx_power(dbm)` | `radio_driver.setTxPower(dbm)` |
+| `radio_get_rng_seed()` | `radio_driver.getRngSeed()` |
+
+The definitions are deleted from all `variants/*/target.{cpp,h}` (upstream's deletion applies cleanly — we never modified them). But our **call sites** are on lines we never edited, so git auto-merges them to the *old* names with **no conflict marker** → **link-time "undefined reference."** The diff looks clean; only the build catches it.
+
+**In-scope call sites to migrate (companion + repeater):**
+
+| File | Calls |
+|---|---|
+| `examples/companion_radio/MyMesh.cpp` | `radio_set_tx_power` (1079, 1548), `radio_set_params` (1078, 1531) — partly inside the §3.2 conflict hunk |
+| `examples/companion_radio/main.cpp` | `radio_get_rng_seed` (168) — inside the §3.3 conflict |
+| `examples/simple_repeater/MyMesh.cpp` | `radio_set_tx_power` (960, 1061), `radio_set_params` (959, 1290, 1296) |
+| `examples/simple_repeater/main.cpp` | `radio_get_rng_seed` (908) |
+
+Out-of-scope (room_server, simple_sensor, simple_secure_chat, kiss_modem mains also call them — migrate only if/when built; not in CI scope).
+
+**Closeout assertion:** after resolution, `git grep -nE '\bradio_(set_params|set_tx_power|get_rng_seed)\b' -- examples/` must return **zero** for in-scope envs.
+
+---
+
+## 5. Runtime / semantic checks (build-gate, #131)
+
+- **WiFi reconnect double-drive:** upstream added ESP32 auto-reconnect (`WiFi.onEvent` + trackers); our `offband::wifiObserverLoop()` already manages WiFi. Ensure they don't both drive reconnect on WiFi+observer builds.
+- **Prefs pre-1.16 load:** bench-load a prefs blob written by 1.15-era firmware (shorter than the new length) and confirm the short-read leaves defaults for the new fields (no version byte in the format).
+- **ESP32 `sleep()` rewrite vs OTA `inhibit_sleep`:** upstream rewrote `ESP32Board::sleep()` (drops `enterLightSleep`, adds portMUX/GPIO-wake). The `inhibit_sleep` short-circuit appears preserved — confirm our STA-OTA path still holds off sleep.
+
+## 6. De-risked (good news — no rework)
+
+- ✅ **Heltec V4 FEM/PA path is safe.** Our FEM/LNA logic lives in `LoRaFEMControl.{cpp,h}` + `HeltecV4Board.cpp` (TX/RX-mode switches + `fem` CLI), **not** through the removed `radio_set_tx_power`. heltec_v4 `target.cpp` simply loses the unused free fns. (Only the mechanical `HeltecV4Board.h` adc_mult conflict, §3.6.)
+- ✅ **`bootComplete()` → `onBootComplete()`: zero fork impact.** We neither override nor call it; we just accept upstream's added `board.onBootComplete()` calls.
+- ✅ **`CMD_DEVICE_QEURY` → `CMD_DEVICE_QUERY`:** a local `#define` inside `companion_radio/MyMesh.cpp` (not a library symbol); cosmetic, single-file.
+
+---
+
+## 7. Execution order (within the one integration branch)
+
+1. Branch + `git merge companion-v1.16.0` (re-pin FORK first; re-fetch upstream).
+2. **Prefs reconcile** (§3.1) — highest risk, do first.
+3. **Radio-API migration** (§4) — the silent link break.
+4. Remaining textual hunks (§3.2–3.6) + `.ini` (§3.7) + keep-deleted CI.
+5. CLAUDE.md base→1.16.0 + drop `iotthinks` line (#130).
+6. **Build-gate:** all 6 CI envs green + runtime checks (§5) — #131.
+7. **Integration test:** hardware smoke on Heltec V4 (observer) + RAK (repeater) — #132, the epic acceptance gate.
+
+## 8. Honesty boundary
+
+Conflict counts/hunks are exact as of the pinned SHAs and **will shift** once `firmware-base` advances — re-run `merge-tree` at execution and re-pin. Per-file semantic deep-dives of the auto-merged files are verify-on-build, not pre-resolved.


### PR DESCRIPTION
The resolution-level merge plan for the 1.16.0 base-update epic (#126), from the 3-agent per-file conflict analysis. Covers the 18 textual conflicts (the CommonCLI prefs binary-offset collision being the hardest), the silent `radio_set_*`→`radio_driver.*` link break, the FEM-safe / rename de-risking, runtime checks, and execution order.

Locked decisions: pin `companion-v1.16.0`, drop `iotthinks`, scope companion/observer/repeater.

Closes #127
Part of #126