### PR TITLE
feat(#358): report internal-DRAM heap headroom in stats-core

### DIFF
--- a/src/helpers/StatsFormatHelper.h
+++ b/src/helpers/StatsFormatHelper.h
@@ -2,20 +2,60 @@
 
 #include "Mesh.h"
 
+#if defined(ARDUINO) && defined(ESP_PLATFORM)
+  // #358: heap_caps_* live here. Included explicitly rather than relying on it
+  // arriving transitively via Mesh.h -> Arduino.h.
+  #include <esp_heap_caps.h>
+#endif
+
 class StatsFormatHelper {
 public:
-  static void formatCoreStats(char* reply, 
-                             mesh::MainBoard& board, 
-                             mesh::MillisecondClock& ms, 
+  // #358: heap fields are appended ESP32-only (see below), so the JSON is built
+  // in two steps -- base fields without the closing brace, then the optional
+  // heap pair, then the brace.
+  //
+  // Buffer budget: all three callers (repeater / room-server / sensor) pass
+  // char reply[160]. Worst case here is ~130 chars incl. terminator, leaving
+  // ~30 bytes of margin. sprintf is unbounded, matching every other reply
+  // formatter in this codebase -- the CLI reply chain never plumbs a buffer
+  // size down to the formatters, so bounding it properly is a codebase-wide
+  // change tracked separately, NOT something to half-fix here with a
+  // hardcoded size that a future caller could silently violate.
+  static void formatCoreStats(char* reply,
+                             mesh::MainBoard& board,
+                             mesh::MillisecondClock& ms,
                              uint16_t err_flags,
                              mesh::PacketManager* mgr) {
-    sprintf(reply, 
-      "{\"battery_mv\":%u,\"uptime_secs\":%u,\"errors\":%u,\"queue_len\":%u}",
+    int n = sprintf(reply,
+      "{\"battery_mv\":%u,\"uptime_secs\":%u,\"errors\":%u,\"queue_len\":%u",
       board.getBattMilliVolts(),
       ms.getMillis() / 1000,
       err_flags,
       mgr->getOutboundTotal()
     );
+#if defined(ARDUINO) && defined(ESP_PLATFORM)
+    // Heap headroom (#358). ESP32-only: the nRF52 builds have no equivalent for
+    // these APIs, so the keys are simply absent there rather than reported as a
+    // misleading zero. Additive keys -- existing fields are unchanged.
+    //
+    // INTERNAL DRAM specifically (MALLOC_CAP_INTERNAL), not ESP.getFreeHeap():
+    // boards/heltec_v4.json sets BOARD_HAS_PSRAM (2 MB qspi), and the aggregate
+    // free-heap figure can fold PSRAM in with internal DRAM. That would overstate
+    // the headroom that actually constrains us, since mbedTLS/TLS session buffers
+    // need internal DRAM -- the exact number Epic #308 is trying to establish.
+    //
+    // *_min is the minimum-ever free (low-water mark): it captures peak memory
+    // pressure, which is what matters for headroom. The instantaneous figure can
+    // look healthy right after a spike has already passed.
+    n += sprintf(reply + n,
+      ",\"heap_int_free\":%u,\"heap_int_min\":%u",
+      (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+      (unsigned)heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL)
+    );
+#endif
+    // Single char + terminator; no need to pay for a sprintf call here.
+    reply[n]     = '}';
+    reply[n + 1] = 0;
   }
 
   template<typename RadioDriverType>


### PR DESCRIPTION
## What
Adds `heap_int_free` + `heap_int_min` to `formatCoreStats()` — the shared core-stats formatter used by **repeater / room-server / sensor**. There was no free-heap reporting anywhere in the firmware, so heap headroom couldn't be measured on a live node.

## Why
Unblocks Epic #308 (a) — heap headroom on a repeater with LoRa active — and is permanent observability (same spirit as the DoR's radio-active-time metric), not throwaway debug code.

## Key design call
Reports **internal DRAM** (`MALLOC_CAP_INTERNAL`), not aggregate `ESP.getFreeHeap()`: `boards/heltec_v4.json` sets `BOARD_HAS_PSRAM` (2 MB qspi), and the aggregate figure folds PSRAM in with internal DRAM — overstating the headroom that actually binds, since mbedTLS/TLS buffers need internal DRAM. (Caught by adversarial review; would have skewed the #308 number in exactly the wrong direction.)

- `*_min` = low-water mark (minimum-ever free) — captures peak pressure.
- ESP32-guarded (`ARDUINO && ESP_PLATFORM`, matching `MqttBroker.h`); nRF52/host omit the keys rather than emit a misleading zero. Additive keys only.

## Verification
- Builds: **ESP32** `heltec_v4_repeater_telemetry_stp` ✅ · **nRF52** `RAK_4631_repeater` ✅ (guard proven both sides)
- **Hardware (ST-P, LoRa active):** `stats-core` → `{..."heap_int_free":241724,"heap_int_min":210488}`; existing fields unchanged.

## Adversarial review (standards#145)
Gemini: 1 BLOCKER / 2 MAJOR / 1 MINOR. Dispositions:
- BLOCKER (unbounded sprintf): concern valid but pre-existing + codebase-wide; its inline fix (hardcode 160 in a shared helper) would be worse. Filed **#359** for the proper size-plumbing refactor. Took the point on the wasteful one-brace sprintf → direct char write.
- MAJOR (PSRAM ambiguity): **accepted** → switched to `MALLOC_CAP_INTERNAL`.
- MAJOR (emit null on nRF52): **rejected** — `null` in a numeric field relocates the type error into strict parsers; omitting optional keys is the safer convention.
- MINOR (explicit include): **accepted, corrected** — guarded `<esp_heap_caps.h>` at file top (Gemini's snippet put an `#include` inside a function body and named the wrong header).

Log: `docs/llm-consultations/2026-07-23-358-heap-stats-review-gemini-gemini-2.5-pro.log`

Closes #358. Follow-up: #359.

Agent: CloudyCliff (session 83c8582b)