### PR TITLE
docs: release approval gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,10 @@ Device inventory, RF chain (FEM / TX power), per-device MACs/roles, slot/pin map
 - No secrets in the repo, ever. WiFi PSK / MQTT credentials / OTA tokens live only in gitignored per-host files.
 - Never echo a configured PSK into logs, commit messages, issues, or chat. Log only derived properties (length, checksum) when diagnostics need it.
 
+## Release discipline
+
+- **Release approval gate** — never push a release tag (`-rc` or stable) without first posting a concise **release preview** (version, `-rc`/stable, the CHANGELOG entry, any user-facing string change) and getting an explicit human "ship it." Validation/feedback ("it works" / "happy with it") is **not** release authorization. Scale the preview to the change — keep it light, not ceremony. Full rationale + format in [`VERSIONING.md`](VERSIONING.md) ("Release approval gate").
+
 ## Follow-ups (bootstrap gaps to close)
 
 - `/work` slash command + `session-state.py` compaction-recovery hook: **now published canonically** (standards @27b3ec7 — `/work` #112, `session-state.py` #107). `/work` auto-syncs into `.claude/commands/` via preflight; `session-state.py` is a hook copy-in (not auto-synced). Port deferred by owner — do when picked up.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -88,6 +88,21 @@ flashing to test." `-rc` is the single pre-release tier for now: testers arrive
 after the internal minimum bar, so they're already past "alpha". Add `-beta` only
 if a rougher tier below `-rc` is ever needed.
 
+## Release approval gate
+
+Before pushing **any release tag** (`-rc` or stable), post a concise **release preview** to the maintainer and wait for an explicit "ship it":
+
+- the **version** + whether it's **`-rc` or stable**
+- the **CHANGELOG entry** being released
+- any **user-facing string change** in the release (exact before → after)
+
+Scale the preview to the change — a line or two for a patch, a short list for a feature; don't make it a wall. Two rules behind it:
+
+- **Validation is not authorization.** A maintainer saying a build "works" / "is happy with it" means the *hardware gate is met* — it is not "publish the release." The tag is pushed only on an explicit go.
+- **No unreviewed copy ships.** Anything users read (firmware reply strings, release notes, the CHANGELOG entry) goes in front of the maintainer *before* the tag, not after.
+
+(Adopted 2026-06-14 after a stable release was cut on an inferred go and a user-facing wording change shipped to production unreviewed.)
+
 ## Upstream baseline tracking
 
 The upstream MeshCore version that a given Offband build rides on is


### PR DESCRIPTION
Documents the **release approval gate** agreed 2026-06-14: before pushing any release tag (`-rc` or stable), post a concise release preview (version, `-rc`/stable, CHANGELOG entry, any user-facing string change) and wait for an explicit "ship it." Validation/feedback ("it works") is **not** release authorization; previews are scaled to the change so it stays light.

- `VERSIONING.md` — the gate (rationale + format), under "Release approval gate".
- `CLAUDE.md` — a one-line enforceable rule + pointer.

Process-only; no code. (Born from 0.18.0 being cut on an inferred go and 0.18.1's wording shipping to prod unreviewed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)