### PR TITLE
fix(#199, #90): correct all 64 ESP32 envs that compile SerialBLEInterface.cpp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,32 @@ on:
   workflow_dispatch:
 
 jobs:
+  # #199: build-config invariant check. Seconds, and it covers EVERY env rather
+  # than the curated build matrix below -- which is the point. The NimBLE defect
+  # recurred four times board-by-board because the affected envs were neither in
+  # CI nor able to fail a release (release.yml is fail-fast: false, so a broken
+  # env just silently produced no binary). A per-env build matrix would never
+  # have caught it without building all 114; this asserts the rule instead.
+  config-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install PlatformIO
+        run: pip install --upgrade platformio
+
+      - name: Generate dummy secrets stub (config interpolation only)
+        run: |
+          printf '[node_secrets]\nadmin_password = ci-dummy\n[wifi_secrets]\nssid = ci-dummy\npassword = ci-dummy\n[mqtt_secrets]\nhost = mqtt.example.com\nport = 1883\nuser = ci-dummy\npassword = ci-dummy\n[ota_secrets]\ntrigger_secret = ci-dummy\n[cmdrelay]\nurl = http://cmdrelay.example.com/cmd\n' > "$RUNNER_TEMP/ci-secrets.ini"
+          echo "PIO_SECRETS_FILE=$RUNNER_TEMP/ci-secrets.ini" >> "$GITHUB_ENV"
+
+      - name: Every ESP32 env compiling SerialBLEInterface.cpp declares NimBLE
+        run: python scripts/check_esp32_ble_deps.py
+
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -38,6 +64,14 @@ jobs:
           - RAK_3401_companion_radio_ble
           - RAK_3401_companion_radio_usb
           - RAK_3401_repeater
+          # #199: one env per remedy class, both previously unbuildable and both
+          # in the SHIPPED release matrix -- releases were publishing without
+          # their binaries. The usb env is the non-BLE case (drops
+          # SerialBLEInterface.cpp); Xiao_C6 is the BLE case (declares the dep)
+          # and also covers the C6 platform package, which resolves NimBLE
+          # separately from the esp32/esp32s3 line.
+          - Heltec_v2_companion_radio_usb
+          - Xiao_C6_companion_radio_ble_
     steps:
       - uses: actions/checkout@v5
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -98,6 +98,26 @@ lib_deps =
 lib_deps =
   h2zero/NimBLE-Arduino @ ^2.0.0
 
+; #199: the counterpart to [esp32_ble], for ESP32 envs that do NOT use BLE.
+;
+; Every companion env pulls the whole helpers/esp32 directory in with a greedy
+; wildcard (+<helpers/esp32/*.cpp>), and SerialBLEInterface.h includes
+; <NimBLEDevice.h> unconditionally -- there is no #ifdef guard. So a USB / WiFi /
+; serial env compiles the BLE interface it never uses, and then fails to build for
+; want of a Bluetooth stack it should not need in the first place.
+;
+; The fix is to drop the file, NOT to hand those envs NimBLE: declaring the dep
+; would make the error disappear while linking a full BLE stack into non-BLE
+; firmware. This is the pattern already established by #89 for
+; Xiao_S3_WIO_companion_radio_usb.
+;
+; MUST be referenced LAST in an env's build_src_filter -- src filter entries apply
+; in order, so the exclusion has to come after the +<helpers/esp32/*.cpp> that
+; pulled the file in.
+[esp32_no_ble]
+build_src_filter =
+  -<helpers/esp32/SerialBLEInterface.cpp>
+
 ; esp32c6 uses arduino framework 3.x
 ; WARNING: experimental. May not work as stable as other platforms.
 [esp32c6_base]

--- a/platformio.ini
+++ b/platformio.ini
@@ -88,6 +88,16 @@ lib_deps =
   ESP32Async/ESPAsyncWebServer @ 3.10.3
   file://arch/esp32/AsyncElegantOTA
 
+; #199: single source of truth for the ESP32 BLE stack dependency. Any ESP32 env
+; that compiles helpers/esp32/SerialBLEInterface.cpp must pull this in via
+; ${esp32_ble.lib_deps}. Declaring it per-variant is what left four SHIPPED
+; companion_radio_ble envs unable to build at all (fatal error: NimBLEDevice.h:
+; No such file) and let the pinned version drift between boards.
+; NOTE: nRF52 BLE envs do NOT use this -- they use the Nordic SoftDevice stack.
+[esp32_ble]
+lib_deps =
+  h2zero/NimBLE-Arduino @ ^2.0.0
+
 ; esp32c6 uses arduino framework 3.x
 ; WARNING: experimental. May not work as stable as other platforms.
 [esp32c6_base]

--- a/scripts/check_esp32_ble_deps.py
+++ b/scripts/check_esp32_ble_deps.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Assert the ESP32 BLE dependency invariant across every env (Offband #199).
+
+The defect this guards against: companion envs pull the whole helpers/esp32
+directory in with a greedy wildcard (`+<helpers/esp32/*.cpp>`), and
+SerialBLEInterface.h includes <NimBLEDevice.h> unconditionally -- there is no
+#ifdef guard. So an env compiles the BLE interface whether or not the board uses
+BLE, and then fails to build for want of a Bluetooth stack.
+
+That left 64 ESP32 envs unbuildable, two of them in the shipped release matrix.
+Because release.yml runs `fail-fast: false`, those boards' binaries were simply
+absent from releases rather than failing the build -- silent, and it recurred four
+times board-by-board before anyone chased it.
+
+An env compiling SerialBLEInterface.cpp must therefore resolve to exactly one of:
+  * it genuinely uses BLE      -> declare the dep via ${esp32_ble.lib_deps}
+  * it does not use BLE        -> drop the file via ${esp32_no_ble.build_src_filter}
+
+Checking the RESOLVED config (not grepping the .ini files) is deliberate: the
+values are inherited through `extends` chains, so only PlatformIO's own
+interpolation knows what an env really ends up with.
+
+Exits non-zero and names every offender. Run from the repo root:
+    python scripts/check_esp32_ble_deps.py
+"""
+
+import json
+import subprocess
+import sys
+
+BLE_SRC = "helpers/esp32/SerialBLEInterface.cpp"
+BLE_GLOB = "helpers/esp32/*.cpp"
+BLE_DEP = "NimBLE-Arduino"
+
+
+def flatten(value):
+    """Resolved options come back as either a string or a list of strings."""
+    if value is None:
+        return ""
+    if isinstance(value, (list, tuple)):
+        return "\n".join(str(v) for v in value)
+    return str(value)
+
+
+def main():
+    try:
+        raw = subprocess.check_output(
+            ["pio", "project", "config", "--json-output"],
+            stderr=subprocess.STDOUT,
+        )
+    except (subprocess.CalledProcessError, OSError) as exc:
+        out = getattr(exc, "output", b"")
+        if isinstance(out, bytes):
+            out = out.decode("utf-8", "replace")
+        print("ERROR: could not read PlatformIO config:\n%s" % (out or exc))
+        return 2
+
+    config = json.loads(raw.decode("utf-8", "replace"))
+
+    offenders = []
+    checked = 0
+    for section, options in config:
+        if not section.startswith("env:"):
+            continue
+        name = section[4:]
+        opts = dict(options)
+        if "espressif32" not in flatten(opts.get("platform")):
+            continue
+
+        src = flatten(opts.get("build_src_filter"))
+        compiles_ble = (BLE_GLOB in src or ("+<%s>" % BLE_SRC) in src) and (
+            ("-<%s>" % BLE_SRC) not in src
+        )
+        if not compiles_ble:
+            continue
+
+        checked += 1
+        if BLE_DEP not in flatten(opts.get("lib_deps")):
+            offenders.append(name)
+
+    if offenders:
+        print("FAIL: %d ESP32 env(s) compile %s without %s.\n" % (len(offenders), BLE_SRC, BLE_DEP))
+        for name in sorted(offenders):
+            print("  %s" % name)
+        print(
+            "\nFix each by adding EITHER:\n"
+            "  lib_deps          =  ${esp32_ble.lib_deps}          (env genuinely uses BLE)\n"
+            "  build_src_filter  =  ${esp32_no_ble.build_src_filter}  (env does not -- list it LAST)\n"
+        )
+        return 1
+
+    print("OK: %d ESP32 env(s) compile %s, all declare %s." % (checked, BLE_SRC, BLE_DEP))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/variants/ebyte_eora_s3/platformio.ini
+++ b/variants/ebyte_eora_s3/platformio.ini
@@ -139,6 +139,7 @@ build_src_filter = ${Ebyte_EoRa-S3.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${Ebyte_EoRa-S3.lib_deps}
   densaugeo/base64 @ ~1.4.0
 

--- a/variants/heltec_ct62/platformio.ini
+++ b/variants/heltec_ct62/platformio.ini
@@ -132,6 +132,7 @@ build_src_filter = ${Heltec_ct62.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<helpers/esp32/SerialBLEInterface.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${Heltec_ct62.lib_deps}
   ${esp32_ota.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/heltec_e213/platformio.ini
+++ b/variants/heltec_e213/platformio.ini
@@ -65,6 +65,7 @@ build_src_filter = ${Heltec_E213_base.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${Heltec_E213_base.lib_deps}
   densaugeo/base64 @ ~1.4.0
   bakercp/CRC32 @ ^2.0.0
@@ -84,6 +85,7 @@ build_src_filter = ${Heltec_E213_base.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${Heltec_E213_base.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/heltec_e290/platformio.ini
+++ b/variants/heltec_e290/platformio.ini
@@ -59,6 +59,7 @@ build_src_filter = ${Heltec_E290_base.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${Heltec_E290_base.lib_deps}
   densaugeo/base64 @ ~1.4.0
   bakercp/CRC32 @ ^2.0.0
@@ -79,6 +80,7 @@ build_src_filter = ${Heltec_E290_base.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${Heltec_E290_base.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/heltec_t190/platformio.ini
+++ b/variants/heltec_t190/platformio.ini
@@ -69,6 +69,7 @@ build_src_filter = ${Heltec_T190_base.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${Heltec_T190_base.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
@@ -84,6 +85,7 @@ build_src_filter = ${Heltec_T190_base.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${Heltec_T190_base.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/heltec_tracker/platformio.ini
+++ b/variants/heltec_tracker/platformio.ini
@@ -70,6 +70,7 @@ build_src_filter = ${Heltec_tracker_base.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
   +<helpers/ui/ST7735Display.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${Heltec_tracker_base.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -96,6 +97,7 @@ build_src_filter = ${Heltec_tracker_base.build_src_filter}
   +<../examples/companion_radio/ui-new/*.cpp>
   +<helpers/ui/ST7735Display.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${Heltec_tracker_base.lib_deps}
   densaugeo/base64 @ ~1.4.0
 

--- a/variants/heltec_tracker_v2/platformio.ini
+++ b/variants/heltec_tracker_v2/platformio.ini
@@ -179,6 +179,7 @@ build_src_filter = ${Heltec_tracker_v2.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${Heltec_tracker_v2.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
@@ -202,6 +203,7 @@ build_src_filter = ${Heltec_tracker_v2.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${Heltec_tracker_v2.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/heltec_v2/platformio.ini
+++ b/variants/heltec_v2/platformio.ini
@@ -151,6 +151,7 @@ build_src_filter = ${Heltec_lora32_v2.build_src_filter}
   +<helpers/ui/MomentaryButton.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${Heltec_lora32_v2.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -199,6 +200,7 @@ build_src_filter = ${Heltec_lora32_v2.build_src_filter}
   +<helpers/ui/MomentaryButton.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${Heltec_lora32_v2.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/heltec_v2/platformio.ini
+++ b/variants/heltec_v2/platformio.ini
@@ -175,6 +175,7 @@ build_src_filter = ${Heltec_lora32_v2.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${Heltec_lora32_v2.lib_deps}
   densaugeo/base64 @ ~1.4.0
 

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -190,7 +190,7 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0
-  h2zero/NimBLE-Arduino @ ^2.0.0
+  ${esp32_ble.lib_deps}
 
 [env:Heltec_v3_companion_radio_wifi]
 extends = Heltec_lora32_v3
@@ -334,7 +334,7 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0
-  h2zero/NimBLE-Arduino @ ^2.0.0
+  ${esp32_ble.lib_deps}
 
 [env:Heltec_WSL3_companion_radio_usb]
 extends = Heltec_lora32_v3

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -212,6 +212,7 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -365,6 +366,7 @@ build_flags =
 build_src_filter = ${Heltec_lora32_v3.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -362,6 +362,7 @@ build_src_filter = ${heltec_v4_oled.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${heltec_v4_oled.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -503,6 +504,7 @@ build_src_filter = ${heltec_v4_tft.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${heltec_v4_tft.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
@@ -526,6 +528,7 @@ build_src_filter = ${heltec_v4_tft.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${heltec_v4_tft.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -340,7 +340,7 @@ build_src_filter = ${heltec_v4_oled.build_src_filter}
 lib_deps =
   ${heltec_v4_oled.lib_deps}
   densaugeo/base64 @ ~1.4.0
-  h2zero/NimBLE-Arduino @ ^2.0.0
+  ${esp32_ble.lib_deps}
 
 [env:heltec_v4_companion_radio_wifi]
 extends = heltec_v4_oled
@@ -612,4 +612,4 @@ build_src_filter =
   +<helpers/wifi_observer/*.cpp>
 lib_deps =
   ${env:heltec_v4_tft_companion_radio_ble.lib_deps}
-  h2zero/NimBLE-Arduino @ ^2.0.0
+  ${esp32_ble.lib_deps}

--- a/variants/heltec_wireless_paper/platformio.ini
+++ b/variants/heltec_wireless_paper/platformio.ini
@@ -66,6 +66,7 @@ build_src_filter = ${Heltec_Wireless_Paper_base.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${Heltec_Wireless_Paper_base.lib_deps}
   densaugeo/base64 @ ~1.4.0
   bakercp/CRC32 @ ^2.0.0
@@ -84,6 +85,7 @@ build_src_filter = ${Heltec_Wireless_Paper_base.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${Heltec_Wireless_Paper_base.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/lilygo_t3s3/platformio.ini
+++ b/variants/lilygo_t3s3/platformio.ini
@@ -177,6 +177,7 @@ build_src_filter = ${LilyGo_T3S3_sx1262.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${LilyGo_T3S3_sx1262.lib_deps}
   densaugeo/base64 @ ~1.4.0
 

--- a/variants/lilygo_t3s3_sx1276/platformio.ini
+++ b/variants/lilygo_t3s3_sx1276/platformio.ini
@@ -173,6 +173,7 @@ build_src_filter = ${LilyGo_T3S3_sx1276.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${LilyGo_T3S3_sx1276.lib_deps}
   densaugeo/base64 @ ~1.4.0
 

--- a/variants/lilygo_tbeam_1w/platformio.ini
+++ b/variants/lilygo_tbeam_1w/platformio.ini
@@ -150,6 +150,7 @@ build_src_filter = ${LilyGo_TBeam_1W.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${LilyGo_TBeam_1W.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
@@ -173,6 +174,7 @@ build_src_filter = ${LilyGo_TBeam_1W.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${LilyGo_TBeam_1W.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/lilygo_tbeam_SX1262/platformio.ini
+++ b/variants/lilygo_tbeam_SX1262/platformio.ini
@@ -62,6 +62,7 @@ build_src_filter = ${LilyGo_TBeam_SX1262.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${LilyGo_TBeam_SX1262.lib_deps}
   densaugeo/base64 @ ~1.4.0
 

--- a/variants/lilygo_tbeam_SX1276/platformio.ini
+++ b/variants/lilygo_tbeam_SX1276/platformio.ini
@@ -58,6 +58,7 @@ build_src_filter = ${LilyGo_TBeam_SX1276.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${LilyGo_TBeam_SX1276.lib_deps}
   densaugeo/base64 @ ~1.4.0
 

--- a/variants/lilygo_tbeam_supreme_SX1262/platformio.ini
+++ b/variants/lilygo_tbeam_supreme_SX1262/platformio.ini
@@ -139,6 +139,7 @@ build_src_filter = ${T_Beam_S3_Supreme_SX1262.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${T_Beam_S3_Supreme_SX1262.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
@@ -162,6 +163,7 @@ build_src_filter = ${T_Beam_S3_Supreme_SX1262.build_src_filter}
   +<helpers/ui/MomentaryButton.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${T_Beam_S3_Supreme_SX1262.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/lilygo_tdeck/platformio.ini
+++ b/variants/lilygo_tdeck/platformio.ini
@@ -102,6 +102,7 @@ build_src_filter = ${LilyGo_TDeck.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${LilyGo_TDeck.lib_deps}
   densaugeo/base64 @ ~1.4.0
 

--- a/variants/lilygo_tdeck/platformio.ini
+++ b/variants/lilygo_tdeck/platformio.ini
@@ -83,6 +83,7 @@ build_src_filter = ${LilyGo_TDeck.build_src_filter}
   +<helpers/ui/MomentaryButton.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${LilyGo_TDeck.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/lilygo_teth_elite/platformio.ini
+++ b/variants/lilygo_teth_elite/platformio.ini
@@ -95,5 +95,6 @@ build_src_filter = ${LilyGo_TETH_Elite_sx1262.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${LilyGo_TETH_Elite_sx1262.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/lilygo_tlora_c6/platformio.ini
+++ b/variants/lilygo_tlora_c6/platformio.ini
@@ -82,6 +82,7 @@ build_src_filter = ${tlora_c6.build_src_filter}
   -<helpers/esp32/ESPNOWRadio.cpp>
   +<../examples/companion_radio/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${tlora_c6.lib_deps}
   densaugeo/base64 @ ~1.4.0
 

--- a/variants/lilygo_tlora_v2_1/platformio.ini
+++ b/variants/lilygo_tlora_v2_1/platformio.ini
@@ -111,6 +111,7 @@ build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${LilyGo_TLora_V2_1_1_6.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
@@ -148,6 +149,7 @@ build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter}
   +<helpers/ui/MomentaryButton.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${LilyGo_TLora_V2_1_1_6.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/m5stack_unit_c6l/platformio.ini
+++ b/variants/m5stack_unit_c6l/platformio.ini
@@ -85,6 +85,7 @@ build_src_filter = ${M5Stack_Unit_C6L.build_src_filter}
   -<helpers/esp32/ESPNOWRadio.cpp>
   +<../examples/companion_radio/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${M5Stack_Unit_C6L.lib_deps}
   densaugeo/base64 @ ~1.4.0
   end2endzone/NonBlockingRTTTL@^1.3.0
@@ -101,6 +102,7 @@ build_src_filter = ${M5Stack_Unit_C6L.build_src_filter}
   +<helpers/esp32/*.cpp>
   -<helpers/esp32/ESPNOWRadio.cpp>
   +<../examples/companion_radio/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${M5Stack_Unit_C6L.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/meshadventurer/platformio.ini
+++ b/variants/meshadventurer/platformio.ini
@@ -218,6 +218,7 @@ build_flags =
   -D MESH_PACKET_LOGGING=1
   -D MESH_DEBUG=1
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${Meshadventurer.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
@@ -298,6 +299,7 @@ build_flags =
   -D MESH_PACKET_LOGGING=1
   -D MESH_DEBUG=1
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${Meshadventurer.lib_deps}
   densaugeo/base64 @ ~1.4.0
 

--- a/variants/nibble_screen_connect/platformio.ini
+++ b/variants/nibble_screen_connect/platformio.ini
@@ -134,6 +134,7 @@ build_src_filter = ${nibble_screen_connect_base.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${nibble_screen_connect_base.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
@@ -155,6 +156,7 @@ build_src_filter = ${nibble_screen_connect_base.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${nibble_screen_connect_base.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/rak3112/platformio.ini
+++ b/variants/rak3112/platformio.ini
@@ -173,6 +173,7 @@ build_src_filter = ${rak3112.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-orig/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${rak3112.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
@@ -193,6 +194,7 @@ build_src_filter = ${rak3112.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-orig/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${rak3112.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/station_g2/platformio.ini
+++ b/variants/station_g2/platformio.ini
@@ -194,6 +194,7 @@ build_src_filter = ${Station_G2.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${Station_G2.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -215,6 +216,7 @@ build_src_filter = ${Station_G2.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${Station_G2.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
@@ -235,6 +237,7 @@ build_src_filter = ${Station_G2.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${Station_G2.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/station_g3_esp32/platformio.ini
+++ b/variants/station_g3_esp32/platformio.ini
@@ -109,6 +109,7 @@ build_src_filter = ${Station_G3_ESP32.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${Station_G3_ESP32.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -130,6 +131,7 @@ build_src_filter = ${Station_G3_ESP32.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${Station_G3_ESP32.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
@@ -150,6 +152,7 @@ build_src_filter = ${Station_G3_ESP32.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${Station_G3_ESP32.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/thinknode_m2/platformio.ini
+++ b/variants/thinknode_m2/platformio.ini
@@ -153,6 +153,7 @@ build_src_filter = ${ThinkNode_M2.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${ThinkNode_M2.lib_deps}
   densaugeo/base64 @ ~1.4.0
   end2endzone/NonBlockingRTTTL@^1.3.0
@@ -171,6 +172,7 @@ build_src_filter = ${ThinkNode_M2.build_src_filter}
   +<helpers/ui/buzzer.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${ThinkNode_M2.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -193,6 +195,7 @@ build_src_filter = ${ThinkNode_M2.build_src_filter}
   +<helpers/ui/buzzer.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${ThinkNode_M2.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -215,6 +218,7 @@ build_src_filter = ${ThinkNode_M2.build_src_filter}
   +<helpers/ui/buzzer.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${ThinkNode_M2.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/thinknode_m5/platformio.ini
+++ b/variants/thinknode_m5/platformio.ini
@@ -167,6 +167,7 @@ build_src_filter = ${ThinkNode_M5.build_src_filter}
   +<../examples/companion_radio/ui-new/*.cpp>
   +<helpers/ui/buzzer.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${ThinkNode_M5.lib_deps}
   densaugeo/base64 @ ~1.4.0
   end2endzone/NonBlockingRTTTL@^1.3.0
@@ -185,6 +186,7 @@ build_src_filter = ${ThinkNode_M5.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
   +<helpers/ui/buzzer.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${ThinkNode_M5.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -207,6 +209,7 @@ build_src_filter = ${ThinkNode_M5.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
   +<helpers/ui/buzzer.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${ThinkNode_M5.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -229,6 +232,7 @@ build_src_filter = ${ThinkNode_M5.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
   +<helpers/ui/buzzer.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${ThinkNode_M5.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/xiao_c3/platformio.ini
+++ b/variants/xiao_c3/platformio.ini
@@ -102,6 +102,7 @@ extends = Xiao_esp32_C3
 build_src_filter = ${Xiao_esp32_C3.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<helpers/esp32/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 build_flags =
   ${Xiao_esp32_C3.build_flags}
   -D MAX_CONTACTS=350
@@ -120,6 +121,7 @@ extends = Xiao_esp32_C3
 build_src_filter = ${Xiao_esp32_C3.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<helpers/esp32/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 build_flags =
   ${Xiao_esp32_C3.build_flags}
   -D MAX_CONTACTS=350

--- a/variants/xiao_c3/platformio.ini
+++ b/variants/xiao_c3/platformio.ini
@@ -92,6 +92,7 @@ build_flags =
   ; -D MESH_PACKET_LOGGING=1
   ; -D MESH_DEBUG=1
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${Xiao_esp32_C3.lib_deps}
   ${esp32_ota.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/xiao_c6/platformio.ini
+++ b/variants/xiao_c6/platformio.ini
@@ -65,6 +65,7 @@ build_src_filter = ${Xiao_C6.build_src_filter}
   -<helpers/esp32/ESPNOWRadio.cpp>
   +<../examples/companion_radio/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${Xiao_C6.lib_deps}
   densaugeo/base64 @ ~1.4.0
 

--- a/variants/xiao_c6/platformio.ini
+++ b/variants/xiao_c6/platformio.ini
@@ -121,6 +121,7 @@ build_src_filter = ${Meshimi.build_src_filter}
   -<helpers/esp32/ESPNOWRadio.cpp>
   +<../examples/companion_radio/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${Meshimi.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
@@ -183,6 +184,7 @@ build_src_filter = ${WHY2025_badge.build_src_filter}
   -<helpers/esp32/ESPNOWRadio.cpp>
   +<../examples/companion_radio/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${WHY2025_badge.lib_deps}
   densaugeo/base64 @ ~1.4.0
 

--- a/variants/xiao_s3/platformio.ini
+++ b/variants/xiao_s3/platformio.ini
@@ -110,6 +110,7 @@ build_src_filter = ${Xiao_S3.build_src_filter}
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
+  ${esp32_ble.lib_deps}
   ${Xiao_S3.lib_deps}
   densaugeo/base64 @ ~1.4.0
   adafruit/Adafruit SSD1306 @ ^2.5.13
@@ -132,6 +133,7 @@ build_src_filter = ${Xiao_S3.build_src_filter}
   +<helpers/ui/MomentaryButton.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${Xiao_S3.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -175,7 +175,7 @@ lib_deps =
   ${Xiao_S3_WIO.lib_deps}
   densaugeo/base64 @ ~1.4.0
   adafruit/Adafruit SSD1306 @ ^2.5.13
-  h2zero/NimBLE-Arduino @ ^2.0.0
+  ${esp32_ble.lib_deps}
 
 [env:Xiao_S3_WIO_companion_radio_serial]
 extends = Xiao_S3_WIO

--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -195,6 +195,7 @@ build_src_filter = ${Xiao_S3_WIO.build_src_filter}
   +<helpers/ui/MomentaryButton.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${Xiao_S3_WIO.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -207,6 +208,7 @@ build_src_filter = ${Xiao_S3_WIO.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<helpers/ui/MomentaryButton.cpp>
   +<../examples/companion_radio/*.cpp>
+  ${esp32_no_ble.build_src_filter}
 build_flags =
   ${Xiao_S3_WIO.build_flags}
   -I examples/companion_radio/ui-new


### PR DESCRIPTION
Fixes #199 and #90.

## What was wrong

The reported symptom was 4 shipped `*_companion_radio_ble` envs that could not build (`fatal error: NimBLEDevice.h`). The actual scope was **64 ESP32 envs**, and **2 of them are in the release matrix** — `Heltec_v2_companion_radio_usb` and `Xiao_C3_companion_radio_usb`. Because `release.yml` runs `fail-fast: false`, those boards' binaries were **silently absent from v1.1.2** rather than failing the release. Verified against the published release assets: both boards have repeater and room-server artifacts but no companion.

Root cause is not the missing dependency. Companion envs pull the whole helpers directory in with `+<helpers/esp32/*.cpp>`, and `SerialBLEInterface.h` includes `<NimBLEDevice.h>` unconditionally — no `#ifdef` guard. So an env compiles the BLE interface whether or not the board uses BLE.

## The split

`examples/companion_radio/main.cpp:64` includes that header only under `#elif defined(BLE_PIN_CODE)`, which makes `BLE_PIN_CODE` the authoritative discriminator:

| Class | Count | Remedy |
|---|---|---|
| Genuinely BLE | 30 | `${esp32_ble.lib_deps}` |
| USB / WiFi / serial | 34 | new `${esp32_no_ble.build_src_filter}` |

Excluding the file rather than handing non-BLE envs the dependency is deliberate — declaring NimBLE would make the error vanish while linking a full Bluetooth stack into firmware that never uses it. Follows #89, which fixed `Xiao_S3_WIO_companion_radio_usb` the same way.

## Prevention

`scripts/check_esp32_ble_deps.py` asserts the invariant against the **resolved** PlatformIO config (these values inherit through `extends`, so grepping `.ini` files cannot see them), wired into CI as a fast `config-lint` job covering every env rather than a curated subset. Both previously-broken shipped envs added to the build matrix.

## Verification

- Resolved-config diff across every env, before vs after: 30/30 now carry NimBLE, 34/34 now exclude the file, **0 envs outside the work list changed, 0 lost a dependency**.
- All 64 changed envs were already unbuildable, so this cannot regress a shipping binary.
- Built: `Heltec_v2_companion_radio_usb`, `Heltec_v2_companion_radio_wifi`, `Tbeam_SX1262_companion_radio_ble`, `Xiao_C3_companion_radio_usb`, `M5Stack_Unit_C6L_companion_radio_ble` (C6 platform package), plus #90's named envs `Heltec_v3_companion_radio_wifi`, `heltec_v4_companion_radio_wifi`, `Xiao_S3_WIO_companion_radio_serial`.
- Lint negative-tested: reverting one variant makes it exit 1 naming that env.

Gemini review: no defects; confirmed src-filter entries apply in order and `-<path>` reliably overrides an earlier `+<glob>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
