### PR TITLE
fix(#89): exclude SerialBLEInterface.cpp from Xiao_S3_WIO USB companion

### DIFF
--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -141,6 +141,7 @@ build_flags =
 build_src_filter = ${Xiao_S3_WIO.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<helpers/esp32/*.cpp>
+  -<helpers/esp32/SerialBLEInterface.cpp>   ; #89: USB companion has no BLE (gated on BLE_PIN_CODE); drop NimBLE-only file
   +<helpers/ui/MomentaryButton.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>


### PR DESCRIPTION
## fix(#89): Xiao_S3_WIO USB companion NimBLE build regression

Closes #89.

`Xiao_S3_WIO_companion_radio_usb` failed with `fatal error: NimBLEDevice.h: No such file or directory` — the #288 NimBLE migration added NimBLE only to `_ble` envs, but the USB env still greedy-compiled `helpers/esp32/SerialBLEInterface.cpp` without the dep. The USB companion never uses BLE (gated on `BLE_PIN_CODE`, undefined here), so the fix excludes that NimBLE-only file from the env's `build_src_filter`.

1-line change; build verified green on current firmware-base (Flash 18.6%). Re-applies the original fix (`d89561c4`) that had been stranded on an unmerged stale branch.

Related (separate, tracked): **#90** (non-BLE serial/wifi envs across boards), **#199** (xiao_c6 BLE missing NimBLE dep).
