### PR TITLE
fix(#290): parse ESP32-C6/H2 base MAC in pio-flash bootstrap

### DIFF
--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -1316,6 +1316,29 @@ def cmd_erase_region(args, registry):
     return rc
 
 
+# --- MAC parsing (#290) ------------------------------------------------------
+# On IEEE 802.15.4 chips (ESP32-C6 / ESP32-H2) `esptool read_mac` prints an
+# 8-byte EUI-64 as the FIRST "MAC:" line (e.g. 02:71:bc:ff:fe:12:34:56); its
+# first 6 bytes carry the ff:fe EUI-64 fill and are NOT the device base MAC.
+# The real 6-byte address is on the "BASE MAC:" line. S3/C3 print only a plain
+# 6-byte "MAC:" line (some builds also add "BASE MAC:"). Prefer BASE MAC; fall
+# back to a strict 6-byte MAC whose negative lookahead refuses to capture the
+# head of an 8-byte EUI-64.
+_MAC6 = r"([0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5})"
+_BASE_MAC_RE = re.compile(r"BASE\s+MAC:\s*" + _MAC6, re.IGNORECASE)
+_PLAIN_MAC_RE = re.compile(r"MAC:\s*" + _MAC6 + r"(?![0-9a-fA-F:])", re.IGNORECASE)
+
+
+def parse_base_mac(stdout):
+    """Extract the device base MAC (lowercased) from `esptool read_mac` output.
+
+    Returns the 6-byte MAC as "aa:bb:cc:dd:ee:ff", or None if none is found.
+    See #290 for the C6/H2 EUI-64 mis-parse this replaces.
+    """
+    m = _BASE_MAC_RE.search(stdout) or _PLAIN_MAC_RE.search(stdout)
+    return m.group(1).lower() if m else None
+
+
 def cmd_bootstrap(args, registry):
     """
     Register a new device. User-initiated only. Performs ONE authorized
@@ -1368,13 +1391,12 @@ def cmd_bootstrap(args, registry):
             f"stderr: {result.stderr.strip()}"
         )
 
-    # Parse MAC from esptool output. Format example:
-    #   MAC: <device-mac>
-    m = re.search(r"MAC:\s*([0-9a-fA-F:]{17})", result.stdout)
-    if not m:
+    # Parse MAC from esptool output. Prefer the BASE MAC line so 802.15.4 chips
+    # (C6/H2) don't record the EUI-64 head instead of the base MAC (#290).
+    mac = parse_base_mac(result.stdout)
+    if mac is None:
         out(result.stdout)
         refuse("could not parse MAC from esptool output (see stdout above)")
-    mac = m.group(1).lower()
     out(f"MAC read from device: {mac}")
 
     # Cross-check: does this MAC already belong to a different registered name?

--- a/scripts/test_pio_flash_mac.py
+++ b/scripts/test_pio_flash_mac.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Unit tests for pio-flash's esptool MAC parsing (#290).
+
+Self-contained (no pytest needed):  python scripts/test_pio_flash_mac.py
+
+Regression guard for #290: `esptool read_mac` on IEEE 802.15.4 chips
+(ESP32-C6 / ESP32-H2) prints an 8-byte EUI-64 as the FIRST "MAC:" line; its
+first 6 bytes carry the ff:fe EUI-64 fill and are NOT the device base MAC. The
+real address is on the "BASE MAC:" line. The old naive regex mis-parsed this.
+
+Fixtures use synthetic, locally-administered (02:..) MACs on purpose -- never a
+real device MAC (SAFELANE redaction discipline; real MACs live only in the
+gitignored hardware-devices.yaml). The output *shape* mirrors esptool v5.2.0 as
+observed on an ESP32-C6 (2026-07-14).
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import re
+import sys
+
+SCRIPT = pathlib.Path(__file__).resolve().parent / "pio-flash.py"
+spec = importlib.util.spec_from_file_location("pio_flash", SCRIPT)
+pio_flash = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pio_flash)
+parse_base_mac = pio_flash.parse_base_mac
+
+# --- Fixtures: esptool v5.2.0 output shapes (synthetic MACs) ------------------
+
+# ESP32-C6 (802.15.4): 8-byte EUI-64 first, then the true BASE MAC.
+C6 = """\
+esptool v5.2.0
+Connected to ESP32-C6 on COM23:
+Chip type:          ESP32-C6FH4 (QFN32) (revision v0.2)
+Features:           Wi-Fi 6, BT 5 (LE), IEEE802.15.4
+Crystal frequency:  40MHz
+USB mode:           USB-Serial/JTAG
+MAC:                02:71:bc:ff:fe:12:34:56
+BASE MAC:           02:71:bc:12:34:56
+MAC_EXT:            ff:fe
+"""
+
+# ESP32-S3: plain 6-byte MAC, no BASE MAC line.
+S3_PLAIN = """\
+esptool v5.2.0
+Connected to ESP32-S3 on COM10:
+Chip type:          ESP32-S3 (QFN56) (revision v0.2)
+USB mode:           USB-Serial/JTAG
+MAC:                02:cc:a8:12:34:56
+"""
+
+# Some esptool builds also print BASE MAC for non-802.15.4 chips; must agree.
+S3_WITH_BASE = """\
+Connected to ESP32-S3 on COM10:
+Chip type:          ESP32-S3 (QFN56) (revision v0.2)
+MAC:                02:cc:a8:12:34:56
+BASE MAC:           02:cc:a8:12:34:56
+"""
+
+# Uppercase in the wild -> normalized lowercase.
+UPPER = "MAC:  AA:BB:CC:DD:EE:FF\n"
+
+NO_MAC = "esptool v5.2.0\nConnected to ESP32-S3\nStub flasher running.\n"
+
+CASES = [
+    ("C6 EUI-64 -> BASE MAC", C6, "02:71:bc:12:34:56"),
+    ("S3 plain MAC", S3_PLAIN, "02:cc:a8:12:34:56"),
+    ("S3 with BASE MAC", S3_WITH_BASE, "02:cc:a8:12:34:56"),
+    ("uppercase normalized", UPPER, "aa:bb:cc:dd:ee:ff"),
+    ("no MAC -> None", NO_MAC, None),
+]
+
+
+def main() -> int:
+    failures = []
+
+    # Guard: the OLD naive regex must be demonstrably wrong on C6 (documents #290).
+    old = re.search(r"MAC:\s*([0-9a-fA-F:]{17})", C6)
+    assert old and old.group(1).lower() == "02:71:bc:ff:fe:12", (
+        "fixture drift: old regex should reproduce the #290 bug"
+    )
+
+    for name, stdout, expected in CASES:
+        got = parse_base_mac(stdout)
+        ok = got == expected
+        print(f"[{'PASS' if ok else 'FAIL'}] {name}: got={got!r} expected={expected!r}")
+        if not ok:
+            failures.append(name)
+
+    if failures:
+        print(f"\n{len(failures)} FAILED: {failures}")
+        return 1
+    print(f"\nAll {len(CASES)} cases passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What & why

`pio-flash bootstrap` recorded the **wrong MAC** for ESP32-C6 / H2 (802.15.4 chips). `esptool read_mac` prints an 8-byte **EUI-64** as the first `MAC:` line; the old regex `MAC:\s*([0-9a-fA-F:]{17})` grabbed its first 6 bytes (the `ff:fe` EUI-64 head) instead of the true base MAC on the `BASE MAC:` line. This silently mis-registers every C6/H2 device and weakens the MAC-based identity collision check. Found while registering a Photon-1W XIAO ESP32-C6.

Closes #290.

## Change

- **`scripts/pio-flash.py`** — new `parse_base_mac()`: prefers the `BASE MAC:` line, falls back to a strict 6-byte `MAC:` match whose negative lookahead refuses to capture the head of an 8-byte EUI-64. `cmd_bootstrap` now calls it. S3/C3 (plain 6-byte `MAC:`) behavior unchanged.
- **`scripts/test_pio_flash_mac.py`** — self-contained regression test (no pytest dep). Covers C6 (EUI-64+BASE), S3 plain, S3+BASE, uppercase, no-MAC→None, plus a guard asserting the *old* regex reproduces the bug.

## Test evidence

```
[PASS] C6 EUI-64 -> BASE MAC   [PASS] S3 plain MAC   [PASS] S3 with BASE MAC
[PASS] uppercase normalized    [PASS] no MAC -> None
All 5 cases passed.
```
Red→green confirmed (test failed pre-fix: helper absent). `python -m py_compile` clean.

## Gemini adversarial review

Verdict **Ship**. One MINOR — flagged the `2026-07-14` comment date as a "future typo (→2024)". **Rejected:** 2026-07-14 is the actual current date; the finding is an artifact of the reviewer's training cutoff. No other findings.

## Redaction

Fixtures + a code comment initially carried a real device MAC; now fully synthetic (`02:…` locally-administered). Real MACs live only in the gitignored `hardware-devices.yaml`. Issue #290 body was also redacted to placeholders.

## Follow-up (not in this PR)

The wrapper's **canonical copy in `C:\Dev\LoRa`** needs the same fix in a separate PR against that repo.
