### PR TITLE
fix: redact indented label-less CLI reply (get wifi.ssid) — SSID leak

### DIFF
--- a/scripts/_cap_serial.py
+++ b/scripts/_cap_serial.py
@@ -18,10 +18,13 @@ plus conservative generic catch-alls for the unknown gessaman source.
 Redaction is IN-LINE (the secret value is replaced, the rest of the line is kept)
 so diagnostic context that shares a line with a secret is preserved.
 
-Known limitation: label-less interactive CLI replies — `get guest_password` /
-`get bridge_secret` print `> <value>` with no key — cannot be caught by
-line-checking. Testers are told below not to run password `get` commands during
-capture.
+Known limitation: label-less interactive CLI replies. The serial console prints
+`get wifi.ssid` / `get guest_password` / `get bridge_secret` replies as an
+indented "  > <value>" with no field name. The single-line form IS now caught
+(#382). A hypothetical value-on-the-NEXT-line reply ("> \n<value>") would not be —
+line-based redaction can't see across lines, and our firmware doesn't emit that
+form (CommonCLI `> %s` is single-line). Testers are told below not to run any
+secret-returning `get` command during capture.
 
 Context: OffbandMesh/meshcore-firmware#379 (OKI-Mesh/CoreScope#72) — capture the
 device side of an observer that stopped publishing to MQTT and did not reconnect.
@@ -68,11 +71,15 @@ _REDACTIONS = [
     (re.compile(r"(\b[\w.-]*(?:password|passwd|pwd|psk|secret|token|apikey|api_key|bearer|pass)\b\s*[:=]\s*)([^\r\n]+)",
                 re.IGNORECASE), r"\1<redacted:secret>"),
 
-    # Last-resort net for label-less interactive CLI replies. CommonCLI prints
-    # `get guest_password` / `get bridge_secret` as "> <value>" with no key, so
-    # nothing above can catch them. Normal runtime logs use "[Tag]" prefixes,
-    # not a leading "> ", so over-redaction risk is low. Anchored to line start.
-    (re.compile(r"(^>\s*)([^\r\n]+)"), r"\1<redacted:cli-reply>"),
+    # Last-resort net for label-less interactive CLI replies. The serial console
+    # prints `get wifi.ssid` / `get guest_password` / `get bridge_secret` replies
+    # as "> <value>" with NO field label (CommonCLI `> %s`), so nothing above can
+    # catch them -- the grounded `wifi.ssid =` rule only matches the _sys-channel
+    # format. #382: the live reply is INDENTED ("  > tsunami"), so the anchor must
+    # allow leading whitespace (`^\s*>`); the original `^>` missed it and leaked a
+    # real SSID on the bench. Normal runtime logs use "[Tag]" prefixes, not a
+    # leading ">", so over-redaction risk stays low.
+    (re.compile(r"(^\s*>\s*)([^\r\n]+)"), r"\1<redacted:cli-reply>"),
 ]
 
 
@@ -116,8 +123,9 @@ TESTER_INSTRUCTIONS = """\
  2. Let it run through the problem window (e.g. force the WiFi drop/return you
     are debugging). Capture keeps going until you press Ctrl-C (or --secs).
  3. WiFi SSID, tokens and known secrets are redacted automatically before the
-    file is written -- but DO NOT type `get guest_password` / `get bridge_secret`
-    in the device CLI while capturing (those replies can't be auto-redacted).
+    file is written -- but as a precaution DO NOT run any secret-returning `get`
+    command (e.g. `get guest_password`, `get bridge_secret`) in the device CLI
+    while capturing.
  4. When done, send us the file printed at the end.
 ============================================================================
 """

--- a/scripts/test_observer_log_redaction.py
+++ b/scripts/test_observer_log_redaction.py
@@ -47,6 +47,11 @@ MUST_REDACT = [
     ("reconnect-token: aWReallyLongTokenValue", "aWReallyLongTokenValue"),
     # Label-less interactive CLI reply (Gemini Finding 5)
     ("> s3cr3t_bridge_v4lu3", "s3cr3t_bridge_v4lu3"),
+    # #382 regression: the live `get wifi.ssid` serial reply is INDENTED
+    # ("  > <SSID>"). The old `^>` anchor missed the leading whitespace and
+    # leaked a real SSID on the bench. Placeholder value, never a real SSID.
+    ("  > PlaceholderNet", "PlaceholderNet"),           # two-space indent
+    ("\t> AnotherSSID_value", "AnotherSSID_value"),     # tab indent
 ]
 
 # Diagnostic lines that must survive untouched — redaction must not gut the log.
@@ -64,6 +69,7 @@ MUST_PRESERVE = [
     # catch-all, which would have scrubbed this).
     "observer pubkey = B4680F16DBFC443EC2D00FB7AF2181EA96C2C4D4A65C2E93E054BB159D81F3BA",
     "[WifiObserver] STA connected, RSSI=-67 dBm",    # a normal [Tag] line, not a '>' reply
+    "  [hb] up=61s free_heap=67820",                 # #382: indented tag line must survive (no '>')
 ]
 
 


### PR DESCRIPTION
Closes #382. Fixes the redacting serial-capture tool landed under #379.

## The leak (found on live bench)
`get wifi.ssid` over the **serial console** replies label-less and indented — `  > <SSID>` (CommonCLI `> %s`), not the `_sys`-channel `wifi.ssid = <SSID>` the grounded rule matched. The label-less net was anchored `^>` at column 0, so the leading whitespace defeated it and a **real SSID passed through unredacted**.

## Fix
`^>` → `^\s*>` — indented `> value` replies now redact to `> <redacted:cli-reply>`.

## Tests
Regression cases with the exact live format (space- and tab-indented `> value`, placeholder SSIDs) + an indented `[Tag]` line that must survive. All pass (15+ secret / 11 preserve).

## Gemini re-review
No over-redaction. Flagged a hypothetical value-on-next-line (`> \n<value>`) reply — **declined** the stateful rewrite (our firmware emits single-line `> %s`, verified in source + on device) and instead broadened the tester warning to any secret-returning `get` and documented the residual.