### PR TITLE
Epic F: Offband companion-API config command (+ observer config-layer hardening)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           - heltec_v4_repeater_telemetry
           - heltec_v4_companion_radio_ble
           - RAK_4631_repeater
+          - Heltec_t114_companion_radio_ble   # nRF52 companion coverage (BLE; complements RAK_4631 repeater)
     steps:
       - uses: actions/checkout@v5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ on the **MeshCore 1.16.0** base.
   queue (4 → 12) + stream terminators on reconnect, so a mid-stream reconnect can't leave
   the app's contact / settings sync hung. Affects companion **and** observer. (The root —
   the client's uncapped reconnect retry — is paced client-side in meshcore-client.)
+- **Crash log reliable for the whole boot** (#183) — the 1 Hz heartbeat was flooding the
+  4 KB RTC crash-ring (wrapped in ~50 s) and evicting real crash diagnostics; the heartbeat
+  now writes the ring every 30 s / on a sharp heap drop, so a post-reboot dump keeps the
+  evidence that explains a crash past boot+50 s.
 
 ### CI / build
 - **Heltec T114** (nRF52) companion added to the CI matrix (#185) — first nRF52-companion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,57 @@ Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
 ## [Unreleased]
 
+_Staged for `offband-v1.1.0` — rolls into a dated section at the release tag._
+
+The headline is **Epic F: the companion-API config command** — a WiFi observer can now be
+configured entirely from the app (WiFi, the full MQTT broker pool, display) over BLE —
+plus the observer config/NVS-layer hardening that came out of bench-validating it. Still
+on the **MeshCore 1.16.0** base.
+
+### Added
+- **Companion-API config command (Epic F, #159)** — configure a WiFi observer from the
+  MeshCore/Offband app over BLE: WiFi credentials, the full MQTT broker pool (per-slot
+  url / port / transport / auth / JWT claims / CA-cert / topic-prefix / IATA),
+  enable / disable / clear a slot, and display settings. Wholly observer-gated and surfaced
+  behind a new `WIFI_OBSERVER_SUPPORT` capability bit + `FIRMWARE_VER_CODE 14`, so stock
+  companions are unaffected. (#160–#169)
+- **Per-broker live state in the broker read** (#172) — each slot now reports its live
+  connection state (`connecting` / `up` / `backoff` / `held` …) + last-error class, so the
+  app shows whether a broker actually connected, not just that it's enabled.
+- **Resolved-default hints** (#173, #186) — when `jwt_owner` / `iata_override` are unset,
+  the read shows the value the device will actually use at connect (its own pubkey / the
+  global IATA) as a placeholder instead of a confusing blank — in both the pool dump and
+  the per-field read.
+
+### Changed
+- **Honest observer config writes (SAFELANE §6, #181)** — the config / NVS write path used
+  to silently swallow failures (a broker disable could ACK success while nothing changed).
+  Every writer, the live-reload path, and the crash logger itself now surface + log
+  failures with context. This is what root-caused #179.
+- **Compact broker config storage + seamless migration** (#182) — broker config is stored
+  as small per-key entries (no blank fields) rather than one ~1 KB blob, so writes fit a
+  near-full NVS; a one-time **invisible boot migration** reclaims space on upgrade, so the
+  operator never sees a transient write error.
+- **CoreScope (okimesh) default broker** → `mqtt://mqtt1.okimesh.org:1883` (#170).
+- **Offband tell in MQTT** (#174) — observer nodes append a 📡 to their display name in
+  MQTT payloads, so feeds / maps can flag Offband observers.
+
+### Fixed
+- **#179** — a broker disable ACK'd success while the dump still reported `enabled=1`.
+  Root-caused as a near-full-NVS write failure the old code lied about; fixed by #181
+  (honest write) + #182 (storage that fits). Verified on hardware.
+- **Observer capped at 1 concurrent TLS broker** (#171) — a heap guard stops the OOM reboot
+  when a 2nd TLS/wss broker's ~60 KB mbedTLS context exhausts the Heltec V3 heap. Measured
+  on hardware (1 wss ≈ 63 KB free, 2 wss ≈ crash).
+- **BLE connect survives the client's reconnect-thrash** (#178) — a deeper ESP32 BLE frame
+  queue (4 → 12) + stream terminators on reconnect, so a mid-stream reconnect can't leave
+  the app's contact / settings sync hung. Affects companion **and** observer. (The root —
+  the client's uncapped reconnect retry — is paced client-side in meshcore-client.)
+
+### CI / build
+- **Heltec T114** (nRF52) companion added to the CI matrix (#185) — first nRF52-companion
+  build coverage (complements the existing RAK4631 repeater).
+
 ## [1.0.0] - 2026-06-17
 
 First production-stable Offband release — companion, observer, and repeater roles

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A [MeshCore](https://github.com/meshcore-dev/MeshCore) fork for **cross-role fir
 
 | Role | Status | What Offband adds |
 |------|--------|---------------------|
-| **Companion / Observer** | Active | WiFi + MQTT publishing of LoRa-mesh observations to public brokers (CoreScope, eastme.sh, LetsMesh), NimBLE BLE stack, multi-broker pool with TLS + JWT auth, a GPS&nbsp;>&nbsp;NTP phone-free wall clock for unattended JWT auth, position in the MQTT `/status`, and a `_sys`-channel CLI for WiFi/broker config |
+| **Companion / Observer** | Active | WiFi + MQTT publishing of LoRa-mesh observations to public brokers (CoreScope, eastme.sh, LetsMesh), NimBLE BLE stack, multi-broker pool with TLS + JWT auth, a GPS&nbsp;>&nbsp;NTP phone-free wall clock for unattended JWT auth, position in the MQTT `/status`, and full **in-app configuration over BLE** — WiFi, the MQTT broker pool, and display, via the companion-API config command — alongside the `_sys`-channel CLI |
 | **Repeater** | Active | MQTT telemetry bridging (to Mosquitto and other brokers), burst-WiFi telemetry, heap and power tuning |
 | **Room server** | Not yet | -- |
 | **Bridge** | Not yet | -- |

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1376,8 +1376,31 @@ void MyMesh::handleCmdFrame(size_t len) {
     cmd_frame[len] = 0; // make app_name null terminated
     MESH_DEBUG_PRINTLN("App %s connected", app_name);
 
+    // #178: a reconnect (the client's connect-thrash) can land here mid-stream.
+    // Emit the in-flight stream's terminator BEFORE clearing it, so the client's
+    // contact / settings read completes instead of hanging forever on an END that
+    // never comes. Guarded -> a normal first connect (no stream in flight) is a
+    // no-op. Best-effort: if the BLE send queue is full the terminator may drop
+    // (no worse than today). Terminator byte sequences mirror the stream's own EOF
+    // paths (END_OF_CONTACTS line ~2593, VIEW_END/BROKERS_END in offbandStreamDrain).
+    if (_iter_started) {
+      uint8_t end[5];
+      end[0] = RESP_CODE_END_OF_CONTACTS;
+      memcpy(&end[1], &_most_recent_lastmod, 4);
+      _serial->writeFrame(end, 5);
+      MESH_DEBUG_PRINTLN("APP_START mid-stream: sent END_OF_CONTACTS terminator (#178)");
+    }
     _iter_started = false; // stop any left-over ContactsIterator
 #ifdef OFFBAND_OBSERVER
+    if (_ob_stream == OB_STREAM_VIEW) {
+      uint8_t h[2] = { offband::RESP_CODE_OFFBAND_CONFIG, offband::OCFG_R_VIEW_END };
+      _serial->writeFrame(h, 2);
+      MESH_DEBUG_PRINTLN("APP_START mid-stream: sent VIEW_END terminator (#178)");
+    } else if (_ob_stream == OB_STREAM_BROKERS) {
+      uint8_t h[2] = { offband::RESP_CODE_OFFBAND_CONFIG, offband::OCFG_R_BROKERS_END };
+      _serial->writeFrame(h, 2);
+      MESH_DEBUG_PRINTLN("APP_START mid-stream: sent BROKERS_END terminator (#178)");
+    }
     _ob_stream = OB_STREAM_NONE; // F8 (#169): drop any in-flight config-response stream
 #endif
     int i = 0;

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1308,7 +1308,14 @@ void MyMesh::offbandStreamDrain() {
         return;
       }
       _ob_slot = s;
-      offband::configRenderBrokerSlot((uint8_t)s, _ob_buf, sizeof(_ob_buf));
+      // #172/#173: pass the live runtime state + the device's default jwt_owner
+      // (pubkey hex) so the dump also carries state/last_error + resolved-default
+      // hints (additive -- old clients ignore the extra lines).
+      const offband::BrokerRuntimeState& _rt =
+          offband::wifiObserverPool().broker((uint8_t)s).runtime();
+      char _owner_hex[2 * PUB_KEY_SIZE + 1];
+      offband::wifiObserverPool().deviceOwnerHex(_owner_hex, sizeof(_owner_hex));
+      offband::configRenderBrokerSlot((uint8_t)s, _ob_buf, sizeof(_ob_buf), &_rt, _owner_hex);
       _ob_off = 0;
     }
     // Emit ONE "key=value" line as a BROKER_KV frame for the current slot.

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -20,6 +20,13 @@
 // broad OFFBAND_OBSERVER flag (not the BLE-companion flag) so it is
 // present on every observer build, including future BLE-disabled ones.
 #include "helpers/wifi_observer/CliPassthrough.h"
+// Epic F: the config command codes (#160 contract) + its typed dispatch backend (#165).
+#include "OffbandConfigProtocol.h"
+#include "helpers/wifi_observer/ObserverCli.h"   // configSet/configGet + dispatchObserverCli
+// wifiObserverPool() lives in WifiObserver.h (heavy transitive includes); forward-
+// declare it here as CliPassthrough.cpp does. configSet takes a pool ref (only the
+// broker branch -- F3 -- consumes it, but the signature requires it for flat keys too).
+namespace offband { MqttBrokerPool& wifiObserverPool(); }
 #endif
 
 #define CMD_APP_START                 1
@@ -1176,7 +1183,101 @@ static const char* offbandClientVersion() {
   return buf;
 }
 
+#ifdef OFFBAND_OBSERVER
+// Emit one Offband-config scalar reply frame: [0]=RESP code, [1]=sub-type,
+// [2..]=NUL-terminated text (truncated to the frame).
+void MyMesh::writeOffbandConfigScalar(uint8_t sub, const char* text) {
+  out_frame[0] = offband::RESP_CODE_OFFBAND_CONFIG;
+  out_frame[1] = sub;
+  size_t n = strlen(text);
+  const size_t cap = MAX_FRAME_SIZE - 3;   // [0],[1] header + trailing NUL
+  if (n > cap) n = cap;
+  memcpy(&out_frame[2], text, n);
+  out_frame[2 + n] = 0;
+  _serial->writeFrame(out_frame, 2 + n + 1);
+}
+
+// Offband config command (Epic F / F2, #161). Parse the wire frame and dispatch
+// to the typed configSet/configGet (#165) -- NOT the CLI string parser, so the
+// CLI grammar never enters the wire path. VIEW (a human text dump) routes to a
+// whitelisted read-only dispatchObserverCli selector, chunked. The paginated
+// broker GET (OCFG_BROKERS) lands in F3 (#162). Observer-only. Contract:
+// OffbandConfigProtocol.h.
+void MyMesh::handleOffbandConfigCmd(size_t len) {
+  if (len < 2) { writeOffbandConfigScalar(offband::OCFG_R_ERR, "missing sub-type"); return; }
+  uint8_t op = cmd_frame[1];
+  cmd_frame[len] = 0;                                // NUL-terminate the payload
+  char* payload = (char*)&cmd_frame[2];
+  char reply[512];
+
+  if (op == offband::OCFG_SET) {
+    char* sp = strchr(payload, ' ');                 // split on FIRST space; value = remainder
+    if (sp == nullptr) { writeOffbandConfigScalar(offband::OCFG_R_ERR, "set: expected '<key> <value>'"); return; }
+    *sp = '\0';
+    if (!offband::configSet(payload, sp + 1, reply, sizeof(reply), offband::wifiObserverPool())) {
+      writeOffbandConfigScalar(offband::OCFG_R_ERR, "unknown config key"); return;
+    }
+    bool err = (strncmp(reply, "ERROR", sizeof("ERROR") - 1) == 0);
+    writeOffbandConfigScalar(err ? offband::OCFG_R_ERR : offband::OCFG_R_ACK, reply);
+    return;
+  }
+
+  if (op == offband::OCFG_GET) {
+    if (!offband::configGet(payload, reply, sizeof(reply))) {
+      writeOffbandConfigScalar(offband::OCFG_R_ERR, "unknown config key"); return;
+    }
+    bool err = (strncmp(reply, "ERROR", sizeof("ERROR") - 1) == 0);
+    writeOffbandConfigScalar(err ? offband::OCFG_R_ERR : offband::OCFG_R_VALUE, reply);
+    return;
+  }
+
+  if (op == offband::OCFG_VIEW) {
+    // Read-only dumps only -- never a mutating selector through VIEW.
+    bool ok = (strcmp(payload, "mqtt status") == 0) ||
+              (strncmp(payload, "mqtt view ", 10) == 0) ||
+              (strcmp(payload, "wifi status") == 0);
+    if (!ok) { writeOffbandConfigScalar(offband::OCFG_R_ERR, "view: allowed: mqtt status | mqtt view <N> | wifi status"); return; }
+    if (!offband::dispatchObserverCli(payload, reply, sizeof(reply), offband::wifiObserverPool())) {
+      writeOffbandConfigScalar(offband::OCFG_R_ERR, "view: unrecognized selector"); return;
+    }
+    uint8_t hdr[2] = { offband::RESP_CODE_OFFBAND_CONFIG, offband::OCFG_R_VIEW_START };
+    _serial->writeFrame(hdr, 2);
+    const char* p = reply;
+    size_t remaining = strlen(reply);
+    if (remaining > 0) {                              // empty dump -> just START + END
+      const size_t cap = MAX_FRAME_SIZE - 3;
+      do {
+        size_t take = remaining < cap ? remaining : cap;
+        out_frame[0] = offband::RESP_CODE_OFFBAND_CONFIG;
+        out_frame[1] = offband::OCFG_R_VIEW_CHUNK;
+        memcpy(&out_frame[2], p, take);
+        out_frame[2 + take] = 0;
+        _serial->writeFrame(out_frame, 2 + take + 1);
+        p += take; remaining -= take;
+      } while (remaining > 0);
+    }
+    hdr[1] = offband::OCFG_R_VIEW_END;
+    _serial->writeFrame(hdr, 2);
+    return;
+  }
+
+  if (op == offband::OCFG_BROKERS) {
+    writeOffbandConfigScalar(offband::OCFG_R_ERR, "brokers: not yet implemented (F3 #162)");
+    return;
+  }
+
+  writeOffbandConfigScalar(offband::OCFG_R_ERR, "bad config sub-type");
+}
+#endif  // OFFBAND_OBSERVER
+
 void MyMesh::handleCmdFrame(size_t len) {
+#ifdef OFFBAND_OBSERVER
+  // Epic F (#161): the Offband config command routes to its own observer-only handler.
+  if (cmd_frame[0] == offband::CMD_OFFBAND_CONFIG) {
+    handleOffbandConfigCmd(len);
+    return;
+  }
+#endif
   if (cmd_frame[0] == CMD_DEVICE_QUERY && len >= 2) { // sent when app establishes connection
     app_target_ver = cmd_frame[1];                    // which version of protocol does app understand
 

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1262,7 +1262,37 @@ void MyMesh::handleOffbandConfigCmd(size_t len) {
   }
 
   if (op == offband::OCFG_BROKERS) {
-    writeOffbandConfigScalar(offband::OCFG_R_ERR, "brokers: not yet implemented (F3 #162)");
+    // Paginated broker-pool dump: START(count) -> BROKER_KV x N (one field/frame) -> END.
+    int maxSlots = offband::configBrokerSlotCount();
+    uint8_t count = 0;
+    for (int s = 0; s < maxSlots; ++s)
+      if (offband::configBrokerSlotPopulated((uint8_t)s)) count++;
+    uint8_t hdr[3] = { offband::RESP_CODE_OFFBAND_CONFIG, offband::OCFG_R_BROKERS_START, count };
+    _serial->writeFrame(hdr, 3);
+    char buf[1024];                                       // one slot's "key=value\n" lines
+    for (int s = 0; s < maxSlots; ++s) {
+      if (offband::configRenderBrokerSlot((uint8_t)s, buf, sizeof(buf)) == 0) continue;
+      char* line = buf;
+      while (*line) {
+        char* nl = strchr(line, '\n');
+        if (nl) *nl = '\0';
+        if (*line) {                                      // one BROKER_KV frame per non-empty line
+          out_frame[0] = offband::RESP_CODE_OFFBAND_CONFIG;
+          out_frame[1] = offband::OCFG_R_BROKER_KV;
+          out_frame[2] = (uint8_t)s;
+          size_t klen = strlen(line);
+          const size_t cap = MAX_FRAME_SIZE - 4;          // [0],[1],[2]=slot + trailing NUL
+          if (klen > cap) klen = cap;
+          memcpy(&out_frame[3], line, klen);
+          out_frame[3 + klen] = 0;
+          _serial->writeFrame(out_frame, 3 + klen + 1);
+        }
+        if (!nl) break;
+        line = nl + 1;
+      }
+    }
+    hdr[1] = offband::OCFG_R_BROKERS_END;
+    _serial->writeFrame(hdr, 2);
     return;
   }
 

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1327,6 +1327,16 @@ void MyMesh::handleCmdFrame(size_t len) {
     i += 20;
     out_frame[i++] = _prefs.client_repeat;   // v9+
     out_frame[i++] = _prefs.path_hash_mode;  // v10+
+    // F4 (#163): Offband capability byte. bit0 = WIFI_OBSERVER_SUPPORT -- the
+    // config command's backend (wifi_observer) is compiled in. Additive: pre-v14
+    // clients read a shorter frame and never see it; v14+ clients gate the Observer
+    // config category on this bit (version code alone can't tell observer-in from
+    // observer-out builds). 0 on non-observer node types -> no config at all.
+    uint8_t offband_caps = 0;
+#ifdef OFFBAND_OBSERVER
+    offband_caps |= offband::OFFBAND_CAP_WIFI_OBSERVER;
+#endif
+    out_frame[i++] = offband_caps;           // v14+
     _serial->writeFrame(out_frame, i);
   } else if (cmd_frame[0] == CMD_APP_START &&
              len >= 8) { // sent when app establishes connection, respond with node ID

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -977,6 +977,7 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
   _obs_cli_len = 0;
   _obs_cli_redact = false;
   _obs_cli_buf[0] = 0;
+  _ob_stream = OB_STREAM_NONE;   // F8 (#169): no config-response stream in flight
 #endif
   offline_queue_len = 0;
   app_target_ver = 0;
@@ -1237,66 +1238,96 @@ void MyMesh::handleOffbandConfigCmd(size_t len) {
               (strncmp(payload, "mqtt view ", 10) == 0) ||
               (strcmp(payload, "wifi status") == 0);
     if (!ok) { writeOffbandConfigScalar(offband::OCFG_R_ERR, "view: allowed: mqtt status | mqtt view <N> | wifi status"); return; }
-    if (!offband::dispatchObserverCli(payload, reply, sizeof(reply), offband::wifiObserverPool())) {
+    // Render into the streaming buffer, send START, then STREAM the chunks one
+    // frame per main-loop pass (offbandStreamDrain) -- a synchronous flood would
+    // overrun the 4-deep BLE queue and drop the tail incl. END (F8 #169).
+    if (!offband::dispatchObserverCli(payload, _ob_buf, sizeof(_ob_buf), offband::wifiObserverPool())) {
       writeOffbandConfigScalar(offband::OCFG_R_ERR, "view: unrecognized selector"); return;
     }
     uint8_t hdr[2] = { offband::RESP_CODE_OFFBAND_CONFIG, offband::OCFG_R_VIEW_START };
     _serial->writeFrame(hdr, 2);
-    const char* p = reply;
-    size_t remaining = strlen(reply);
-    if (remaining > 0) {                              // empty dump -> just START + END
-      const size_t cap = MAX_FRAME_SIZE - 3;
-      do {
-        size_t take = remaining < cap ? remaining : cap;
-        out_frame[0] = offband::RESP_CODE_OFFBAND_CONFIG;
-        out_frame[1] = offband::OCFG_R_VIEW_CHUNK;
-        memcpy(&out_frame[2], p, take);
-        out_frame[2 + take] = 0;
-        _serial->writeFrame(out_frame, 2 + take + 1);
-        p += take; remaining -= take;
-      } while (remaining > 0);
-    }
-    hdr[1] = offband::OCFG_R_VIEW_END;
-    _serial->writeFrame(hdr, 2);
+    _ob_off = 0;
+    _ob_stream = OB_STREAM_VIEW;
     return;
   }
 
   if (op == offband::OCFG_BROKERS) {
-    // Paginated broker-pool dump: START(count) -> BROKER_KV x N (one field/frame) -> END.
+    // Paginated broker-pool dump: START(count) -> BROKER_KV x N -> END, STREAMED one
+    // frame per main-loop pass (offbandStreamDrain). ~30 frames written synchronously
+    // would overrun the 4-deep BLE queue and drop the tail incl. END (F8 #169).
     int maxSlots = offband::configBrokerSlotCount();
     uint8_t count = 0;
     for (int s = 0; s < maxSlots; ++s)
       if (offband::configBrokerSlotPopulated((uint8_t)s)) count++;
     uint8_t hdr[3] = { offband::RESP_CODE_OFFBAND_CONFIG, offband::OCFG_R_BROKERS_START, count };
     _serial->writeFrame(hdr, 3);
-    char buf[1024];                                       // one slot's "key=value\n" lines
-    for (int s = 0; s < maxSlots; ++s) {
-      if (offband::configRenderBrokerSlot((uint8_t)s, buf, sizeof(buf)) == 0) continue;
-      char* line = buf;
-      while (*line) {
-        char* nl = strchr(line, '\n');
-        if (nl) *nl = '\0';
-        if (*line) {                                      // one BROKER_KV frame per non-empty line
-          out_frame[0] = offband::RESP_CODE_OFFBAND_CONFIG;
-          out_frame[1] = offband::OCFG_R_BROKER_KV;
-          out_frame[2] = (uint8_t)s;
-          size_t klen = strlen(line);
-          const size_t cap = MAX_FRAME_SIZE - 4;          // [0],[1],[2]=slot + trailing NUL
-          if (klen > cap) klen = cap;
-          memcpy(&out_frame[3], line, klen);
-          out_frame[3 + klen] = 0;
-          _serial->writeFrame(out_frame, 3 + klen + 1);
-        }
-        if (!nl) break;
-        line = nl + 1;
-      }
-    }
-    hdr[1] = offband::OCFG_R_BROKERS_END;
-    _serial->writeFrame(hdr, 2);
+    _ob_slot   = -1;          // drain advances to the first populated slot
+    _ob_buf[0] = '\0';        // empty -> drain renders the next slot before emitting
+    _ob_off    = 0;
+    _ob_stream = OB_STREAM_BROKERS;
     return;
   }
 
   writeOffbandConfigScalar(offband::OCFG_R_ERR, "bad config sub-type");
+}
+
+// F8 (#169): emit ONE frame of an in-flight multi-frame config response. Called
+// from checkSerialInterface once per idle main-loop pass while !isWriteBusy(), so
+// the BLE send queue (FRAME_QUEUE_SIZE=4, drops-when-full) drains between frames
+// instead of being flooded. Mirrors the ContactsIterator streaming pattern.
+void MyMesh::offbandStreamDrain() {
+  if (_ob_stream == OB_STREAM_VIEW) {
+    if (_ob_buf[_ob_off] == '\0') {                  // text exhausted -> END, done
+      uint8_t hdr[2] = { offband::RESP_CODE_OFFBAND_CONFIG, offband::OCFG_R_VIEW_END };
+      _serial->writeFrame(hdr, 2);
+      _ob_stream = OB_STREAM_NONE;
+      return;
+    }
+    const size_t cap = MAX_FRAME_SIZE - 3;
+    size_t remaining = strlen(&_ob_buf[_ob_off]);
+    size_t take = remaining < cap ? remaining : cap;
+    out_frame[0] = offband::RESP_CODE_OFFBAND_CONFIG;
+    out_frame[1] = offband::OCFG_R_VIEW_CHUNK;
+    memcpy(&out_frame[2], &_ob_buf[_ob_off], take);
+    out_frame[2 + take] = 0;
+    _serial->writeFrame(out_frame, 2 + take + 1);
+    _ob_off += take;
+    return;
+  }
+
+  if (_ob_stream == OB_STREAM_BROKERS) {
+    // Advance to the next populated slot whenever the current buffer is exhausted.
+    while (_ob_buf[_ob_off] == '\0') {
+      int maxSlots = offband::configBrokerSlotCount();
+      int s = _ob_slot + 1;
+      while (s < maxSlots && !offband::configBrokerSlotPopulated((uint8_t)s)) s++;
+      if (s >= maxSlots) {                           // all populated slots streamed -> END
+        uint8_t hdr[2] = { offband::RESP_CODE_OFFBAND_CONFIG, offband::OCFG_R_BROKERS_END };
+        _serial->writeFrame(hdr, 2);
+        _ob_stream = OB_STREAM_NONE;
+        return;
+      }
+      _ob_slot = s;
+      offband::configRenderBrokerSlot((uint8_t)s, _ob_buf, sizeof(_ob_buf));
+      _ob_off = 0;
+    }
+    // Emit ONE "key=value" line as a BROKER_KV frame for the current slot.
+    char* line = &_ob_buf[_ob_off];
+    char* nl = strchr(line, '\n');
+    size_t linelen = nl ? (size_t)(nl - line) : strlen(line);
+    const size_t cap = MAX_FRAME_SIZE - 4;           // [0],[1],[2]=slot + trailing NUL
+    if (linelen > cap) linelen = cap;
+    if (linelen > 0) {
+      out_frame[0] = offband::RESP_CODE_OFFBAND_CONFIG;
+      out_frame[1] = offband::OCFG_R_BROKER_KV;
+      out_frame[2] = (uint8_t)_ob_slot;
+      memcpy(&out_frame[3], line, linelen);
+      out_frame[3 + linelen] = 0;
+      _serial->writeFrame(out_frame, 3 + linelen + 1);
+    }
+    _ob_off += nl ? (size_t)(nl - line) + 1 : strlen(line);
+    return;
+  }
 }
 #endif  // OFFBAND_OBSERVER
 
@@ -1346,6 +1377,9 @@ void MyMesh::handleCmdFrame(size_t len) {
     MESH_DEBUG_PRINTLN("App %s connected", app_name);
 
     _iter_started = false; // stop any left-over ContactsIterator
+#ifdef OFFBAND_OBSERVER
+    _ob_stream = OB_STREAM_NONE; // F8 (#169): drop any in-flight config-response stream
+#endif
     int i = 0;
     out_frame[i++] = RESP_CODE_SELF_INFO;
     out_frame[i++] = ADV_TYPE_CHAT; // what this node Advert identifies as (maybe node's pronouns too?? :-)
@@ -2531,6 +2565,11 @@ void MyMesh::checkSerialInterface() {
   size_t len = _serial->checkRecvFrame(cmd_frame);
   if (len > 0) {
     handleCmdFrame(len);
+#ifdef OFFBAND_OBSERVER
+  } else if (_ob_stream != OB_STREAM_NONE   // F8 (#169): drain an in-flight config
+             && !_serial->isWriteBusy()) {  // response, one frame per idle pass
+    offbandStreamDrain();
+#endif
   } else if (_iter_started              // check if our ContactsIterator is 'running'
              && !_serial->isWriteBusy() // don't spam the Serial Interface too quickly!
   ) {

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -5,7 +5,7 @@
 #include "AbstractUITask.h"
 
 /*------------ Frame Protocol --------------*/
-#define FIRMWARE_VER_CODE 13
+#define FIRMWARE_VER_CODE 14   // #163 (Epic F): + Offband caps byte / config command
 
 #ifndef FIRMWARE_BUILD_DATE
 #define FIRMWARE_BUILD_DATE "6 Jun 2026"

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -118,6 +118,11 @@ public:
   // OFFBAND_OBSERVER. Wire contract: OffbandConfigProtocol.h.
   void handleOffbandConfigCmd(size_t len);
   void writeOffbandConfigScalar(uint8_t sub, const char* text);
+  // F8 (#169): multi-frame config responses (OCFG_BROKERS / OCFG_VIEW) STREAM one
+  // frame per idle main-loop pass via offbandStreamDrain() -- mirroring
+  // ContactsIterator -- instead of flooding the 4-deep BLE send queue synchronously,
+  // which dropped frames including the *_END terminator (F5 device test, mc #79).
+  void offbandStreamDrain();
 #endif
 
 #ifdef OFFBAND_OBSERVER_BLE_COMPANION
@@ -265,6 +270,14 @@ private:
   char _obs_cli_buf[128];
   uint8_t _obs_cli_len;
   bool _obs_cli_redact;   // true once "set wifi.pwd " seen -> stop echoing the PSK
+  // F8 (#169): streaming state for multi-frame config responses (OCFG_BROKERS /
+  // OCFG_VIEW). offbandStreamDrain() emits ONE frame per idle main-loop pass
+  // (mirroring ContactsIterator) so it never floods the 4-deep BLE send queue.
+  enum : uint8_t { OB_STREAM_NONE = 0, OB_STREAM_BROKERS, OB_STREAM_VIEW };
+  uint8_t _ob_stream;     // OB_STREAM_* ; constructor-init to NONE
+  int     _ob_slot;       // BROKERS: slot whose rendered lines are in _ob_buf
+  size_t  _ob_off;        // next line (BROKERS) / chunk (VIEW) offset into _ob_buf
+  char    _ob_buf[1024];  // current slot's "key=value\n" lines, or the VIEW text
 #endif
   uint8_t app_target_ver;
   uint8_t *sign_data;

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -112,6 +112,12 @@ public:
   // the mesh object.
   uint16_t getErrFlags()         const { return _err_flags; }
   int      getOutboundQueueLen() const { return _mgr->getOutboundTotal(); }
+
+  // Epic F (#161): Offband config command handler (CMD_OFFBAND_CONFIG). Observer-
+  // only -- the backend (configSet/configGet, ConfigSchema) compiles only under
+  // OFFBAND_OBSERVER. Wire contract: OffbandConfigProtocol.h.
+  void handleOffbandConfigCmd(size_t len);
+  void writeOffbandConfigScalar(uint8_t sub, const char* text);
 #endif
 
 #ifdef OFFBAND_OBSERVER_BLE_COMPANION

--- a/examples/companion_radio/OffbandConfigProtocol.h
+++ b/examples/companion_radio/OffbandConfigProtocol.h
@@ -76,6 +76,9 @@ enum OffbandConfigResp : uint8_t {
 // ---------------------------------------------------------------------------
 // Broker enum values (shared so neither side hard-codes magic numbers)
 // ---------------------------------------------------------------------------
+// NVS-internal ordinals (the stored enum). On the WIRE, transport/auth_type are
+// transmitted as the STRING NAME the firmware CLI parses + returns -- "tcp"/"tls"/
+// "wss" and "none"/"basic"/"jwt" -- NOT these numbers.
 enum MqttTransport : uint8_t { MQTT_TCP = 0, MQTT_TLS = 1, MQTT_WSS = 2 };
 enum MqttAuthType  : uint8_t { MQTT_AUTH_NONE = 0, MQTT_AUTH_BASIC = 1, MQTT_AUTH_JWT = 2 };
 
@@ -101,20 +104,20 @@ constexpr uint8_t OFFBAND_CAP_WIFI_OBSERVER = 0x01;  // bit 0: config backend (w
 //   mqtt.iata   mqtt.status_interval
 //   display.always_on   display.rotation (0|180)
 // Broker pool (OCFG_SET per-field; read via OCFG_BROKERS):
-//   mqtt.broker.<0-9>.{ enabled, url, port, transport(MqttTransport),
-//     auth_type(MqttAuthType), username, password(WO), topic_prefix,
-//     iata_override, jwt_aud, jwt_refresh, jwt_owner, jwt_email, ca_cert,
-//     jwt_token(WO) }
-// Secrets (password, jwt_token) are WRITE-ONLY: never returned by GET/BROKERS;
-// rendered as "(set)" / "(unset)" only (existing ConfigSchema redaction).
+//   mqtt.broker.<0-9>.{ enabled, url, port, transport(tcp|tls|wss),
+//     auth_type(none|basic|jwt), username, password(WO), topic_prefix,
+//     iata_override, jwt_audience, jwt_refresh, jwt_owner, jwt_email, ca_cert }
+//   (jwt_token is NOT a config key -- it is live-minted at connect, never set/read.)
+// The secret `password` is WRITE-ONLY: never returned by GET/BROKERS; rendered as
+// "(set)" / "(unset)" only (existing ConfigSchema redaction).
 
 // ---------------------------------------------------------------------------
 // WIRE ENCODING RULES (resolve every parsing ambiguity -- both sides MUST follow)
 // ---------------------------------------------------------------------------
-// 1. ALL values are ASCII TEXT. Numerics (port, transport, auth_type,
-//    jwt_refresh, enabled, status_interval, rotation) are sent and returned as
-//    DECIMAL ASCII strings ("8883", not a binary u16). There is no binary
-//    integer anywhere in this protocol -- it tunnels the text CLI.
+// 1. ALL values are ASCII TEXT. Numerics (port, jwt_refresh, enabled,
+//    status_interval, rotation) are sent and returned as DECIMAL ASCII strings
+//    ("8883", not a binary u16). transport/auth_type are the STRING enum NAMES
+//    (tcp|tls|wss ; none|basic|jwt), matching the firmware CLI. No binary anywhere.
 // 2. OCFG_SET payload = "<key> <value>" split on the FIRST space ONLY. <value>
 //    is the verbatim remainder and MAY contain spaces (e.g. wifi.ssid "My Net");
 //    it is NOT quoted and MUST NOT be re-tokenized past the first space.

--- a/examples/companion_radio/OffbandConfigProtocol.h
+++ b/examples/companion_radio/OffbandConfigProtocol.h
@@ -108,6 +108,12 @@ constexpr uint8_t OFFBAND_CAP_WIFI_OBSERVER = 0x01;  // bit 0: config backend (w
 //     auth_type(none|basic|jwt), username, password(WO), topic_prefix,
 //     iata_override, jwt_audience, jwt_refresh, jwt_owner, jwt_email, ca_cert }
 //   (jwt_token is NOT a config key -- it is live-minted at connect, never set/read.)
+//   ACTIONS (F6 #166, OCFG_SET only -- routed to activation/wipe handlers, not stored
+//   as plain fields):
+//     mqtt.broker.<N>.enabled <0|1> -- activate/deactivate the slot (write LAST; see
+//       the recovery handshake below). Read back via OCFG_BROKERS + OCFG_GET.
+//     mqtt.broker.<N>.clear <any>   -- wipe the slot (clearBrokerConfig). Value is
+//       ignored; write-only (no GET).
 // The secret `password` is WRITE-ONLY: never returned by GET/BROKERS; rendered as
 // "(set)" / "(unset)" only (existing ConfigSchema redaction).
 
@@ -144,7 +150,7 @@ constexpr uint8_t OFFBAND_CAP_WIFI_OBSERVER = 0x01;  // bit 0: config backend (w
 //   * Each field SET returns OCFG_R_ACK / OCFG_R_ERR for THAT field, so the client
 //     knows exactly which field failed.
 //   * On any ERR/timeout the client re-reads true state (OCFG_BROKERS), shows a
-//     "partial save" error, and offers retry or discard via the existing
-//     `mqtt clear <N>` (clearBrokerConfig) definitive wipe.
+//     "partial save" error, and offers retry or discard via the
+//     `mqtt.broker.<N>.clear` action (F6 #166 -> clearBrokerConfig) definitive wipe.
 
 }  // namespace offband

--- a/examples/companion_radio/OffbandConfigProtocol.h
+++ b/examples/companion_radio/OffbandConfigProtocol.h
@@ -25,6 +25,22 @@
 #pragma once
 #include <stdint.h>
 
+// ===========================================================================
+// HARDENING GUARD (F7 #168) -- the config command must NOT ship on the
+// UNAUTHENTICATED TCP companion.
+// ===========================================================================
+// main.cpp selects SerialWifiInterface (a WiFiServer on TCP port 5000 with NO
+// connection auth) whenever WIFI_SSID is defined -- in preference to PIN-paired
+// BLE. CMD_OFFBAND_CONFIG can rewrite WiFi/MQTT-broker credentials and repoint
+// the MQTT uplink, so exposing it on that socket = an unauthenticated control
+// channel reachable by any host on the device's LAN. Observer builds use runtime
+// WiFi (WifiBootstrap) + BLE companion and deliberately omit WIFI_SSID; this
+// guard makes that invariant load-bearing instead of a convention. Authenticating
+// the TCP companion is the real fix -- tracked in #167 (P1).
+#if defined(OFFBAND_OBSERVER) && defined(WIFI_SSID)
+#error "Offband observer config command would be exposed on the unauthenticated TCP companion (WIFI_SSID selects SerialWifiInterface :5000, no auth). Build the observer with BLE_PIN_CODE + runtime WiFi (WifiBootstrap), not WIFI_SSID. See #167 / #168."
+#endif
+
 namespace offband {
 
 // ---------------------------------------------------------------------------

--- a/examples/companion_radio/OffbandConfigProtocol.h
+++ b/examples/companion_radio/OffbandConfigProtocol.h
@@ -1,0 +1,144 @@
+// examples/companion_radio/OffbandConfigProtocol.h
+//
+// Offband config command -- companion-API wire CONTRACT (Epic F / F1, #160).
+//
+// Design-of-record: OffbandMesh/meshcore-firmware#143 (Option 2 -- locked).
+// Epic F: #159.  Client mirror: OffbandMesh/meshcore-client #64 (agent DarkBasin).
+//
+// ONE Offband-owned companion-API command (CMD_OFFBAND_CONFIG) lets the Offband
+// client read/write observer + companion settings as key/value, plus a paginated
+// read of the 10-slot MQTT broker pool. It is a THIN ADAPTER over
+// dispatchObserverCli() -- the exact backend the `_sys` channel uses -- so it
+// inherits ConfigSchema validation + secret redaction with zero new logic.
+//
+// This header is the contract BOTH repos implement; keep it byte-for-byte in sync
+// with the client codec (#64).
+//
+// CODE OWNERSHIP --------------------------------------------------------------
+// Offband-owned, deliberately high to stay clear of upstream MeshCore growth:
+//   upstream CMD codes today: 1..65 (max 65); 44..49 reserved (WiFi); 40/41 are
+//   custom-vars.  upstream RESP codes today: 0..28.
+// We never reuse an upstream code and never define inside 44..49. Because the
+// command is ours, we are NOT bound by the 140-byte GET_CUSTOM_VARS sub-cap --
+// frames use the full MAX_FRAME_SIZE (176).
+
+#pragma once
+#include <stdint.h>
+
+namespace offband {
+
+// ---------------------------------------------------------------------------
+// Command + response codes (companion-API frame byte [0])
+// ---------------------------------------------------------------------------
+// Offband extension space starts at 0xC0 -- far above upstream's current max
+// (65); leaves 66..191 for upstream growth, 0xC0.. for Offband.
+constexpr uint8_t CMD_OFFBAND_CONFIG       = 0xC0;  // request:  cmd_frame[0]
+constexpr uint8_t RESP_CODE_OFFBAND_CONFIG = 0xC0;  // response: out_frame[0]
+
+// Capability negotiation: the command exists when the device reports
+// FIRMWARE_VER_CODE >= this value (bumped 13 -> 14 in F4). Stock / lower-version
+// clients never send CMD_OFFBAND_CONFIG, so they are unaffected (purely additive).
+constexpr uint8_t OFFBAND_CONFIG_MIN_VER = 14;
+
+// ---------------------------------------------------------------------------
+// Request sub-type -- cmd_frame[1]
+// ---------------------------------------------------------------------------
+enum OffbandConfigOp : uint8_t {
+    OCFG_SET     = 0x00,  // cmd[2..] = "<key> <value>"  (see WIRE ENCODING RULES)
+    OCFG_GET     = 0x01,  // cmd[2..] = "<key>"          -> one OCFG_R_VALUE frame
+    OCFG_VIEW    = 0x02,  // cmd[2..] = read-only selector ("mqtt status", "mqtt view 0")
+    OCFG_BROKERS = 0x03,  // (no payload)                -> paginated broker-pool dump
+};
+
+// ---------------------------------------------------------------------------
+// Response sub-type -- out_frame[1]
+// ---------------------------------------------------------------------------
+enum OffbandConfigResp : uint8_t {
+    // scalar replies (single frame; out[2..] = NUL-terminated text)
+    OCFG_R_ACK   = 0x00,  // SET ok; out[2..] = optional confirmation text
+    OCFG_R_ERR   = 0x01,  // any op failed; out[2..] = error text
+    OCFG_R_VALUE = 0x02,  // GET ok;  out[2..] = value text (one field, fits one frame)
+
+    // broker-pool dump -- modeled on the contacts START -> ITEM -> END stream.
+    // FIELD-granular because one populated slot's non-secret fields total ~513 B,
+    // far over MAX_FRAME_SIZE (176): a slot cannot fit in one frame.
+    // Empty pool: START(count=0) is sent, immediately followed by END.
+    OCFG_R_BROKERS_START = 0x10,  // out[2] = count of populated slots to follow
+    OCFG_R_BROKER_KV     = 0x11,  // out[2] = slot index (0..9), out[3..] = "key=value"
+    OCFG_R_BROKERS_END   = 0x12,
+
+    // VIEW text dump -- chunked, because `mqtt view`/`status` text can exceed one frame.
+    OCFG_R_VIEW_START = 0x20,
+    OCFG_R_VIEW_CHUNK = 0x21,  // out[2..] = NUL-terminated text chunk
+    OCFG_R_VIEW_END   = 0x22,
+};
+
+// ---------------------------------------------------------------------------
+// Broker enum values (shared so neither side hard-codes magic numbers)
+// ---------------------------------------------------------------------------
+enum MqttTransport : uint8_t { MQTT_TCP = 0, MQTT_TLS = 1, MQTT_WSS = 2 };
+enum MqttAuthType  : uint8_t { MQTT_AUTH_NONE = 0, MQTT_AUTH_BASIC = 1, MQTT_AUTH_JWT = 2 };
+
+// ---------------------------------------------------------------------------
+// Device capability bit -- appended to RESP_CODE_DEVICE_INFO (CMD_DEVICE_QUERY)
+// ---------------------------------------------------------------------------
+// F4 appends ONE `offband_caps` byte to the device-info reply, after the existing
+// path_hash_mode byte (additive -- pre-v14 clients read a shorter frame and ignore
+// it). Version code alone cannot distinguish a build with wifi_observer compiled
+// OUT from one with it IN, so the client gates the wifi/mqtt config category on
+// WIFI_OBSERVER below; display.* keys gate on FIRMWARE_VER_CODE >= 14 alone
+// (display applies to companion + observer builds -- no observer required).
+constexpr uint8_t OFFBAND_CAP_WIFI_OBSERVER = 0x01;  // bit 0: wifi_observer compiled in
+
+// ---------------------------------------------------------------------------
+// Key schema -- the firmware<->client contract surface
+// ---------------------------------------------------------------------------
+// Flat keys (OCFG_SET / OCFG_GET):
+//   wifi.ssid   wifi.pwd(WO)   wifi.enabled
+//   mqtt.iata   mqtt.status_interval
+//   display.always_on   display.rotation (0|180)
+// Broker pool (OCFG_SET per-field; read via OCFG_BROKERS):
+//   mqtt.broker.<0-9>.{ enabled, url, port, transport(MqttTransport),
+//     auth_type(MqttAuthType), username, password(WO), topic_prefix,
+//     iata_override, jwt_aud, jwt_refresh, jwt_owner, jwt_email, ca_cert,
+//     jwt_token(WO) }
+// Secrets (password, jwt_token) are WRITE-ONLY: never returned by GET/BROKERS;
+// rendered as "(set)" / "(unset)" only (existing ConfigSchema redaction).
+
+// ---------------------------------------------------------------------------
+// WIRE ENCODING RULES (resolve every parsing ambiguity -- both sides MUST follow)
+// ---------------------------------------------------------------------------
+// 1. ALL values are ASCII TEXT. Numerics (port, transport, auth_type,
+//    jwt_refresh, enabled, status_interval, rotation) are sent and returned as
+//    DECIMAL ASCII strings ("8883", not a binary u16). There is no binary
+//    integer anywhere in this protocol -- it tunnels the text CLI.
+// 2. OCFG_SET payload = "<key> <value>" split on the FIRST space ONLY. <value>
+//    is the verbatim remainder and MAY contain spaces (e.g. wifi.ssid "My Net");
+//    it is NOT quoted and MUST NOT be re-tokenized past the first space.
+// 3. OCFG_R_BROKER_KV payload = "<key>=<value>" split on the FIRST '=' ONLY.
+//    <value> MAY contain '=' (e.g. a URL query string) -- never split again.
+// 4. NUL-TERMINATION: every string payload (OCFG_R_VALUE, OCFG_R_BROKER_KV,
+//    OCFG_R_VIEW_CHUNK) is NUL-terminated; payload bytes incl. the NUL never
+//    exceed the frame's remaining space (MAX_FRAME_SIZE minus the [0]/[1] header
+//    bytes, and minus the [2] slot byte for OCFG_R_BROKER_KV).
+// 5. SINGLE-FRAME SCALARS: every flat OCFG_GET value (wifi.ssid<=32, mqtt.iata<=8,
+//    status_interval, display.*) and every broker OCFG_R_BROKER_KV "key=value"
+//    (largest field url<=128 -> "url=" + 128 + NUL < 176) fits ONE frame by
+//    construction. Multi-frame applies ONLY to OCFG_BROKERS and OCFG_VIEW.
+
+// ---------------------------------------------------------------------------
+// BROKER-SET RECOVERY HANDSHAKE (decided on #143; field-at-a-time, no
+// transactional setBroker -- stays upstream-consistent)
+// ---------------------------------------------------------------------------
+//   * `enabled` is written LAST = the activation guard. A broker only goes live
+//     when enabled=true, so a partial SET leaves the slot DISABLED (never
+//     live-corrupt).
+//       - Configure: write all fields, then enabled=true only after every field ACKs.
+//       - Edit a live broker: enabled=false first -> update fields -> enabled=true last.
+//   * Each field SET returns OCFG_R_ACK / OCFG_R_ERR for THAT field, so the client
+//     knows exactly which field failed.
+//   * On any ERR/timeout the client re-reads true state (OCFG_BROKERS), shows a
+//     "partial save" error, and offers retry or discard via the existing
+//     `mqtt clear <N>` (clearBrokerConfig) definitive wipe.
+
+}  // namespace offband

--- a/examples/companion_radio/OffbandConfigProtocol.h
+++ b/examples/companion_radio/OffbandConfigProtocol.h
@@ -84,11 +84,14 @@ enum MqttAuthType  : uint8_t { MQTT_AUTH_NONE = 0, MQTT_AUTH_BASIC = 1, MQTT_AUT
 // ---------------------------------------------------------------------------
 // F4 appends ONE `offband_caps` byte to the device-info reply, after the existing
 // path_hash_mode byte (additive -- pre-v14 clients read a shorter frame and ignore
-// it). Version code alone cannot distinguish a build with wifi_observer compiled
-// OUT from one with it IN, so the client gates the wifi/mqtt config category on
-// WIFI_OBSERVER below; display.* keys gate on FIRMWARE_VER_CODE >= 14 alone
-// (display applies to companion + observer builds -- no observer required).
-constexpr uint8_t OFFBAND_CAP_WIFI_OBSERVER = 0x01;  // bit 0: wifi_observer compiled in
+// it). The ENTIRE config command is observer-only: its backend (ConfigSchema +
+// dispatchObserverCli) compiles only under OFFBAND_OBSERVER, so on a non-observer
+// node type there is no config at all -- display config included (the #141/#148
+// display prefs are persisted via ConfigSchema, itself observer-only). Version code
+// alone cannot tell an observer-out build from an observer-in one, so the client
+// gates the WHOLE command -- every key, display included -- on WIFI_OBSERVER_SUPPORT
+// (in addition to FIRMWARE_VER_CODE >= 14). There is NO display-without-observer path.
+constexpr uint8_t OFFBAND_CAP_WIFI_OBSERVER = 0x01;  // bit 0: config backend (wifi_observer) compiled in
 
 // ---------------------------------------------------------------------------
 // Key schema -- the firmware<->client contract surface

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -50,6 +50,12 @@ static uint32_t _atoi(const char* sp) {
 
 #ifdef ESP32
   #ifdef WIFI_SSID
+    // SECURITY (Offband #167/#168): SerialWifiInterface is a TCP server on
+    // TCP_PORT (5000) with NO connection auth -- any host on the LAN that reaches
+    // it becomes the companion peer (full companion-API control). Do NOT pair
+    // WIFI_SSID with OFFBAND_OBSERVER: the config command would land on this
+    // unauthenticated socket (a compile-time #error in OffbandConfigProtocol.h
+    // enforces that). Authenticating this transport is tracked in #167 (P1).
     #include <helpers/esp32/SerialWifiInterface.h>
     SerialWifiInterface serial_interface;
     #ifndef TCP_PORT

--- a/scripts/test_observer_nvs_round_trip.py
+++ b/scripts/test_observer_nvs_round_trip.py
@@ -55,6 +55,7 @@ class Preferences {
     bool begin(const char* ns, bool /*ro*/) { ns_ = ns; return true; }
     void end() {}
     bool clear() { kvs_[ns_].clear(); return true; }
+    bool remove(const char* k) { return kvs_[ns_].erase(k) > 0; }  // #182: erase key (no-blank writes)
     bool   putBool   (const char* k, bool v)        { kvs_[ns_][k] = v ? "1":"0"; return true; }
     bool   getBool   (const char* k, bool def)      { auto& m = kvs_[ns_]; auto it=m.find(k); return it==m.end()?def:(it->second=="1"); }
     size_t putString (const char* k, const char* v) { kvs_[ns_][k] = v; return strlen(v); }
@@ -240,6 +241,26 @@ int main() {
                slot0_again.url, slot0.url);
         return 1;
     }
+
+    // #182: migration smoke -- migrateBrokerStorage() preserves config, stamps the
+    // schema flag, and is idempotent (a second call is a no-op).
+    BrokerConfig pre2; readBrokerConfig(2, pre2);
+    migrateBrokerStorage();
+    BrokerConfig post2;
+    if (!readBrokerConfig(2, post2)) { puts("FAIL re-read slot 2 post-migration"); return 1; }
+    if (strcmp(post2.url, pre2.url) != 0 || strcmp(post2.jwt_audience, pre2.jwt_audience) != 0) {
+        printf("FAIL migration altered slot 2: url '%s' aud '%s'\n", post2.url, post2.jwt_audience);
+        return 1;
+    }
+    {
+        Preferences obs; obs.begin(kNvsObserver, true);
+        uint8_t ver = obs.getUChar(kKeyCfgSchema, 0);
+        obs.end();
+        if (ver != kCfgSchemaVersion) { printf("FAIL schema flag not stamped: %u\n", ver); return 1; }
+    }
+    migrateBrokerStorage();  // idempotent: flag set -> no-op
+    BrokerConfig post2b; readBrokerConfig(2, post2b);
+    if (strcmp(post2b.url, pre2.url) != 0) { puts("FAIL migration not idempotent"); return 1; }
 
     puts("OK");
     return 0;

--- a/scripts/test_observer_nvs_round_trip.py
+++ b/scripts/test_observer_nvs_round_trip.py
@@ -65,6 +65,10 @@ class Preferences {
     uint8_t getUChar (const char* k, uint8_t def)   { auto& m = kvs_[ns_]; auto it=m.find(k); return it==m.end()?def:(uint8_t)std::stoi(it->second); }
     size_t putULong  (const char* k, uint32_t v)    { kvs_[ns_][k] = std::to_string(v); return 4; }
     uint32_t getULong(const char* k, uint32_t def)  { auto& m = kvs_[ns_]; auto it=m.find(k); return it==m.end()?def:(uint32_t)std::stoul(it->second); }
+    // #181: blob accessors for the single versioned broker-config blob.
+    size_t putBytes  (const char* k, const void* v, size_t len) { kvs_[ns_][k] = std::string((const char*)v, len); return len; }
+    size_t getBytes  (const char* k, void* out, size_t len)     { auto& m = kvs_[ns_]; auto it=m.find(k); if (it==m.end()) return 0; size_t n = it->second.size() < len ? it->second.size() : len; memcpy(out, it->second.data(), n); return n; }
+    size_t getBytesLength(const char* k)                        { auto& m = kvs_[ns_]; auto it=m.find(k); return it==m.end() ? 0 : it->second.size(); }
  private:
     static inline std::map<std::string, std::map<std::string,std::string>> kvs_;
     std::string ns_;
@@ -160,7 +164,7 @@ int main() {
     if (!readBrokerConfig(3, slot3)) { puts("FAIL read slot 3"); return 1; }
 
     // Slot 0 = CoreScope: plaintext + anonymous, the ONLY default-enabled slot.
-    if (strcmp(slot0.url, "mqtt://mqtt.w8oof.net:1883") != 0) {
+    if (strcmp(slot0.url, "mqtt://mqtt1.okimesh.org:1883") != 0) {  // #170: was mqtt.w8oof.net
         printf("FAIL slot 0 url after populate: '%s'\n", slot0.url);
         return 1;
     }

--- a/src/helpers/esp32/SerialBLEInterface.h
+++ b/src/helpers/esp32/SerialBLEInterface.h
@@ -25,7 +25,10 @@ class SerialBLEInterface : public BaseSerialInterface, NimBLEServerCallbacks, Ni
     uint8_t buf[MAX_FRAME_SIZE];
   };
 
-  #define FRAME_QUEUE_SIZE  4
+  // #178: was 4. Absorb the connect-time command/response burst so the client's
+  // uncapped-retry (connect-thrash) never gets a dropped frame and re-storms.
+  // Sizes BOTH recv + send queues; nrf52 already uses 12. ~a few KB static .bss.
+  #define FRAME_QUEUE_SIZE  12
   int recv_queue_len;
   Frame recv_queue[FRAME_QUEUE_SIZE];
   int send_queue_len;

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -196,7 +196,7 @@ bool clearBrokerConfig(uint8_t slot) {
 // changing this layout does NOT re-shuffle slots on a device already seeded
 // under an older layout; it takes effect only on a fresh NVS.)
 //
-//   slot 0  CoreScope Dayton   mqtt://mqtt.w8oof.net:1883       tcp / anon   ENABLED
+//   slot 0  CoreScope Dayton   mqtt://mqtt1.okimesh.org:1883    tcp / anon   ENABLED
 //   slot 1  LetsMesh-US        wss://mqtt-us-v1.letsmesh.net    wss / jwt    disabled
 //   slot 2  Eastme.sh          wss://mqtt.eastme.sh             wss / jwt    disabled
 //   slot 3  MeshMapper         wss://mqtt.meshmapper.net        wss / jwt    disabled
@@ -245,7 +245,7 @@ struct DefaultBrokerSpec {
 // Slots 0-5. Slots 6-9 (MQTT Custom) are intentionally absent so they stay empty.
 // jwt_audience is the BARE host (#95); ca_cert names resolve in MqttBroker.cpp.
 constexpr DefaultBrokerSpec kDefaultBrokerSpecs[] = {
-    {true,  "mqtt://mqtt.w8oof.net:1883",             BrokerTransport::Tcp, 1883, BrokerAuthType::None, "",                        ""},
+    {true,  "mqtt://mqtt1.okimesh.org:1883",          BrokerTransport::Tcp, 1883, BrokerAuthType::None, "",                        ""},
     {false, "wss://mqtt-us-v1.letsmesh.net:443/mqtt", BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt-us-v1.letsmesh.net", "gts-r4"},
     {false, "wss://mqtt.eastme.sh:443/mqtt",          BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt.eastme.sh",          "letsencrypt"},
     {false, "wss://mqtt.meshmapper.net:443/mqtt",     BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt.meshmapper.net",     "isrg-x2"},

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -46,6 +46,38 @@ static void logCfgWriteFailure(const char* where, const char* ns) {
 static void logCfgWriteFailure(const char*, const char*) {}
 #endif
 
+// #181: the config READERS default to a SAFE value on a miss (empty iata, 30s
+// interval, display off/0deg, empty-url broker) and the Arduino read-only API
+// can't distinguish "key absent" -- the legitimate first-boot state -- from a
+// deeper error, so silence-with-safe-default IS the correct, documented contract
+// for a read-miss (NOT a SAFELANE 6 violation). The one read-side anomaly worth
+// surfacing is "data present but unusable": a broker blob of the right SIZE that
+// reads back short = NVS corruption, distinct from a clean miss. logCfgReadFailure
+// records that. Real-device only; host gets the no-op stub.
+//
+// The same logic deliberately covers a read-only begin() returning false: on a
+// readonly handle that is the EXPECTED "namespace not yet created" first-boot miss
+// (nvs_open -> ESP_ERR_NVS_NOT_FOUND), which the Arduino wrapper collapses into the
+// same `false` as a genuine NVS error. Logging it would flag every fresh /
+// unconfigured namespace as an error and flood a first-boot log (violating §1). A
+// SYSTEMIC NVS failure still surfaces -- the WRITE path and the boot counter DO log
+// their begin() failures (a read-WRITE begin failure is genuinely anomalous;
+// NVS_READWRITE creates the namespace). So the readers intentionally do not log
+// begin()==false; the safe get-defaults flow through unchanged.
+#if defined(ESP_PLATFORM)
+static void logCfgReadFailure(const char* where, const char* ns) {
+    nvs_stats_t st;
+    if (nvs_get_stats(NULL, &st) == ESP_OK) {
+        crashLogf("[cfg] %s READ FAILED ns=%s nvs[used=%u free=%u total=%u]", where, ns,
+                  (unsigned)st.used_entries, (unsigned)st.free_entries, (unsigned)st.total_entries);
+    } else {
+        crashLogf("[cfg] %s READ FAILED ns=%s (nvs_get_stats unavailable)", where, ns);
+    }
+}
+#else
+static void logCfgReadFailure(const char*, const char*) {}
+#endif
+
 bool readGlobalIata(char* out, size_t out_len) {
     Preferences p;
     p.begin(kNvsMqtt, /*readOnly=*/true);
@@ -176,11 +208,18 @@ bool readBrokerConfig(uint8_t slot, BrokerConfig& out) {
     // absent and fall through to the legacy per-key read (pre-#181 devices).
     if (p.getBytesLength(kKeyBrokerBlob) == sizeof(BrokerBlob)) {
         BrokerBlob blob;
-        if (p.getBytes(kKeyBrokerBlob, &blob, sizeof(blob)) == sizeof(blob)
-            && blob.version == kBrokerBlobVersion) {
+        size_t got = p.getBytes(kKeyBrokerBlob, &blob, sizeof(blob));
+        if (got == sizeof(blob) && blob.version == kBrokerBlobVersion) {
             out = blob.cfg;
             p.end();
             return true;
+        }
+        // A right-sized blob that reads back SHORT = NVS corruption, not a clean
+        // miss: surface it (SAFELANE 6), then fall through to the legacy keys.
+        // A version mismatch is the expected non-destructive migration path
+        // (downgrade / future bump) -> fall through silently.
+        if (got != sizeof(blob)) {
+            logCfgReadFailure("readBrokerConfig.blob", ns);
         }
     }
     out.enabled   = p.getBool(kKeyBrokerEnabled, false);

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -28,6 +28,24 @@ void mqttBrokerNamespace(uint8_t broker_index, char* out, size_t out_len) {
 
 #ifdef ARDUINO
 
+// #181: surface a config-write failure (SAFELANE 6 -- never silent) AND measure
+// the cause (free-entry count answers "is NVS full?" with evidence, not a guess).
+// Shared by every NVS writer below. Real-device only; the host round-trip test
+// gets the no-op stub (it defines ARDUINO but not ESP_PLATFORM).
+#if defined(ESP_PLATFORM)
+static void logCfgWriteFailure(const char* where, const char* ns) {
+    nvs_stats_t st;
+    if (nvs_get_stats(NULL, &st) == ESP_OK) {
+        crashLogf("[cfg] %s WRITE FAILED ns=%s nvs[used=%u free=%u total=%u]", where, ns,
+                  (unsigned)st.used_entries, (unsigned)st.free_entries, (unsigned)st.total_entries);
+    } else {
+        crashLogf("[cfg] %s WRITE FAILED ns=%s (nvs_get_stats unavailable)", where, ns);
+    }
+}
+#else
+static void logCfgWriteFailure(const char*, const char*) {}
+#endif
+
 bool readGlobalIata(char* out, size_t out_len) {
     Preferences p;
     p.begin(kNvsMqtt, /*readOnly=*/true);
@@ -42,11 +60,22 @@ bool readGlobalIata(char* out, size_t out_len) {
     return true;
 }
 
-void writeGlobalIata(const char* iata) {
+bool writeGlobalIata(const char* iata) {
     Preferences p;
-    p.begin(kNvsMqtt, /*readOnly=*/false);
-    p.putString(kKeyMqttIata, iata);
+    if (!p.begin(kNvsMqtt, /*readOnly=*/false)) {   // #181: never silent -- report begin failure
+        logCfgWriteFailure("writeGlobalIata.begin", kNvsMqtt);
+        return false;
+    }
+    size_t wrote = p.putString(kKeyMqttIata, iata);
     p.end();
+    // putString returns chars written (0 on NVS failure). An empty value also
+    // returns 0 but is a legitimate clear, so only treat 0 as failure when there
+    // was actually content to store.
+    if (wrote == 0 && iata != nullptr && iata[0] != '\0') {
+        logCfgWriteFailure("writeGlobalIata.putString", kNvsMqtt);
+        return false;
+    }
+    return true;
 }
 
 uint16_t readStatusIntervalSec() {
@@ -60,13 +89,21 @@ uint16_t readStatusIntervalSec() {
     return v;
 }
 
-void writeStatusIntervalSec(uint16_t seconds) {
+bool writeStatusIntervalSec(uint16_t seconds) {
     if (seconds < kMinStatusIntervalSec) seconds = kMinStatusIntervalSec;
     if (seconds > kMaxStatusIntervalSec) seconds = kMaxStatusIntervalSec;
     Preferences p;
-    p.begin(kNvsMqtt, /*readOnly=*/false);
-    p.putUShort(kKeyMqttStatusInterval, seconds);
+    if (!p.begin(kNvsMqtt, /*readOnly=*/false)) {
+        logCfgWriteFailure("writeStatusIntervalSec.begin", kNvsMqtt);
+        return false;
+    }
+    size_t wrote = p.putUShort(kKeyMqttStatusInterval, seconds);
     p.end();
+    if (wrote != sizeof(uint16_t)) {    // putUShort returns 2 on success, 0 on failure
+        logCfgWriteFailure("writeStatusIntervalSec.putUShort", kNvsMqtt);
+        return false;
+    }
+    return true;
 }
 
 // #141: display always-on toggle, in the fork-branded "offband_ui" namespace.
@@ -78,11 +115,19 @@ bool getDisplayAlwaysOn() {
     return v;
 }
 
-void setDisplayAlwaysOn(bool on) {
+bool setDisplayAlwaysOn(bool on) {
     Preferences p;
-    p.begin(kNvsOffbandUi, /*readOnly=*/false);
-    p.putBool(kKeyDisplayAlwaysOn, on);
+    if (!p.begin(kNvsOffbandUi, /*readOnly=*/false)) {
+        logCfgWriteFailure("setDisplayAlwaysOn.begin", kNvsOffbandUi);
+        return false;
+    }
+    size_t wrote = p.putBool(kKeyDisplayAlwaysOn, on);
     p.end();
+    if (wrote != sizeof(uint8_t)) {     // putBool stores 1 byte; 0 on failure
+        logCfgWriteFailure("setDisplayAlwaysOn.putBool", kNvsOffbandUi);
+        return false;
+    }
+    return true;
 }
 
 // #148: display rotation (0/180) in the "offband_ui" namespace. Clamped to the
@@ -95,11 +140,19 @@ uint8_t getDisplayRotation() {
     return (v == 180) ? 180 : 0;
 }
 
-void setDisplayRotation(uint8_t deg) {
+bool setDisplayRotation(uint8_t deg) {
     Preferences p;
-    p.begin(kNvsOffbandUi, /*readOnly=*/false);
-    p.putUChar(kKeyDisplayRotation, (deg == 180) ? 180 : 0);
+    if (!p.begin(kNvsOffbandUi, /*readOnly=*/false)) {
+        logCfgWriteFailure("setDisplayRotation.begin", kNvsOffbandUi);
+        return false;
+    }
+    size_t wrote = p.putUChar(kKeyDisplayRotation, (deg == 180) ? 180 : 0);
     p.end();
+    if (wrote != sizeof(uint8_t)) {     // putUChar stores 1 byte; 0 on failure
+        logCfgWriteFailure("setDisplayRotation.putUChar", kNvsOffbandUi);
+        return false;
+    }
+    return true;
 }
 
 // #181: broker config persists as ONE versioned blob (kKeyBrokerBlob), not 15
@@ -112,23 +165,6 @@ void setDisplayRotation(uint8_t deg) {
 static constexpr uint16_t    kBrokerBlobVersion = 1;
 static constexpr const char* kKeyBrokerBlob     = "cfg_blob";
 struct BrokerBlob { uint16_t version; BrokerConfig cfg; };
-
-// #181: surface a config-write failure (SAFELANE 6 -- never silent) AND measure
-// the cause (free-entry count answers "is NVS full?" with evidence, not a guess).
-// Real-device only; the host round-trip test gets the no-op stub.
-#if defined(ESP_PLATFORM)
-static void logCfgWriteFailure(const char* where, const char* ns) {
-    nvs_stats_t st;
-    if (nvs_get_stats(NULL, &st) == ESP_OK) {
-        crashLogf("[cfg] %s WRITE FAILED ns=%s nvs[used=%u free=%u total=%u]", where, ns,
-                  (unsigned)st.used_entries, (unsigned)st.free_entries, (unsigned)st.total_entries);
-    } else {
-        crashLogf("[cfg] %s WRITE FAILED ns=%s (nvs_get_stats unavailable)", where, ns);
-    }
-}
-#else
-static void logCfgWriteFailure(const char*, const char*) {}
-#endif
 
 bool readBrokerConfig(uint8_t slot, BrokerConfig& out) {
     if (slot >= OFFBAND_MAX_BROKERS) return false;
@@ -298,11 +334,12 @@ constexpr uint8_t kNumDefaultBrokers =
 }  // namespace
 
 void populateDefaultBrokers() {
+    bool all_ok = true;
     // Seed the owner's IATA (HAO) if unset -- SWOH default to simplify setup
     // for most operators; non-SWOH operators override via the global mqtt iata.
     char iata[8] = {0};
     if (!readGlobalIata(iata, sizeof(iata)) || iata[0] == '\0') {
-        writeGlobalIata("HAO");
+        all_ok &= writeGlobalIata("HAO");
     }
 
     for (uint8_t slot = 0;
@@ -329,7 +366,14 @@ void populateDefaultBrokers() {
         // is auto-built at connect, and jwt_owner/jwt_email are the operator's
         // identity claims, set via `set mqtt.broker.<N>.jwt_owner|jwt_email`
         // (#63). NOT device-derivable here -- see header comment (#95).
-        writeBrokerConfig(slot, def);
+        all_ok &= writeBrokerConfig(slot, def);
+    }
+    // #181: each failed write already self-logged its NVS cause + free-entry
+    // stats; surface a single boot-time summary so an incomplete default-seed
+    // is never silent (SAFELANE 6). Boot-time best-effort: a failed seed retries
+    // on the next boot (populateDefaultBrokers is idempotent / skip-if-present).
+    if (!all_ok) {
+        logCfgWriteFailure("populateDefaultBrokers", "(default-seed: 1+ write failed)");
     }
 }
 

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -4,6 +4,10 @@
 #ifdef ARDUINO
   #include <Arduino.h>
   #include <Preferences.h>
+  #if defined(ESP_PLATFORM)
+    #include <nvs.h>        // #181: nvs_get_stats() -- write-failure diagnostic (real device only)
+    #include "CrashLog.h"   // #181: crashLogf() -- persistent + Serial failure log
+  #endif
 #else
   // Host build: provide a thin Preferences shim so the file compiles
   // for host-runnable tests. The shim is in scripts/test_*.py harness.
@@ -98,12 +102,51 @@ void setDisplayRotation(uint8_t deg) {
     p.end();
 }
 
+// #181: broker config persists as ONE versioned blob (kKeyBrokerBlob), not 15
+// separate keys. A write is all-or-nothing at the app level, so no partial/corrupt
+// slot is possible, and NVS leaves the prior blob intact if a write fails (the blob
+// is committed via its index). Bump kBrokerBlobVersion whenever BrokerConfig's
+// layout changes so a stale-size blob is treated as absent -> the legacy per-key
+// read below supplies the value (non-destructive migration: legacy keys are never
+// deleted, so they remain a fallback even after a slot has migrated).
+static constexpr uint16_t    kBrokerBlobVersion = 1;
+static constexpr const char* kKeyBrokerBlob     = "cfg_blob";
+struct BrokerBlob { uint16_t version; BrokerConfig cfg; };
+
+// #181: surface a config-write failure (SAFELANE 6 -- never silent) AND measure
+// the cause (free-entry count answers "is NVS full?" with evidence, not a guess).
+// Real-device only; the host round-trip test gets the no-op stub.
+#if defined(ESP_PLATFORM)
+static void logCfgWriteFailure(const char* where, const char* ns) {
+    nvs_stats_t st;
+    if (nvs_get_stats(NULL, &st) == ESP_OK) {
+        crashLogf("[cfg] %s WRITE FAILED ns=%s nvs[used=%u free=%u total=%u]", where, ns,
+                  (unsigned)st.used_entries, (unsigned)st.free_entries, (unsigned)st.total_entries);
+    } else {
+        crashLogf("[cfg] %s WRITE FAILED ns=%s (nvs_get_stats unavailable)", where, ns);
+    }
+}
+#else
+static void logCfgWriteFailure(const char*, const char*) {}
+#endif
+
 bool readBrokerConfig(uint8_t slot, BrokerConfig& out) {
     if (slot >= OFFBAND_MAX_BROKERS) return false;
     char ns[16];
     mqttBrokerNamespace(slot, ns, sizeof(ns));
     Preferences p;
     p.begin(ns, /*readOnly=*/true);
+    // #181: prefer the versioned blob. A size or version mismatch -> treat as
+    // absent and fall through to the legacy per-key read (pre-#181 devices).
+    if (p.getBytesLength(kKeyBrokerBlob) == sizeof(BrokerBlob)) {
+        BrokerBlob blob;
+        if (p.getBytes(kKeyBrokerBlob, &blob, sizeof(blob)) == sizeof(blob)
+            && blob.version == kBrokerBlobVersion) {
+            out = blob.cfg;
+            p.end();
+            return true;
+        }
+    }
     out.enabled   = p.getBool(kKeyBrokerEnabled, false);
     String url    = p.getString(kKeyBrokerUrl, "");
     strncpy(out.url, url.c_str(), sizeof(out.url));
@@ -147,25 +190,23 @@ bool writeBrokerConfig(uint8_t slot, const BrokerConfig& cfg) {
     char ns[16];
     mqttBrokerNamespace(slot, ns, sizeof(ns));
     Preferences p;
-    p.begin(ns, /*readOnly=*/false);
-    p.putBool   (kKeyBrokerEnabled,      cfg.enabled);
-    p.putString (kKeyBrokerUrl,          cfg.url);
-    p.putUShort (kKeyBrokerPort,         cfg.port);
-    p.putUChar  (kKeyBrokerTransport,    (uint8_t)cfg.transport);
-    p.putUChar  (kKeyBrokerAuthType,     (uint8_t)cfg.auth_type);
-    p.putString (kKeyBrokerUsername,     cfg.username);
-    p.putString (kKeyBrokerPassword,     cfg.password);
-    p.putString (kKeyBrokerJwtToken,     cfg.jwt_token);
-    p.putString (kKeyBrokerTopicPrefix,  cfg.topic_prefix);
-    p.putString (kKeyBrokerIataOverride, cfg.iata_override);
-    // Plan 2 v2 additions
-    p.putString (kKeyBrokerJwtAudience,  cfg.jwt_audience);
-    p.putULong  (kKeyBrokerJwtRefresh,   cfg.jwt_refresh_sec);
-    p.putString (kKeyBrokerCaCertName,   cfg.ca_cert_name);
-    // #63 additions: JWT identity claims
-    p.putString (kKeyBrokerJwtOwner,     cfg.jwt_owner);
-    p.putString (kKeyBrokerJwtEmail,     cfg.jwt_email);
+    if (!p.begin(ns, /*readOnly=*/false)) {     // #181: never silent -- report a begin failure
+        logCfgWriteFailure("writeBrokerConfig.begin", ns);
+        return false;
+    }
+    // #181: ONE versioned blob, all-or-nothing. putBytes returns the byte count
+    // written (0 / short on failure, e.g. NVS exhausted). On failure: log the
+    // cause (free-entry stats) and return false, so the caller's ACK reflects
+    // reality instead of claiming success on a write that never landed.
+    BrokerBlob blob{};                        // #181: zero padding -> deterministic NVS bytes
+    blob.version = kBrokerBlobVersion;
+    blob.cfg     = cfg;
+    size_t wrote = p.putBytes(kKeyBrokerBlob, &blob, sizeof(blob));
     p.end();
+    if (wrote != sizeof(blob)) {
+        logCfgWriteFailure("writeBrokerConfig.putBytes", ns);
+        return false;
+    }
     return true;
 }
 

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -46,37 +46,23 @@ static void logCfgWriteFailure(const char* where, const char* ns) {
 static void logCfgWriteFailure(const char*, const char*) {}
 #endif
 
-// #181: the config READERS default to a SAFE value on a miss (empty iata, 30s
-// interval, display off/0deg, empty-url broker) and the Arduino read-only API
-// can't distinguish "key absent" -- the legitimate first-boot state -- from a
-// deeper error, so silence-with-safe-default IS the correct, documented contract
-// for a read-miss (NOT a SAFELANE 6 violation). The one read-side anomaly worth
-// surfacing is "data present but unusable": a broker blob of the right SIZE that
-// reads back short = NVS corruption, distinct from a clean miss. logCfgReadFailure
-// records that. Real-device only; host gets the no-op stub.
+// #181/#182: the config READERS default to a SAFE value on a miss (empty iata,
+// 30s interval, display off/0deg, empty-url broker), and the Arduino read-only
+// API can't distinguish "key absent" -- the legitimate first-boot/unset state --
+// from a deeper error, so silence-with-safe-default IS the correct, documented
+// contract for a read-miss (NOT a SAFELANE 6 violation). This is exactly why
+// writeBrokerConfig can safely REMOVE an empty field's key (#182): an absent key
+// just reads back as the default.
 //
 // The same logic deliberately covers a read-only begin() returning false: on a
-// readonly handle that is the EXPECTED "namespace not yet created" first-boot miss
-// (nvs_open -> ESP_ERR_NVS_NOT_FOUND), which the Arduino wrapper collapses into the
-// same `false` as a genuine NVS error. Logging it would flag every fresh /
-// unconfigured namespace as an error and flood a first-boot log (violating §1). A
-// SYSTEMIC NVS failure still surfaces -- the WRITE path and the boot counter DO log
-// their begin() failures (a read-WRITE begin failure is genuinely anomalous;
+// readonly handle that is the EXPECTED "namespace not yet created" miss (nvs_open
+// -> ESP_ERR_NVS_NOT_FOUND), which the Arduino wrapper collapses into the same
+// `false` as a genuine NVS error. Logging it would flag every fresh / unconfigured
+// namespace as an error and flood a first-boot log (violating §1). A SYSTEMIC NVS
+// failure still surfaces -- the WRITE path and the boot counter DO log their
+// begin() failures (a read-WRITE begin failure is genuinely anomalous;
 // NVS_READWRITE creates the namespace). So the readers intentionally do not log
 // begin()==false; the safe get-defaults flow through unchanged.
-#if defined(ESP_PLATFORM)
-static void logCfgReadFailure(const char* where, const char* ns) {
-    nvs_stats_t st;
-    if (nvs_get_stats(NULL, &st) == ESP_OK) {
-        crashLogf("[cfg] %s READ FAILED ns=%s nvs[used=%u free=%u total=%u]", where, ns,
-                  (unsigned)st.used_entries, (unsigned)st.free_entries, (unsigned)st.total_entries);
-    } else {
-        crashLogf("[cfg] %s READ FAILED ns=%s (nvs_get_stats unavailable)", where, ns);
-    }
-}
-#else
-static void logCfgReadFailure(const char*, const char*) {}
-#endif
 
 bool readGlobalIata(char* out, size_t out_len) {
     Preferences p;
@@ -187,16 +173,13 @@ bool setDisplayRotation(uint8_t deg) {
     return true;
 }
 
-// #181: broker config persists as ONE versioned blob (kKeyBrokerBlob), not 15
-// separate keys. A write is all-or-nothing at the app level, so no partial/corrupt
-// slot is possible, and NVS leaves the prior blob intact if a write fails (the blob
-// is committed via its index). Bump kBrokerBlobVersion whenever BrokerConfig's
-// layout changes so a stale-size blob is treated as absent -> the legacy per-key
-// read below supplies the value (non-destructive migration: legacy keys are never
-// deleted, so they remain a fallback even after a slot has migrated).
-static constexpr uint16_t    kBrokerBlobVersion = 1;
-static constexpr const char* kKeyBrokerBlob     = "cfg_blob";
-struct BrokerBlob { uint16_t version; BrokerConfig cfg; };
+// #182: broker config is stored as individual per-key NVS entries. The #181
+// single-blob attempt was reverted: a ~1.1KB blob needs one large contiguous
+// allocation that a near-full partition cannot place -- measured on HV4 as
+// nvs_set_blob NOT_ENOUGH_SPACE at used=504 free=126 total=630 (the #179 root) --
+// whereas small per-key writes slot into fragmented free space. The old migration
+// blob key is removed on the next write (writeBrokerConfig) to reclaim its entries.
+static constexpr const char* kKeyBrokerBlob = "cfg_blob";
 
 bool readBrokerConfig(uint8_t slot, BrokerConfig& out) {
     if (slot >= OFFBAND_MAX_BROKERS) return false;
@@ -204,24 +187,10 @@ bool readBrokerConfig(uint8_t slot, BrokerConfig& out) {
     mqttBrokerNamespace(slot, ns, sizeof(ns));
     Preferences p;
     p.begin(ns, /*readOnly=*/true);
-    // #181: prefer the versioned blob. A size or version mismatch -> treat as
-    // absent and fall through to the legacy per-key read (pre-#181 devices).
-    if (p.getBytesLength(kKeyBrokerBlob) == sizeof(BrokerBlob)) {
-        BrokerBlob blob;
-        size_t got = p.getBytes(kKeyBrokerBlob, &blob, sizeof(blob));
-        if (got == sizeof(blob) && blob.version == kBrokerBlobVersion) {
-            out = blob.cfg;
-            p.end();
-            return true;
-        }
-        // A right-sized blob that reads back SHORT = NVS corruption, not a clean
-        // miss: surface it (SAFELANE 6), then fall through to the legacy keys.
-        // A version mismatch is the expected non-destructive migration path
-        // (downgrade / future bump) -> fall through silently.
-        if (got != sizeof(blob)) {
-            logCfgReadFailure("readBrokerConfig.blob", ns);
-        }
-    }
+    // #182: per-key read. A missing key returns its default (empty / sentinel),
+    // which is correct because writeBrokerConfig REMOVES empty fields rather than
+    // storing blanks. Any #181 migration blob is ignored here and is cleaned up on
+    // the next write.
     out.enabled   = p.getBool(kKeyBrokerEnabled, false);
     String url    = p.getString(kKeyBrokerUrl, "");
     strncpy(out.url, url.c_str(), sizeof(out.url));
@@ -265,24 +234,113 @@ bool writeBrokerConfig(uint8_t slot, const BrokerConfig& cfg) {
     char ns[16];
     mqttBrokerNamespace(slot, ns, sizeof(ns));
     Preferences p;
-    if (!p.begin(ns, /*readOnly=*/false)) {     // #181: never silent -- report a begin failure
+    if (!p.begin(ns, /*readOnly=*/false)) {     // never silent -- report a begin failure
         logCfgWriteFailure("writeBrokerConfig.begin", ns);
         return false;
     }
-    // #181: ONE versioned blob, all-or-nothing. putBytes returns the byte count
-    // written (0 / short on failure, e.g. NVS exhausted). On failure: log the
-    // cause (free-entry stats) and return false, so the caller's ACK reflects
-    // reality instead of claiming success on a write that never landed.
-    BrokerBlob blob{};                        // #181: zero padding -> deterministic NVS bytes
-    blob.version = kBrokerBlobVersion;
-    blob.cfg     = cfg;
-    size_t wrote = p.putBytes(kKeyBrokerBlob, &blob, sizeof(blob));
+    // #182: per-key writes (reverted from the #181 blob -- a ~1.1KB blob needs one
+    // large contiguous allocation a near-full partition can't place; small per-key
+    // writes slot into fragmented free space). The string fields live in a table so
+    // they can be processed in two phases (removes, then puts). topic_prefix, the
+    // numerics, and enabled are handled separately below.
+    const struct { const char* key; const char* val; } kStrFields[] = {
+        {kKeyBrokerUrl,          cfg.url},
+        {kKeyBrokerUsername,     cfg.username},
+        {kKeyBrokerPassword,     cfg.password},
+        {kKeyBrokerJwtToken,     cfg.jwt_token},
+        {kKeyBrokerIataOverride, cfg.iata_override},
+        {kKeyBrokerJwtAudience,  cfg.jwt_audience},
+        {kKeyBrokerCaCertName,   cfg.ca_cert_name},
+        {kKeyBrokerJwtOwner,     cfg.jwt_owner},
+        {kKeyBrokerJwtEmail,     cfg.jwt_email},
+    };
+
+    // Phase 1 -- REMOVES first: drop the migration blob + every empty field so their
+    // NVS entries become reclaimable BEFORE the value puts. On a near-full partition
+    // this lets the puts complete in one shot (GC reclaims the freed entries) instead
+    // of erroring on the first attempt -- and stores no blanks either (#182). The
+    // removes always land here even if a later put can't, so the space reclaim is
+    // what the one-time boot migration (migrateBrokerStorage) relies on.
+    p.remove(kKeyBrokerBlob);
+    for (const auto& f : kStrFields) {
+        if (f.val[0] == '\0') p.remove(f.key);
+    }
+
+    // Phase 2 -- value puts, each CHECKED (the #181 SAFELANE-6 honesty is kept).
+    // Only non-empty strings; topic_prefix is ALWAYS stored because its read-default
+    // is "meshcore", not "" -- removing it would lose an explicit value to the default.
+    bool ok = true;
+    for (const auto& f : kStrFields) {
+        if (f.val[0] != '\0') ok &= (p.putString(f.key, f.val) == strlen(f.val));
+    }
+    ok &= (p.putString(kKeyBrokerTopicPrefix, cfg.topic_prefix) == strlen(cfg.topic_prefix));
+    ok &= (p.putUShort(kKeyBrokerPort,      cfg.port)               == sizeof(uint16_t));
+    ok &= (p.putUChar (kKeyBrokerTransport, (uint8_t)cfg.transport) == sizeof(uint8_t));
+    ok &= (p.putUChar (kKeyBrokerAuthType,  (uint8_t)cfg.auth_type) == sizeof(uint8_t));
+    ok &= (p.putULong (kKeyBrokerJwtRefresh, cfg.jwt_refresh_sec)   == sizeof(uint32_t));
+
+    // Phase 3 -- enabled LAST, and only if every value put succeeded. enabled is the
+    // gate that decides whether the broker goes live; writing it last means a failed
+    // write leaves the enable/disable state UNCHANGED, so the slot's live state stays
+    // consistent with the returned ERROR (a failed write never silently flips it).
+    if (ok) ok &= (p.putBool(kKeyBrokerEnabled, cfg.enabled) == sizeof(uint8_t));
     p.end();
-    if (wrote != sizeof(blob)) {
-        logCfgWriteFailure("writeBrokerConfig.putBytes", ns);
+
+    if (!ok) {     // a put failed -- surface the cause (free-entry stats) + don't ACK success
+        logCfgWriteFailure("writeBrokerConfig.put", ns);
         return false;
     }
     return true;
+}
+
+// #182: one-time boot migration so an UPGRADED observer reclaims NVS space behind
+// the scenes -- the user never sees the interactive "first write errors, then
+// works", because the reclaim already happened here at boot. Gated by a schema
+// version flag so it runs exactly once; idempotent (re-running on a clean slot is
+// cheap). For each configured slot it rewrites the config into the per-key /
+// no-blank format; writeBrokerConfig's REMOVES phase frees that slot's blanks even
+// if its puts can't all complete on a near-full partition, so the reclaim always
+// lands. A retry completes the rewrite once the first pass has freed enough.
+// Old values are preserved on a failed put, so a partial migration never loses
+// config. Call once at observer startup, after populateDefaultBrokers().
+void migrateBrokerStorage() {
+    Preferences obs;
+    if (obs.begin(kNvsObserver, /*readOnly=*/true)) {
+        uint8_t ver = obs.getUChar(kKeyCfgSchema, 0);
+        obs.end();
+        if (ver >= kCfgSchemaVersion) return;   // already migrated
+    }
+
+    uint8_t migrated = 0, failed = 0;
+    for (uint8_t slot = 0; slot < OFFBAND_MAX_BROKERS; ++slot) {
+        BrokerConfig cfg;
+        if (!readBrokerConfig(slot, cfg)) continue;
+        if (cfg.url[0] == '\0') continue;        // unconfigured slot -- nothing to migrate
+        // Retry once: the first write frees the slot's blanks, so a retry fits if the
+        // first couldn't fully complete (writeBrokerConfig self-logs any failure).
+        if (writeBrokerConfig(slot, cfg) || writeBrokerConfig(slot, cfg)) migrated++;
+        else failed++;
+    }
+
+    // Stamp the schema version so this runs exactly once. Even if a slot's rewrite
+    // didn't fully complete, its blanks were reclaimed (removes land first) and its
+    // old values are preserved, so a later interactive write finishes the job in one
+    // shot -- the user never hits the first-write error.
+    Preferences w;
+    if (w.begin(kNvsObserver, /*readOnly=*/false)) {
+        w.putUChar(kKeyCfgSchema, kCfgSchemaVersion);
+        w.end();
+    }
+
+    // #182: the migration is invisible to the user by design, so record that it ran
+    // (+ outcome) to the persistent crash-log -- observable for validation + field
+    // diagnosis, never user-facing. Real-device only (host has no crashLogf here).
+#if defined(ESP_PLATFORM)
+    crashLogf("[cfg] migrateBrokerStorage: schema->%u migrated=%u failed=%u",
+              (unsigned)kCfgSchemaVersion, (unsigned)migrated, (unsigned)failed);
+#else
+    (void)migrated; (void)failed;
+#endif
 }
 
 // #98: clear a broker slot by WIPING its NVS namespace (every key removed), so

--- a/src/helpers/wifi_observer/ConfigSchema.h
+++ b/src/helpers/wifi_observer/ConfigSchema.h
@@ -77,19 +77,22 @@ constexpr const char* kDefaultTopicPrefix = "meshcore";
 // ---------------------------------------------------------------------------
 // Returns false if NVS error / missing. Defaults applied at call site.
 bool readGlobalIata(char* out, size_t out_len);
-void writeGlobalIata(const char* iata);
+// #181: writers return false on NVS failure (begin/put), and self-log the cause
+// (+ free-entry stats) before returning -- never silent (SAFELANE 6). Callers
+// must surface the failure rather than ACK success on an unverified write.
+bool writeGlobalIata(const char* iata);
 
 uint16_t readStatusIntervalSec();
-void     writeStatusIntervalSec(uint16_t seconds);
+bool     writeStatusIntervalSec(uint16_t seconds);
 
 // #141: display always-on toggle. When true, UITask never auto-blanks the
 // screen. Stored in the fork-branded "offband_ui" NVS namespace.
 bool getDisplayAlwaysOn();
-void setDisplayAlwaysOn(bool on);
+bool setDisplayAlwaysOn(bool on);   // #181: false on NVS failure (logged)
 
 // #148: display rotation in degrees (0 or 180). Stored in "offband_ui".
 uint8_t getDisplayRotation();
-void    setDisplayRotation(uint8_t deg);
+bool    setDisplayRotation(uint8_t deg);   // #181: false on NVS failure (logged)
 
 // Broker-slot accessors. Slot range [0, OFFBAND_MAX_BROKERS).
 // Returns sensible defaults on read-miss (e.g., empty url, enabled=false,

--- a/src/helpers/wifi_observer/ConfigSchema.h
+++ b/src/helpers/wifi_observer/ConfigSchema.h
@@ -63,6 +63,12 @@ constexpr const char* kKeyBrokerCaCertName   = "ca_cert";      // Plan 2 v2: ref
 constexpr const char* kKeyBrokerTopicPrefix  = "topic_prefix";
 constexpr const char* kKeyBrokerIataOverride = "iata_override";
 
+// #182: per-key / no-blank broker-storage schema version, stored in the "observer"
+// namespace. migrateBrokerStorage() runs the one-time reclaim when the stored
+// version is older than this, then stamps it so the migration runs exactly once.
+constexpr const char* kKeyCfgSchema    = "cfg_schema";
+constexpr uint8_t     kCfgSchemaVersion = 1;
+
 enum class BrokerTransport : uint8_t { Tcp = 0, Tls = 1, Wss = 2 };
 enum class BrokerAuthType  : uint8_t { None = 0, Basic = 1, Jwt = 2 };
 
@@ -134,6 +140,12 @@ bool clearBrokerConfig(uint8_t slot);
 // pending operator opt-in + JWT identity claims; slots 6-9 are left empty for
 // operator-custom brokers.
 void populateDefaultBrokers();
+
+// #182: one-time boot migration of an upgraded observer to the per-key / no-blank
+// storage format. Reclaims NVS space behind the scenes so the user never sees the
+// interactive "first write errors, then works". Gated + idempotent; call once at
+// observer startup, AFTER populateDefaultBrokers(). See ConfigSchema.cpp.
+void migrateBrokerStorage();
 
 // #98: render a broker slot's stored config to a human-readable, multi-line
 // text block (one "  key = value" per line) for `mqtt view <N>`. SECRETS ARE

--- a/src/helpers/wifi_observer/CrashLog.cpp
+++ b/src/helpers/wifi_observer/CrashLog.cpp
@@ -174,8 +174,11 @@ void crashLogBegin() {
 }
 
 void crashLogf(const char* fmt, ...) {
-    if (!s_begin_called) return;  // pre-init writes go nowhere
-
+    // #181: NEVER drop a line on the floor pre-begin. The crash logger silently
+    // losing a line is the one failure that erases the very evidence the log
+    // exists to capture (SAFELANE 6/1). Before crashLogBegin(), still emit to the
+    // live path (Serial/stdout); only the RTC ring -- which begin() initializes --
+    // is skipped until ready (mirrors crashlog_vprintf's pre-begin handling).
     char line[kCrashLogLineMax + 1];
     int  prefix_len = 0;
 
@@ -207,13 +210,16 @@ void crashLogf(const char* fmt, ...) {
     }
 
 #ifdef ARDUINO
-    // Write to serial (live monitoring path).
+    // Live monitoring path -- ALWAYS, even before begin() (the ring isn't ready
+    // yet, but the line must not vanish).
     Serial.write((const uint8_t*)line, total);
 
-    // Write to ring buffer (crash-survival path).
-    portENTER_CRITICAL(&s_log_mux);
-    writeToRing(line, total);
-    portEXIT_CRITICAL(&s_log_mux);
+    // Crash-survival ring -- only once begin() has initialized the header.
+    if (s_begin_called) {
+        portENTER_CRITICAL(&s_log_mux);
+        writeToRing(line, total);
+        portEXIT_CRITICAL(&s_log_mux);
+    }
 #else
     // Host build: just write to stdout.
     fputs(line, stdout);
@@ -393,8 +399,13 @@ void heartbeatBegin() {
     if (ok) {
         s_nvs_boot_count       = s_boot_prefs.getUInt("count", 0) + 1;
         s_prev_boot_uptime_s   = s_boot_prefs.getUInt("last_up_s", 0);
-        s_boot_prefs.putUInt("count", s_nvs_boot_count);
-        s_boot_prefs.putUInt("last_up_s", 0);  // reset; will be updated periodically
+        // #181: the boot counter IS crash-cycle evidence -- a silent put failure
+        // would freeze the count and mask a reboot loop (SAFELANE 6). Surface it.
+        if (s_boot_prefs.putUInt("count", s_nvs_boot_count) == 0) {
+            crashLogf("[boot] WARN: NVS cw_boot 'count' write FAILED (count=%u not persisted)",
+                      (unsigned)s_nvs_boot_count);
+        }
+        s_boot_prefs.putUInt("last_up_s", 0);  // reset; maybeSaveUptime overwrites within 5s
         s_boot_prefs.end();
     } else {
         crashLogf("[boot] WARN: NVS cw_boot namespace open failed; falling back to RTC counter");
@@ -429,11 +440,29 @@ static void maybeSaveUptime(uint32_t now_ms) {
     // Save every 5 seconds (matches stats cadence; balances flash wear)
     if (now_ms - s_last_uptime_save_ms < 5000) return;
     s_last_uptime_save_ms = now_ms;
+    // #181: feeds "prev boot lasted Ns" -- the crash-cycle-PERIOD evidence. Runs
+    // every 5s, so a silent failure would erase that evidence indefinitely. Log a
+    // failure ONCE and re-arm on the next success, rather than flooding the 4KB
+    // ring with a repeating warning (SAFELANE 6).
+    static bool s_uptime_save_warned = false;
     ::Preferences p;
-    if (p.begin("cw_boot", /*readOnly=*/false)) {
-        p.putUInt("last_up_s", now_ms / 1000);
-        p.end();
+    if (!p.begin("cw_boot", /*readOnly=*/false)) {
+        if (!s_uptime_save_warned) {
+            crashLogf("[boot] WARN: uptime save -- NVS cw_boot open FAILED (suppressing repeats)");
+            s_uptime_save_warned = true;
+        }
+        return;
     }
+    size_t wrote = p.putUInt("last_up_s", now_ms / 1000);
+    p.end();
+    if (wrote == 0) {
+        if (!s_uptime_save_warned) {
+            crashLogf("[boot] WARN: uptime save -- NVS 'last_up_s' write FAILED (suppressing repeats)");
+            s_uptime_save_warned = true;
+        }
+        return;
+    }
+    s_uptime_save_warned = false;  // re-arm: a recovered write re-logs the next failure
 }
 
 void subloopMark(uint8_t which) {

--- a/src/helpers/wifi_observer/CrashLog.cpp
+++ b/src/helpers/wifi_observer/CrashLog.cpp
@@ -491,7 +491,18 @@ void heartbeatTick(uint32_t now_ms) {
     s_loop_iter_delta  = 0;
     portEXIT_CRITICAL(&s_hb_mux);
 
-    crashLogf("[hb] up=%us iter=+%u boot=%u phases=[W:%c M:%c S:%c U:%c] free_heap=%u",
+    uint32_t heap = ESP.getFreeHeap();
+
+    // #183: build the heartbeat line ONCE (same [millis] prefix crashLogf would add)
+    // and emit it to Serial every second for live monitoring -- but write it to the
+    // RTC crash ring only PERIODICALLY or on a real anomaly. A 1 Hz ring write floods
+    // the 4 KB ring (~50 s to wrap) and evicts the crash diagnostics the ring exists
+    // to preserve across a reboot. At one ring beat per 30 s the ring holds ~25 min of
+    // uptime markers AND keeps real events readable for the whole boot.
+    char line[180];
+    int n = snprintf(line, sizeof(line),
+              "[%lu] [hb] up=%us iter=+%u boot=%u phases=[W:%c M:%c S:%c U:%c] free_heap=%u\n",
+              (unsigned long)millis(),
               (unsigned)(now_ms / 1000),
               (unsigned)delta_iter,
               (unsigned)bootCounterValue(),
@@ -499,7 +510,28 @@ void heartbeatTick(uint32_t now_ms) {
               (flags & SUBLOOP_MESH)    ? 'Y' : 'N',
               (flags & SUBLOOP_SENSORS) ? 'Y' : 'N',
               (flags & SUBLOOP_UI)      ? 'Y' : 'N',
-              (unsigned)ESP.getFreeHeap());
+              (unsigned)heap);
+    if (n > 0) {
+        size_t total = ((size_t)n < sizeof(line)) ? (size_t)n : sizeof(line) - 1;
+        Serial.write((const uint8_t*)line, total);   // live monitoring, every second
+
+        // Ring-write only when the beat carries new signal: every 30 s, or the moment
+        // free heap drops sharply (>8 KB since the last beat) -- a memory-pressure
+        // anomaly worth preserving. (A hung subloop is still covered: the next periodic
+        // beat shows the N flags, and the shutdown handler dumps the ring on the
+        // watchdog reset.)
+        static uint32_t s_last_hb_ring_ms = 0;
+        static uint32_t s_last_hb_heap    = 0;
+        bool heap_drop = (s_last_hb_heap != 0) && (heap + 8192u < s_last_hb_heap);
+        bool periodic  = (s_last_hb_ring_ms == 0) || (now_ms - s_last_hb_ring_ms >= 30000u);
+        if (periodic || heap_drop) {
+            portENTER_CRITICAL(&s_log_mux);
+            writeToRing(line, total);
+            portEXIT_CRITICAL(&s_log_mux);
+            s_last_hb_ring_ms = now_ms;
+        }
+        s_last_hb_heap = heap;
+    }
 
     // Persist current uptime to NVS so next boot can report "previous
     // boot lasted Ns" -- definitive evidence of cycle period.

--- a/src/helpers/wifi_observer/MqttBroker.cpp
+++ b/src/helpers/wifi_observer/MqttBroker.cpp
@@ -3,6 +3,7 @@
 // Plan 2 v2 Task 7. esp_mqtt_client wrapper with pluggable auth.
 
 #include "MqttBroker.h"
+#include "WifiObserverConfig.h"  // #171: OFFBAND_TLS_HEAP_FLOOR_BYTES
 #include <cstring>
 #include <cstdio>
 #include <ctime>          // #69: std::time() for the wall-clock sanity gate
@@ -46,6 +47,18 @@ uint32_t brokerBackoffMs(uint32_t retry_count) {
 // connect only burns backoff cycles. Threshold = 2025-01-01 UTC.
 static bool wallClockSane() {
     return std::time(nullptr) > 1735689600;
+}
+
+// #171: the TLS heap budget is "ok" when free heap is above the floor -- a
+// catastrophe backstop to the pool's count cap (OFFBAND_MAX_LIVE_TLS) so a
+// wss/TLS handshake (transiently ~60KB) can't be started into an OOM. Host
+// builds have no esp heap, so they always pass.
+static bool tlsHeapBudgetOk() {
+#if defined(ARDUINO) && defined(ESP_PLATFORM)
+    return ESP.getFreeHeap() >= OFFBAND_TLS_HEAP_FLOOR_BYTES;
+#else
+    return true;
+#endif
 }
 
 // ---------------------------------------------------------------------------
@@ -198,7 +211,7 @@ bool MqttBroker::begin(uint8_t slot, const BrokerConfig& cfg) {
 // tryConnect: state machine entry point. Initiates a connection attempt
 // if the broker is eligible (enabled + Down + backoff window expired).
 // ---------------------------------------------------------------------------
-bool MqttBroker::tryConnect(uint32_t now_ms) {
+bool MqttBroker::tryConnect(uint32_t now_ms, bool tls_budget_ok) {
 #if defined(ARDUINO) && defined(ESP_PLATFORM)
     ClientLockGuard _g(client_lock_);
 #endif
@@ -228,6 +241,20 @@ bool MqttBroker::tryConnect(uint32_t now_ms) {
         // tryConnect for HeldNoClock slots, so this releases on the first tick
         // after wallClockSane() becomes true (NTP sync or GPS lock).
         rt_.state = BrokerState::HeldNoClock;
+        return false;
+    }
+
+    // #171: each wss/TLS broker holds a ~60KB mbedTLS context, and a bring-up's
+    // handshake transient can drive HV3's heap to an OOM reboot. Defer -- without
+    // burning a backoff cycle -- when the pool's TLS budget is full
+    // (tls_budget_ok=false: already OFFBAND_MAX_LIVE_TLS live) or free heap is
+    // below the floor. The pool re-drives HeldNoHeap slots each tick, so this
+    // releases the moment a TLS slot frees or heap recovers (mirrors the
+    // HeldNoClock hold above). tcp brokers hold no mbedTLS context -- exempt.
+    if ((cfg_.transport == BrokerTransport::Tls ||
+         cfg_.transport == BrokerTransport::Wss) &&
+        (!tls_budget_ok || !tlsHeapBudgetOk())) {
+        rt_.state = BrokerState::HeldNoHeap;
         return false;
     }
 

--- a/src/helpers/wifi_observer/MqttBroker.h
+++ b/src/helpers/wifi_observer/MqttBroker.h
@@ -28,6 +28,11 @@ enum class BrokerState : uint8_t {
     HeldNoClock = 4,  // #87: wss/TLS deferred pending a sane wall clock (NTP/GPS).
                       // NOT a failure -- no retry burned; released automatically on
                       // the next drive tick once wallClockSane() becomes true.
+    HeldNoHeap  = 5,  // #171: wss/TLS bring-up deferred -- the pool's TLS budget is
+                      // full (>= OFFBAND_MAX_LIVE_TLS live) or free heap is below
+                      // the floor. NOT a failure -- no retry burned; released on a
+                      // later drive tick once a TLS slot frees or heap recovers
+                      // (mirrors HeldNoClock).
 };
 
 enum class BrokerErrorClass : uint8_t {
@@ -78,7 +83,11 @@ public:
     // Initiate connection if not already up/connecting. Honors backoff.
     // Returns true if a connect attempt is in progress after this call,
     // false if disabled or backoff window unexpired.
-    bool tryConnect(uint32_t now_ms);
+    // tls_budget_ok: pool-supplied, REQUIRED (no default -- so no caller can
+    // silently bypass the concurrency guard #171). false means OFFBAND_MAX_LIVE_TLS
+    // TLS contexts are already live, so a wss/TLS bring-up self-defers to
+    // HeldNoHeap. Pass true for tcp brokers (the guard ignores them).
+    bool tryConnect(uint32_t now_ms, bool tls_budget_ok);
 
     // Drive auth refresh + any housekeeping. Called every pool tick.
     void loop(uint32_t now_ms);

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -4,6 +4,7 @@
 
 #include "MqttBrokerPool.h"
 #include "MqttPayload.h"
+#include "CrashLog.h"   // #181: crashLogf() -- worker has no user ACK channel
 #include <cstring>
 #include <cstdio>
 
@@ -338,7 +339,18 @@ void MqttBrokerPool::reconcileSlot(uint8_t slot) {
         brokers_[slot].shutdown();   // no/empty config -> ensure no client
         return;
     }
-    brokers_[slot].begin(slot, cfg, *identity_);
+    // #181: the worker runs off any user channel, so a reconcile that fails to
+    // bring up a configured + ENABLED slot must surface in the persistent crash
+    // log (SAFELANE 6) -- otherwise the slot silently stays Down with only
+    // rt_.state as evidence. begin() returns false on bad auth / client-init OOM;
+    // a DISABLED slot returns true with no client (expected, not a failure).
+    // URL is omitted from the log -- a broker URL may carry inline credentials.
+    if (!brokers_[slot].begin(slot, cfg, *identity_) && cfg.enabled) {
+        crashLogf("[pool] reconcileSlot %u begin FAILED state=%d err_class=%d",
+                  (unsigned)slot,
+                  (int)brokers_[slot].runtime().state,
+                  (int)brokers_[slot].runtime().last_error_class);
+    }
 }
 
 namespace {

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -47,6 +47,11 @@ void MqttBrokerPool::begin(const mesh::LocalIdentity& identity,
 
     // Seed defaults (idempotent -- no-op if slots already populated).
     populateDefaultBrokers();
+    // #182: one-time reclaim of an upgraded observer's NVS to the per-key/no-blank
+    // format, BEFORE any slot is read or a worker runs -- so the space is freed at
+    // boot and the user never sees the interactive first-write error. Gated to run
+    // once; idempotent on already-migrated/fresh devices.
+    migrateBrokerStorage();
 
     // Read global iata + status interval from NVS.
     if (!readGlobalIata(global_iata_, sizeof(global_iata_))) {

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -25,7 +25,21 @@ void MqttBrokerPool::begin(const mesh::LocalIdentity& identity,
                            const char* model) {
     identity_         = &identity;
     device_id_        = device_id        != nullptr ? device_id        : "";
-    node_name_        = node_name        != nullptr ? node_name        : "";
+    // Append the Offband tell (radar emoji U+1F4E1 = UTF-8 F0 9F 93 A1) to the
+    // observer's display name in every MQTT payload's `origin`, so feeds/maps show
+    // "<name> [radar]" for Offband observers. Falls back to device_id when there is
+    // no node_name, so it is never a bare emoji. node_name_ is the only OWNED cached
+    // string (the rest borrow the caller's lifetime). The TOPIC uses device_id, not
+    // this, so the emoji never reaches a topic.
+    {
+        const char* nm_base = (node_name != nullptr && node_name[0] != '\0') ? node_name
+                            : (device_id != nullptr ? device_id : "");
+        // Bound the base name with %.*s so the trailing " " + 4-byte emoji + NUL
+        // (6 bytes) always fit whole -- the emoji is never split mid-UTF-8 even on a
+        // pathologically long name (>58 chars). escapeJsonString passes the bytes >=0x20.
+        snprintf(node_name_, sizeof(node_name_), "%.*s \xF0\x9F\x93\xA1",
+                 (int)(sizeof(node_name_) - 6), nm_base);
+    }
     client_version_   = client_version   != nullptr ? client_version   : "";
     firmware_version_ = firmware_version != nullptr ? firmware_version : "";
     model_            = model            != nullptr ? model            : "";

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -452,4 +452,19 @@ uint8_t MqttBrokerPool::upCount() const {
     return n;
 }
 
+// #173: UPPERCASE hex of the device's own pubkey -- the connect-time default for a
+// broker's jwt_owner (#95). Renders "" when the identity is unset or on host builds
+// (no identity_), so the caller simply omits jwt_owner_resolved in that case.
+void MqttBrokerPool::deviceOwnerHex(char* out, size_t out_len) const {
+    if (out == nullptr || out_len == 0) return;
+    out[0] = '\0';
+#if defined(ARDUINO)
+    if (identity_ == nullptr || out_len < 2 * PUB_KEY_SIZE + 1) return;
+    for (size_t i = 0; i < PUB_KEY_SIZE; ++i) {
+        snprintf(&out[i * 2], 3, "%02X", identity_->pub_key[i]);
+    }
+    out[2 * PUB_KEY_SIZE] = '\0';
+#endif
+}
+
 }  // namespace offband

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -341,6 +341,14 @@ void MqttBrokerPool::reconcileSlot(uint8_t slot) {
     brokers_[slot].begin(slot, cfg, *identity_);
 }
 
+namespace {
+// #171: a broker holds a ~60KB mbedTLS context only for TLS/wss transports.
+inline bool isTlsTransport(const BrokerConfig& c) {
+    return c.transport == BrokerTransport::Tls ||
+           c.transport == BrokerTransport::Wss;
+}
+}  // namespace
+
 void MqttBrokerPool::workerLoop() {
     for (;;) {
         // Block for a reconcile request, but wake every 500ms to drive the
@@ -361,16 +369,37 @@ void MqttBrokerPool::workerLoop() {
         // the same slot serializes safely (and loopTask only publishes to Up
         // slots, never one the worker is connect-blocking on).
         uint32_t now = millis();
+        // #171: count TLS contexts already live (Up/Connecting). Each holds a
+        // ~60KB mbedTLS context; HV3's heap fits ~2 before a 3rd handshake OOM-
+        // reboots. We refuse to START a TLS bring-up past OFFBAND_MAX_LIVE_TLS
+        // (the broker self-defers to HeldNoHeap). Plaintext brokers are exempt.
+        uint8_t tls_live = 0;
+        for (uint8_t s = 0; s < OFFBAND_MAX_BROKERS; ++s) {
+            const MqttBroker& b = brokers_[s];
+            if (!b.isConfigured() || !isTlsTransport(b.config())) continue;
+            BrokerState st = b.runtime().state;
+            if (st == BrokerState::Up || st == BrokerState::Connecting) tls_live++;
+        }
         for (uint8_t s = 0; s < OFFBAND_MAX_BROKERS; ++s) {
             if (reconciling_[s]) continue;
             MqttBroker& b = brokers_[s];
             if (!b.isConfigured()) continue;
             b.loop(now);
-            if (b.runtime().state == BrokerState::Down ||
-                b.runtime().state == BrokerState::Backoff ||
-                b.runtime().state == BrokerState::HeldNoClock) {  // #87: re-check the clock gate each tick so held wss slots release the moment the clock is sane
+            BrokerState st = b.runtime().state;
+            // Re-drive idle/held slots. HeldNoClock releases when the clock is
+            // sane (#87); HeldNoHeap releases when a TLS slot frees (#171).
+            if (st == BrokerState::Down || st == BrokerState::Backoff ||
+                st == BrokerState::HeldNoClock || st == BrokerState::HeldNoHeap) {
                 uint32_t biased = now + static_cast<uint32_t>(s) * 1000U;
-                (void)b.tryConnect(biased);
+                // TLS budget: non-TLS always OK; TLS only if a live slot is free.
+                bool budget_ok = !isTlsTransport(b.config()) ||
+                                 (tls_live < OFFBAND_MAX_LIVE_TLS);
+                (void)b.tryConnect(biased, budget_ok);
+                // Consume a budget slot if this TLS broker just began bringing up.
+                if (isTlsTransport(b.config()) &&
+                    b.runtime().state == BrokerState::Connecting) {
+                    tls_live++;
+                }
             }
         }
     }

--- a/src/helpers/wifi_observer/MqttBrokerPool.h
+++ b/src/helpers/wifi_observer/MqttBrokerPool.h
@@ -128,7 +128,7 @@ private:
 
     // Cached strings for ctx fills (caller owns lifetime).
     const char* device_id_        = "";
-    const char* node_name_        = "";
+    char        node_name_[64]    = "";  // OWNED (built in begin()): "<name> radar-emoji" Offband tell
     const char* client_version_   = "";
     const char* firmware_version_ = "";
     const char* model_            = "";

--- a/src/helpers/wifi_observer/MqttBrokerPool.h
+++ b/src/helpers/wifi_observer/MqttBrokerPool.h
@@ -103,6 +103,10 @@ public:
     uint8_t enabledCount()    const;
     uint8_t upCount()         const;
     const MqttBroker& broker(uint8_t slot) const { return brokers_[slot]; }
+    // #173: the device's own pubkey as UPPERCASE hex (the connect-time default for a
+    // broker's jwt_owner when none is set, #95) -- so the OCFG_BROKERS dump can show
+    // the resolved owner as a placeholder. Writes "" if identity unset / host build.
+    void deviceOwnerHex(char* out, size_t out_len) const;
 
 private:
 #ifdef ARDUINO

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -167,7 +167,10 @@ static bool handleSetIata(char* reply, size_t reply_size, const char* value) {
         snprintf(reply, reply_size, "ERROR: usage: set mqtt.iata <code>\n");
         return true;
     }
-    writeGlobalIata(value);
+    if (!writeGlobalIata(value)) {   // #181: surface NVS failure -- never ACK an unverified write
+        snprintf(reply, reply_size, "ERROR: failed to save mqtt.iata (NVS write failed)\n");
+        return true;
+    }
     snprintf(reply, reply_size, "mqtt.iata = %s\n", value);
     return true;
 }
@@ -183,7 +186,10 @@ static bool handleSetStatusInterval(char* reply, size_t reply_size, const char* 
         snprintf(reply, reply_size, "ERROR: status_interval %ld out of range [10, 3600]\n", v);
         return true;
     }
-    writeStatusIntervalSec((uint16_t)v);
+    if (!writeStatusIntervalSec((uint16_t)v)) {   // #181: surface NVS failure
+        snprintf(reply, reply_size, "ERROR: failed to save mqtt.status_interval (NVS write failed)\n");
+        return true;
+    }
     snprintf(reply, reply_size, "mqtt.status_interval = %ld\n", v);
     return true;
 }
@@ -577,7 +583,13 @@ void setDisplayAlwaysOnApplier(void (*fn)(bool)) {
 }
 
 static bool handleDisplayAlwaysOn(char* reply, size_t reply_size, bool on) {
-    setDisplayAlwaysOn(on);                                            // persist (offband_ui NVS)
+    // #181: if persistence fails, surface it and do NOT apply to the live display
+    // -- applying a setting that won't survive a reboot would mislead the user
+    // about what's actually stored (SAFELANE 6: state must match the ACK).
+    if (!setDisplayAlwaysOn(on)) {                                     // persist (offband_ui NVS)
+        snprintf(reply, reply_size, "ERROR: failed to save display setting (NVS write failed)\n");
+        return true;
+    }
     if (s_display_always_on_applier) s_display_always_on_applier(on);  // apply to the live display
     snprintf(reply, reply_size,
              on ? "display: always on (screen stays lit)\n"
@@ -620,7 +632,12 @@ static bool handleDisplayRotate(char* reply, size_t reply_size, uint8_t deg) {
         snprintf(reply, reply_size, "display: rotation not supported on this display\n");
         return true;
     }
-    setDisplayRotation(deg);                                                  // persist (offband_ui NVS)
+    // #181: persist first; on NVS failure surface it and leave the cache + live
+    // display untouched, so RAM state, NVS, and the ACK all stay consistent.
+    if (!setDisplayRotation(deg)) {                                           // persist (offband_ui NVS)
+        snprintf(reply, reply_size, "ERROR: failed to save display rotation (NVS write failed)\n");
+        return true;
+    }
     s_rotation_cache = deg;                                                   // keep the in-session cache current
     if (s_display_rotation_applier) s_display_rotation_applier(deg);          // apply to the live display
     snprintf(reply, reply_size,

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -912,8 +912,24 @@ bool configSet(const char* key, const char* value, char* reply, size_t reply_siz
 
     {
         int slot; const char* field;
-        if (parseBrokerKey(key, slot, field))
+        if (parseBrokerKey(key, slot, field)) {
+            // F6 (#166): `enabled` and `clear` are ACTIONS, not persisted fields.
+            // handleSetBrokerField has no enabled-set and force-disables the slot
+            // on any field write (#53), so route these to their own handlers --
+            // this is what lets the client write `enabled` LAST as the activation
+            // guard and wipe a slot via `clear`. Everything else is a real field.
+            if (eq(field, "enabled")) {
+                bool on;
+                if (!parseConfigBool(value, on)) {
+                    snprintf(reply, reply_size, "ERROR: mqtt.broker.%d.enabled expects 0|1\n", slot);
+                    return true;
+                }
+                return handleEnableSet(reply, reply_size, pool, slot, on);
+            }
+            if (eq(field, "clear"))
+                return handleClearBroker(reply, reply_size, pool, slot);
             return handleSetBrokerField(reply, reply_size, pool, slot, field, value);
+        }
         if (strncmp(key, "mqtt.broker.", 12) == 0) {
             snprintf(reply, reply_size, "ERROR: bad broker key '%s' (mqtt.broker.<0..%d>.<field>)\n",
                      key, OFFBAND_MAX_BROKERS - 1);

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -844,4 +844,133 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
     return false;
 }
 
+// ===========================================================================
+// Typed config dispatch (Epic F / #165) -- the wire path's set/get backend.
+// ===========================================================================
+// The Offband config command (CMD_OFFBAND_CONFIG; OffbandConfigProtocol.h)
+// calls configSet/configGet instead of re-parsing a CLI string. Each key routes
+// straight to the SAME static handler dispatchObserverCli uses, so the
+// ConfigSchema/NVS logic, validation, and secret redaction stay single-source
+// at the handler layer -- the CLI grammar never enters the wire path.
+// dispatchObserverCli (the _sys string front-end) is intentionally unchanged.
+//   reply : NUL-terminated human text (the same the CLI returns).
+//   return: true if the key was handled (incl. an ERROR reply); false if the
+//           key is unknown to the observer config surface.
+
+// "1"/"true"/"on" -> true; "0"/"false"/"off" -> false; else leave out, return false.
+static bool parseConfigBool(const char* v, bool& out) {
+    if (v == nullptr) return false;
+    while (*v == ' ') ++v;
+    if (eq(v, "1") || eq(v, "true")  || eq(v, "on"))  { out = true;  return true; }
+    if (eq(v, "0") || eq(v, "false") || eq(v, "off")) { out = false; return true; }
+    return false;
+}
+
+// Parse "mqtt.broker.<slot>.<field>" -> slot index + field pointer. Returns
+// true iff the key is a well-formed broker key (slot in range, '.' before a
+// non-empty field); out_field then points just past the '.'. Shared by
+// configSet/configGet so the slot/field walk lives in one place.
+static bool parseBrokerKey(const char* key, int& out_slot, const char*& out_field) {
+    if (strncmp(key, "mqtt.broker.", 12) != 0) return false;
+    const char* p = key + 12;
+    int slot = parseSlot(p);
+    if (slot < 0) return false;
+    while (*p >= '0' && *p <= '9') ++p;   // past slot digit(s)
+    if (*p != '.' || *(p + 1) == '\0') return false;
+    out_slot = slot;
+    out_field = p + 1;
+    return true;
+}
+
+bool configSet(const char* key, const char* value, char* reply, size_t reply_size,
+               MqttBrokerPool& pool) {
+    if (key == nullptr || value == nullptr || reply == nullptr || reply_size == 0) return false;
+    reply[0] = '\0';
+
+    if (eq(key, "mqtt.iata"))            return handleSetIata(reply, reply_size, value);
+    if (eq(key, "mqtt.status_interval")) return handleSetStatusInterval(reply, reply_size, value);
+
+    if (eq(key, "display.always_on")) {
+        bool on;
+        if (!parseConfigBool(value, on)) { snprintf(reply, reply_size, "ERROR: display.always_on expects 0|1\n"); return true; }
+        return handleDisplayAlwaysOn(reply, reply_size, on);
+    }
+    if (eq(key, "display.rotation")) {
+        if (eq(value, "0"))   return handleDisplayRotate(reply, reply_size, 0);
+        if (eq(value, "180")) return handleDisplayRotate(reply, reply_size, 180);
+        snprintf(reply, reply_size, "ERROR: display.rotation expects 0|180\n");
+        return true;
+    }
+
+    if (eq(key, "wifi.enabled")) {
+        bool on;
+        if (!parseConfigBool(value, on)) { snprintf(reply, reply_size, "ERROR: wifi.enabled expects 0|1\n"); return true; }
+        return handleSetWifiEnabled(reply, reply_size, on);
+    }
+    if (strncmp(key, "wifi.", 5) == 0)            // wifi.ssid / wifi.pwd
+        return handleSetWifiField(reply, reply_size, key + 5, value);
+
+    {
+        int slot; const char* field;
+        if (parseBrokerKey(key, slot, field))
+            return handleSetBrokerField(reply, reply_size, pool, slot, field, value);
+        if (strncmp(key, "mqtt.broker.", 12) == 0) {
+            snprintf(reply, reply_size, "ERROR: bad broker key '%s' (mqtt.broker.<0..%d>.<field>)\n",
+                     key, OFFBAND_MAX_BROKERS - 1);
+            return true;
+        }
+    }
+
+    return false;  // unknown key -- not part of the observer config surface
+}
+
+bool configGet(const char* key, char* reply, size_t reply_size) {
+    if (key == nullptr || reply == nullptr || reply_size == 0) return false;
+    reply[0] = '\0';
+
+    if (eq(key, "wifi.enabled")) {
+#ifdef ARDUINO
+        Preferences p; bool en = true;
+        if (p.begin("wifi", /*readOnly=*/true)) { en = p.getBool("enabled", true); p.end(); }
+        snprintf(reply, reply_size, "wifi.enabled = %d\n", en ? 1 : 0);
+#else
+        snprintf(reply, reply_size, "wifi.enabled = (host build)\n");
+#endif
+        return true;
+    }
+    if (strncmp(key, "wifi.", 5) == 0)             // wifi.ssid (wifi.pwd -> write-only error)
+        return handleGetWifi(reply, reply_size, key + 5);
+
+    if (eq(key, "mqtt.iata")) {
+        char iata[8] = {0};
+        readGlobalIata(iata, sizeof(iata));
+        snprintf(reply, reply_size, "mqtt.iata = %s\n", iata[0] ? iata : "(unset)");
+        return true;
+    }
+    if (eq(key, "mqtt.status_interval")) {
+        snprintf(reply, reply_size, "mqtt.status_interval = %u\n", (unsigned)readStatusIntervalSec());
+        return true;
+    }
+    if (eq(key, "display.always_on")) {
+        snprintf(reply, reply_size, "display.always_on = %d\n", getDisplayAlwaysOn() ? 1 : 0);
+        return true;
+    }
+    if (eq(key, "display.rotation")) {
+        snprintf(reply, reply_size, "display.rotation = %u\n", (unsigned)getDisplayRotation());
+        return true;
+    }
+
+    {
+        int slot; const char* field;
+        if (parseBrokerKey(key, slot, field))
+            return handleGetBrokerField(reply, reply_size, slot, field);
+        if (strncmp(key, "mqtt.broker.", 12) == 0) {
+            snprintf(reply, reply_size, "ERROR: bad broker key '%s'\n", key);
+            return true;
+        }
+    }
+
+    return false;  // unknown key
+}
+
 }  // namespace offband

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -88,6 +88,7 @@ static const char* stateStr(BrokerState s) {
         case BrokerState::Up:          return "up";
         case BrokerState::Backoff:     return "backoff";
         case BrokerState::HeldNoClock: return "held(no-clock)";
+        case BrokerState::HeldNoHeap:  return "held(no-heap)";
         default:                       return "?";
     }
 }

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -544,6 +544,11 @@ static bool handleSetWifiEnabled(char* reply, size_t reply_size, bool enabled) {
 // existing "set mqtt.broker.<N>.<key>". Key vocabulary mirrors
 // handleSetBrokerField. Secret fields (password) are write-only and refused
 // here, per the wifi.pwd policy + the CLAUDE.md "never echo a secret" rule.
+// #172/#173: reach the observer pool for live runtime + the device owner hex, so the
+// runtime/resolved fields below are individually GETtable (not just in the dump) --
+// the client editor's single-slot Refresh uses per-field get, not the pool dump.
+MqttBrokerPool& wifiObserverPool();
+
 static bool handleGetBrokerField(char* reply, size_t reply_size,
                                  int slot, const char* key) {
     if (slot < 0 || key == nullptr) {
@@ -573,6 +578,32 @@ static bool handleGetBrokerField(char* reply, size_t reply_size,
     else if (eq(key, "jwt_refresh"))   snprintf(reply, reply_size, "mqtt.broker.%d.jwt_refresh = %u\n", slot, (unsigned)cfg.jwt_refresh_sec);
     else if (eq(key, "jwt_owner"))     snprintf(reply, reply_size, "mqtt.broker.%d.jwt_owner = %s\n", slot, cfg.jwt_owner);
     else if (eq(key, "jwt_email"))     snprintf(reply, reply_size, "mqtt.broker.%d.jwt_email = %s\n", slot, cfg.jwt_email);
+    // #172/#173: runtime + resolved-default fields, individually GETtable so the
+    // client's single-slot Refresh (per-field get) matches the OCFG_BROKERS dump.
+    // Wire tokens identical to the dump (brokerStateWire/brokerErrorWire). A valid
+    // slot is guaranteed here (readBrokerConfig above rejects out-of-range).
+    else if (eq(key, "state"))         snprintf(reply, reply_size, "mqtt.broker.%d.state = %s\n",      slot, brokerStateWire(wifiObserverPool().broker((uint8_t)slot).runtime().state));
+    else if (eq(key, "last_error"))    snprintf(reply, reply_size, "mqtt.broker.%d.last_error = %s\n", slot, brokerErrorWire(wifiObserverPool().broker((uint8_t)slot).runtime().last_error_class));
+    else if (eq(key, "jwt_owner_resolved")) {
+        // The owner used at connect: the explicit jwt_owner if set, else the device pubkey (#95).
+        if (cfg.jwt_owner[0] != '\0') {
+            snprintf(reply, reply_size, "mqtt.broker.%d.jwt_owner_resolved = %s\n", slot, cfg.jwt_owner);
+        } else {
+            char hex[72] = {0};
+            wifiObserverPool().deviceOwnerHex(hex, sizeof(hex));
+            snprintf(reply, reply_size, "mqtt.broker.%d.jwt_owner_resolved = %s\n", slot, hex);
+        }
+    }
+    else if (eq(key, "iata_resolved")) {
+        // The IATA used at connect: the explicit iata_override if set, else the global IATA.
+        if (cfg.iata_override[0] != '\0') {
+            snprintf(reply, reply_size, "mqtt.broker.%d.iata_resolved = %s\n", slot, cfg.iata_override);
+        } else {
+            char giata[8] = {0};
+            readGlobalIata(giata, sizeof(giata));
+            snprintf(reply, reply_size, "mqtt.broker.%d.iata_resolved = %s\n", slot, giata);
+        }
+    }
     else snprintf(reply, reply_size, "ERROR: unknown broker field '%s'\n", key);
     return true;
 }

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -155,7 +155,15 @@ static bool handleEnableSet(char* reply, size_t reply_size, MqttBrokerPool& pool
         snprintf(reply, reply_size, "ERROR: cannot write slot %d\n", slot);
         return true;
     }
-    pool.reloadSlot((uint8_t)slot);
+    if (!pool.reloadSlot((uint8_t)slot)) {
+        // #181: NVS is updated, but the live client wasn't reconciled now (worker
+        // queue full / not ready). Surface it instead of ACKing a clean toggle --
+        // the change still takes effect at the next reboot (SAFELANE 6).
+        snprintf(reply, reply_size,
+                 "mqtt slot %d: %s saved, but live reload failed -- effective after reboot\n",
+                 slot, enable ? "enabled" : "disabled");
+        return true;
+    }
     snprintf(reply, reply_size, "mqtt slot %d: %s\n",
              slot, enable ? "enabled" : "disabled");
     return true;
@@ -314,7 +322,15 @@ static bool handleSetBrokerField(char* reply, size_t reply_size,
     // owned (the reconciling_[] guard serializes it against loopTask), so this is
     // race-safe; for a disabled slot the worker just re-reads NVS into cfg_ with
     // no client touch.
-    pool.reloadSlot((uint8_t)slot);
+    if (!pool.reloadSlot((uint8_t)slot)) {
+        // #181: saved to NVS, but the cached cfg_ wasn't refreshed (worker queue
+        // full / not ready) -- `mqtt status` shows stale until reboot. Surface it
+        // rather than ACK a clean set (SAFELANE 6).
+        snprintf(reply, reply_size,
+                 "mqtt.broker.%d.%s saved, but live reload failed -- effective after reboot\n",
+                 slot, key);
+        return true;
+    }
 
     if (was_enabled) {
         snprintf(reply, reply_size,

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -973,4 +973,53 @@ bool configGet(const char* key, char* reply, size_t reply_size) {
     return false;  // unknown key
 }
 
+// ---------------------------------------------------------------------------
+// Broker-pool enumeration (Epic F / F3, #162) -- backs the OCFG_BROKERS read.
+// ---------------------------------------------------------------------------
+int configBrokerSlotCount() { return OFFBAND_MAX_BROKERS; }
+
+bool configBrokerSlotPopulated(uint8_t slot) {
+    BrokerConfig cfg;
+    return readBrokerConfig(slot, cfg) && cfg.url[0] != '\0';
+}
+
+// Render a populated slot's non-secret config as wire "key=value\n" lines (the
+// OCFG_BROKER_KV payload bodies). transport/auth_type as the string enum names
+// (matching the SET grammar); password redacted to "(set)"/"(unset)"; jwt_token
+// omitted (not a config key). Returns bytes written (0 if the slot is empty).
+// Caller passes a buffer large enough for a full slot (~700 B) and splits the
+// result on '\n', emitting one BROKER_KV frame per line.
+size_t configRenderBrokerSlot(uint8_t slot, char* out, size_t out_size) {
+    if (out == nullptr || out_size == 0) return 0;
+    out[0] = '\0';
+    BrokerConfig cfg;
+    if (!readBrokerConfig(slot, cfg) || cfg.url[0] == '\0') return 0;
+    size_t n = 0;
+    // Clamp the accumulation: snprintf returns the WOULD-BE length, so on
+    // truncation w_ can exceed the remaining space -- never let n pass out_size
+    // (else the next call's `out_size - n` underflows, size_t -> UB).
+#define BKV(...) do { \
+    if (n < out_size) { \
+        int w_ = snprintf(out + n, out_size - n, __VA_ARGS__); \
+        if (w_ > 0) n += ((size_t)w_ < out_size - n) ? (size_t)w_ : (out_size - n - 1); \
+    } \
+} while (0)
+    BKV("enabled=%d\n",       cfg.enabled ? 1 : 0);
+    BKV("url=%s\n",           cfg.url);
+    BKV("port=%u\n",          (unsigned)cfg.port);
+    BKV("transport=%s\n",     transportStr(cfg.transport));
+    BKV("auth_type=%s\n",     authStr(cfg.auth_type));
+    BKV("username=%s\n",      cfg.username);
+    BKV("password=%s\n",      cfg.password[0] ? "(set)" : "(unset)");
+    BKV("topic_prefix=%s\n",  cfg.topic_prefix);
+    BKV("iata_override=%s\n", cfg.iata_override);
+    BKV("jwt_audience=%s\n",  cfg.jwt_audience);
+    BKV("jwt_refresh=%u\n",   (unsigned)cfg.jwt_refresh_sec);
+    BKV("jwt_owner=%s\n",     cfg.jwt_owner);
+    BKV("jwt_email=%s\n",     cfg.jwt_email);
+    BKV("ca_cert=%s\n",       cfg.ca_cert_name);
+#undef BKV
+    return n;   // clamped written length (== strlen(out))
+}
+
 }  // namespace offband

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -93,6 +93,31 @@ static const char* stateStr(BrokerState s) {
     }
 }
 
+// #172: WIRE-safe state/error tokens for the OCFG_BROKERS dump (no parens/spaces,
+// distinct from stateStr's human "held(no-clock)"). These MUST match the client
+// contract (see #172 / OffbandConfigProtocol.h).
+static const char* brokerStateWire(BrokerState s) {
+    switch (s) {
+        case BrokerState::Down:        return "down";
+        case BrokerState::Connecting:  return "connecting";
+        case BrokerState::Up:          return "up";
+        case BrokerState::Backoff:     return "backoff";
+        case BrokerState::HeldNoClock: return "held_no_clock";
+        case BrokerState::HeldNoHeap:  return "held_no_heap";
+        default:                       return "down";
+    }
+}
+static const char* brokerErrorWire(BrokerErrorClass e) {
+    switch (e) {
+        case BrokerErrorClass::None:  return "none";
+        case BrokerErrorClass::Tcp:   return "tcp";
+        case BrokerErrorClass::Auth:  return "auth";
+        case BrokerErrorClass::Tls:   return "tls";
+        case BrokerErrorClass::Other: return "other";
+        default:                      return "other";
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Subcommand handlers
 // ---------------------------------------------------------------------------
@@ -1039,7 +1064,9 @@ bool configBrokerSlotPopulated(uint8_t slot) {
 // omitted (not a config key). Returns bytes written (0 if the slot is empty).
 // Caller passes a buffer large enough for a full slot (~700 B) and splits the
 // result on '\n', emitting one BROKER_KV frame per line.
-size_t configRenderBrokerSlot(uint8_t slot, char* out, size_t out_size) {
+size_t configRenderBrokerSlot(uint8_t slot, char* out, size_t out_size,
+                              const BrokerRuntimeState* rt,
+                              const char* owner_default_hex) {
     if (out == nullptr || out_size == 0) return 0;
     out[0] = '\0';
     BrokerConfig cfg;
@@ -1068,6 +1095,26 @@ size_t configRenderBrokerSlot(uint8_t slot, char* out, size_t out_size) {
     BKV("jwt_owner=%s\n",     cfg.jwt_owner);
     BKV("jwt_email=%s\n",     cfg.jwt_email);
     BKV("ca_cert=%s\n",       cfg.ca_cert_name);
+    // #172: live runtime state + last-error (additive; passed from the pool). Lets
+    // the app show the REAL connect result, not just the config `enabled` flag.
+    // Old clients ignore unknown keys.
+    if (rt != nullptr) {
+        BKV("state=%s\n",      brokerStateWire(rt->state));
+        BKV("last_error=%s\n", brokerErrorWire(rt->last_error_class));
+    }
+    // #173: resolved-default placeholders (additive). Emitted ONLY when the raw
+    // field is blank, carrying the value the firmware actually uses at connect, so
+    // the client shows it as a hint WITHOUT writing it back as an explicit override
+    // -- the raw key above stays blank and remains the source of truth for writes.
+    if (cfg.jwt_owner[0] == '\0' && owner_default_hex != nullptr && owner_default_hex[0] != '\0') {
+        BKV("jwt_owner_resolved=%s\n", owner_default_hex);
+    }
+    if (cfg.iata_override[0] == '\0') {
+        char giata[8] = {0};
+        if (readGlobalIata(giata, sizeof(giata)) && giata[0] != '\0') {
+            BKV("iata_resolved=%s\n", giata);
+        }
+    }
 #undef BKV
     return n;   // clamped written length (== strlen(out))
 }

--- a/src/helpers/wifi_observer/ObserverCli.h
+++ b/src/helpers/wifi_observer/ObserverCli.h
@@ -57,6 +57,15 @@ bool configSet(const char* key, const char* value, char* reply, size_t reply_siz
                MqttBrokerPool& pool);
 bool configGet(const char* key, char* reply, size_t reply_size);
 
+// Epic F (#162): broker-pool enumeration for the OCFG_BROKERS paginated read.
+// configBrokerSlotCount() = max slots to iterate; configBrokerSlotPopulated() =
+// is slot N set (non-empty url); configRenderBrokerSlot() renders a populated
+// slot's non-secret fields as wire "key=value\n" lines (string enums; password
+// redacted; jwt_token omitted), returning bytes written (0 if empty).
+int    configBrokerSlotCount();
+bool   configBrokerSlotPopulated(uint8_t slot);
+size_t configRenderBrokerSlot(uint8_t slot, char* out, size_t out_size);
+
 // #141: register a callback the app provides so a `display always on/off`
 // command applies to the live UITask immediately (no reboot). Raw function
 // pointer (not std::function) to avoid heap on tight-RAM boards.

--- a/src/helpers/wifi_observer/ObserverCli.h
+++ b/src/helpers/wifi_observer/ObserverCli.h
@@ -46,6 +46,17 @@ namespace offband {
 bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
                          MqttBrokerPool& pool);
 
+// Epic F (#165): typed config dispatch -- the wire path's set/get backend.
+// configSet/configGet route a config key straight to the same handlers the
+// _sys CLI uses (above), WITHOUT re-parsing a CLI string. Consumed by the
+// companion-API config command (CMD_OFFBAND_CONFIG / OffbandConfigProtocol.h).
+// `reply` is NUL-terminated human text; returns true if the key was handled
+// (reply populated, incl. an ERROR string), false if the key is unknown.
+// Secrets stay write-only on get (wifi.pwd / broker password|jwt_token).
+bool configSet(const char* key, const char* value, char* reply, size_t reply_size,
+               MqttBrokerPool& pool);
+bool configGet(const char* key, char* reply, size_t reply_size);
+
 // #141: register a callback the app provides so a `display always on/off`
 // command applies to the live UITask immediately (no reboot). Raw function
 // pointer (not std::function) to avoid heap on tight-RAM boards.

--- a/src/helpers/wifi_observer/ObserverCli.h
+++ b/src/helpers/wifi_observer/ObserverCli.h
@@ -62,9 +62,18 @@ bool configGet(const char* key, char* reply, size_t reply_size);
 // is slot N set (non-empty url); configRenderBrokerSlot() renders a populated
 // slot's non-secret fields as wire "key=value\n" lines (string enums; password
 // redacted; jwt_token omitted), returning bytes written (0 if empty).
+//
+// #172/#173 (additive, backward-compatible): when `rt` is provided, also emits
+// `state=`/`last_error=` (the live connection state, not just config `enabled`);
+// when `owner_default_hex` is provided, emits `jwt_owner_resolved=`/`iata_resolved=`
+// for blank jwt_owner/iata_override -- the value used at connect, shown by the
+// client as a hint and NOT written back as an override. Both nullable (omit -> no
+// extra lines). The raw keys are unchanged, so old clients are unaffected.
 int    configBrokerSlotCount();
 bool   configBrokerSlotPopulated(uint8_t slot);
-size_t configRenderBrokerSlot(uint8_t slot, char* out, size_t out_size);
+size_t configRenderBrokerSlot(uint8_t slot, char* out, size_t out_size,
+                              const BrokerRuntimeState* rt = nullptr,
+                              const char* owner_default_hex = nullptr);
 
 // #141: register a callback the app provides so a `display always on/off`
 // command applies to the live UITask immediately (no reboot). Raw function

--- a/src/helpers/wifi_observer/WifiObserverConfig.h
+++ b/src/helpers/wifi_observer/WifiObserverConfig.h
@@ -52,6 +52,35 @@
   #define OFFBAND_MAX_BROKERS 10
 #endif
 
+// #171 -- TLS broker concurrency cap (TEMPORARY; superseded by the round-robin
+// scheduler #175). Each live wss/TLS broker holds a ~60KB mbedTLS context.
+// MEASURED on HV3 (~124KB free with WiFi up): ONE wss broker settles at ~63KB
+// free (heap_min ~52KB) -- safe; TWO wss brokers collapse free heap to ~1.5KB
+// (heap_min 456 bytes) -- the #171 OOM knife-edge. So HV3 safely holds exactly
+// ONE concurrent TLS context. The pool refuses to START a TLS handshake past
+// this many live contexts; the broker self-defers to BrokerState::HeldNoHeap
+// (no retry burned, released once the live slot frees). Plaintext (tcp) brokers
+// hold no mbedTLS context -- exempt. (=1 also removes the start-race where two
+// brokers begin handshakes in one pass before either's async ~60KB lands.) The
+// scheduler #175 cycles feeds through this 1-wide budget on PSRAM-less boards;
+// PSRAM boards override higher.
+#ifndef OFFBAND_MAX_LIVE_TLS
+  #define OFFBAND_MAX_LIVE_TLS 1
+#endif
+
+// Free-heap floor (bytes): the actual safety guarantee. Bringing up a wss broker
+// transiently peaks at ~72KB consumed (MEASURED on HV3: free 124KB -> heap_min
+// ~52KB during the handshake, settling to ~63KB). We refuse to START a TLS
+// handshake unless free heap exceeds this floor, so the transient always fits --
+// the floor MUST exceed the ~72KB transient or the check is worse than useless
+// (at 50KB free it would pass, then OOM mid-handshake; Gemini #171 BLOCKER).
+// 80KB = ~72KB measured transient + margin. With OFFBAND_MAX_LIVE_TLS=1 this is
+// a backstop (the count cap already prevents a 2nd context); it also guards the
+// 1st bring-up under any pre-existing low-heap condition. ESP.getFreeHeap() units.
+#ifndef OFFBAND_TLS_HEAP_FLOOR_BYTES
+  #define OFFBAND_TLS_HEAP_FLOOR_BYTES (80u * 1024u)
+#endif
+
 // ---------------------------------------------------------------------------
 // AP-mode SSID prefix
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Epic F — Offband companion-API config command (firmware)

Adds the observer config command to the Offband companion API (configure WiFi + MQTT brokers + display from the app), plus the hardening that came out of bench-validating it on real hardware. 19 commits onto `firmware-base`.

### Config command (Epic F, #159)
- **F1** wire contract, wholly observer-gated (#160)
- **F2** typed config dispatch (`configSet`/`configGet`) + flat-settings wire handler (#165, #161)
- **F3** broker-pool paginated GET + contract reconciliation (#162)
- **F4** `WIFI_OBSERVER_SUPPORT` capability byte + `FIRMWARE_VER_CODE` (#163)
- **F6** broker enable/disable/clear wired into `configSet` (#166)
- **F7** compile-time guard against the config command on an unauth TCP companion (#168)
- **F8** stream multi-frame config responses to fix dropped BLE frames (#169)

### Hardening (from on-device validation)
- **#171** cap observer at 1 concurrent TLS broker (heap guard) to stop OOM reboot — measured on HV3
- **#178** make BLE connect survive the client's reconnect-thrash
- **#170 / #174** default broker URL → `mqtt1.okimesh.org`; append the Offband radar tell to the observer name in MQTT

### Observer config/NVS layer — SAFELANE §6 + the #179 root fix
- **#181 (5 commits)** — error-visibility remediation: the config write path was silently swallowing NVS failures (a #179 "ACK success but nothing changed" lie). Now every writer + the reconcile/reload path + the crash logger itself surface and log failures honestly; the read path defaults-on-miss are documented as correct.
- **#182** — the honest write **exposed** #179's real cause: on a near-full NVS the write genuinely fails. Reverted the brief single-blob storage (a ~1.1 KB blob can't be placed in fragmented free space — measured `NOT_ENOUGH_SPACE` at used=504/free=126) to **per-key + no-blank** storage that fits, with a removes-first/`enabled`-last write order and a **one-time invisible boot migration** so upgraded devices reclaim space without the user ever seeing a transient error. **Fixes #179.**

### Validation
- Gemini-reviewed at every step (SAFELANE §6/§1), including a final full-diff pass on #182 — sound, no findings.
- Host round-trip + clamp + migration-smoke tests pass; **7-env CI matrix builds green** locally (3 observer + v4 tft + repeater-telemetry + radio-ble + RAK nRF52).
- **Hardware-validated:** HV4 — the `mqtt disable` that #179 reported now succeeds; the §6 layer correctly reported the underlying failure instead of lying. HV3 — flashed clean (no brick/wedge); an NVS backup confirmed the migration completed (`cfg_schema` stamped, `cfg_blob` gone, all 6 slots in per-key/no-blank format).

### Remaining before merge (do NOT merge yet)
- **#172** — surface per-broker runtime state + last-error in `OCFG_BROKERS` (P1)
- **#173** — render resolved defaults (jwt_owner / iata_override) in the dump, not blank (P1)
- **F5** integration-test sign-off

### Separate / out of scope for this PR
- **P0 #183** — CrashLog: the 1 Hz heartbeat floods the 4 KB RTC ring (~50 s wrap), evicting crash diagnostics. Pre-existing crash-log infra issue surfaced during #182 validation; tracked + fixed on its own.

Fixes #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
