### PR TITLE
docs(#315): drop ephemeral agent codename from block contract

### DIFF
--- a/docs/architecture/2026-06-28-block-user-firmware-app-contract.md
+++ b/docs/architecture/2026-06-28-block-user-firmware-app-contract.md
@@ -2,7 +2,7 @@
 
 **Status:** **AS-BUILT** — firmware half shipped (#246 / PR #247, `FIRMWARE_VER_CODE 15`) and verified end-to-end (#242). Wire codes below are final.
 **Date:** 2026-06-28 · **As-built revision:** 2026-07-14 (#313)
-**Parties:** Offband firmware (`OffbandMesh/meshcore-firmware`) ↔ Offband client app (`OffbandMesh/meshcore-client` / DustyBasin).
+**Parties:** Offband firmware (`OffbandMesh/meshcore-firmware`) ↔ Offband client app (`OffbandMesh/meshcore-client`).
 **Tracking:** Feature [#241](https://github.com/OffbandMesh/meshcore-firmware/issues/241) · Epic [#242](https://github.com/OffbandMesh/meshcore-firmware/issues/242) · this doc [#244](https://github.com/OffbandMesh/meshcore-firmware/issues/244) · as-built reconciliation [#313](https://github.com/OffbandMesh/meshcore-firmware/issues/313).
 **Scope of this doc:** the firmware ↔ app interface and the division of responsibility. Wire-level codes are **as-built** (verified on hardware); everything else is the agreed design.
 


### PR DESCRIPTION
Doc-only, one line. Closes #315. Refs #313.

The Parties line named the client agent `DustyBasin` — an identity that **does not exist** (server-verified 2026-07-16; the client-side agent is `DarkBasin`).

Rather than swap one codename for another, **remove it**. Agent codenames are ephemeral per-session coordination identities that rotate constantly; this contract is a published artifact that outlives any of them. Hard-coding one guarantees stale references and tells a human reader nothing. Coordination identities belong in the issue thread / Agent Mail, not the artifact.

Parties are now identified by **repo + role only**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)