### PR TITLE
chore(#280): per-session identity hooks (ruff-clean hooks #212)

### DIFF
--- a/.claude/hooks/session-identity.py
+++ b/.claude/hooks/session-identity.py
@@ -55,7 +55,7 @@ import sys
 import time
 from pathlib import Path
 
-_UUID_RE = re.compile(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
+_UUID_RE = re.compile(r"[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}")
 _MAX_IDENTITY_LEN = 64
 
 ADJ = ["Amber", "Azure", "Basalt", "Cobalt", "Crimson", "Dusk", "Ember", "Flint",
@@ -68,7 +68,7 @@ NOUN = ["Basin", "Bluff", "Canyon", "Cedar", "Creek", "Delta", "Dune", "Falls",
         "Thicket", "Thorn", "Vale", "Warren", "Wharf", "Wren", "Yarrow", "Zephyr"]
 
 
-class CorruptRecord(Exception):
+class CorruptRecordError(Exception):
     """The session's record file exists but could not be read/parsed."""
 
 
@@ -149,7 +149,7 @@ def record_path(uuid: str) -> Path:
 def read_record(uuid: str):
     """Return the record dict, or None if ABSENT.
 
-    Raises CorruptRecord if the file EXISTS but cannot be read/parsed — the
+    Raises CorruptRecordError if the file EXISTS but cannot be read/parsed — the
     caller must NOT treat that as "absent" (that would re-derive over a real
     identity). Distinguishing absent from corrupt is the core safety property.
     """
@@ -159,9 +159,9 @@ def read_record(uuid: str):
     try:
         data = json.loads(f.read_text(encoding="utf-8"))
     except Exception as e:  # unreadable / invalid JSON / permission / truncated
-        raise CorruptRecord(f"{f}: {e}") from e
+        raise CorruptRecordError(f"{f}: {e}") from e
     if not isinstance(data, dict):
-        raise CorruptRecord(f"{f}: not a JSON object")
+        raise CorruptRecordError(f"{f}: not a JSON object")
     return data
 
 
@@ -175,10 +175,10 @@ def _require_uuid():
 
 
 def _read_or_die(uuid: str):
-    """read_record but turn CorruptRecord into a loud exit(2) — never override."""
+    """read_record but turn CorruptRecordError into a loud exit(2) — never override."""
     try:
         return read_record(uuid)
-    except CorruptRecord as e:
+    except CorruptRecordError as e:
         print(
             f"BLOCKED: session identity record is unreadable — refusing to "
             f"re-derive over it.\n  {e}\n  Fix or remove the file by hand once "
@@ -322,7 +322,7 @@ def cmd_migrate(scratch_root=None) -> int:
             continue
         try:
             existing = read_record(uuid)
-        except CorruptRecord:
+        except CorruptRecordError:
             print(f"  ! {uuid}: canonical record corrupt — skipping (fix by hand)", file=sys.stderr)
             skipped += 1
             continue
@@ -354,8 +354,9 @@ def cmd_list() -> int:
                 continue
     for r in rows:
         if isinstance(r, dict):
-            print("  %-20s %-14s %s" % (
-                r.get("identity", "?"), r.get("entrypoint", "?"), r.get("uuid", "?")))
+            ident = r.get("identity", "?")
+            entry = r.get("entrypoint", "?")
+            print(f"  {ident!s:<20} {entry!s:<14} {r.get('uuid', '?')!s}")
     print(f"  ({len(rows)} session(s))")
     return 0
 

--- a/.claude/hooks/session-state.py
+++ b/.claude/hooks/session-state.py
@@ -54,7 +54,10 @@ SCHEMA_VERSION = 1
 
 
 def iso_now() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    # timezone.utc (NOT the 3.11+ `datetime.UTC` alias) keeps this hook importable
+    # on Python < 3.11 — an ImportError here fires at module load, before main()'s
+    # best-effort guard can catch it, breaking bootstrap (Gemini review, standards#212).
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")  # noqa: UP017
 
 
 def project_root() -> Path:


### PR DESCRIPTION
Fan-out/refresh of the canonical identity mechanism (standards PRs 199/200/205): session-identity.py (AM-valid plain adjective+noun derive, git-common-dir anchored) + session-state.py (sources sibling) + gitignore .claude/sessions/ + SessionStart register.

Closes #280