### PR TITLE
chore: Offband 1.2.0 release content (CHANGELOG + Discord)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
 ## [1.2.0] - Unreleased
 
-Adds **MeshSmith Photon‑1W support** (both MCU flavors) on the **MeshCore 1.16.0** base,
+Adds **MeshSmith Photon‑1W support** (both MCU flavors) on the **MeshCore 1.16.0** base, and **receive-sensitivity recovery on Heltec V4** (external FEM LNA control, which stock MeshCore leaves bypassed),
 plus the ESP32‑C6 I2C‑scan boot‑hang fix found bench‑validating it, a NimBLE build fix,
 and flashing‑docs corrections.
 
@@ -27,6 +27,16 @@ and flashing‑docs corrections.
   minimal MeshCore‑consistent base edits (antenna‑switch virtuals, protected `_gps_serial`, NimBLE dep);
   nRF52 needed none. The **ESP32‑C6 companion + repeater are bench‑verified** on hardware; the
   **nRF52 variant is not yet bench‑verified** — review findings tracked as bench checkpoints on #193/#194.
+- **External FEM LNA control on Heltec V4 companions (#298).** MeshCore leaves the Heltec V4
+  front-end module's LNA bypassed at boot, so V4 companions ran with degraded receive
+  sensitivity. Offband now enables it at companion boot from a persisted `radio_fem_rxgain`
+  preference (default on), on the boards whose FEM exposes an independent LNA line
+  (`heltec_v4`, `heltec_tracker_v2`, `heltec_t096`). A new companion-API command (`0xC3`,
+  SET/GET) plus a capability bit lets the client show a user toggle, gated on the
+  runtime-detected FEM chip. `FIRMWARE_VER_CODE` 15 -> 16. Verified end-to-end on a
+  KCT8103L (V4.3) board.
+- **Model string names the detected FEM part (#327)** — reads `Heltec V4 OLED (KCT8103L)`
+  or `(GC1109)`, so a V4.3 (independent LNA control) is distinguishable from a V4.2 in the app.
 
 ### Fixed
 - **Photon‑1W ESP32‑C6 hung at boot, dead on the mesh (#294).** The C6 variant declares its I2C bus,
@@ -34,6 +44,25 @@ and flashing‑docs corrections.
   the I2C peripheral (hangs at addr `0x0d`) and never returns, so `setup()` never reached `loop()`.
   The scan is now skipped on boards that set `ENV_SKIP_I2C_SENSOR_SCAN` (guard vendored verbatim from
   MeshSmith's fork); every other board is unchanged.
+- **CLI accepted garbage after a valid key (#299).** `get radio foobar` returned the radio
+  settings, and `set radio 910.525,62.5,7,5,junk` silently applied the first four values and
+  dropped the rest. Keys now require a whole-token match; extra `set radio` parameters are rejected.
+- **64 ESP32 BLE companion environments could not build (#199, #90).** The NimBLE dependency was
+  declared per-variant with no shared source, and the greedy source filter pulled the BLE
+  interface into non-BLE (`usb`/`wifi`) builds too. Factored into a shared config; restores
+  boards silently absent from prior releases, including `Heltec_v2_companion_radio_usb` and
+  `Xiao_C3_companion_radio_usb`. A CI invariant now guards every ESP32 env. (The #89 fix below
+  is the first, single-env instance of this class.)
+- **FEM auto-detect source comment corrected (#318, #321).** The Heltec V4 FEM type is set by a
+  board strap, not chip-internal pulls as the code claimed; documented against schematics + the
+  GC1109 datasheet. A boot detection probe is available behind `-D FEM_DEBUG_PROBE` (off by default).
+- **`pio-flash` identified devices by USB port-path, not identity (#336, #323).** Boards were
+  misidentified after any USB port or device swap, and a no-discriminator registry entry
+  wildcard-matched its whole chip family. Now keys on the device-unique USB serial and refuses
+  ambiguous matches; hardware-verified across colliding same-VID:PID boards. Bench tooling, not
+  shipped firmware.
+- **`pio-flash` bootstrap parses the ESP32-C6/H2 base MAC and anchors its MAC regexes (#290, #292).**
+  Bench tooling.
 - **`Xiao_S3_WIO_companion_radio_usb` build (#89)** — exclude `SerialBLEInterface.cpp` from the USB
   companion env (it has no BLE), resolving the `NimBLEDevice.h` regression from the #288 NimBLE migration.
 - **Flashing docs pointed at the wrong page and omitted a release file** (#326). The
@@ -53,6 +82,12 @@ and flashing‑docs corrections.
 - **CLAUDE.md: no‑upstream‑merge policy (#197)** — Offband does not merge from upstream MeshCore; the
   `upstream` remote stays fetch‑only for reference. Keep MeshCore nomenclature/coding‑standard consistency
   for clean rebasing.
+
+### Documentation
+- Heltec V4 FEM/LNA ground-truth from schematics, the GC1109 datasheet, and on-device
+  measurement, including V4.2-vs-V4.3 RX-path differences (#320, #321).
+- Repeater WiFi-telemetry genericization design-of-record (#296, design only).
+- Block-user companion-API contract reconciled to as-built (#313, #315).
 
 ## [1.1.2] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and flashing‑docs corrections.
 ### Added
 - **MeshSmith Photon‑1W support — ESP32‑C6 + nRF52 (#193, #194)** — vendors MeshSmith's MIT Photon
   variants (`meshsmith_photon_esp32c6`, `meshsmith_photon_nrf52`; Seeed XIAO ESP32‑C6 / XIAO nRF52840 +
-  Ebyte E22‑900M30S 1 W radio) and wires all roles into CI + the release pipeline. ESP32‑C6 needed
+  Ebyte E22‑900M30S 1W radio) and wires all roles into CI + the release pipeline. ESP32‑C6 needed
   minimal MeshCore‑consistent base edits (antenna‑switch virtuals, protected `_gps_serial`, NimBLE dep);
   nRF52 needed none. The **ESP32‑C6 companion + repeater are bench‑verified** on hardware; the
   **nRF52 variant is not yet bench‑verified** — review findings tracked as bench checkpoints on #193/#194.

--- a/discord/1.2.0.md
+++ b/discord/1.2.0.md
@@ -1,8 +1,8 @@
 **Offband 1.2.0 is out** 📡
 
-Big one this round — a new 1-watt board family and receive-sensitivity recovery on Heltec V4, plus build and CLI fixes.
+Big one this round — a new 1W board family and receive-sensitivity recovery on Heltec V4, plus build and CLI fixes.
 
-📡 **Photon-1W (MeshSmith)** — new 1 W board family, both flavors: XIAO ESP32-C6 and XIAO nRF52840, each with the Ebyte E22-900M30S 1 W front-end. Companion (BLE + USB), repeater, and room-server builds for both MCUs. The C6 companion + repeater are bench-verified; the nRF52 variant is still shaking out — up for testing.
+📡 **Photon-1W (MeshSmith)** — new 1W board family, both flavors: XIAO ESP32-C6 and XIAO nRF52840, each with the Ebyte E22-900M30S 1W front-end. Companion (BLE + USB), repeater, and room-server builds for both MCUs. The C6 companion + repeater are bench-verified; the nRF52 variant is still shaking out — up for testing.
 
 📶 **Heltec V4 FEM LNA** — stock MeshCore boots the V4 front-end module with its LNA bypassed, which hurt RX sensitivity. Offband now enables it at boot on the boards that support it (V4, Tracker V2, T096), from a persisted setting that defaults on. The app can expose a toggle — and it only shows where the auto-detected FEM chip actually supports it, so you won't see a control your board can't honor. Verified on real V4.3 hardware. The model string now names the FEM part too — `Heltec V4 OLED (KCT8103L)` vs `(GC1109)` — so you can tell a high-power V4.3 from a V4.2 right in the app.
 

--- a/discord/1.2.0.md
+++ b/discord/1.2.0.md
@@ -1,0 +1,13 @@
+**Offband 1.2.0 is out** 📡
+
+Big one this round — a new 1-watt board family and receive-sensitivity recovery on Heltec V4, plus build and CLI fixes.
+
+📡 **Photon-1W (MeshSmith)** — new 1 W board family, both flavors: XIAO ESP32-C6 and XIAO nRF52840, each with the Ebyte E22-900M30S 1 W front-end. Companion (BLE + USB), repeater, and room-server builds for both MCUs. The C6 companion + repeater are bench-verified; the nRF52 variant is still shaking out — up for testing.
+
+📶 **Heltec V4 FEM LNA** — stock MeshCore boots the V4 front-end module with its LNA bypassed, which hurt RX sensitivity. Offband now enables it at boot on the boards that support it (V4, Tracker V2, T096), from a persisted setting that defaults on. The app can expose a toggle — and it only shows where the auto-detected FEM chip actually supports it, so you won't see a control your board can't honor. Verified on real V4.3 hardware. The model string now names the FEM part too — `Heltec V4 OLED (KCT8103L)` vs `(GC1109)` — so you can tell a high-power V4.3 from a V4.2 right in the app.
+
+🔧 **Fixes** — the CLI rejects junk after a key now (`get radio foobar` used to hand back the radio settings; `set radio` used to quietly drop extra params). And 64 ESP32 BLE build targets that couldn't build at all are back, including two (`Heltec_v2` and `Xiao_C3` USB companions) that were silently missing from past releases.
+
+**Flashing** — ESP32: flasher.meshcore.io → Custom Firmware → your board. nRF52: UF2 drag-drop is easiest, or `.zip` for serial DFU. Full per-board table on the release page.
+
+Full changelog in the repo. Report anything odd here.

--- a/discord/README.md
+++ b/discord/README.md
@@ -1,0 +1,17 @@
+# Discord announcement
+
+One file per release: `discord/<version>.md`, e.g. `discord/1.2.0.md` (matching the
+`offband-v*` tag core, without the `offband-v` prefix or any `-rc`/`-beta` suffix).
+
+## Style
+
+Casual, paste-ready community announcement. What landed, in plain excited-but-honest
+terms, with the download link. Emoji fine. This is the message the owner posts to Discord.
+
+**The owner pastes this into Discord manually.** Nothing here posts automatically — posting
+to a community is an external, human-triggered action.
+
+Mirrors the convention in the client repo (`OffbandMesh/meshcore-client`), which keeps
+`discord/`, `release-notes/`, and `play/` files per version. Firmware's GitHub release body
+is built from the matching `CHANGELOG.md` section (see `.github/workflows/release.yml`), so
+there is no separate `release-notes/` file here; the CHANGELOG entry is the release notes.


### PR DESCRIPTION
Assembles the 1.2.0 release content as committed repo files, matching the client's release convention (reviewed as a PR diff, not an artifact).

## What's here
- **`CHANGELOG.md` [1.2.0]** — merged this cycle's work into the existing section (which already carried Photon-1W + #294/#89/#326/#197). Added: FEM LNA #298, model string #327. Fixed: CLI #299, 64-env build #199/#90, FEM detect #318, pio-flash serial #336/#323, pio-flash MAC #290/#292. Documentation: #320/#321, #296, #313/#315. Lead paragraph now names the FEM LNA headline alongside Photon-1W.
- **`discord/1.2.0.md` + `discord/README.md`** — paste-ready community post, owner posts manually; mirrors the client repo's `discord/` convention.

## Review focus
This is user-facing copy — please check the wording of both the CHANGELOG [1.2.0] entry and the Discord post. Firmware's GitHub release body is auto-built from the CHANGELOG section, so what's in [1.2.0] here is what the release page shows.

## Not in scope
No tag. `offband-v1.2.0` is the separate, human-gated ship-it step (release preview + explicit go), per VERSIONING.md.

Closes #343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)