### PR TITLE
chore(#374): repoint FUNDING.yml from upstream to Offband

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
-github: meshcore-dev
+github: [Strycher]
+ko_fi: offband


### PR DESCRIPTION
`.github/FUNDING.yml` was inherited from the upstream fork (`github: meshcore-dev`), so this repo's Sponsor button funded upstream MeshCore instead of this project.

Repoints to the live paths:
- GitHub Sponsors: github.com/sponsors/Strycher
- Ko-fi: ko-fi.com/offband

Upstream attribution is untouched (README, LICENSE, offband.org/about). No code impact; `.github/` only. Closes #374.