### PR TITLE
feat(#298): apply FEM LNA on all FEM-capable boards + 0xC3 client control surface

### DIFF
--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -241,6 +241,11 @@ void DataStore::loadPrefsInt(const char *filename, NodePrefs& _prefs, double& no
     file.read((uint8_t *)&_prefs.rx_boosted_gain, sizeof(_prefs.rx_boosted_gain));         // 89
     file.read((uint8_t *)_prefs.default_scope_name, sizeof(_prefs.default_scope_name));    // 90
     file.read((uint8_t *)_prefs.default_scope_key, sizeof(_prefs.default_scope_key));     // 121
+    // #298: APPEND-ONLY, must stay last. Prefs files written before this field ended at
+    // 137, so on those this read short-reads to EOF and leaves the caller-set default
+    // (LNA ON) intact. A uint8 append is all-or-nothing, so there is no partial-read
+    // hazard. Never insert a new field mid-sequence.
+    file.read((uint8_t *)&_prefs.radio_fem_rxgain, sizeof(_prefs.radio_fem_rxgain));      // 137
 
     file.close();
   }
@@ -281,6 +286,8 @@ void DataStore::savePrefs(const NodePrefs& _prefs, double node_lat, double node_
     file.write((uint8_t *)&_prefs.rx_boosted_gain, sizeof(_prefs.rx_boosted_gain));         // 89
     file.write((uint8_t *)_prefs.default_scope_name, sizeof(_prefs.default_scope_name));    // 90
     file.write((uint8_t *)_prefs.default_scope_key, sizeof(_prefs.default_scope_key));     // 121
+    // #298: APPEND-ONLY, must stay last -- see the matching note in loadPrefsInt().
+    file.write((uint8_t *)&_prefs.radio_fem_rxgain, sizeof(_prefs.radio_fem_rxgain));      // 137
 
     file.close();
   }

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1451,6 +1451,39 @@ void MyMesh::handleCmdFrame(size_t len) {
     }
     return;
   }
+  // #298: external FEM LNA control (companion-API only; NEVER on the mesh -- it changes
+  // only this node's own receive front-end, touching no forwarding/relay/advert path).
+  // The client emits this only when OFFBAND_CAP_FEM_LNA is set, so the not-capable
+  // branch is purely defensive against a mis-gated or stale client.
+  if (cmd_frame[0] == offband::CMD_OFFBAND_FEM_LNA && len >= 2) {
+    uint8_t sub = cmd_frame[1];
+    if (!board.canControlLoRaFemLna()) {
+      writeErrFrame(ERR_CODE_UNSUPPORTED_CMD);
+    } else if (sub == offband::OFFBAND_FEM_LNA_SET && len >= 3) {
+      // Persist ONLY on an actual change: a client slider bound to onChange can emit
+      // a burst of SETs, and an unconditional savePrefs() would put that burst
+      // straight onto flash. The hardware apply stays unconditional so a pref that
+      // already matches still re-asserts the FEM state (cheap, and self-healing).
+      uint8_t new_val = cmd_frame[2] ? 1 : 0;           // normalise: any non-zero = on
+      if (_prefs.radio_fem_rxgain != new_val) {
+        _prefs.radio_fem_rxgain = new_val;
+        savePrefs();                                    // survives reboot, like the CLI path
+      }
+      board.setLoRaFemLnaEnabled(_prefs.radio_fem_rxgain != 0);
+      // Reply the POST-APPLY hardware state rather than echoing the request, so a set
+      // the FEM refuses shows the client the truth instead of a silent lie.
+      out_frame[0] = offband::RESP_CODE_OFFBAND_FEM_LNA; out_frame[1] = sub;
+      out_frame[2] = board.isLoRaFemLnaEnabled() ? 1 : 0;
+      _serial->writeFrame(out_frame, 3);
+    } else if (sub == offband::OFFBAND_FEM_LNA_GET) {
+      out_frame[0] = offband::RESP_CODE_OFFBAND_FEM_LNA; out_frame[1] = sub;
+      out_frame[2] = board.isLoRaFemLnaEnabled() ? 1 : 0;
+      _serial->writeFrame(out_frame, 3);
+    } else {
+      writeErrFrame(ERR_CODE_ILLEGAL_ARG);
+    }
+    return;
+  }
   if (cmd_frame[0] == CMD_DEVICE_QUERY && len >= 2) { // sent when app establishes connection
     app_target_ver = cmd_frame[1];                    // which version of protocol does app understand
 
@@ -1480,7 +1513,16 @@ void MyMesh::handleCmdFrame(size_t len) {
     offband_caps |= offband::OFFBAND_CAP_WIFI_OBSERVER;
 #endif
     offband_caps |= offband::OFFBAND_CAP_BLOCK;  // #241: block list always present on the companion
+    // #298: FEM LNA control is PER-UNIT, not per-model -- on Heltec V4 it depends on
+    // which FEM chip the runtime probe found, so two V4s can legitimately differ.
+    // Deriving the bit from the board keeps the client off model/version guessing.
+    if (board.canControlLoRaFemLna()) offband_caps |= offband::OFFBAND_CAP_FEM_LNA;
     out_frame[i++] = offband_caps;           // v14+
+    // #298: current FEM LNA state (v16+), so the client renders the toggle on connect
+    // without a 0xC3 GET round trip. Appended UNCONDITIONALLY -- the frame layout must
+    // stay fixed for a given version code; the cap bit above, not this byte's presence,
+    // is what tells the client whether to show the control. Reads 0 when not capable.
+    out_frame[i++] = board.isLoRaFemLnaEnabled() ? 1 : 0;   // v16+
     _serial->writeFrame(out_frame, i);
   } else if (cmd_frame[0] == CMD_APP_START &&
              len >= 8) { // sent when app establishes connection, respond with node ID

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1028,6 +1028,11 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
   _prefs.rx_boosted_gain = 1; // enabled by default
 #endif
 #endif
+
+  // #298: external FEM LNA enabled by default, matching the repeater default. Set here
+  // (before loadPrefs) so a prefs file written before the field existed short-reads to
+  // EOF and leaves this default in place. No-op on boards without a controllable FEM.
+  _prefs.radio_fem_rxgain = 1;
 }
 
 void MyMesh::begin(bool has_display) {
@@ -1119,6 +1124,25 @@ void MyMesh::begin(bool has_display) {
   radio_driver.setRxBoostedGainMode(_prefs.rx_boosted_gain);
   MESH_DEBUG_PRINTLN("RX Boosted Gain Mode: %s",
                      radio_driver.getRxBoostedGainMode() ? "Enabled" : "Disabled");
+
+  // #298: the companion role never applied the external FEM LNA setting -- only
+  // simple_repeater did (MyMesh.cpp:973-974) -- so Heltec V4 companions fell
+  // through to the class default (lna_enabled=false, LNA bypassed) and ran with
+  // degraded RX sensitivity. That is exactly the 1.16-base behavior reported
+  // upstream (meshcore-dev/MeshCore#2732). Enable the LNA at boot to match the
+  // repeater default.
+  //
+  // No-op on boards without a controllable FEM: base MainBoard::canControlLoRaFemLna()
+  // returns false, and today only HeltecV4Board overrides it -- where the answer is
+  // itself runtime-gated by the auto-detected FEM type (KCT8103L vs GC1109), so it
+  // is a per-unit capability, not a per-model one.
+  //
+  // Driven by the persisted radio_fem_rxgain pref (default ON). The user-facing toggle
+  // arrives with the #298 wire contract (capability bit + setter + device-info value),
+  // which needs a matching client change; until that ships the pref stays at its default.
+  if (board.canControlLoRaFemLna()) {
+    board.setLoRaFemLnaEnabled(_prefs.radio_fem_rxgain != 0);
+  }
 }
 
 const char *MyMesh::getNodeName() {

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -5,7 +5,7 @@
 #include "AbstractUITask.h"
 
 /*------------ Frame Protocol --------------*/
-#define FIRMWARE_VER_CODE 15   // #241: + block-list cap bit (0x02) / 0xC2 block sync command
+#define FIRMWARE_VER_CODE 16   // #298: + FEM LNA cap bit (0x04) / 0xC3 command / LNA state in device-info
 
 #ifndef FIRMWARE_BUILD_DATE
 #define FIRMWARE_BUILD_DATE "6 Jun 2026"

--- a/examples/companion_radio/NodePrefs.h
+++ b/examples/companion_radio/NodePrefs.h
@@ -29,6 +29,13 @@ struct NodePrefs {  // persisted to file
   uint32_t gps_interval;     // GPS read interval in seconds
   uint8_t autoadd_config;    // bitmask for auto-add contacts config
   uint8_t rx_boosted_gain; // SX126x RX boosted gain mode (0=power saving, 1=boosted)
+  // #298: external FEM LNA enable (1 = LNA on, 0 = bypass). Default 1 (ON), matching
+  // the repeater. Only meaningful where MainBoard::canControlLoRaFemLna() is true.
+  // NOTE: serialized LAST in DataStore (offset 137), NOT next to rx_boosted_gain --
+  // the prefs file is a flat offset-tracked stream with no version/length/CRC, so new
+  // fields must be appended at the end or they shift every field after them and
+  // corrupt saved config on already-deployed devices.
+  uint8_t radio_fem_rxgain;
   uint8_t client_repeat;
   uint8_t path_hash_mode;    // which path mode to use when sending
   uint8_t autoadd_max_hops;  // 0 = no limit, 1 = direct (0 hops), N = up to N-1 hops (max 64)

--- a/examples/companion_radio/OffbandConfigProtocol.h
+++ b/examples/companion_radio/OffbandConfigProtocol.h
@@ -112,6 +112,7 @@ enum MqttAuthType  : uint8_t { MQTT_AUTH_NONE = 0, MQTT_AUTH_BASIC = 1, MQTT_AUT
 // (in addition to FIRMWARE_VER_CODE >= 14). There is NO display-without-observer path.
 constexpr uint8_t OFFBAND_CAP_WIFI_OBSERVER = 0x01;  // bit 0: config backend (wifi_observer) compiled in
 constexpr uint8_t OFFBAND_CAP_BLOCK         = 0x02;  // bit 1: user-block list (BlockStore) compiled in (#241)
+constexpr uint8_t OFFBAND_CAP_FEM_LNA       = 0x04;  // bit 2: FEM LNA runtime control available (#298)
 
 // Block-list sync (fork command 0xC2; companion-API only, NEVER on the mesh -- the
 // block list is receive-side only and changes no forwarding/relay/advert path,
@@ -122,6 +123,29 @@ constexpr uint8_t OFFBAND_BLOCK_ADD    = 0x01;
 constexpr uint8_t OFFBAND_BLOCK_REMOVE = 0x02;
 constexpr uint8_t OFFBAND_BLOCK_LIST   = 0x03;
 constexpr uint8_t OFFBAND_BLOCK_CLEAR  = 0x04;
+
+// External FEM LNA control (fork command 0xC3; companion-API only, NEVER on the
+// mesh -- it changes only this node's own receive front-end, touching no
+// forwarding/relay/advert path). Sub-typed like 0xC2; replies echo the sub-code.
+//
+// The client emits 0xC3 ONLY when OFFBAND_CAP_FEM_LNA is set in the device-info
+// caps byte, so stock/unsupported radios never see this command. The capability is
+// PER-UNIT, not per-model: on Heltec V4 it derives from the auto-detected FEM chip
+// (KCT8103L vs GC1109), so two V4s can legitimately disagree -- never gate on model
+// or version code. Boards whose FEM cannot bypass the LNA independently keep the
+// bit clear (e.g. rak3401's SKY66122, where one line gates the LNA and the PA path
+// together, so a toggle would kill TX).
+//
+// Malformed requests reply with the generic [RESP_CODE_ERR][ERR_CODE_ILLEGAL_ARG]
+// 2-byte error, so the client needs no command-specific error handling.
+//   SET: [0xC3][0x01][value]  ->  [0xC3][0x01][value]    value: 0 = bypass, 1 = on
+//   GET: [0xC3][0x02]         ->  [0xC3][0x02][value]
+// The current value is ALSO appended to the device-info reply (v16+) so the client
+// renders the toggle on connect with no extra round trip; GET is the fallback.
+constexpr uint8_t CMD_OFFBAND_FEM_LNA       = 0xC3;  // request:  cmd_frame[0]
+constexpr uint8_t RESP_CODE_OFFBAND_FEM_LNA = 0xC3;  // response: out_frame[0]
+constexpr uint8_t OFFBAND_FEM_LNA_SET = 0x01;
+constexpr uint8_t OFFBAND_FEM_LNA_GET = 0x02;
 
 // ---------------------------------------------------------------------------
 // Key schema -- the firmware<->client contract surface

--- a/variants/heltec_t096/LoRaFEMControl.h
+++ b/variants/heltec_t096/LoRaFEMControl.h
@@ -12,7 +12,12 @@ class LoRaFEMControl
     void setRxModeEnable(void);
     void setRxModeEnableWhenMCUSleep(void);
     void setLNAEnable(bool enabled);
-    bool isLnaCanControl(void) { return lna_can_control; }
+    // #298: read back the current LNA state (mirrors the heltec_v4 FEM control API)
+    // so the board can implement MainBoard::isLoRaFemLnaEnabled().
+    bool isLnaEnabled(void) const { return lna_enabled; }
+    // #298: const so MainBoard::canControlLoRaFemLna() (a const method) can call it
+    // without a const_cast. Read-only accessor.
+    bool isLnaCanControl(void) const { return lna_can_control; }
     void setLnaCanControl(bool can_control) { lna_can_control = can_control; }
 
   private:

--- a/variants/heltec_t096/T096Board.cpp
+++ b/variants/heltec_t096/T096Board.cpp
@@ -124,3 +124,21 @@ void T096Board::powerOff() {
 const char* T096Board::getManufacturerName() const {
   return "Heltec T096";
 }
+
+// #298: runtime control of the external FEM LNA (mirrors HeltecV4Board). TX/RX mode
+// switching happens automatically on each transmit via onBeforeTransmit/
+// onAfterTransmit; changing the enable flag here only takes effect on the next
+// RX-mode entry, so re-enter RX mode to apply it immediately.
+bool T096Board::setLoRaFemLnaEnabled(bool enable) {
+  loRaFEMControl.setLNAEnable(enable);
+  loRaFEMControl.setRxModeEnable();
+  return loRaFEMControl.isLnaCanControl();
+}
+
+bool T096Board::canControlLoRaFemLna() const {
+  return loRaFEMControl.isLnaCanControl();
+}
+
+bool T096Board::isLoRaFemLnaEnabled() const {
+  return loRaFEMControl.isLnaEnabled();
+}

--- a/variants/heltec_t096/T096Board.h
+++ b/variants/heltec_t096/T096Board.h
@@ -25,4 +25,11 @@ public:
   uint16_t getBattMilliVolts() override;
   const char* getManufacturerName() const override ;
   void powerOff() override;
+
+  // #298: external FEM LNA runtime control. Capability-gated -- the base MainBoard
+  // reports "not supported", and this board overrides it because its KCT8103L FEM
+  // exposes an independent LNA path (same as heltec_v4).
+  bool setLoRaFemLnaEnabled(bool enable) override;
+  bool canControlLoRaFemLna() const override;
+  bool isLoRaFemLnaEnabled() const override;
 };

--- a/variants/heltec_tracker_v2/HeltecTrackerV2Board.cpp
+++ b/variants/heltec_tracker_v2/HeltecTrackerV2Board.cpp
@@ -82,3 +82,21 @@ void HeltecTrackerV2Board::begin() {
   const char* HeltecTrackerV2Board::getManufacturerName() const {
     return "Heltec Tracker V2";
   }
+
+  // #298: runtime control of the external FEM LNA (mirrors HeltecV4Board). TX/RX mode
+  // switching happens automatically on each transmit via onBeforeTransmit/
+  // onAfterTransmit; changing the enable flag here only takes effect on the next
+  // RX-mode entry, so re-enter RX mode to apply it immediately.
+  bool HeltecTrackerV2Board::setLoRaFemLnaEnabled(bool enable) {
+    loRaFEMControl.setLNAEnable(enable);
+    loRaFEMControl.setRxModeEnable();
+    return loRaFEMControl.isLnaCanControl();
+  }
+
+  bool HeltecTrackerV2Board::canControlLoRaFemLna() const {
+    return loRaFEMControl.isLnaCanControl();
+  }
+
+  bool HeltecTrackerV2Board::isLoRaFemLnaEnabled() const {
+    return loRaFEMControl.isLnaEnabled();
+  }

--- a/variants/heltec_tracker_v2/HeltecTrackerV2Board.h
+++ b/variants/heltec_tracker_v2/HeltecTrackerV2Board.h
@@ -22,4 +22,11 @@ public:
   uint16_t getBattMilliVolts() override;
   const char* getManufacturerName() const override ;
 
+  // #298: external FEM LNA runtime control. Capability-gated -- the base MainBoard
+  // reports "not supported", and this board overrides it because its KCT8103L FEM
+  // exposes an independent LNA path (same as heltec_v4).
+  bool setLoRaFemLnaEnabled(bool enable) override;
+  bool canControlLoRaFemLna() const override;
+  bool isLoRaFemLnaEnabled() const override;
+
 };

--- a/variants/heltec_tracker_v2/LoRaFEMControl.h
+++ b/variants/heltec_tracker_v2/LoRaFEMControl.h
@@ -12,7 +12,12 @@ class LoRaFEMControl
     void setRxModeEnable(void);
     void setRxModeEnableWhenMCUSleep(void);
     void setLNAEnable(bool enabled);
-    bool isLnaCanControl(void) { return lna_can_control; }
+    // #298: read back the current LNA state (mirrors the heltec_v4 FEM control API)
+    // so the board can implement MainBoard::isLoRaFemLnaEnabled().
+    bool isLnaEnabled(void) const { return lna_enabled; }
+    // #298: const so MainBoard::canControlLoRaFemLna() (a const method) can call it
+    // without a const_cast. Read-only accessor.
+    bool isLnaCanControl(void) const { return lna_can_control; }
     void setLnaCanControl(bool can_control) { lna_can_control = can_control; }
 
   private:


### PR DESCRIPTION
Fixes #298.

## What this delivers

The companion role never applied the FEM LNA setting, so V4 companions ran with degraded RX sensitivity while the repeater role had it right. This adds the boot-time apply, board support, and the client-facing control surface.

- **Boot apply** from persisted `radio_fem_rxgain` (default on), behind a capability check
- **Board support** on `heltec_v4`, `heltec_tracker_v2`, `heltec_t096`
- **`0xC3` companion-API command** — SET (`0x01`) / GET (`0x02`), reply `[0xC3][sub][value]`, malformed → `[0x01][0x06]`
- **`OFFBAND_CAP_FEM_LNA = 0x04`** cap bit, `FIRMWARE_VER_CODE` 15 → 16
- **LNA state in the device-info reply** at offset 83 (frame length now 84), appended unconditionally so the offset never depends on hardware

Wire contract was negotiated with the client-side agent and accepted verbatim. Three deviations were flagged on the issue rather than left to surface at integration: the SET reply carries post-apply hardware state rather than echoing the request; a non-capable board answers `ERR_CODE_UNSUPPORTED_CMD`; and `savePrefs()` only runs on an actual change (Gemini caught that an unconditional save would put a slider's `onChange` burst straight onto flash).

## Hardware-verified

Owner confirmed the setting works end-to-end with the client on **Firestar (KCT8103L / V4.3)**.

Capability is **per-unit, not per-model** — and that is now demonstrated, not asserted: two Heltec V4 OLEDs from the same order resolve differently. Firestar is KCT8103L and exposes the control; ST-P is GC1109 and correctly does not. The client must gate on the cap bit, never on a model allowlist. See #318 for the detection evidence.

`rak3401` stays excluded by design — its SKY66122 gates LNA and PA off one line, so a toggle would kill TX.

## Builds

`heltec_v4_companion_radio_ble` (FEM-capable), `Heltec_v3_companion_radio_ble` (base `MainBoard` virtuals, no FEM override), `RAK_4631_companion_radio_ble` (nRF52), plus all 10 non-companion envs on the two boards whose classes changed (repeater, room server, sensor, kiss modem, terminal chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
