### PR TITLE
chore: sync pre-commit to canonical (§0.6) + pin DW_PROJECT=Crosswire

### DIFF
--- a/.claude/hooks/pre-commit
+++ b/.claude/hooks/pre-commit
@@ -65,6 +65,52 @@ if [ -n "$REPO_ROOT_FOR_AGENT_CHECK" ] && [ -f "$REPO_ROOT_FOR_AGENT_CHECK/.agen
   fi
 fi
 
+# ─── 0.6. Safe Lane: primary-clone (main working tree) block (agent only) ───
+# Per SAFELANE §5, agent edits/commits must happen in a git *worktree*, not the
+# primary clone. The §0.5 branch check above misses one path: `git checkout -b`
+# *inside* the primary clone leaves the main working tree on a feature branch —
+# the branch check then passes while main's working tree is still polluted.
+# This check closes that loophole: it refuses commits made in the MAIN working
+# tree regardless of branch.
+#
+# Detection: a linked worktree's git dir always lives under `.git/worktrees/`;
+# the main working tree's never does. (A `--git-dir == --git-common-dir` compare
+# is NOT subdir-safe — see block-primary-clone-edit.py.)
+#
+# Gated on .agent-identity (agent commits only) — humans may commit in the
+# primary clone. See DifferentWire/standards#181.
+if [ -n "$REPO_ROOT_FOR_AGENT_CHECK" ] && [ -f "$REPO_ROOT_FOR_AGENT_CHECK/.agent-identity" ]; then
+  if [ "${DW_ALLOW_PRIMARY_CLONE:-0}" = "1" ]; then
+    echo "⚠ PRIMARY-CLONE COMMIT BYPASSED — DW_ALLOW_PRIMARY_CLONE=1" >&2
+    echo "  This bypass is logged. Use only for emergencies." >&2
+  else
+    # Detection: a linked worktree's git dir differs from its *common* git dir
+    # (the git dir is <common>/worktrees/<name>); the main working tree's git
+    # dir IS the common dir. Comparing the two (absolute) is precise and can't
+    # be fooled by a repo cloned under a path that merely contains the string
+    # ".git/worktrees/" — a substring match on the git dir alone can (see
+    # block-primary-clone-edit.py and standards#181 review). Submodules are
+    # exempt (their own working tree is the only place to edit them). Fails
+    # CLOSED (block) on uncertainty — this hook only ever runs inside a repo.
+    SUPERPROJECT=$(git rev-parse --show-superproject-working-tree 2>/dev/null)
+    GIT_DIR_ABS=$(git rev-parse --path-format=absolute --git-dir 2>/dev/null | tr 'A-Z' 'a-z')
+    COMMON_DIR_ABS=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | tr 'A-Z' 'a-z')
+    if [ -n "$SUPERPROJECT" ]; then
+      : # inside a submodule — its own working tree is the only place to edit; exempt
+    elif [ -n "$GIT_DIR_ABS" ] && [ "$GIT_DIR_ABS" != "$COMMON_DIR_ABS" ]; then
+      : # linked worktree (git dir != common dir) — allowed
+    else
+      # main working tree (git dir == common dir), or detection failed -> block
+      echo "✗ Safe Lane: agent commit in the PRIMARY CLONE (main working tree) is blocked." >&2
+      echo "  Repo: ${REPO_ROOT_FOR_AGENT_CHECK}" >&2
+      echo "  Its working tree mirrors 'main' and must stay clean. Work in a worktree:" >&2
+      echo "    git worktree add /c/Dev/<project>-<topic>/ -b <type>/<issue>-<topic> main" >&2
+      echo "  Emergency bypass: DW_ALLOW_PRIMARY_CLONE=1 git commit ... (logged)" >&2
+      exit 1
+    fi
+  fi
+fi
+
 CITADEL_API="https://getunfocused.app/citadel"
 
 # Detect project name from DW_PROJECT env var or directory name
@@ -89,71 +135,69 @@ except Exception:
     print('true')
 " 2>/dev/null)
 
-# ─── 2. Check for in_progress tasks (with optional issue-link check) ────
+# ─── 2. Resolve THE active task for this work, deterministically ───────
+# Pick the task tied to THIS unit of work (DW_TASK > branch issue > the lone
+# in_progress task) instead of whichever in_progress task Citadel returns
+# first — that coarse check misreports with two tasks open and is exploitable.
+# Fail closed when ambiguous. Strycher/LoRa#241, DifferentWire/standards#172.
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+BRANCH_ISSUE=$(printf '%s' "$BRANCH" | grep -oE '^[A-Za-z]+/[0-9]+[-_]' | grep -oE '[0-9]+' | head -1)
 RESPONSE=$(curl -s --max-time 5 "${CITADEL_API}/projects/${PROJECT}/tasks?status=in_progress" 2>/dev/null)
-
 if [ -z "$RESPONSE" ]; then
   echo "✗ Citadel unreachable — cannot verify task claim." >&2
-  echo "  Fix Citadel connectivity or set DW_SKIP_CITADEL_CHECK=1 for emergency." >&2
+  echo "  Fix Citadel connectivity and retry." >&2
   exit 1
 fi
 
-HAS_CLAIMED=$(echo "$RESPONSE" | REQUIRE_ISSUE_LINK="$REQUIRE_ISSUE_LINK" python3 -c "
-import json, os, sys
-require = os.environ.get('REQUIRE_ISSUE_LINK', 'true') == 'true'
-try:
-    tasks = json.load(sys.stdin)
-    claimed = [t for t in tasks if t.get('status') == 'in_progress']
-    if not claimed:
-        print('NO_TASK')
-    elif not require:
-        # Relaxed: any claimed task is sufficient. Report issue link if
-        # present for informational purposes, but don't require it.
-        t = claimed[0]
-        iss = t.get('external_issue_number')
-        if iss:
-            print(f'OK:{t[\"short_id\"]}:#{iss}')
-        else:
-            print(f'OK_RELAXED:{t[\"short_id\"]}')
-    else:
-        # Strict (default): at least one claimed task must have an issue link
-        linked = [t for t in claimed if t.get('external_issue_number')]
-        if linked:
-            print(f'OK:{linked[0][\"short_id\"]}:#{linked[0][\"external_issue_number\"]}')
-        else:
-            print(f'NO_ISSUE:{claimed[0][\"short_id\"]}')
-except Exception:
-    print('ERROR')
-" 2>/dev/null)
-
-case "$HAS_CLAIMED" in
-  OK:*)
-    TASK_ID=$(echo "$HAS_CLAIMED" | cut -d: -f2)
-    ISSUE=$(echo "$HAS_CLAIMED" | cut -d: -f3)
-    echo "✓ Citadel: active task ${TASK_ID} (${ISSUE})" >&2
-    ;;
-  OK_RELAXED:*)
-    TASK_ID=$(echo "$HAS_CLAIMED" | cut -d: -f2)
-    echo "✓ Citadel: active task ${TASK_ID} (project '${PROJECT}' has issue-link requirement relaxed)" >&2
+HOOK_DIR=$(dirname "$0")
+RESOLVER="$HOOK_DIR/resolve-active-task.py"
+if [ ! -f "$RESOLVER" ]; then
+  echo "⚠ Safe Lane: resolve-active-task.py not installed next to pre-commit — active-task gate SKIPPED (non-bricking)." >&2
+  echo "  Copy the canonical hooks from standards; it ships with pre-commit. standards#172." >&2
+  RESULT="SKIP"
+else
+  RESULT=$(printf '%s' "$RESPONSE" | python3 "$RESOLVER" --branch-issue "$BRANCH_ISSUE" --dw-task "${DW_TASK:-}" --require-issue-link "$REQUIRE_ISSUE_LINK" 2>/dev/null)
+fi
+read -r CODE A B <<< "$RESULT"
+case "$CODE" in
+  SKIP) : ;;  # helper not installed (warned above) — do not block
+  OK)
+    echo "✓ Citadel: active task $A ($B)" >&2
     ;;
   NO_TASK)
-    echo "✗ No claimed task in Citadel for project '${PROJECT}'." >&2
-    echo "  Run: dw --project ${PROJECT} claim <task-id>" >&2
-    echo "  You must claim a task before committing code." >&2
+    echo "✗ Safe Lane: no in_progress task in Citadel for project '${PROJECT}'." >&2
+    echo "  Claim the task for the work being committed: dw -p ${PROJECT} claim <ShortId>" >&2
     exit 1
     ;;
-  NO_ISSUE:*)
-    TASK_ID=$(echo "$HAS_CLAIMED" | cut -d: -f2)
-    echo "✗ Task ${TASK_ID} has no GitHub issue link." >&2
-    echo "  Every task must be linked to a GitHub issue before work begins." >&2
-    echo "  (Project '${PROJECT}' requires issue linkage — if this project doesn't" >&2
-    echo "   need it, have an admin run:" >&2
-    echo "     dw project-update ${PROJECT} --require-issue-link false)" >&2
+  AMBIGUOUS)
+    echo "✗ Safe Lane: $A tasks are in_progress and none matches this work." >&2
+    echo "  The hook cannot tell which task this commit is for. Make it deterministic:" >&2
+    echo "    - work on a feat/<issue#>-... branch (the hook reads the issue from it), or" >&2
+    echo "    - export DW_TASK=<ShortId> in this worktree." >&2
+    exit 1
+    ;;
+  BRANCH_NO_MATCH)
+    echo "✗ Safe Lane: this branch implies issue #$A, but no in_progress task is linked to it." >&2
+    echo "  Claim the task for #$A (dw -p ${PROJECT} claim <ShortId>), or set DW_TASK to the right task." >&2
+    exit 1
+    ;;
+  DW_TASK_BAD)
+    echo "✗ Safe Lane: DW_TASK=$A is not an in_progress task in project '${PROJECT}'." >&2
+    echo "  Claim it first (dw -p ${PROJECT} claim $A) or unset DW_TASK." >&2
+    exit 1
+    ;;
+  NO_ISSUE)
+    echo "✗ Safe Lane: task $A has no linked GitHub issue (project '${PROJECT}' requires one)." >&2
+    echo "  Link it: dw -p ${PROJECT} update $A -i <issue#>  (or relax: dw project-update ${PROJECT} --require-issue-link false)." >&2
+    exit 1
+    ;;
+  AMBIGUOUS_ISSUE)
+    echo "✗ Safe Lane: two in_progress tasks are linked to issue #$A — cannot tell which." >&2
+    echo "  Disambiguate: export DW_TASK=<ShortId> in this worktree." >&2
     exit 1
     ;;
   *)
-    echo "✗ Could not verify Citadel task status." >&2
-    echo "  Set DW_SKIP_CITADEL_CHECK=1 for emergency bypass." >&2
+    echo "✗ Safe Lane: could not resolve the active task (Citadel parse error / BAD_INPUT)." >&2
     exit 1
     ;;
 esac

--- a/.claude/hooks/resolve-active-task.py
+++ b/.claude/hooks/resolve-active-task.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+r"""
+resolve-active-task.py - deterministic "which task is this work for?" resolver.
+
+Shared by the canonical pre-commit / pre-push / preflight hooks so they all agree
+on THE active task, instead of grabbing whichever in_progress task Citadel returns
+first. That coarse "any in_progress" check misreports the task when two are open
+AND is exploitable (the gate can be satisfied by an unrelated stale claim) -
+Strycher/LoRa#241, DifferentWire/standards#172.
+
+Reads the project's in_progress tasks as a JSON list on stdin (the hook does the
+curl; keeping I/O in the hook leaves this pure and unit-testable). Resolves in
+priority order:
+
+  1. --dw-task <short_id>   explicit per-worktree override (DW_TASK env)
+  2. --branch-issue <N>     from a `<type>/<N>-...` branch -> in_progress task
+                            whose external_issue_number == N
+  3. exactly one in_progress task -> that task (unambiguous)
+  4. otherwise -> AMBIGUOUS; the caller FAILS CLOSED (standards#172 decision)
+
+The issue-link requirement (--require-issue-link) is then applied to the SELECTED
+task only - never to "some other in_progress task".
+
+Output: one line on stdout (first word is the code) + a matching exit code so the
+tool is usable both from a shell `case` and directly:
+
+  OK <short_id> <#issue|->     0    resolved + satisfies the issue-link rule
+  NO_TASK                      10   no in_progress task at all
+  NO_ISSUE <short_id>          11   resolved, but strict mode + no issue link
+  AMBIGUOUS <n> <branch|->     12   multiple in_progress, none matched -> block
+  DW_TASK_BAD <short_id>       13   DW_TASK is not an in_progress task
+  BRANCH_NO_MATCH <N>          14   branch implies #N but no in_progress task linked
+  AMBIGUOUS_ISSUE <N>          15   two in_progress tasks linked to the same issue #N
+  BAD_INPUT                    1    stdin was not a JSON list of tasks
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def _issue_of(task: dict) -> str:
+    v = task.get("external_issue_number")
+    return str(v) if v not in (None, "") else ""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dw-task", default="")
+    ap.add_argument("--branch-issue", default="")
+    ap.add_argument("--require-issue-link", default="true")
+    args = ap.parse_args()
+
+    require = args.require_issue_link.strip().lower() == "true"
+    dw_task = args.dw_task.strip()
+    branch_issue = args.branch_issue.strip()
+
+    try:
+        tasks = json.load(sys.stdin)
+        if not isinstance(tasks, list):
+            raise ValueError("expected a JSON list of tasks")
+    except Exception:
+        print("BAD_INPUT")
+        return 1
+
+    inprog = [t for t in tasks if isinstance(t, dict) and t.get("status") == "in_progress"]
+    if not inprog:
+        print("NO_TASK")
+        return 10
+
+    # 1. Explicit per-worktree override wins, but must be a real in_progress task.
+    if dw_task:
+        match = [t for t in inprog if t.get("short_id") == dw_task]
+        if not match:
+            print(f"DW_TASK_BAD {dw_task}")
+            return 13
+        selected = match[0]
+    # 2. Branch issue number -> the in_progress task linked to it.
+    elif branch_issue:
+        match = [t for t in inprog if _issue_of(t) == branch_issue]
+        if not match:
+            print(f"BRANCH_NO_MATCH {branch_issue}")
+            return 14
+        if len(match) > 1:
+            # Two in_progress tasks linked to the same issue -> still ambiguous;
+            # don't silently pick one. Disambiguate with DW_TASK.
+            print(f"AMBIGUOUS_ISSUE {branch_issue}")
+            return 15
+        selected = match[0]
+    # 3. Exactly one in_progress task is unambiguous.
+    elif len(inprog) == 1:
+        selected = inprog[0]
+    # 4. Multiple, with no deterministic signal -> fail closed (caller blocks).
+    else:
+        print(f"AMBIGUOUS {len(inprog)} {branch_issue or '-'}")
+        return 12
+
+    iss = _issue_of(selected)
+    sid = selected.get("short_id", "?")
+    if require and not iss:
+        print(f"NO_ISSUE {sid}")
+        return 11
+    print(f"OK {sid} {('#' + iss) if iss else '-'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "DW_PROJECT": "Crosswire"
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
Closes #248

## What
1. **Resync `.claude/hooks/pre-commit` to canonical** — adds the §0.6 primary-clone (worktree-only) block from standards#182. Now byte-identical to `DifferentWire/standards/hooks/pre-commit`; clears the drift flag.
2. **Add `resolve-active-task.py`** — it was **missing**, and the pre-commit depends on it (standards#172, they ship together). Without it the active-task gate was silently **skipped** (`⚠ resolve-active-task.py not installed … gate SKIPPED`). With it present, the gate now resolves the correct task (verified: `✓ Citadel: active task Crosswire-5ka (#248)`).
3. **Pin `DW_PROJECT=Crosswire`** in `.claude/settings.json` `env` — folder basename (`meshcore-firmware`) ≠ Citadel project (`Crosswire`); resolution previously relied on a global shell env var. Now explicit + machine-independent.

## Verified
- pre-commit byte-identical to canonical
- gate runs and resolves the right task (was skipping)
- settings.json valid
- done in an isolated worktree (no collision with the active firmware worktrees)

## Not included (offered as follow-up)
- The PreToolUse half of #182 (`block-primary-clone-edit.py` + settings wiring) — the *edit-time* worktree guard. This PR is the *commit-time* (§0.6) half + the env pin, per request. Given this repo runs 8 worktrees, wiring the edit-time guard too is worth doing next.