### PR TITLE
chore(#292): line-anchor pio-flash MAC regexes to match canonical

### DIFF
--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -1325,8 +1325,12 @@ def cmd_erase_region(args, registry):
 # back to a strict 6-byte MAC whose negative lookahead refuses to capture the
 # head of an 8-byte EUI-64.
 _MAC6 = r"([0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5})"
-_BASE_MAC_RE = re.compile(r"BASE\s+MAC:\s*" + _MAC6, re.IGNORECASE)
-_PLAIN_MAC_RE = re.compile(r"MAC:\s*" + _MAC6 + r"(?![0-9a-fA-F:])", re.IGNORECASE)
+# Anchored to line start (re.MULTILINE) so noisy log text like
+# "Note: check BASE MAC: .. on sticker" can never be mistaken for the field.
+_BASE_MAC_RE = re.compile(r"^BASE\s+MAC:\s*" + _MAC6, re.IGNORECASE | re.MULTILINE)
+_PLAIN_MAC_RE = re.compile(
+    r"^MAC:\s*" + _MAC6 + r"(?![0-9a-fA-F:])", re.IGNORECASE | re.MULTILINE
+)
 
 
 def parse_base_mac(stdout):

--- a/scripts/test_pio_flash_mac.py
+++ b/scripts/test_pio_flash_mac.py
@@ -63,11 +63,19 @@ UPPER = "MAC:  AA:BB:CC:DD:EE:FF\n"
 
 NO_MAC = "esptool v5.2.0\nConnected to ESP32-S3\nStub flasher running.\n"
 
+# Noisy mid-line "BASE MAC:" must NOT be mistaken for the real field; only the
+# line-anchored MAC line counts (guards the #292 anchoring hardening).
+NOISY = (
+    "Note: check BASE MAC: aa:bb:cc:dd:ee:ff on the sticker\n"
+    "MAC:  02:dd:ee:11:22:33\n"
+)
+
 CASES = [
     ("C6 EUI-64 -> BASE MAC", C6, "02:71:bc:12:34:56"),
     ("S3 plain MAC", S3_PLAIN, "02:cc:a8:12:34:56"),
     ("S3 with BASE MAC", S3_WITH_BASE, "02:cc:a8:12:34:56"),
     ("uppercase normalized", UPPER, "aa:bb:cc:dd:ee:ff"),
+    ("noisy mid-line BASE MAC ignored", NOISY, "02:dd:ee:11:22:33"),
     ("no MAC -> None", NO_MAC, None),
 ]
 


### PR DESCRIPTION
## What & why

Aligns the vendored `scripts/pio-flash.py` MAC parser with the **canonical** copy in `Strycher/LoRa` (PR #368). Follow-up to #290/#291.

Closes #292.

## Change

- **`scripts/pio-flash.py`** — line-anchor `_BASE_MAC_RE` / `_PLAIN_MAC_RE` (`^` + `re.MULTILINE`) so stray log text (e.g. `Note: check BASE MAC: .. on sticker`) can never be mistaken for the field.
- **`scripts/test_pio_flash_mac.py`** — add the "noisy mid-line BASE MAC ignored" regression case (5 → 6).

No behavior change for well-formed esptool output — pure robustness + copy-sync. The parser logic is now identical to the canonical LoRa wrapper.

## Test evidence

```
All 6 cases passed.
```
`py_compile` clean.

## Gemini review

This exact anchoring change (+ the noisy-input test) was adversarially reviewed and **recommended** by Gemini in `Strycher/LoRa#368` — it was Gemini's own MINOR finding there. No new logic is introduced here, so that review covers this back-port; not re-run to avoid a redundant call.
