### PR TITLE
fix(#262): don't auto-enable OKIMesh CoreScope on fresh flash + default region XYZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ prior to 0.13.0 predate it; see `git tag -l 'crosswire-v*'` and the tag
 annotations for that history (highlights: v0.12.0 NimBLE migration, v0.11.x
 Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
-## [1.1.2] - 2026-06-28
+## [1.1.2] - 2026-07-02
 
 Companion **GPS auto-baud + on-demand GPS status**, plus the wedge/time fixes
-found while validating it on real hardware. Still on the **MeshCore 1.16.0** base.
+found while validating it on real hardware, and a **safer first-flash default** — a
+fresh Observer no longer auto-publishes to a preset MQTT broker. Still on the
+**MeshCore 1.16.0** base.
 
 ### Added
 - **GPS auto-baud detection** — the companion now detects the GPS modem's baud rate at
@@ -30,6 +32,17 @@ found while validating it on real hardware. Still on the **MeshCore 1.16.0** bas
 - **On-device build identity** — an optional build tag shows on the app device-info
   field and the OLED splash, so a specific build is identifiable without a serial
   console. (#222)
+
+### Changed
+- **Fresh flashes no longer auto-publish to OKIMesh CoreScope.** A newly-flashed
+  Observer previously seeded the CoreScope (Dayton) broker **enabled**, so a device
+  flashed anywhere in the world immediately fed MQTT to OKIMesh CoreScope tagged as a
+  Dayton node. On a fresh flash every broker now ships **disabled** — the operator
+  opts in per slot. (#262)
+- **Default region is now `XYZ`** (a non-geographic placeholder) instead of `HAO`
+  (Dayton), so an out-of-region device stops mislabeling itself until the operator sets
+  its region via `mqtt iata`. Fresh / NVS-erased devices only; existing devices keep
+  their stored config. (#262)
 
 ### Fixed
 - **GPS at high baud could wedge BLE.** An unbounded GPS read loop let a fast modem

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -370,7 +370,7 @@ bool clearBrokerConfig(uint8_t slot) {
 // changing this layout does NOT re-shuffle slots on a device already seeded
 // under an older layout; it takes effect only on a fresh NVS.)
 //
-//   slot 0  CoreScope Dayton   mqtt://mqtt1.okimesh.org:1883    tcp / anon   ENABLED
+//   slot 0  CoreScope Dayton   mqtt://mqtt1.okimesh.org:1883    tcp / anon   disabled  (#262)
 //   slot 1  LetsMesh-US        wss://mqtt-us-v1.letsmesh.net    wss / jwt    disabled
 //   slot 2  Eastme.sh          wss://mqtt.eastme.sh             wss / jwt    disabled
 //   slot 3  MeshMapper         wss://mqtt.meshmapper.net        wss / jwt    disabled
@@ -378,8 +378,11 @@ bool clearBrokerConfig(uint8_t slot) {
 //   slot 5  Eastmesh.au        wss://mqtt2.eastmesh.au          wss / jwt    disabled
 //   slots 6-9  (MQTT Custom)   left empty for the operator to fill
 //
-// CoreScope is plaintext + anonymous, so it is the only slot enabled by
-// default: no TLS cert, no JWT identity (validated live on HV3 -- #42/#48).
+// As of #262 NO slot is enabled by default -- a fresh flash must not
+// auto-publish to any upstream broker. CoreScope (slot 0, plaintext + anon,
+// no TLS cert / no JWT; validated live on HV3 -- #42/#48) was formerly the
+// sole default-enabled slot, which made out-of-region fresh flashes feed
+// OKIMesh CoreScope tagged as Dayton/HAO.
 // The wss brokers stay disabled until the operator opts in; their ca_cert
 // names ("gts-r4", "letsencrypt", "isrg-x2") all resolve in MqttBroker.cpp's
 // lookupCaCertPem(), and while disabled they never connect anyway.
@@ -419,7 +422,7 @@ struct DefaultBrokerSpec {
 // Slots 0-5. Slots 6-9 (MQTT Custom) are intentionally absent so they stay empty.
 // jwt_audience is the BARE host (#95); ca_cert names resolve in MqttBroker.cpp.
 constexpr DefaultBrokerSpec kDefaultBrokerSpecs[] = {
-    {true,  "mqtt://mqtt1.okimesh.org:1883",          BrokerTransport::Tcp, 1883, BrokerAuthType::None, "",                        ""},
+    {false, "mqtt://mqtt1.okimesh.org:1883",          BrokerTransport::Tcp, 1883, BrokerAuthType::None, "",                        ""},
     {false, "wss://mqtt-us-v1.letsmesh.net:443/mqtt", BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt-us-v1.letsmesh.net", "gts-r4"},
     {false, "wss://mqtt.eastme.sh:443/mqtt",          BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt.eastme.sh",          "letsencrypt"},
     {false, "wss://mqtt.meshmapper.net:443/mqtt",     BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt.meshmapper.net",     "isrg-x2"},
@@ -432,11 +435,13 @@ constexpr uint8_t kNumDefaultBrokers =
 
 void populateDefaultBrokers() {
     bool all_ok = true;
-    // Seed the owner's IATA (HAO) if unset -- SWOH default to simplify setup
-    // for most operators; non-SWOH operators override via the global mqtt iata.
+    // Seed a NON-geographic placeholder IATA ("XYZ") if unset -- #262. A fresh
+    // flash must not masquerade as a real region; HAO (Dayton/SWOH) was the old
+    // default and mislabeled out-of-region devices. The operator sets their real
+    // region via the global `mqtt iata`.
     char iata[8] = {0};
     if (!readGlobalIata(iata, sizeof(iata)) || iata[0] == '\0') {
-        all_ok &= writeGlobalIata("HAO");
+        all_ok &= writeGlobalIata("XYZ");
     }
 
     for (uint8_t slot = 0;

--- a/src/helpers/wifi_observer/ConfigSchema.h
+++ b/src/helpers/wifi_observer/ConfigSchema.h
@@ -135,10 +135,11 @@ bool clearBrokerConfig(uint8_t slot);
 
 // Phase 2 (#48; layout revised in #95): seed the public-broker registry into
 // empty slots only (cfg.url[0] == '\0'); never overwrites user-set values;
-// idempotent. Slot 0 = CoreScope (tcp/anon) ships ENABLED; slots 1-5 (wss/jwt:
-// LetsMesh-US, Eastme.sh, MeshMapper, LetsMesh-EU, Eastmesh.au) ship disabled
-// pending operator opt-in + JWT identity claims; slots 6-9 are left empty for
-// operator-custom brokers.
+// idempotent. As of #262 ALL seeded slots ship DISABLED (slot 0 = CoreScope
+// tcp/anon; slots 1-5 wss/jwt: LetsMesh-US, Eastme.sh, MeshMapper, LetsMesh-EU,
+// Eastmesh.au) -- a fresh flash must not auto-publish to any upstream broker;
+// the operator opts in per slot (+ JWT identity claims for the wss brokers).
+// Slots 6-9 are left empty for operator-custom brokers.
 void populateDefaultBrokers();
 
 // #182: one-time boot migration of an upgraded observer to the per-key / no-blank


### PR DESCRIPTION
Closes #262. Part of Epic #261 / Feature #260.

## What
Fresh-flash MQTT default safety. A newly-flashed Observer previously seeded slot 0 (CoreScope / OKIMesh Dayton) **enabled + anonymous** and defaulted the global region to **HAO**, so a device flashed anywhere in the world immediately published to OKIMesh CoreScope tagged as a Dayton node — an unintended consequence of the #95/#48 broker pre-config.

## Change (`src/helpers/wifi_observer/ConfigSchema.cpp` + `.h`)
- `kDefaultBrokerSpecs[0]` CoreScope `enabled` **true → false** — no broker auto-enabled on a fresh flash; operator opts in per slot.
- Default global IATA **HAO → XYZ** (non-geographic placeholder; XYZ is the original pre-#95 default). Operator sets real region via `mqtt iata`.
- Stale comments synced; CHANGELOG entry added to the **1.1.2** section.

**Scope:** fresh-NVS only — `populateDefaultBrokers` is skip-if-present, so existing field devices are unaffected. Retroactive migration for already-deployed devices is tracked in Epic #261.

## Verification
- Build: `Heltec_v3_companion_observer_wifi` **SUCCESS** (00:02:45). Variant-agnostic change (no GPS guards / statics).
- Gemini adversarial review: BLOCKER (uninit `BrokerConfig def`) = **false positive** — struct has default member initializers on every field (`ConfigSchema.h:111-127`); MAJOR (`clearBrokerConfig` silent failure) is pre-existing/out-of-scope, filed as **#264**.

## Release
Folds into **offband-v1.1.2**.