### PR TITLE
docs(#326): point community flashing at flasher.meshcore.io, document the nRF52 .zip

### DIFF
--- a/.github/release-footer.md
+++ b/.github/release-footer.md
@@ -5,8 +5,15 @@
 
 | File | What it is | When to use it |
 |---|---|---|
-| `*-merged.bin` (ESP32 — Heltec V3/V4, XIAO) | **Full image** — bootloader + partition table + app in one, flashed at `0x0` after a chip erase. Self-contained, works on a blank chip. | **First install / clean setup.** In a web flasher this is the **"Full Firmware"** option. |
-| `*.bin` (ESP32) | **App only** — flashed at the app offset (`0x10000`); the bootloader must already be on the chip. | **Updating** an existing node — OTA / **"Update Only."** Keeps the device identity + WiFi/MQTT config. |
+| `*-merged.bin` (ESP32 — Heltec V3/V4, XIAO) | **Full image** — bootloader + partition table + app in one, flashed at `0x0` after a chip erase. Self-contained, works on a blank chip. | **First install / clean setup.** |
+| `*.bin` (ESP32) | **App only** — flashed at the app offset (`0x10000`); the bootloader must already be on the chip. | **Updating** an existing node — OTA. Keeps the device identity + WiFi/MQTT config. |
 | `*.uf2` (nRF52 — RAK, T-Echo, XIAO nRF52) | Complete self-contained image. | **First install *and* updates** — double-tap reset, then drag-drop onto the USB drive. (nRF52 has no merged/app split.) |
+| `*.zip` (nRF52) | **Adafruit DFU package** — the same image as the `*.uf2`, DFU-wrapped. | Serial DFU tooling (`adafruit-nrfutil`). Most people want the `*.uf2` instead. |
 
-> ⚠️ **ESP32:** the app-only `*.bin` will **not boot** if flashed at `0x0` — use `*-merged.bin` for a fresh install. A full erase / "Full Firmware" wipes the device's identity + saved config, so use it only for a first install or recovery, **never** a routine update.
+> ⚠️ **ESP32:** the app-only `*.bin` will **not boot** if flashed at `0x0` — use `*-merged.bin` for a fresh install. A full erase wipes the device's identity + saved config, so use it only for a first install or recovery, **never** a routine update.
+
+### How do I flash it?
+
+- **nRF52** — double-tap reset; the board mounts as a USB drive; drag the `*.uf2` onto it. No tools needed.
+- **ESP32** — [MeshCore web flasher](https://flasher.meshcore.io/) → **Custom Firmware**, which takes a file straight off your disk. Chromium-based browser required (Web Serial). It detects the `-merged.bin` suffix and warns before erasing — expected on a first install.
+- **From source** — `pio run -e <env> -t upload`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ prior to 0.13.0 predate it; see `git tag -l 'crosswire-v*'` and the tag
 annotations for that history (highlights: v0.12.0 NimBLE migration, v0.11.x
 Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
+## [Unreleased]
+
+### Fixed
+- **Flashing docs pointed at the wrong page and omitted a release file** (#326). The
+  README's web-flasher link went to `meshcore.co.uk/flasher.html` — a wrapper page that
+  forwards to a configurator, not the flasher. It now points at
+  [`flasher.meshcore.io`](https://flasher.meshcore.io/). The per-release download table
+  (README + `.github/release-footer.md`) also never listed the nRF52 `*.zip` DFU package —
+  40 of the 130 assets in a release — so it now has a row, pointing at serial DFU tooling
+  while steering most users to the simpler `*.uf2`. Both tables described the merged image as a web-flasher **"Full Firmware"**
+  option; that is the device-catalog flow, and an Offband user takes the **Custom Firmware**
+  flow instead, where the flasher auto-detects the `-merged.bin` suffix and prompts before
+  erasing. Corrected, and both surfaces gained a short "how do I flash it" section covering
+  the nRF52 UF2 drag-drop path, the ESP32 web-flasher path, and building from source.
+  Documentation only — no firmware change.
+
 ## [1.1.2] - 2026-07-02
 
 Companion **GPS auto-baud + on-demand GPS status**, plus the wedge/time fixes

--- a/README.md
+++ b/README.md
@@ -23,13 +23,20 @@ The firmware lives here: **`firmware-base`** is the canonical Offband tree (the 
 
 | File | What it is | When |
 |---|---|---|
-| `<env>-...-merged.bin` (ESP32) | full image (bootloader + partitions + app), flashed at `0x0` after erase | **first install** — web flasher "Full Firmware"; self-contained |
-| `<env>-....bin` (ESP32) | app only, flashed at the app offset | **update** — OTA / "Update Only"; keeps identity + config |
+| `<env>-...-merged.bin` (ESP32) | full image (bootloader + partitions + app), flashed at `0x0` after erase | **first install** — self-contained, boots a blank chip |
+| `<env>-....bin` (ESP32) | app only, flashed at the app offset (`0x10000`) | **update** — keeps identity + config |
 | `<env>-....uf2` (nRF52) | complete self-contained image | first install **and** update — double-tap reset, drag-drop |
+| `<env>-....zip` (nRF52) | Adafruit DFU package — the same image as the `.uf2`, DFU-wrapped | serial DFU tooling (`adafruit-nrfutil`). Most people want the `.uf2` instead |
 
-> On ESP32 the app-only `.bin` will **not boot** if written at `0x0` — use `-merged.bin` for a fresh install. A full erase wipes the device identity + config (first-install / recovery only). nRF52 `.uf2` has no merged/app split.
+> On ESP32 the app-only `.bin` will **not boot** if written at `0x0` — use `-merged.bin` for a fresh install. A full erase wipes the device identity + config (first-install / recovery only). nRF52 has no merged/app split; the `.uf2` and `.zip` carry the same image in different wrappers.
 
-Flash from a browser ([MeshCore web flasher](https://meshcore.co.uk/flasher.html) → custom firmware), or `pio run -e <env> -t upload`. Each release's notes repeat this guidance.
+**Flashing — no toolchain required:**
+
+- **nRF52 (RAK, T-Echo, XIAO nRF52)** — double-tap reset; the board mounts as a USB drive; drag the `.uf2` onto it. Nothing to install. This is the simplest path.
+- **ESP32** — the [MeshCore web flasher](https://flasher.meshcore.io/) → **Custom Firmware**, which takes a file straight off your disk. Needs a Chromium-based browser (Web Serial). It detects the `-merged.bin` suffix and warns before erasing — expected on a first install.
+- **From source** — `pio run -e <env> -t upload`.
+
+Each release's notes repeat this guidance.
 
 **Build from source** — install [PlatformIO](https://platformio.org/), then build the env that matches your board + role:
 


### PR DESCRIPTION
Closes the work tracked on #326 (issue closed ahead of the push — the pre-push hook requires referenced issues closed in Citadel + GitHub before a branch can be pushed).

**Documentation only. No firmware change, no code.**

## Why

Offband had no working on-ramp for anyone without the maintainer bench setup. `scripts/pio-flash` needs a populated `hardware-devices.yaml`, a PlatformIO toolchain, and the repo checked out — correct for flash discipline, useless for a community user.

The question was whether Offband needs its own web flasher. It does not. The MeshCore flasher's **Custom Firmware** path takes a file straight off the user's disk, and our release assets already fit it unmodified. The gap was purely that our docs pointed at the wrong page and described the wrong flow.

## What changed

| Defect | Fix |
|---|---|
| README linked `meshcore.co.uk/flasher.html` — a wrapper page that forwards to a *configurator*, not the flasher (`flash.meshcore.co.uk` doesn't resolve at all) | point at [`flasher.meshcore.io`](https://flasher.meshcore.io/) |
| The nRF52 `*.zip` DFU package was undocumented — 40 of the 130 assets in `offband-v1.1.2` | added a table row in both surfaces |
| Both tables called the merged image a web-flasher **"Full Firmware"** option — that's the device-catalog flow, not the Custom Firmware flow an Offband user takes | corrected; the flasher auto-detects the `-merged.bin` suffix and prompts before erasing |

Both surfaces also gain a short **"how do I flash it"** section: nRF52 UF2 drag-drop, ESP32 web flasher, build-from-source.

Files: `README.md`, `.github/release-footer.md` (appended to every GitHub Release body), `CHANGELOG.md`.

## Evidence

- `gh release view offband-v1.1.2` → **130 assets**: 50 `.bin` (25 `-merged.bin` + 25 app-only), 40 `.uf2`, 40 `.zip`
- `meshcore-dev/flasher.meshcore.io@main`, `flasher.js:395-420` / `:493-521` — default `espFlashAddress: 0x10000`; a filename ending `merged.bin` sets `wipe = true` → `espFlashAddress = 0x00000`, `eraseAll: true`, behind a confirmation prompt. Our `build.sh` naming matches by shared upstream lineage, not coincidence.
- URL status: `flasher.meshcore.io` 200 (the tool) · `meshcore.co.uk/flasher.html` 200 (wrapper → configurator) · `flash.meshcore.co.uk` no resolve

## Deliberate omission

The flasher's nRF52 path is its own JS reimplementation of `adafruit-nrfutil` serial DFU. Our `.zip` is a known-good DFU package (verified end-to-end via `pio-flash` on WSMJ898-RAK4631, 2026-06-23), but **that JS path has not been tested against an Offband `.zip` on hardware.** So the docs describe what the `.zip` *is* and route nRF52 users to the UF2 drag-drop path — which needs no tooling at all and is the better instruction regardless. No user is told to flash nRF52 via the web flasher.

## Gemini adversarial review

`docs/llm-consultations/2026-07-19-326-flashing-docs-review-gemini-gemini-2.5-pro.log`

- **BLOCKER — accepted and fixed.** The `.zip` row originally read *"this is the file a web flasher wants"*, which signposts users straight at the unverified nRF52 path the diff otherwise avoids. Reworded to *"serial DFU tooling (`adafruit-nrfutil`). Most people want the `.uf2` instead."*
- **MINOR — rejected with evidence.** Claimed `release-footer.md` omits the `0x10000` app offset while README has it. Backwards: `release-footer.md:9` already carried `(0x10000)`; the README is the file that lacked it, and this PR adds it. No change made.

## Follow-up

#331 (backlog, P3) — Offband-branded flasher fork. Deferred by owner decision: *"I don't feel like I need to brand a flasher yet."*

Agent: WhiteLynx (session 57d3444e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
