### PR TITLE
fix(#239): round CLI frequency output to 3 decimals (ftoa3)

### DIFF
--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -1037,7 +1037,7 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
 #endif
   } else if (memcmp(config, "radio", 5) == 0) {
     char freq[16], bw[16];
-    strcpy(freq, StrHelper::ftoa(_prefs->freq));
+    strcpy(freq, StrHelper::ftoa3(_prefs->freq));
     strcpy(bw, StrHelper::ftoa3(_prefs->bw));
     sprintf(reply, "> %s,%s,%d,%d", freq, bw, (uint32_t)_prefs->sf, (uint32_t)_prefs->cr);
   } else if (memcmp(config, "rxdelay", 7) == 0) {
@@ -1077,7 +1077,7 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
   } else if (memcmp(config, "tx", 2) == 0 && (config[2] == 0 || config[2] == ' ')) {
     sprintf(reply, "> %d", (int32_t) _prefs->tx_power_dbm);
   } else if (memcmp(config, "freq", 4) == 0) {
-    sprintf(reply, "> %s", StrHelper::ftoa(_prefs->freq));
+    sprintf(reply, "> %s", StrHelper::ftoa3(_prefs->freq));
   } else if (memcmp(config, "public.key", 10) == 0) {
     strcpy(reply, "> ");
     mesh::Utils::toHex(&reply[2], _callbacks->getSelfId().pub_key, PUB_KEY_SIZE);


### PR DESCRIPTION
## What
`get radio` and `get freq` printed the LoRa frequency via `StrHelper::ftoa()` (7-decimal precision), so `910.525` MHz surfaced as `910.5250244` — float32 display noise, **not** a tuning error (nearest float32 to 910.525 is 910.5250244140625; the radio is tuned correctly).

Both sites now use `StrHelper::ftoa3()` — 3-decimal (kHz) rounding with trailing-zero stripping — the helper **already used for the bandwidth field on the adjacent line**, so output is consistent.

## Result
- `get freq` → `910.525`
- `get radio` → `910.525,62.5,...`
- Whole MHz renders clean (`915`, no `.000`)

## Scope
- **CLI display only.** The OLED already rounds (`%06.3f`); the client app rounds its own frequency display. Shared `CommonCLI.cpp` → covers every role (repeater/companion/etc.).
- Note: reported as `get tx`, but `get tx` returns *tx power* (int) — the long value came from `get radio` / `get freq`.

## Verification
- Built `heltec_v4_repeater` ✅
- Gemini-reviewed (gemini-2.5-pro): correct rounding, no precision loss, no static-buffer aliasing.

Closes #239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
