### PR TITLE
fix(#336): identify devices by USB serial, not Windows port-path

### DIFF
--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -145,20 +145,35 @@ Get-PnpDevice -Class Ports -PresentOnly | Where-Object { $_.Status -eq 'OK' } | 
     if ($did -match 'VID_([0-9A-Fa-f]{4}).*PID_([0-9A-Fa-f]{4})') {
         $vid = $matches[1].ToUpper(); $prodid = $matches[2].ToUpper()
     }
-    # Capture just the two-segment device-hash portion (e.g., "8&1A77809D") and
-    # discard the trailing port-address segments (e.g., "&0&0000"), which vary
-    # with physical USB topology. Standards-canonical hash format per
-    # proposal-flash-discipline.md.
+    # LEGACY, PORT-PATH ONLY (#323). "8&1A77809D" identifies the USB SOCKET, not the
+    # board: move a device to another port and this changes; plug another device into
+    # that port and it inherits this value. Retained only as a weak fallback for
+    # registry entries that predate usb_serial. NEVER treat it as identity.
     $inst = ''
     if ($did -match '\\([0-9A-Fa-f]+&[0-9A-Fa-f]+)(?:&[0-9A-Fa-f]+)*$') {
         $inst = $matches[1]
     }
+    # IDENTITY (#323): the device-unique USB serial. A COM port is an interface
+    # (…&MI_00\<port-path>); its PARENT is the USB device, whose instance id ends in
+    # the serial: USB\VID_303A&PID_0002\441BF662448C. Port paths always contain '&',
+    # serials do not -- that is how we tell them apart when a device is not composite
+    # and the parent lookup returns another port-path.
+    $serial = ''
+    try {
+        $parent = (Get-PnpDeviceProperty -InstanceId $_.InstanceId -KeyName 'DEVPKEY_Device_Parent' -ErrorAction Stop).Data
+        if ($parent -is [array]) { $parent = $parent[0] }
+        if ("$parent" -match '\\([^\\]+)$') {
+            $tail = $matches[1]
+            if ($tail -notmatch '&') { $serial = $tail.ToUpper() }
+        }
+    } catch { }
     # Emit one JSON line per port. ConvertTo-Json with -Compress is single-line.
     @{
         com = $com
         vid_pid = ($vid + ':' + $prodid)
         deviceid_full = $did
         instance_hash = $inst
+        usb_serial = $serial
         description = $name
     } | ConvertTo-Json -Compress
 }
@@ -200,8 +215,40 @@ def enumerate_ports() -> list[dict]:
 # registered device (or foreign device). Returns (kind, name, entry) where
 # kind is "device" / "foreign" / None.
 # ---------------------------------------------------------------------------
+def norm_serial(value: Any) -> str:
+    """Normalise a USB serial for comparison (#323).
+
+    The SAME board reports its serial differently depending on which USB endpoint
+    it enumerates on -- observed on one ESP32-S3: 'E8:F6:0A:CA:4E:54' via one
+    interface and 'E8F60ACA4E54' via the other. Comparing raw strings would fail
+    precisely when the device changes mode (runtime vs bootloader), which is the
+    moment identification matters most. Compare on alphanumerics only, uppercased.
+    """
+    return re.sub(r"[^0-9A-Za-z]", "", str(value or "")).upper()
+
+
+def entry_usb_serials(entry: dict) -> list[str]:
+    """Device-unique USB serial(s) recorded for a registry entry (#323).
+
+    Accepted at either `usb_serial:` (top level) or
+    `discriminators.windows.usb_serial`; a single value or a list. Returned
+    normalised via norm_serial().
+    """
+    d = (entry.get("discriminators") or {}).get("windows") or {}
+    vals = [entry.get("usb_serial"), d.get("usb_serial")]
+    out = []
+    for v in vals:
+        if not v:
+            continue
+        if isinstance(v, (list, tuple)):
+            out.extend(norm_serial(x) for x in v if x)
+        else:
+            out.append(norm_serial(v))
+    return [s for s in out if s]
+
+
 def find_in_registry(
-    registry: dict, vid_pid: str, instance_hash: str
+    registry: dict, vid_pid: str, instance_hash: str, usb_serial: str = ""
 ) -> tuple[Optional[str], Optional[str], Optional[dict]]:
     # Two-tier match: an exact DeviceID-instance match ALWAYS wins over a weaker
     # VID:PID-class-only match. A class-only candidate (no instance hash recorded,
@@ -214,32 +261,47 @@ def find_in_registry(
     # companion sitting on a different bench port than its recorded hash). In that
     # ambiguous case we return UNMATCHED so the caller surfaces an honest
     # "unidentified" port instead of a confidently-wrong device name.
-    class_only_candidates: list[tuple[Optional[str], Optional[str], Optional[dict]]] = []
+    serial_up = norm_serial(usb_serial)
+    legacy_candidates: list[tuple[Optional[str], Optional[str], Optional[dict]]] = []
+
     for kind_key, kind_label in [("devices", "device"), ("foreign_devices", "foreign")]:
         for name, entry in (registry.get(kind_key) or {}).items():
             entry_vid_pids = entry.get("vid_pid") or []
             if vid_pid not in entry_vid_pids:
                 continue
-            # VID:PID class match. Now check DeviceID instance hash if known.
+
+            # TIER 1 -- USB serial. Device-unique and port-independent: this IS identity.
+            serials = entry_usb_serials(entry)
+            if serials:
+                if serial_up and serial_up in serials:
+                    return (kind_label, name, entry)
+                # This entry has a serial and it is NOT this port's device. Excluding
+                # it here is what stops a registered board from impersonating another
+                # board that happens to sit in a port it once used.
+                continue
+
+            # TIER 2 -- legacy port-path hash, for entries predating usb_serial.
             d = (entry.get("discriminators") or {}).get("windows") or {}
             known_hashes = [
                 d.get("runtime_deviceid_instance"),
                 d.get("bootloader_deviceid_instance"),
             ]
             known_hashes = [h for h in known_hashes if h]
-            if known_hashes:
-                if instance_hash in known_hashes:
-                    # Exact instance match -- strongest signal, return immediately.
-                    return (kind_label, name, entry)
-                # Has hashes but none match this port -- definitely not this device.
-                continue
-            # No per-instance hash recorded: a class-only candidate.
-            class_only_candidates.append((kind_label, name, entry))
-    # Settle for a class-only candidate only when it UNIQUELY claims this VID:PID;
-    # an ambiguous class-only guess is reported as unidentified (None), never as a
-    # specific device.
-    if len(class_only_candidates) == 1:
-        return class_only_candidates[0]
+            if known_hashes and instance_hash in known_hashes:
+                legacy_candidates.append((kind_label, name, entry))
+
+            # TIER 3 -- neither serial nor hash (e.g. discriminators.windows == null).
+            # DELIBERATELY NOT A CANDIDATE (#323). Such an entry matches its whole
+            # VID:PID class, so it silently swallows any unrecognised board of that
+            # chip family. That is how a node physically mounted in the garage ceiling
+            # was reported as sitting on the bench. Unidentified is the honest answer;
+            # a confidently-wrong device name gets firmware written to the wrong board.
+
+    # A legacy hash match is accepted only when it is unambiguous. Note this is
+    # weaker than a serial match and follows the socket, not the board -- callers
+    # warn the operator to record usb_serial.
+    if len(legacy_candidates) == 1:
+        return legacy_candidates[0]
     return (None, None, None)
 
 
@@ -266,34 +328,66 @@ def resolve_device(name: str, registry: dict) -> tuple[dict, dict]:
 
     ports = enumerate_ports()
 
-    # First, see if any present port matches THIS device's registered hashes.
+    # #323: identify by USB serial (device-unique, port-independent) when the entry
+    # records one; fall back to the legacy port-path hash only for entries that
+    # predate it; refuse outright when neither exists.
+    serials = entry_usb_serials(entry)
     matches = []
-    for p in ports:
-        if p["vid_pid"] not in entry_vid_pids:
-            continue
+
+    if serials:
+        # Deliberately NOT filtered by vid_pid: the serial already identifies the
+        # board, and a device in bootloader mode legitimately presents a different
+        # PID than in runtime. Filtering on VID:PID here is what made a board
+        # "disappear" when it enumerated on its other USB endpoint.
+        matches = [p for p in ports if norm_serial(p.get("usb_serial")) in serials]
+        if not matches:
+            present_summary = ", ".join(
+                f"{p['com']}={p['vid_pid']} serial={p.get('usb_serial') or '(none)'}"
+                for p in ports
+            ) or "(no ports)"
+            refuse(
+                f"no present port carries device '{name}' USB serial "
+                f"{sorted(serials)} -- it is not attached to this host. "
+                f"Present: {present_summary}"
+            )
+    else:
         d = (entry.get("discriminators") or {}).get("windows") or {}
         known_hashes = [
             d.get("runtime_deviceid_instance"),
             d.get("bootloader_deviceid_instance"),
         ]
         known_hashes = [h for h in known_hashes if h]
-        if known_hashes and p["instance_hash"] in known_hashes:
-            matches.append(p)
-        elif not known_hashes:
-            # Class match only - registry has no hash yet. Accept but warn.
-            matches.append(p)
-
-    if not matches:
-        # No port matches this device. Surface what IS present so the user can
-        # see whether they expected this device to be connected.
-        present_summary = ", ".join(
-            f"{p['com']}={p['vid_pid']}({p['description']})" for p in ports
-        ) or "(no ports)"
-        refuse(
-            f"no present port matches device '{name}' "
-            f"(expected VID:PID in {sorted(entry_vid_pids)}, "
-            f"known DeviceID hashes from registry). "
-            f"Present: {present_summary}"
+        if not known_hashes:
+            # Previously this accepted ANY port of the right VID:PID class -- the
+            # defect behind #323. A chip-family match is not an identity.
+            refuse(
+                f"device '{name}' records neither usb_serial nor a DeviceID hash, so it "
+                "cannot be identified -- only its VID:PID class, which every board of "
+                "that chip family shares. Refusing rather than guessing (#323). "
+                "Run 'pio-flash list' to read this board's usb_serial, then record it "
+                "on the entry as 'usb_serial: <VALUE>'."
+            )
+        matches = [
+            p for p in ports
+            if p["vid_pid"] in entry_vid_pids and p["instance_hash"] in known_hashes
+        ]
+        if not matches:
+            present_summary = ", ".join(
+                f"{p['com']}={p['vid_pid']} serial={p.get('usb_serial') or '(none)'}"
+                for p in ports
+            ) or "(no ports)"
+            refuse(
+                f"no present port matches device '{name}' by legacy DeviceID port-path "
+                f"hash {sorted(known_hashes)}. NOTE: that hash identifies the USB SOCKET, "
+                "not the board, so it stops matching whenever the device is moved to a "
+                "different port. Record 'usb_serial:' on this entry to make it "
+                f"port-independent (#323). Present: {present_summary}"
+            )
+        err(
+            f"WARNING: '{name}' was matched by legacy DeviceID port-path hash, which "
+            "identifies the USB socket rather than the board. Record "
+            f"'usb_serial: {matches[0].get('usb_serial') or '<unavailable>'}' on this "
+            "entry so identification survives a port change (#323)."
         )
 
     if len(matches) > 1:
@@ -308,7 +402,9 @@ def resolve_device(name: str, registry: dict) -> tuple[dict, dict]:
     # to know about it (it's a candidate for bootstrap or foreign registration).
     unregistered = []
     for p in ports:
-        kind, _, _ = find_in_registry(registry, p["vid_pid"], p["instance_hash"])
+        kind, _, _ = find_in_registry(
+            registry, p["vid_pid"], p["instance_hash"], p.get("usb_serial", "")
+        )
         if kind is None:
             unregistered.append(p)
     if unregistered:
@@ -377,17 +473,25 @@ def cmd_list(args, registry):
     """Tier 0: enumerate present ports vs registry. No device touch."""
     ports = enumerate_ports()
     out(f"Present ports ({len(ports)}):")
-    out(f"{'COM':<8} {'VID:PID':<12} {'instance':<14} {'match':<22} description")
-    out("-" * 100)
+    # usb_serial is the identity column (#323); instance is the legacy port-path and
+    # is shown only so an operator can see what the old matcher was keying on.
+    out(f"{'COM':<8} {'VID:PID':<12} {'usb_serial':<16} {'port-path':<12} {'match':<22} description")
+    out("-" * 110)
     for p in ports:
-        kind, name, _ = find_in_registry(registry, p["vid_pid"], p["instance_hash"])
+        kind, name, _ = find_in_registry(
+            registry, p["vid_pid"], p["instance_hash"], p.get("usb_serial", "")
+        )
         if kind == "device":
             tag = f"device:{name}"
         elif kind == "foreign":
             tag = f"FOREIGN:{name}"
         else:
             tag = "unregistered"
-        out(f"{p['com']:<8} {p['vid_pid']:<12} {p['instance_hash']:<14} {tag:<22} {p['description']}")
+        ser = p.get("usb_serial") or "(none)"
+        out(
+            f"{p['com']:<8} {p['vid_pid']:<12} {ser:<16} {p['instance_hash']:<12} "
+            f"{tag:<22} {p['description']}"
+        )
     if not ports:
         out("(no present serial ports)")
     return 0

--- a/scripts/test_pio_flash_device_match.py
+++ b/scripts/test_pio_flash_device_match.py
@@ -1,0 +1,160 @@
+"""Device-identity matching tests for pio-flash (#323).
+
+The defect these pin: `pio-flash` identified boards by the Windows DeviceID
+instance (`8&XXXXXXX`), which is a **port path** -- it names the USB socket, not
+the board. Move a board to another port and it stopped matching; plug a different
+board into that port and it inherited the previous occupant's identity. Compounding
+it, a registry entry with `discriminators.windows: null` matched its whole VID:PID
+class and silently swallowed any unrecognised board of that chip family.
+
+Real-world consequence: the tool reported a node that is physically mounted in the
+owner's garage ceiling as sitting on the bench. A wrong match here writes firmware
+to the wrong board.
+
+These cases cannot be produced by unplugging hardware (you cannot easily make two
+boards trade sockets on demand, and you certainly cannot fabricate a third board),
+so they are pinned here. The hardware port-swap test required to close #323 is
+complementary to this, not replaced by it.
+
+Run: python -m pytest scripts/test_pio_flash_device_match.py -q
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "pio_flash", Path(__file__).resolve().parent / "pio-flash.py"
+)
+pio_flash = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(pio_flash)
+
+find_in_registry = pio_flash.find_in_registry
+norm_serial = pio_flash.norm_serial
+
+VID = "303A:0002"
+
+
+def reg(devices):
+    return {"devices": devices, "foreign_devices": {}}
+
+
+# --------------------------------------------------------------------------
+# Serial normalisation
+# --------------------------------------------------------------------------
+def test_norm_serial_strips_separators_and_cases():
+    # The same board reports both forms depending on which USB endpoint it
+    # enumerates on -- observed on an ESP32-S3 across runtime vs bootloader.
+    assert norm_serial("E8:F6:0A:CA:4E:54") == norm_serial("e8f60aca4e54")
+    assert norm_serial("44-1B-F6-62-44-8C") == "441BF662448C"
+    assert norm_serial(None) == ""
+
+
+# --------------------------------------------------------------------------
+# Tier 1: serial is identity
+# --------------------------------------------------------------------------
+def test_serial_matches_regardless_of_port_path():
+    """The whole point: identity must survive moving to a different USB port."""
+    r = reg({"Firestar": {"vid_pid": [VID], "usb_serial": "441BF662448C"}})
+    # Port path deliberately bears no relation to anything recorded.
+    kind, name, _ = find_in_registry(r, VID, "9&DEADBEEF", "441BF662448C")
+    assert (kind, name) == ("device", "Firestar")
+
+
+def test_serial_matches_in_other_usb_mode_with_different_pid_format():
+    r = reg({"ST-P": {"vid_pid": [VID], "usb_serial": "E8F60ACA4E54"}})
+    kind, name, _ = find_in_registry(r, VID, "8&519AF3A", "E8:F6:0A:CA:4E:54")
+    assert (kind, name) == ("device", "ST-P")
+
+
+def test_registered_device_does_not_impersonate_another_board():
+    """A board with a recorded serial must NOT claim a port holding a different board.
+
+    This is the LIBT failure: the entry matched on class/port-path and adopted a
+    stranger's port.
+    """
+    r = reg({"LIBT": {"vid_pid": [VID], "usb_serial": "AAAABBBBCCCC"}})
+    kind, name, _ = find_in_registry(r, VID, "8&3A6FE2F5", "441BF662448C")
+    assert (kind, name) == (None, None)
+
+
+# --------------------------------------------------------------------------
+# Tier 3: class-only entries must never match
+# --------------------------------------------------------------------------
+def test_class_only_entry_never_matches():
+    """`discriminators.windows: null` + no serial => matches nothing, ever.
+
+    Previously this returned the entry whenever it was the SOLE class-only
+    candidate -- which is exactly the situation that misreported the garage node
+    as attached.
+    """
+    r = reg({"LIBT": {"vid_pid": [VID], "discriminators": {"windows": None}}})
+    kind, name, _ = find_in_registry(r, VID, "8&3A6FE2F5", "441BF662448C")
+    assert (kind, name) == (None, None)
+
+
+def test_class_only_entry_does_not_shadow_a_real_serial_match():
+    r = reg({
+        "LIBT": {"vid_pid": [VID], "discriminators": {"windows": None}},
+        "Firestar": {"vid_pid": [VID], "usb_serial": "441BF662448C"},
+    })
+    kind, name, _ = find_in_registry(r, VID, "8&3A6FE2F5", "441BF662448C")
+    assert (kind, name) == ("device", "Firestar")
+
+
+# --------------------------------------------------------------------------
+# Tier 2: legacy fallback, for entries predating usb_serial
+# --------------------------------------------------------------------------
+def test_legacy_hash_still_matches_when_no_serial_recorded():
+    r = reg({"Old": {
+        "vid_pid": [VID],
+        "discriminators": {"windows": {"runtime_deviceid_instance": "8&519AF3A"}},
+    }})
+    kind, name, _ = find_in_registry(r, VID, "8&519AF3A", "E8F60ACA4E54")
+    assert (kind, name) == ("device", "Old")
+
+
+def test_serial_entry_beats_legacy_hash_entry_on_same_port():
+    """If one entry claims the port by stale port-path and another owns the serial,
+    the serial wins -- otherwise a moved board is mislabelled by whoever inherited
+    its old socket."""
+    r = reg({
+        "StaleOccupant": {
+            "vid_pid": [VID],
+            "discriminators": {"windows": {"runtime_deviceid_instance": "8&3A6FE2F5"}},
+        },
+        "Firestar": {"vid_pid": [VID], "usb_serial": "441BF662448C"},
+    })
+    kind, name, _ = find_in_registry(r, VID, "8&3A6FE2F5", "441BF662448C")
+    assert (kind, name) == ("device", "Firestar")
+
+
+# --------------------------------------------------------------------------
+# The scenario that produced #323
+# --------------------------------------------------------------------------
+def test_two_boards_swapping_ports_each_resolve_to_themselves():
+    r = reg({
+        "A": {"vid_pid": [VID], "usb_serial": "AAAAAAAAAAAA"},
+        "B": {"vid_pid": [VID], "usb_serial": "BBBBBBBBBBBB"},
+    })
+    port_a, port_b = "8&1111111", "8&2222222"
+    # Before the swap
+    assert find_in_registry(r, VID, port_a, "AAAAAAAAAAAA")[1] == "A"
+    assert find_in_registry(r, VID, port_b, "BBBBBBBBBBBB")[1] == "B"
+    # After swapping sockets -- identities must follow the boards, not the ports
+    assert find_in_registry(r, VID, port_b, "AAAAAAAAAAAA")[1] == "A"
+    assert find_in_registry(r, VID, port_a, "BBBBBBBBBBBB")[1] == "B"
+
+
+def test_unknown_board_is_unregistered_not_someone_else():
+    r = reg({
+        "LIBT": {"vid_pid": [VID], "discriminators": {"windows": None}},
+        "Firestar": {"vid_pid": [VID], "usb_serial": "441BF662448C"},
+    })
+    kind, name, _ = find_in_registry(r, VID, "8&9999999", "FFFFFFFFFFFF")
+    assert (kind, name) == (None, None)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Implements task #336, under parent issue #323 (P0).

**Parent #323 stays OPEN.** It closes only on a demonstrated hardware port-swap on real boards. This PR is the implementation half.

## The defect

`pio-flash` identified a board by its Windows DeviceID instance (`8&XXXXXXX`). That is a **port path** — it names the USB socket, not the device:

```
USB\VID_303A&PID_0002&MI_00\8&3A6FE2F5&0&0000   interface + port path  (what it used)
USB\VID_303A&PID_0002\441BF662448C              parent + serial        (identity)
```

Move a board to another port → it stops matching. Plug a different board into that port → it inherits the previous occupant's identity. Compounding it, an entry with `discriminators.windows: null` matched on VID:PID alone; the prior fix only refused when **two or more** such entries existed, so a single one still won.

That is how the tool reported a node **physically mounted in the garage ceiling** as attached to the bench. This script gates every flash, so a wrong match writes firmware to the wrong board.

## Reproduced, not asserted

Against pre-fix code:

```
find_in_registry(reg, "303A:0002", "8&3A6FE2F5")  ->  ('device', 'LIBT')
```

New code returns unidentified for the same input.

## The change

Three-tier matching:
1. **`usb_serial`** — authoritative. An entry that *has* a serial and does not match is **excluded**, so a registered board cannot impersonate another.
2. **legacy port-path hash** — only for un-migrated entries, only when unambiguous, and the caller warns with the serial to record.
3. **class-only** (no serial, no hash) — **never matches**. Unidentified is the honest answer.

`resolve_device` prefers the serial and deliberately does **not** filter by VID:PID on that path — a board in bootloader mode presents a different PID, and that filter is what made a board "disappear" on its other USB endpoint.

`norm_serial`: the same board reports `E8:F6:0A:CA:4E:54` on one endpoint and `E8F60ACA4E54` on the other. Comparison is on alphanumerics only — raw matching would fail precisely when a device changes mode.

Registry data (`hardware-devices.yaml`) is gitignored per-host and not in this diff; `usb_serial:` was recorded there for the attached boards.

## Tests

`scripts/test_pio_flash_device_match.py` — 10 passing:
- port swap: two boards trade sockets, identities follow the **boards**
- no impersonation; class-only never matches; serial beats a stale hash; normalisation across formats

None of these can be produced by unplugging hardware, which is why they are pinned here.

## Review

Gemini: no defects. Confirmed the serial-vs-port-path heuristic, that Tier 1 exclusion contains the remaining legacy path, and that dropping the VID:PID filter on the serial path is correct for mode-changing devices.

## Not done

Hardware port-swap demonstration on real boards — the closure condition for #323, recorded there when run.
