### PR TITLE
fix(observer): wifi.pwd confirmation wording (0.18.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-06-14
+
+### Fixed
+- **WiFi password confirmation wording** — `set wifi.pwd` now replies
+  `wifi.pwd set (N chars entered)` instead of `wifi.pwd set (length=N)`, which was
+  being misread as a 17-character maximum. The reply reports the length of what was
+  *entered* (never the secret PSK); it is not a cap. WiFi passwords accept the full
+  WPA2 range (8–63 chars).
+
 ## [0.18.0] - 2026-06-14
 
 ### Added

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -2343,7 +2343,7 @@ void MyMesh::checkSerialInterface() {
 // what they type, EXCEPT once the accumulated line is recognized as
 // "set wifi.pwd " -- from that point the remaining chars (the PSK)
 // are NOT echoed, so the secret never lands in the serial log. The
-// reply path already redacts the PSK ("wifi.pwd set (length=N)").
+// reply path already redacts the PSK ("wifi.pwd set (N chars entered)").
 //
 // Strycher/LoRa#325 (Gemini review finding): the prefix match below
 // MUST mirror both input tolerances that cliPassthroughExecute applies

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -367,7 +367,7 @@ static bool handleSetWifiField(char* reply, size_t reply_size,
     if (eq(field, "pwd")) {
         // Never echo the PSK in any code path.
         snprintf(reply, reply_size,
-                 "wifi.pwd set (length=%u). Reboot or run "
+                 "wifi.pwd set (%u chars entered). Reboot or run "
                  "'wifi status' after STA retry.\n",
                  (unsigned)strlen(value));
     } else {


### PR DESCRIPTION
Patch. The `set wifi.pwd` reply read `wifi.pwd set (length=17)`, which users (and at least one Discord helper) misread as a **17-character maximum**. It actually reports the length of what was *entered* — we never echo the PSK. Reworded to `wifi.pwd set (N chars entered)` to kill the ambiguity.

- `ObserverCli.cpp` — the reply string.
- `MyMesh.cpp` — the companion-path comment that quoted the old wording.
- CHANGELOG `[0.18.1]`.

No functional change (string + comment only). WiFi passwords accept the full WPA2 range (8–63 chars); there was never a 17 cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)