### PR TITLE
fix(rak3401): companion GPS probe floats WB_IO2, killing the 1W radio (#211)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,13 @@ jobs:
           - heltec_v4_companion_radio_ble
           - RAK_4631_repeater
           - Heltec_t114_companion_radio_ble   # nRF52 companion coverage (BLE; complements RAK_4631 repeater)
+          # RAK3401 (WisMesh 1W) -- a widely-used device; its RAK_BOARD GPS path is
+          # rak3401-specific and was previously built nowhere in CI (#211 shipped a
+          # companion that couldn't TX). Cover both fix-touched companion envs (the
+          # RAK3401_NO_GPS no-GPS path) + the repeater (live-GPS branch of the gate).
+          - RAK_3401_companion_radio_ble
+          - RAK_3401_companion_radio_usb
+          - RAK_3401_repeater
     steps:
       - uses: actions/checkout@v5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ prior to 0.13.0 predate it; see `git tag -l 'crosswire-v*'` and the tag
 annotations for that history (highlights: v0.12.0 NimBLE migration, v0.11.x
 Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
+## [1.1.1] - 2026-06-26
+
+Urgent patch: the **RAK3401 1W companion** radio was dead on v1.1.0. Still on the
+**MeshCore 1.16.0** base.
+
+### Fixed
+- **RAK3401 1W companion radio dead on Offband (no TX/RX).** Offband's GPS support
+  (#104) probed a pin that doubles as the radio's power-enable on the RAK3401; with no
+  GPS attached it left the radio unpowered, so it couldn't transmit or receive. GPS is
+  now disabled on the RAK3401 companion build until the probe is fixed. (#211)
+
 ## [1.1.0] - 2026-06-24
 
 The headline is **Epic F: the companion-API config command** — a WiFi observer can now be

--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -160,7 +160,10 @@ static Adafruit_VL53L0X VL53L0X;
 static RAK12035_SoilMoisture RAK12035;
 #endif
 
-#if ENV_INCLUDE_GPS && defined(RAK_BOARD) && !defined(RAK_WISMESH_TAG)
+// RAK3401 companion opts out of GPS via -D RAK3401_NO_GPS: on this board the GPS probe
+// (gpsIsAwake) toggles WB_IO2 = PIN_3V3_EN = the radio power-enable, and a failed probe
+// leaves it floating -> SX1262 TCXO can't start (-707). Repeater (has GPS) keeps the path.
+#if ENV_INCLUDE_GPS && defined(RAK_BOARD) && !defined(RAK_WISMESH_TAG) && !defined(RAK3401_NO_GPS)
 #define RAK_WISBLOCK_GPS
 #endif
 

--- a/variants/rak3401/platformio.ini
+++ b/variants/rak3401/platformio.ini
@@ -81,6 +81,7 @@ build_flags =
   -D DISPLAY_CLASS=SSD1306Display
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
+  -D RAK3401_NO_GPS              ; companion has no GPS; boot probe floats WB_IO2 (radio power) -> kills TX (-707)
 ; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
 ; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
 build_src_filter = ${rak3401.build_src_filter}
@@ -104,6 +105,7 @@ build_flags =
   -D BLE_PIN_CODE=123456
   -D BLE_DEBUG_LOGGING=1
   -D OFFLINE_QUEUE_SIZE=256
+  -D RAK3401_NO_GPS              ; companion has no GPS; boot probe floats WB_IO2 (radio power) -> kills TX (-707)
   ;-D MESH_PACKET_LOGGING=1
   ;-D MESH_DEBUG=1
 build_src_filter = ${rak3401.build_src_filter}


### PR DESCRIPTION
## Summary
Urgent fix for **#211** — the RAK3401 1W **companion** radio is dead on Offband v1.1.0 (`startTransmit`/`startReceive` return **-707** / `XOSC_START_ERR`, no TX/RX).

**Root cause:** the #104 GPS probe (`EnvironmentSensorManager::gpsIsAwake`) toggles `WB_IO2` to find the RAK12500. On the RAK3401, `WB_IO2 == PIN_3V3_EN ==` the radio's power-enable; a failed probe (no GPS attached) leaves it floating, so the SX1262 TCXO can't start. Stock upstream MeshCore 1.16.0 transmits fine — the regression is in Offband's #104 GPS support.

**Fix:** scope the GPS path off the companion — guard `RAK_WISBLOCK_GPS` with `!defined(RAK3401_NO_GPS)` and set `-D RAK3401_NO_GPS` on the two companion envs only. Repeater + every other rak3401 env are byte-for-byte unchanged.

## Verification
- **Static:** GPS-probe marker string absent from companion firmware, present in repeater.
- **Build:** companion BLE + repeater both green.
- **Hardware:** radio transmits on Offband after the fix (was -707).
- **Gemini review:** LGTM — `docs/llm-consultations/2026-06-25-211-companion-gps-probe-fix-gemini-gemini-2.5-pro.log`.

## Follow-up (separate, not this PR)
Proper `gpsIsAwake` fix — never use `WB_IO2` as a GPS pin on this board, restore radio pins instead of floating. Required before GPS returns to the companion (#209/#210).

**Merge as a merge-commit (no squash).** Ships as `offband-v1.1.1`.

Fixes #211.
