### PR TITLE
chore(#352): pin Agent Mail project via .claude/hooks/am-project

### DIFF
--- a/.claude/hooks/am-project
+++ b/.claude/hooks/am-project
@@ -1,0 +1,1 @@
+app-c-dev-crosswire


### PR DESCRIPTION
Marker holds app-c-dev-crosswire so sessions stop registering by path and re-minting the stray app-c-dev-meshcore-firmware. Per standards#237. Closes #352