### PR TITLE
fix(#233): autobaud re-probes (no 9600 give-up) + CHANGELOG [1.2.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,30 @@ prior to 0.13.0 predate it; see `git tag -l 'crosswire-v*'` and the tag
 annotations for that history (highlights: v0.12.0 NimBLE migration, v0.11.x
 Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
+## [1.2.0] - 2026-06-28
+
+Companion **GPS auto-baud + on-demand GPS status**, plus the wedge/time fixes found
+validating it on real hardware. Still on the **MeshCore 1.16.0** base.
+
+### Added
+- **GPS auto-baud detection** — the companion now detects the GPS modem's baud rate at
+  runtime (probing 115200 then 9600, validating by a checksum-good NMEA sentence), so one
+  image reads either a standard 9600 module or a 115200 one with no rebuild. It re-probes
+  on a GPS enable and keeps trying if a modem is slow to start at boot. (#216, #233)
+- **On-demand GPS status to the app (`0xC1`)** — the client can query live GPS state
+  (enabled / detected / fix / baud / lat / lon / alt / sats / time) instead of only seeing
+  position at connect. (#216)
+- **Build identity on-device** — an optional build tag shows on the app device-info field
+  and the OLED splash, so a specific build is identifiable without a serial console. (#222)
+
+### Fixed
+- **GPS at high baud could wedge BLE.** An unbounded GPS read loop let a fast modem
+  (e.g. 115200, multi-constellation) monopolize the main loop and starve BLE — the app
+  would slog or stall. GPS ingestion is now bounded per loop. (#231)
+- **GPS time showed garbage before the date was acquired.** A valid position fix can
+  arrive before the calendar date; the device now reports `time=0` ("acquiring") until a
+  real date is parsed, instead of a wrapped-garbage timestamp. (#232)
+
 ## [1.1.1] - 2026-06-26
 
 Urgent patch: the **RAK3401 1W companion** radio was dead on v1.1.0. Still on the

--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -791,8 +791,9 @@ bool EnvironmentSensorManager::nmeaScanByte(char c) {
 // #149: ONE non-blocking step of the auto-baud state machine (Meshtastic-style).
 // Called from loop() while gps_active && !_gps_baud_locked. Reads only already-buffered
 // bytes (no blocking wait), scans for a valid sentence, advances to the next candidate
-// when a candidate's ~1.5s window elapses, and falls back to the first candidate +
-// locks (stops probing -- no spin/wedge) if none answer.
+// when a candidate's ~1.5s window elapses, and LOCKS (detected=true) the instant a
+// candidate yields a valid sentence. #233: if none answer in a pass it wraps and keeps
+// re-probing (a modem may be slow to start) -- non-blocking, never spins/wedges.
 void EnvironmentSensorManager::autoBaudStep() {
   static const uint32_t cand[] = {
     #ifdef GPS_BAUD_RATE
@@ -820,14 +821,17 @@ void EnvironmentSensorManager::autoBaudStep() {
     }
   }
 
-  if (millis() - _baud_window_ms >= 1500) {       // candidate timed out -> next, or fall back
+  if (millis() - _baud_window_ms >= 1500) {       // candidate timed out -> next candidate
     _baud_window_ms = 0;
     if (++_baud_idx >= NCAND) {
+      // #233: wrap and KEEP probing -- never give up / lock a fallback. A modem can be
+      // slow to start at boot (cold start), so exhausting one pass does NOT mean "no GPS".
+      // We re-probe the candidates indefinitely; the next pass locks (detected=true) the
+      // instant a candidate yields a valid sentence. The wrap leaves _baud_window_ms==0,
+      // so the next step re-opens cand[0]'s window (updateBaudRate + RX flush) cleanly.
+      // Harmless if truly no GPS is present: non-blocking, just cycles the baud on an idle
+      // UART and stays detected=false (was: lock cand[0] with detected=false and stop).
       _baud_idx = 0;
-      _gps_baud = cand[0];
-      Serial1.updateBaudRate(_gps_baud);
-      while (Serial1.available()) Serial1.read();  // #231: flush stale bytes from the probe rate (Gemini review)
-      _gps_baud_locked = true;                    // lock to default; no GPS present (gps_detected stays false)
     }
   }
 }


### PR DESCRIPTION
Closes #233. Prep for **v1.2.0-rc1**.

### #233 — autobaud retry
`autoBaudStep` gave up after one pass and locked the 9600 fallback with `detected=false`, so a GPS slow to start at boot was never detected until a manual reset (observed intermittently on the M100). It now **wraps and keeps re-probing**, locking (`detected=true`) the instant a candidate yields a valid sentence. Non-blocking, never spins/wedges, harmless with no GPS attached.

### CHANGELOG
Adds the **[1.2.0]** entry covering the GPS work merged in #234 (autobaud, 0xC1 query, #231 wedge fix, #232 time guard, #222 build tag) — required so the release page isn't "(No CHANGELOG entry)".

### Verification
- Builds (heltec_v4 companion) ✓; CI runs the full matrix.
- Gemini adversarial review: **0 blocker / 0 major / 1 minor** (cosmetic `baud=` display while scanning; left as-is, `detected=0` disambiguates).
- #233's slow-start path is intermittent; the fix is logic-verified + reviewed, and field-validates via the rc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)