### PR TITLE
refactor(#364): extract role-agnostic config-command dispatch into src/helpers/config/

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -28,10 +28,13 @@
 #include "helpers/wifi_observer/CliPassthrough.h"
 // Epic F: the config command codes (#160 contract) live in OffbandConfigProtocol.h,
 // now included unconditionally above (#241). Its typed dispatch backend (#165):
-#include "helpers/wifi_observer/ObserverCli.h"   // configSet/configGet + dispatchObserverCli
+#include "helpers/wifi_observer/ObserverCli.h"   // dispatchObserverCli + broker enumeration
+#include "helpers/config/ConfigDispatch.h"       // #364: role-agnostic config set/get
 // wifiObserverPool() lives in WifiObserver.h (heavy transitive includes); forward-
-// declare it here as CliPassthrough.cpp does. configSet takes a pool ref (only the
-// broker branch -- F3 -- consumes it, but the signature requires it for flat keys too).
+// declare it here as CliPassthrough.cpp does. Still needed by the VIEW passthrough
+// and the F3 broker enumeration below; the config set/get path no longer takes a
+// pool ref (#364 -- the shared dispatcher must not know about MqttBrokerPool, so
+// the observer's provider fetches the pool itself).
 namespace offband { MqttBrokerPool& wifiObserverPool(); }
 #endif
 
@@ -1275,7 +1278,7 @@ void MyMesh::handleOffbandConfigCmd(size_t len) {
     char* sp = strchr(payload, ' ');                 // split on FIRST space; value = remainder
     if (sp == nullptr) { writeOffbandConfigScalar(offband::OCFG_R_ERR, "set: expected '<key> <value>'"); return; }
     *sp = '\0';
-    if (!offband::configSet(payload, sp + 1, reply, sizeof(reply), offband::wifiObserverPool())) {
+    if (!offband::config::dispatchSet(payload, sp + 1, reply, sizeof(reply))) {
       writeOffbandConfigScalar(offband::OCFG_R_ERR, "unknown config key"); return;
     }
     bool err = (strncmp(reply, "ERROR", sizeof("ERROR") - 1) == 0);
@@ -1284,7 +1287,7 @@ void MyMesh::handleOffbandConfigCmd(size_t len) {
   }
 
   if (op == offband::OCFG_GET) {
-    if (!offband::configGet(payload, reply, sizeof(reply))) {
+    if (!offband::config::dispatchGet(payload, reply, sizeof(reply))) {
       writeOffbandConfigScalar(offband::OCFG_R_ERR, "unknown config key"); return;
     }
     bool err = (strncmp(reply, "ERROR", sizeof("ERROR") - 1) == 0);

--- a/src/helpers/config/ConfigDispatch.cpp
+++ b/src/helpers/config/ConfigDispatch.cpp
@@ -1,0 +1,133 @@
+// src/helpers/config/ConfigDispatch.cpp
+//
+// Epic #300 item 1 (#364). See ConfigDispatch.h for the model and rationale.
+
+#include "ConfigDispatch.h"
+#include <cstring>
+#include <cstdlib>
+#include <cstdio>    // fprintf -- the non-Arduino (host/test) diagnostic path
+
+#ifdef ARDUINO
+  #include <Arduino.h>   // Serial -- diagnostics only; Arduino-generic, NOT
+                         // ESP-only, so this component builds for nRF52 too.
+#endif
+
+namespace offband {
+namespace config {
+
+namespace {
+
+struct Provider {
+    SetFn       set_fn;
+    GetFn       get_fn;
+    const char* role;
+};
+
+// POD with static storage duration -> zero-initialised in .bss during static
+// initialisation, which completes before any dynamic initialiser runs. That is
+// what makes a file-scope ProviderRegistrar in another TU safe at any link order.
+Provider g_providers[kMaxProviders];
+int      g_count;
+
+// Latched so a client polling config cannot turn this into a log flood
+// (SAFELANE 11 rule 10: diagnostics must not become the outage).
+bool g_warned_empty;
+
+// SAFELANE 6: an unregistered config surface must not silently masquerade as
+// "unknown config key" to the client. Report it once, visibly.
+void warnIfNoProvider(const char* op) {
+    if (g_count != 0 || g_warned_empty) return;
+    g_warned_empty = true;
+    // #364 review MAJOR-1: must be loud on EVERY target, not just Arduino --
+    // otherwise a host/unit-test build hides a dead config surface entirely.
+#ifdef ARDUINO
+    Serial.printf("ERROR: config %s with NO provider registered "
+                  "(config surface is dead; a role failed to link/register)\n", op);
+#else
+    fprintf(stderr, "ERROR: config %s with NO provider registered "
+                    "(config surface is dead; a role failed to link/register)\n", op);
+#endif
+}
+
+}  // namespace
+
+bool registerProvider(SetFn set_fn, GetFn get_fn, const char* role_name) {
+    if (set_fn == nullptr && get_fn == nullptr) return false;
+    if (g_count >= kMaxProviders) {
+        // Loud on every target: a role silently dropped here loses its whole
+        // config surface (#364 review MAJOR-1).
+        const char* who = role_name != nullptr ? role_name : "?";
+#ifdef ARDUINO
+        Serial.printf("ERROR: config provider table full (%d); '%s' NOT registered\n",
+                      kMaxProviders, who);
+#else
+        fprintf(stderr, "ERROR: config provider table full (%d); '%s' NOT registered\n",
+                kMaxProviders, who);
+#endif
+        return false;
+    }
+    g_providers[g_count].set_fn = set_fn;
+    g_providers[g_count].get_fn = get_fn;
+    g_providers[g_count].role   = role_name;
+    ++g_count;
+    return true;
+}
+
+int providerCount() { return g_count; }
+
+bool dispatchSet(const char* key, const char* value, char* reply, size_t reply_size) {
+    if (key == nullptr || value == nullptr || reply == nullptr || reply_size == 0) return false;
+    reply[0] = '\0';
+    warnIfNoProvider("set");
+    for (int i = 0; i < g_count; ++i) {
+        if (g_providers[i].set_fn == nullptr) continue;
+        if (g_providers[i].set_fn(key, value, reply, reply_size)) return true;
+    }
+    return false;   // no role claims this key
+}
+
+bool dispatchGet(const char* key, char* reply, size_t reply_size) {
+    if (key == nullptr || reply == nullptr || reply_size == 0) return false;
+    reply[0] = '\0';
+    warnIfNoProvider("get");
+    for (int i = 0; i < g_count; ++i) {
+        if (g_providers[i].get_fn == nullptr) continue;
+        if (g_providers[i].get_fn(key, reply, reply_size)) return true;
+    }
+    return false;   // no role claims this key
+}
+
+// ---------------------------------------------------------------------------
+// Shared parse helpers
+// ---------------------------------------------------------------------------
+
+bool strEq(const char* a, const char* b) {
+    return a != nullptr && b != nullptr && strcmp(a, b) == 0;
+}
+
+bool parseBool(const char* v, bool& out) {
+    if (v == nullptr) return false;
+    while (*v == ' ') ++v;
+    if (strEq(v, "1") || strEq(v, "true")  || strEq(v, "on"))  { out = true;  return true; }
+    if (strEq(v, "0") || strEq(v, "false") || strEq(v, "off")) { out = false; return true; }
+    return false;
+}
+
+bool parseIndexedKey(const char* key, const char* prefix, int max_index,
+                     int& out_index, const char*& out_field) {
+    if (key == nullptr || prefix == nullptr || max_index <= 0) return false;
+    size_t pl = strlen(prefix);
+    if (strncmp(key, prefix, pl) != 0) return false;
+    const char* p = key + pl;
+    if (*p < '0' || *p > '9') return false;          // index must be present
+    long v = strtol(p, nullptr, 10);
+    if (v < 0 || v >= (long)max_index) return false; // out of range
+    while (*p >= '0' && *p <= '9') ++p;              // past index digit(s)
+    if (*p != '.' || *(p + 1) == '\0') return false; // need '.' + non-empty field
+    out_index = (int)v;
+    out_field = p + 1;
+    return true;
+}
+
+}  // namespace config
+}  // namespace offband

--- a/src/helpers/config/ConfigDispatch.h
+++ b/src/helpers/config/ConfigDispatch.h
@@ -1,0 +1,118 @@
+// src/helpers/config/ConfigDispatch.h
+//
+// Epic #300 item 1 (#364): role-agnostic config-command dispatch.
+//
+// Extracted from wifi_observer/ObserverCli.cpp, where configSet/configGet were
+// hardwired to observer keys and took MqttBrokerPool&. This component owns only
+// the DISPATCH MECHANISM + the role-agnostic parse helpers; every key handler
+// stays owned by its role.
+//
+// Backs the companion-API config command (CMD_OFFBAND_CONFIG /
+// OffbandConfigProtocol.h). The firmware<->client wire contract (#143/#160) is
+// UNCHANGED by this component: `reply` is the same NUL-terminated human text the
+// role's handler produced, and a false return still means "no role claims this
+// key" (the caller answers OCFG_R_ERR "unknown config key").
+//
+// Registration model (Epic #300 decomposition item 1, owner-approved "Option A"):
+// each role registers ONE set/get function pair. The dispatcher asks each
+// provider in registration order; the first to claim the key wins. A role's
+// internal key ordering therefore stays entirely its own business -- which is
+// what lets the observer's order-sensitive if-chain (exact `wifi.enabled` MUST be
+// tested before the generic `wifi.` prefix, else the on/off switch is silently
+// written as a wifi field named "enabled") move across untouched.
+//
+// The repeater (#301/#305) registers its own provider for `wifi.mode`, WiFi
+// creds, command-queue and OTA keys without this file or the observer changing.
+//
+// Nothing here uses a platform-specific API beyond an #ifdef ARDUINO diagnostic
+// print, which is why the component is portable to nRF52 as well as ESP32.
+
+#pragma once
+#include <stddef.h>
+
+namespace offband {
+namespace config {
+
+// !! KEY SPACES MUST BE DISJOINT ACROSS ROLES -- FIRST PROVIDER WINS. !!
+//
+// Dispatch short-circuits on the first provider that returns true, so a provider
+// registered EARLIER shadows a later one for any key both would claim, silently.
+// This is a live hazard for #301, not a theoretical one: the observer provider
+// claims the ENTIRE `wifi.` prefix (`wifi.ssid`, `wifi.pwd`), so a repeater
+// provider registered after it will never be asked about those keys and its WiFi
+// config would be unreachable over the wire with no diagnostic.
+//
+// Before adding a role: enumerate its keys against every already-registered
+// role's keys and prefixes, and either keep them disjoint or deliberately reuse
+// the owning role's handler. A build/debug-time overlap detector is tracked
+// separately (see the #364 review follow-up) -- until it exists this is a manual
+// review obligation.
+//
+// A role's config entry points.
+//   reply  : NUL-terminated human text (what the client displays).
+//   return : true  -> this key is mine; `reply` is populated (incl. an "ERROR: "
+//                     string, which is still a handled key).
+//            false -> not my key; the dispatcher tries the next provider.
+//
+// CONTRACT: a provider MUST NOT leave content in `reply` when it returns false.
+// The dispatcher clears `reply` once before the walk; a provider that wrote
+// partial text and then declined the key would leave that text visible to the
+// next provider (and to a future provider that appends rather than overwrites).
+// Providers may clear `reply` themselves -- that is deliberate, so each stays
+// correct if ever called directly (e.g. from a test).
+typedef bool (*SetFn)(const char* key, const char* value, char* reply, size_t reply_size);
+typedef bool (*GetFn)(const char* key, char* reply, size_t reply_size);
+
+// Provider table capacity. Observer + repeater today, with headroom. Fixed
+// static storage -- no heap (tight-RAM boards; matches the raw-function-pointer
+// precedent in ObserverCli.h).
+static const int kMaxProviders = 4;
+
+// Register a role's provider. `role_name` is a static string used only in
+// diagnostics. Returns false if the table is full (SAFELANE 6: the caller must
+// not ignore this).
+bool registerProvider(SetFn set_fn, GetFn get_fn, const char* role_name);
+
+// Number of registered providers (diagnostics / tests).
+int providerCount();
+
+// Walk providers in registration order; first to claim `key` wins.
+// Returns false if NO provider claimed the key.
+bool dispatchSet(const char* key, const char* value, char* reply, size_t reply_size);
+bool dispatchGet(const char* key, char* reply, size_t reply_size);
+
+// ---------------------------------------------------------------------------
+// Shared, role-agnostic parse helpers (moved verbatim in behaviour from
+// ObserverCli.cpp so every role parses config values identically).
+// ---------------------------------------------------------------------------
+
+// NULL-safe strcmp == 0.
+bool strEq(const char* a, const char* b);
+
+// "1"/"true"/"on" -> true; "0"/"false"/"off" -> false; anything else leaves
+// `out` untouched and returns false. Leading spaces skipped.
+// (Was ObserverCli.cpp::parseConfigBool.)
+bool parseBool(const char* v, bool& out);
+
+// Parse "<prefix><index>.<field>" -> index + field pointer. Returns true iff the
+// key is well-formed: `prefix` matches, an index in [0, max_index) follows, and a
+// '.' precedes a NON-EMPTY field. `out_field` then points just past that '.'.
+// (Was ObserverCli.cpp::parseBrokerKey, generalised off the hardcoded
+// "mqtt.broker." / OFFBAND_MAX_BROKERS so the repeater can reuse it for its own
+// indexed key spaces.)
+bool parseIndexedKey(const char* key, const char* prefix, int max_index,
+                     int& out_index, const char*& out_field);
+
+// File-scope registrar: declaring one static instance in a role's .cpp registers
+// that role during static initialisation. The provider table is POD and lives in
+// .bss (zero-initialised before ANY dynamic initialiser runs), so this is safe
+// regardless of translation-unit link order -- and it removes the "a new role
+// forgot to call registerProvider()" failure mode entirely.
+struct ProviderRegistrar {
+    ProviderRegistrar(SetFn set_fn, GetFn get_fn, const char* role_name) {
+        registerProvider(set_fn, get_fn, role_name);
+    }
+};
+
+}  // namespace config
+}  // namespace offband

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -6,6 +6,9 @@
 #include "ConfigSchema.h"
 #include "WifiBootstrap.h"   // Plan 3 Task 10: get wifi.status walks
                              // WifiBootstrap::state()
+#include "../config/ConfigDispatch.h"   // #364: role-agnostic config dispatch --
+                                        // this file registers the observer's
+                                        // provider at the bottom.
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
@@ -947,35 +950,33 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
 //   return: true if the key was handled (incl. an ERROR reply); false if the
 //           key is unknown to the observer config surface.
 
-// "1"/"true"/"on" -> true; "0"/"false"/"off" -> false; else leave out, return false.
-static bool parseConfigBool(const char* v, bool& out) {
-    if (v == nullptr) return false;
-    while (*v == ' ') ++v;
-    if (eq(v, "1") || eq(v, "true")  || eq(v, "on"))  { out = true;  return true; }
-    if (eq(v, "0") || eq(v, "false") || eq(v, "off")) { out = false; return true; }
-    return false;
+// #364 (Epic #300 item 1): the parse LOGIC moved to the shared dispatcher
+// (helpers/config/ConfigDispatch.h) so every role parses config values
+// identically. These two thin adapters bind the observer's own constant
+// (OFFBAND_MAX_BROKERS) and keep the dispatch chain below byte-for-byte
+// unchanged -- behaviour is identical to the former local implementations.
+static inline bool parseConfigBool(const char* v, bool& out) {
+    return config::parseBool(v, out);
+}
+static inline bool parseBrokerKey(const char* key, int& out_slot, const char*& out_field) {
+    return config::parseIndexedKey(key, "mqtt.broker.", OFFBAND_MAX_BROKERS,
+                                   out_slot, out_field);
 }
 
-// Parse "mqtt.broker.<slot>.<field>" -> slot index + field pointer. Returns
-// true iff the key is a well-formed broker key (slot in range, '.' before a
-// non-empty field); out_field then points just past the '.'. Shared by
-// configSet/configGet so the slot/field walk lives in one place.
-static bool parseBrokerKey(const char* key, int& out_slot, const char*& out_field) {
-    if (strncmp(key, "mqtt.broker.", 12) != 0) return false;
-    const char* p = key + 12;
-    int slot = parseSlot(p);
-    if (slot < 0) return false;
-    while (*p >= '0' && *p <= '9') ++p;   // past slot digit(s)
-    if (*p != '.' || *(p + 1) == '\0') return false;
-    out_slot = slot;
-    out_field = p + 1;
-    return true;
-}
-
-bool configSet(const char* key, const char* value, char* reply, size_t reply_size,
-               MqttBrokerPool& pool) {
+// #364: the observer's config-SET provider, registered with the shared
+// dispatcher at the bottom of this file. Formerly the public
+// configSet(..., MqttBrokerPool&). The body is UNCHANGED; the only difference is
+// that the pool is taken from wifiObserverPool() instead of a parameter, because
+// the role-agnostic dispatcher must not know about MqttBrokerPool.
+//
+// Key ORDER below is load-bearing and must not be reordered: exact
+// `wifi.enabled` is tested before the generic `wifi.` prefix (else the on/off
+// switch is silently written as a wifi field named "enabled"), and the exact
+// `mqtt.*` keys before the `mqtt.broker.` family.
+static bool observerConfigSet(const char* key, const char* value, char* reply, size_t reply_size) {
     if (key == nullptr || value == nullptr || reply == nullptr || reply_size == 0) return false;
     reply[0] = '\0';
+    MqttBrokerPool& pool = wifiObserverPool();
 
     if (eq(key, "mqtt.iata"))            return handleSetIata(reply, reply_size, value);
     if (eq(key, "mqtt.status_interval")) return handleSetStatusInterval(reply, reply_size, value);
@@ -1030,7 +1031,10 @@ bool configSet(const char* key, const char* value, char* reply, size_t reply_siz
     return false;  // unknown key -- not part of the observer config surface
 }
 
-bool configGet(const char* key, char* reply, size_t reply_size) {
+// #364: the observer's config-GET provider (registered at the bottom of this
+// file). Formerly the public configGet(). Body unchanged. Secrets stay
+// write-only here (wifi.pwd / broker password|jwt_token).
+static bool observerConfigGet(const char* key, char* reply, size_t reply_size) {
     if (key == nullptr || reply == nullptr || reply_size == 0) return false;
     reply[0] = '\0';
 
@@ -1149,5 +1153,30 @@ size_t configRenderBrokerSlot(uint8_t slot, char* out, size_t out_size,
 #undef BKV
     return n;   // clamped written length (== strlen(out))
 }
+
+// ---------------------------------------------------------------------------
+// #364 (Epic #300 item 1): register the observer as a config provider.
+//
+// File-scope registrar -> runs during static initialisation. The dispatcher's
+// provider table is POD in .bss (zero-initialised before ANY dynamic
+// initialiser), so this is link-order safe, and there is nothing for a future
+// role to forget to call from main().
+//
+// This registration is the ONLY thing that couples the observer to the shared
+// dispatcher. The repeater (#301/#305) adds its own registrar for its own keys
+// without touching this file.
+// ---------------------------------------------------------------------------
+// __attribute__((used)): belt-and-braces against the compiler/linker dropping an
+// object whose only purpose is its constructor's side effect. NOT a fix for an
+// observed defect -- verified present on the linked ESP32-S3 image (#364 review,
+// BLOCKER-1): .init_array entry 6 == _GLOBAL__sub_I_...setDisplayAlwaysOnApplier,
+// whose whole body is one call to config::registerProvider. ESP-IDF's linker
+// script KEEPs .init_array, and this TU is always pulled in (dispatchObserverCli
+// / configBrokerSlotCount are referenced elsewhere), so it cannot be dropped as
+// an unextracted archive member either. Kept as free insurance against a future
+// toolchain/flag change, since the failure mode -- every config key answering
+// "unknown config key" on a deployed fleet -- is severe.
+static __attribute__((used)) config::ProviderRegistrar _observer_config_provider(
+    &observerConfigSet, &observerConfigGet, "observer");
 
 }  // namespace offband

--- a/src/helpers/wifi_observer/ObserverCli.h
+++ b/src/helpers/wifi_observer/ObserverCli.h
@@ -47,15 +47,19 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
                          MqttBrokerPool& pool);
 
 // Epic F (#165): typed config dispatch -- the wire path's set/get backend.
-// configSet/configGet route a config key straight to the same handlers the
-// _sys CLI uses (above), WITHOUT re-parsing a CLI string. Consumed by the
-// companion-API config command (CMD_OFFBAND_CONFIG / OffbandConfigProtocol.h).
-// `reply` is NUL-terminated human text; returns true if the key was handled
-// (reply populated, incl. an ERROR string), false if the key is unknown.
+// A config key routes straight to the same handlers the _sys CLI uses (above),
+// WITHOUT re-parsing a CLI string. Consumed by the companion-API config command
+// (CMD_OFFBAND_CONFIG / OffbandConfigProtocol.h).
+//
+// #364 (Epic #300 item 1): the former public configSet()/configGet() are now
+// file-static providers in ObserverCli.cpp, registered with the role-agnostic
+// dispatcher in helpers/config/ConfigDispatch.h. Call
+// offband::config::dispatchSet() / dispatchGet() instead -- same reply text,
+// same "false == unknown key" contract, same wire behaviour (#143/#160
+// unchanged), but the repeater can register its own keys alongside the
+// observer's. Registration is automatic when this translation unit is linked.
+//
 // Secrets stay write-only on get (wifi.pwd / broker password|jwt_token).
-bool configSet(const char* key, const char* value, char* reply, size_t reply_size,
-               MqttBrokerPool& pool);
-bool configGet(const char* key, char* reply, size_t reply_size);
 
 // Epic F (#162): broker-pool enumeration for the OCFG_BROKERS paginated read.
 // configBrokerSlotCount() = max slots to iterate; configBrokerSlotPopulated() =

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -438,3 +438,4 @@ build_flags =
 build_src_filter =
   ${env:Heltec_v3_companion_radio_ble.build_src_filter}
   +<helpers/wifi_observer/*.cpp>
+  +<helpers/config/*.cpp>            ; #364: shared role-agnostic config dispatch

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -584,6 +584,7 @@ build_flags =
 build_src_filter =
   ${env:heltec_v4_companion_radio_ble.build_src_filter}
   +<helpers/wifi_observer/*.cpp>
+  +<helpers/config/*.cpp>            ; #364: shared role-agnostic config dispatch
 [env:heltec_v4_kiss_modem]
 extends = Heltec_lora32_v4
 build_src_filter = ${Heltec_lora32_v4.build_src_filter}
@@ -613,6 +614,7 @@ build_flags =
 build_src_filter =
   ${env:heltec_v4_tft_companion_radio_ble.build_src_filter}
   +<helpers/wifi_observer/*.cpp>
+  +<helpers/config/*.cpp>            ; #364: shared role-agnostic config dispatch
 lib_deps =
   ${env:heltec_v4_tft_companion_radio_ble.lib_deps}
   ${esp32_ble.lib_deps}

--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -272,6 +272,7 @@ build_flags =
 build_src_filter =
   ${env:Xiao_S3_WIO_companion_radio_ble.build_src_filter}
   +<helpers/wifi_observer/*.cpp>
+  +<helpers/config/*.cpp>            ; #364: shared role-agnostic config dispatch
 [env:Xiao_S3_WIO_kiss_modem]
 extends = Xiao_S3_WIO
 build_src_filter = ${Xiao_S3_WIO.build_src_filter}


### PR DESCRIPTION
Closes #364. **Epic #300 item 1** of Feature #295. Design-of-record: `docs/architecture/2026-07-17-repeater-telemetry-genericization-dor.md` §5 / D2.

**Pure internal refactor — no behaviour change, wire contract byte-compatible.**

## What this does

Moves the config-command **dispatch mechanism** out of the observer role so other roles can register their own config keys. Every key **handler** stays owned by its role.

New `src/helpers/config/ConfigDispatch.{h,cpp}`:
- **Provider registry** — each role registers one `{SetFn, GetFn}` pair; dispatch walks providers in registration order, first to claim a key wins.
- **Shared role-agnostic parse helpers** — `parseBool`, `parseIndexedKey`, `strEq` (were `parseConfigBool` / `parseBrokerKey` inside `ObserverCli.cpp`).
- **Fixed static storage, no heap.** POD table in `.bss`.
- **Loud on every target** (Arduino *and* host) if the table is empty or full.

`ObserverCli`: the former public `configSet`/`configGet` become file-static providers registered by a file-scope `ProviderRegistrar`.

`MyMesh`: the two wire call sites now use `offband::config::dispatchSet` / `dispatchGet`. The pool is no longer threaded through the config path.

## Why "Option A" (one function pair per role, not a per-key table)

The observer's key chain is **order-sensitive** and the ordering is load-bearing: exact `wifi.enabled` must be tested before the generic `wifi.` prefix, or the boolean switch gets written to NVS as a wifi field literally named `enabled`. Same trap with exact `mqtt.*` ahead of the `mqtt.broker.` family.

Registering one function pair let that chain move across **unmodified**, so ordering is preserved *by construction* rather than re-encoded into a table's precedence rules. Two thin local adapters bind `OFFBAND_MAX_BROKERS` to the shared helpers so the chain body itself is untouched.

## Verification

| Gate | Result |
|---|---|
| Client-visible reply/format strings | **131 strings, empty diff** before vs after (mechanical extract + compare, re-run against the post-rebase base) |
| Parse-helper parity vs originals | **52/52 inputs, 0 failures** — out-of-range slot, `00`/`+1` indices, NULL, leading whitespace, case variants. Host build, `-Wall -Wextra` clean |
| Registration actually links **and** runs | `.init_array` entry 6 → ObserverCli's static-init ctor → single `call8` to `config::registerProvider`, read off the linked ESP32-S3 image |
| Builds | **5/5 SUCCESS** — `heltec_v4`, `Heltec_v3`, `heltec_v4_tft`, `Xiao_S3_WIO` observer envs + `RAK_4631_companion_radio_usb` (nRF52) |
| Non-observer compilation | Component compiled clean into the nRF52 env with **zero observer sources present** (temporary filter add, reverted) |

The reply text is part of the contract — the client displays it — which is why the string diff is the primary gate rather than an eyeball review.

## Gemini adversarial review — adjudicated

Review log: `docs/llm-consultations/2026-07-24-364-config-dispatch-review-gemini-gemini-2.5-pro.log` (untracked, per repo convention for consult logs).

**1 BLOCKER / 2 MAJOR / 3 MINOR raised. 4 accepted, 2 rejected.**

### BLOCKER-1 — "linker may discard the registrar, killing the whole config surface" → accepted as hardening, **severity rejected**
Claim: `--gc-sections`/LTO could drop the file-scope registrar, so every config key would answer "unknown config key" on a deployed fleet.

**Not a current defect** — verified on the linked image before the review even ran: the ctor **is** `.init_array` entry 6 and its entire body is one call to `registerProvider`. It also cannot be dropped as an unextracted archive member, because other symbols in that TU (`dispatchObserverCli`, `configBrokerSlotCount`) are referenced elsewhere, and ESP-IDF's linker script `KEEP`s `.init_array`.

Added `__attribute__((used))` anyway — free, and the failure mode is severe enough to insure against a future toolchain/flag change. The code comment records it as **insurance, not a fix**, so nobody later mistakes it for a bug that existed.

### MAJOR-1 — error reporting only under `#ifdef ARDUINO` → **accepted, fixed**
Empty/full provider table was silent on non-Arduino builds, so a host or unit-test build would hide a dead config surface. Added an `fprintf(stderr, …)` path for non-Arduino. Kept non-fatal rather than `assert` — aborting is a policy decision this library shouldn't make for its callers.

### MAJOR-2 — first-provider-wins silently shadows overlapping keys → **accepted**
Real and live, not theoretical: the observer provider claims the **entire `wifi.` prefix**, so a future repeater/companion provider registered after it would never be asked about `wifi.ssid`/`wifi.pwd` — no error, no diagnostic.

Documented prominently in `ConfigDispatch.h` with the concrete `wifi.` example. Mechanical detection filed as **#366**, sequenced with/before #301. Also cross-linked to **#365** (Companion WiFi at runtime), where this trap would bite first.

### MINOR-2 — provider returning `false` may leave stale `reply` → **accepted**
Contract documented ("a provider MUST NOT leave content in `reply` when it returns false"). Verified the observer providers comply: only two `return false` paths each — the NULL-arg guard (before any write) and the final unknown-key return (buffer holds only `'\0'`).

### MINOR-1 — "remove the redundant `reply[0]='\0'` from providers" → **REJECTED**
The redundancy is deliberate: it keeps each provider correct if ever called directly (e.g. from a test), and removing those lines would edit the very function bodies whose byte-identity is this change's core safety property. Cost is one store instruction. Intent documented instead.

### MINOR-3 — "replace `eq()` with NULL-safe `strEq()` everywhere" → **REJECTED, premise is factually wrong**
The existing `eq()` **is** NULL-safe (`ObserverCli.cpp:25`):
```cpp
static bool eq(const char* a, const char* b) {
    return a != nullptr && b != nullptr && strcmp(a, b) == 0;
}
```
The stated impact ("would crash on a NULL key") does not exist. Separately, `eq` has 71 call sites across the whole CLI path — out of scope, and churning them in a zero-behaviour-change refactor is exactly the risk this change is structured to avoid.

## Explicitly NOT in this PR

- **Observer hardware no-regression gate** — Epic #300 decomposition **item 3**. Operating a real observer on this firmware against the **currently released** app. **MANDATORY before #301 proceeds.** Not done, not claimed; needs its own task and bench time.
- Repeater key registration (#301 / #305).
- Broker-slot enumeration API (`configBrokerSlotCount` / `configBrokerSlotPopulated` / `configRenderBrokerSlot`) — deliberately left observer-owned.
- Extracting the `wifi.*` handlers into a shared `WifiConfigProvider` — needed by **#365**; owner decision pending on whether that lands under #300 or #365.

## Review notes

- Base moved during the work (`0ae494c5` → `b49babc0`); rebased onto current `firmware-base` and **all audits + all 5 builds re-run after the rebase**. No file overlap with the intervening commits.
- Branch was force-pushed once (`--force-with-lease`) to update it after that rebase — unshared branch, no prior PR.

⚠ **`firmware-base` has no required status checks, so `--auto` merges immediately.** Please merge deliberately; I have not enabled auto-merge.

Agent: DarkLynx (session 17550faa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
