### PR TITLE
feat(#152): sync device clock from GPS (provider-agnostic) + gps time/sync readout

### DIFF
--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -519,10 +519,23 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
         int sats = l->satellitesCount();
         bool active = !strcmp(_sensors->getSettingByKey("gps"), "1");
         if (enabled) {
-          sprintf(reply, "on, %s, %s, %d sats",
+          // #152: GPS time + clock-sync state (visible on any GPS path), appended to
+          // the status line and formatted like `clock` so both compare at a glance.
+          long gps_epoch = l->getTimestamp();
+          bool synced = _sensors->getGpsClockSyncTime() != 0;
+          char gbuf[48];
+          if (gps_epoch >= (long)GPS_CLOCK_SANE_MIN) {
+            DateTime gdt = DateTime((uint32_t)gps_epoch);
+            snprintf(gbuf, sizeof(gbuf), "gps %02d:%02d - %d/%d/%d UTC, %s",
+              gdt.hour(), gdt.minute(), gdt.day(), gdt.month(), gdt.year(),
+              synced ? "synced" : "unsynced");
+          } else {
+            snprintf(gbuf, sizeof(gbuf), "gps --, %s", synced ? "synced" : "unsynced");
+          }
+          snprintf(reply, 160, "on, %s, %s, %d sats, %s",
             active?"active":"deactivated",
             fix?"fix":"no fix",
-            sats);
+            sats, gbuf);
         } else {
           strcpy(reply, "off");
         }

--- a/src/helpers/SensorManager.h
+++ b/src/helpers/SensorManager.h
@@ -9,6 +9,11 @@
 
 #define TELEM_CHANNEL_SELF   1   // LPP data channel for 'self' device
 
+// #152: GPS clock-sync (provider-agnostic). A GPS epoch below this (2025-01-01
+// UTC) is treated as "no valid time"; avoids chip-specific GPS validity flags.
+static const uint32_t      GPS_CLOCK_SANE_MIN       = 1735689600UL;
+static const unsigned long GPS_CLOCK_SYNC_INTERVAL  = 1800000UL;   // re-sync every 30 min
+
 class SensorManager {
 public:
   double node_lat, node_lon;  // modify these, if you want to affect Advert location
@@ -23,6 +28,7 @@ public:
   virtual const char* getSettingValue(int i) const { return NULL; }
   virtual bool setSettingValue(const char* name, const char* value) { return false; }
   virtual LocationProvider* getLocationProvider() { return NULL; }
+  virtual uint32_t getGpsClockSyncTime() const { return 0; }   // #152: millis() of last GPS clock-sync (0 = never)
 
   // Helper functions to manage setting by keys (useful in many places ...)
   const char* getSettingByKey(const char* key) {

--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -181,7 +181,10 @@ class RAK12500LocationProvider : public LocationProvider {
   int _sats = 0;
   long _epoch = 0;
   bool _fix = false;
+  mesh::RTCClock* _clock = nullptr;                          // #152: inherited from the UART provider; the manager syncs the clock from getTimestamp()
 public:
+  void setClock(mesh::RTCClock* clock) { _clock = clock; }   // #152
+  mesh::RTCClock* getClock() override { return _clock; }     // #152: idempotent re-init hand-off
   long getLatitude() override { return _lat; }
   long getLongitude() override { return _lng; }
   long getAltitude() override { return _alt; }
@@ -202,7 +205,7 @@ public:
     } else {
       _fix = false;
     }
-    _epoch = ublox_GNSS.getUnixEpoch(2);
+    _epoch = ublox_GNSS.getUnixEpoch(2);   // #152: GPS time; the manager syncs the clock from getTimestamp()
   }
   bool isEnabled() override { return true; }
 };
@@ -832,6 +835,9 @@ bool EnvironmentSensorManager::gpsIsAwake(uint8_t ioPin){
     gps_active = true;
     gps_detected = true;
 
+    // #152: hand the I2C GPS provider the same RTC clock the UART provider holds,
+    // so it can sync the device clock from GPS time.
+    RAK12500_provider.setClock(_location != nullptr ? _location->getClock() : nullptr);
     _location = &RAK12500_provider;
     return true;
   } else if (Serial1.available()) {
@@ -892,6 +898,21 @@ void EnvironmentSensorManager::loop() {
   static long next_gps_update = 0;
   if (gps_active) {
     _location->loop();
+    // #152: provider-agnostic GPS clock-sync. Any active provider reporting a
+    // plausible GPS epoch (>= GPS_CLOCK_SANE_MIN, i.e. after 2025) sets the device
+    // clock -- on the first valid reading, then every GPS_CLOCK_SYNC_INTERVAL. No
+    // position-fix or chip-specific-flag gate, so time syncs before a fix and the
+    // logic holds across GPS modules / slots / architectures. (UART providers also
+    // self-sync; this writes the same value, harmless.)
+    mesh::RTCClock* gps_clk = _location->getClock();
+    long gps_epoch = _location->getTimestamp();
+    if (gps_clk != nullptr && gps_epoch >= (long)GPS_CLOCK_SANE_MIN) {
+      if (_last_gps_clock_sync == 0 ||
+          (millis() - _last_gps_clock_sync) > GPS_CLOCK_SYNC_INTERVAL) {
+        gps_clk->setCurrentTime((uint32_t)gps_epoch);
+        _last_gps_clock_sync = millis();
+      }
+    }
   }
   if (millis() > next_gps_update) {
 

--- a/src/helpers/sensors/EnvironmentSensorManager.h
+++ b/src/helpers/sensors/EnvironmentSensorManager.h
@@ -25,6 +25,7 @@ protected:
 
   #if ENV_INCLUDE_GPS
   LocationProvider* _location;
+  unsigned long _last_gps_clock_sync = 0;   // #152: millis() of last GPS clock-sync (0 = never)
   void start_gps();
   void stop_gps();
   void initBasicGPS();
@@ -43,6 +44,7 @@ public:
   #endif
   #if ENV_INCLUDE_GPS
   bool gpsHasFix() { return gps_active && _location != nullptr && _location->isValid(); }
+  uint32_t getGpsClockSyncTime() const override { return _last_gps_clock_sync; }   // #152
   #endif
   bool begin() override;
   bool querySensors(uint8_t requester_permissions, CayenneLPP& telemetry) override;

--- a/src/helpers/sensors/LocationProvider.h
+++ b/src/helpers/sensors/LocationProvider.h
@@ -16,6 +16,9 @@ public:
     virtual long satellitesCount() = 0;
     virtual bool isValid() = 0;
     virtual long getTimestamp() = 0;
+    // #152: the RTC clock this provider keeps in sync (nullptr if none). Lets a
+    // manager hand the same clock to a different active provider (UART -> I2C GPS).
+    virtual mesh::RTCClock* getClock() { return nullptr; }
     virtual void sendSentence(const char * sentence);
     virtual void reset() = 0;
     virtual void begin() = 0;

--- a/src/helpers/sensors/MicroNMEALocationProvider.h
+++ b/src/helpers/sensors/MicroNMEALocationProvider.h
@@ -122,10 +122,12 @@ public :
     long satellitesCount() override { return nmea.getNumSatellites(); }
     bool isValid() override { return nmea.isValid(); }
 
-    long getTimestamp() override { 
+    long getTimestamp() override {
         DateTime dt(nmea.getYear(), nmea.getMonth(),nmea.getDay(),nmea.getHour(),nmea.getMinute(),nmea.getSecond());
         return dt.unixtime();
-    } 
+    }
+
+    mesh::RTCClock* getClock() override { return _clock; }  // #152: expose clock for provider hand-off
 
     void sendSentence(const char *sentence) override {
         nmea.sendSentence(*_gps_serial, sentence);


### PR DESCRIPTION
## What
The device clock now syncs from GPS time, and `gps` reports the GPS time + sync state. Closes #152.

The RAK3401's I²C u-blox path was **position-only** — the clock sat at the `15/5/2024` default until set manually.

## Design (provider-agnostic)
Rather than duplicate the UART provider's clock-sync onto the I²C provider, the sync is done **once in the sensor manager** so it holds across GPS modules / slots / architectures:

- `EnvironmentSensorManager::loop()` syncs the RTC from the **active** `LocationProvider`'s `getTimestamp()` — first plausible reading, then every 30 min.
- **Gate = a sane GPS epoch** (`>= 2025-01-01`), *not* a position fix and *not* chip-specific validity flags. So time syncs **before** a fix, and the brittle u-blox `getTimeValid/getDateValid` (which never passed on hardware — the actual bug) is gone.
- The manager gets the clock via `LocationProvider::getClock()` (new): the UART provider returns its ctor-injected clock; the I²C provider returns the clock it inherits at the `gpsIsAwake()` swap.
- The **UART provider's own self-sync is left untouched** (it still self-syncs; the manager writes the same value, harmless) — so the UART path needs no re-verification.
- `gps` CLI now appends `gps <HH:MM - D/M/Y UTC>, <synced|unsynced>`, formatted like `clock`, visible on **any** GPS path.

## Verification
- Builds green: `RAK_3401_repeater` + `RAK_3401_companion_radio_ble` (I²C), `Heltec_mesh_solar_companion_radio_ble` (UART), `heltec_v4_companion_radio_ble` (general).
- Gemini-reviewed — core logic clean; the one MEDIUM (`strcat` → bounded `snprintf`) is fixed.
- **Hardware-verified on the RAK3401 1W (I²C u-blox):** clock advances to real UTC with no manual `clock sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
