### PR TITLE
feat: Heltec V4 TFT observer build (always-build) + flash docs & tooling

### DIFF
--- a/.github/release-envs.txt
+++ b/.github/release-envs.txt
@@ -95,7 +95,8 @@ heltec_v4_repeater
 #heltec_v4_repeater_telemetry   # GATED: uncomment after #20 (runtime-config secrets)
 heltec_v4_room_server
 
-# Heltec V4 TFT (ESP32-S3)
+# Heltec V4 TFT (ESP32-S3) -- includes observer
+heltec_v4_tft_companion_observer_wifi
 heltec_v4_tft_companion_radio_ble
 heltec_v4_tft_companion_radio_usb
 heltec_v4_tft_repeater

--- a/.github/release-footer.md
+++ b/.github/release-footer.md
@@ -1,0 +1,12 @@
+
+---
+
+### Which file do I download?
+
+| File | What it is | When to use it |
+|---|---|---|
+| `*-merged.bin` (ESP32 — Heltec V3/V4, XIAO) | **Full image** — bootloader + partition table + app in one, flashed at `0x0` after a chip erase. Self-contained, works on a blank chip. | **First install / clean setup.** In a web flasher this is the **"Full Firmware"** option. |
+| `*.bin` (ESP32) | **App only** — flashed at the app offset (`0x10000`); the bootloader must already be on the chip. | **Updating** an existing node — OTA / **"Update Only."** Keeps the device identity + WiFi/MQTT config. |
+| `*.uf2` (nRF52 — RAK, T-Echo, XIAO nRF52) | Complete self-contained image. | **First install *and* updates** — double-tap reset, then drag-drop onto the USB drive. (nRF52 has no merged/app split.) |
+
+> ⚠️ **ESP32:** the app-only `*.bin` will **not boot** if flashed at `0x0` — use `*-merged.bin` for a fresh install. A full erase / "Full Firmware" wipes the device's identity + saved config, so use it only for a first install or recovery, **never** a routine update.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - Heltec_v3_companion_observer_wifi
           - Xiao_S3_WIO_companion_observer_wifi
           - heltec_v4_companion_observer_wifi
+          - heltec_v4_tft_companion_observer_wifi
           - heltec_v4_repeater_telemetry
           - heltec_v4_companion_radio_ble
           - RAK_4631_repeater

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,8 @@ jobs:
           if [ ! -s body.md ]; then
             echo "(No CHANGELOG entry for ${ver}.)" > body.md
           fi
+          # Append the static "which file do I download?" flashing guide to every release
+          cat .github/release-footer.md >> body.md 2>/dev/null || true
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,10 @@ Thumbs.db
 # per-host device registry (LAN IPs/MACs) -- never commit; use hardware-devices.example.yaml
 hardware-devices.yaml
 
+# per-host hardware inventory / RF chain / device facts (LAN IPs, MACs, SSID, BLE PINs, GPS coords)
+# -- never commit. Symlink/mirror of canonical C:\Dev\LoRa\HARDWARE.md; read before any hardware work.
+HARDWARE.local.md
+
 # per-host flash audit log + full-flash backups (device MACs/DeviceIDs) -- never commit
 flash-history.jsonl
 flash-backups/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,29 @@ Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-06-14
+
+### Added
+- **Heltec V4 TFT observer build** (`heltec_v4_tft_companion_observer_wifi`) — the
+  observer role on the TFT (ST7789) display variant, switched to the NimBLE stack
+  the observer requires. Added to the CI build matrix and the release env set so it
+  **always builds and ships**.
+
+### Changed
+- **Firmware download clarity** — a "Which file?" table in the README and a static
+  footer appended to every GitHub Release, explaining `-merged.bin` (first install)
+  vs `.bin` (update) vs `.uf2` (nRF52).
+
+### Fixed
+- **`pio-flash` device matching** — `find_in_registry` prefers an exact
+  DeviceID-instance match over a class-only label, so a registered chip is no longer
+  shadowed by a same-class device with null discriminators (fixes nRF52/ESP32
+  mislabels where two boards share a VID:PID).
+
+### Internal
+- Wire a gitignored `HARDWARE.local.md` (symlink to the LoRa hardware inventory) plus
+  a CLAUDE.md "read before any hardware work" pointer.
+
 ## [0.17.0] - 2026-06-14
 
 First release under **OffbandMesh/meshcore-firmware**. Bundles the 0.16.0 observer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,10 @@ Intentionally-kept tags/branches that are **NOT on the build line** and must **N
 
 Decision record: **OffbandMesh/meshcore-firmware#5** (closed, preserved-by-design). Do not casually merge any of these into `firmware-base`.
 
+## Hardware facts — read before any hardware work
+
+Device inventory, RF chain (FEM / TX power), per-device MACs/roles, slot/pin maps, and flash paths live in **`HARDWARE.local.md`** (gitignored, per-host; symlink to the canonical `C:\Dev\LoRa\HARDWARE.md`). **Read it before asking about or acting on hardware**, and record newly-stated hardware facts there so the user never has to restate them. It holds LAN IPs / MACs / SSID / BLE PINs / GPS coordinates — **never commit it or paste its contents** into issues/PRs/chat.
+
 ## Security
 
 - MIT fork: preserve upstream copyright in `LICENSE.txt`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,17 @@ The firmware lives here: **`firmware-base`** is the canonical Offband tree (the 
 
 ## Getting started
 
-**Pre-built firmware** — grab a `.bin` from the [Releases page](../../releases) and flash it (web flasher, `esptool`, or `pio run -e <env> -t upload`). Each release's notes carry per-board flashing details.
+**Pre-built firmware** — grab the file for your board from the [Releases page](../../releases) and flash it. **Which file depends on whether it's a first install or an update:**
+
+| File | What it is | When |
+|---|---|---|
+| `<env>-...-merged.bin` (ESP32) | full image (bootloader + partitions + app), flashed at `0x0` after erase | **first install** — web flasher "Full Firmware"; self-contained |
+| `<env>-....bin` (ESP32) | app only, flashed at the app offset | **update** — OTA / "Update Only"; keeps identity + config |
+| `<env>-....uf2` (nRF52) | complete self-contained image | first install **and** update — double-tap reset, drag-drop |
+
+> On ESP32 the app-only `.bin` will **not boot** if written at `0x0` — use `-merged.bin` for a fresh install. A full erase wipes the device identity + config (first-install / recovery only). nRF52 `.uf2` has no merged/app split.
+
+Flash from a browser ([MeshCore web flasher](https://meshcore.co.uk/flasher.html) → custom firmware), or `pio run -e <env> -t upload`. Each release's notes repeat this guidance.
 
 **Build from source** — install [PlatformIO](https://platformio.org/), then build the env that matches your board + role:
 

--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -203,6 +203,15 @@ def enumerate_ports() -> list[dict]:
 def find_in_registry(
     registry: dict, vid_pid: str, instance_hash: str
 ) -> tuple[Optional[str], Optional[str], Optional[dict]]:
+    # Two-tier match: an exact DeviceID-instance match ALWAYS wins over a weaker
+    # VID:PID-class-only match, regardless of registry order. Without this, a
+    # device with null/empty discriminators (class-only) that happens to be
+    # listed earlier shadows a later device that has the exact instance hash
+    # recorded -- which is how a board sitting on another device's old USB port
+    # gets mislabeled (e.g. a XIAO on a Meshtastic node's former port). The
+    # class-only candidate is kept only as a fallback when nothing matches by
+    # instance.
+    class_only_fallback: tuple[Optional[str], Optional[str], Optional[dict]] = (None, None, None)
     for kind_key, kind_label in [("devices", "device"), ("foreign_devices", "foreign")]:
         for name, entry in (registry.get(kind_key) or {}).items():
             entry_vid_pids = entry.get("vid_pid") or []
@@ -215,17 +224,18 @@ def find_in_registry(
                 d.get("bootloader_deviceid_instance"),
             ]
             known_hashes = [h for h in known_hashes if h]
-            if not known_hashes:
-                # Registry has this device class but no per-instance hash yet.
-                # Match by VID:PID alone is weaker but acceptable for first
-                # registration of a known-class device.
-                return (kind_label, name, entry)
-            if instance_hash in known_hashes:
-                return (kind_label, name, entry)
-            # VID:PID matched but instance hash didn't - keep searching, another
-            # entry might match. (Possible if user has two devices of the same
-            # class on the bus, e.g., two Heltec V4s.)
-    return (None, None, None)
+            if known_hashes:
+                if instance_hash in known_hashes:
+                    # Exact instance match -- strongest signal, return immediately.
+                    return (kind_label, name, entry)
+                # Has hashes but none match this port -- definitely not this device.
+                continue
+            # No per-instance hash recorded: a class-only candidate. Remember the
+            # first one as a fallback, but keep looking for an exact instance match
+            # before settling for it.
+            if class_only_fallback == (None, None, None):
+                class_only_fallback = (kind_label, name, entry)
+    return class_only_fallback
 
 
 # ---------------------------------------------------------------------------

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -555,3 +555,31 @@ build_flags =
 build_src_filter =
   ${env:heltec_v4_companion_radio_ble.build_src_filter}
   +<helpers/wifi_observer/*.cpp>
+
+; TFT sibling of heltec_v4_companion_observer_wifi: identical observer flags +
+; wifi_observer sources, but on the TFT companion-BLE base (ST7789 display)
+; instead of the OLED base. Observer minima (MAX_CONTACTS / OFFLINE_QUEUE_SIZE /
+; MAX_GROUP_CHANNELS) mirror the OLED env to free .bss for the WiFi+MQTT stack
+; (the TFT framebuffer is RAM-heavier than the OLED).
+[env:heltec_v4_tft_companion_observer_wifi]
+extends = env:heltec_v4_tft_companion_radio_ble
+monitor_rts = 0
+monitor_dtr = 0
+build_flags =
+  ${env:heltec_v4_tft_companion_radio_ble.build_flags}
+  -DMAX_GROUP_CHANNELS=11
+  -Wno-builtin-macro-redefined
+  -D OFFBAND_OBSERVER
+  -D OFFBAND_OBSERVER_BLE_COMPANION
+  -D WITH_MQTT_UPLINK
+  -D MAX_CONTACTS=50
+  -D OFFLINE_QUEUE_SIZE=16
+  ; observer uses the NimBLE stack; the TFT companion base defaults to Bluedroid
+  -D CONFIG_BT_NIMBLE_ENABLED=1
+  -D CONFIG_BT_BLUEDROID_ENABLED=0
+build_src_filter =
+  ${env:heltec_v4_tft_companion_radio_ble.build_src_filter}
+  +<helpers/wifi_observer/*.cpp>
+lib_deps =
+  ${env:heltec_v4_tft_companion_radio_ble.lib_deps}
+  h2zero/NimBLE-Arduino @ ^2.0.0


### PR DESCRIPTION
Bundles the Heltec V4 TFT observer build with related flash-documentation and tooling fixes (one branch, per request).

## Commits
- **feat(heltec_v4_tft):** new `heltec_v4_tft_companion_observer_wifi` env — sibling of the OLED observer on the TFT (ST7789) base, switched to the NimBLE stack the observer requires. Added to the `ci.yml` build matrix and `release-envs.txt` so it **always builds + ships**.
- **docs:** merged-vs-non-merged firmware clarity — a "Which file?" table in the README and a static `release-footer.md` appended to every release (`-merged.bin` = first install; `.bin` = update; `.uf2` = nRF52).
- **fix(pio-flash):** `find_in_registry` now prefers an exact DeviceID-instance match over a class-only label, so a recorded chip wins over a null-discriminator shadower (fixes the nRF52/ESP32 mislabels).
- **chore:** wire the gitignored `HARDWARE.local.md` (symlink to the LoRa canonical) + a CLAUDE.md "read before hardware work" pointer.

## Status / caveat
- All envs **build green** (TFT observer verified locally: Flash 22.3%).
- ⚠️ The TFT observer is **green-build-only — not yet booted on real Heltec V4 TFT hardware.** First field test pending.

After merge, an `offband-v*-rc*` tag builds + publishes the curated set including the new TFT observer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)