### PR TITLE
docs: tester guide for the serial-log-capture tool

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ Offband is a [MeshCore](https://github.com/meshcore-dev/MeshCore) fork for cross
 - [Observer CLI (`_sys` channel)](./observer-cli-commands.md) — WiFi / MQTT broker config for the observer
 - [Observer GPS & location](./observer-gps-location-config.md) — GPS / time-source / privacy configuration
 - [Serial CLI & MQTT commands](./cli-and-mqtt-commands.md) — serial CLI plus the MQTT command / OTA reference
+- [Capturing a serial log](./serial-log-capture.md) — download & run the host-side capture tool (redacts WiFi creds) to send us a device log
 - [SafeBoot](./safeboot.md) — pre-init power guard for solar / battery nodes
 - [Observer architecture](./architecture/2026-06-01-observer-architecture-review.md) — design of record
 

--- a/docs/serial-log-capture.md
+++ b/docs/serial-log-capture.md
@@ -1,0 +1,19 @@
+# Capturing a serial log from a device
+
+When a device misbehaves (e.g. an observer stops publishing to MQTT), we may ask you to capture its **serial log** and send it back. `scripts/_cap_serial.py` does this and **strips WiFi credentials and tokens** before writing the file.
+
+**You need:** the device on USB, Python 3, and pyserial (`pip install pyserial`).
+
+## Steps
+
+1. Download the tool: [`scripts/_cap_serial.py`](https://raw.githubusercontent.com/OffbandMesh/meshcore-firmware/firmware-base/scripts/_cap_serial.py)
+2. Plug the device into USB.
+3. Run `python _cap_serial.py` — it auto-detects the port, handles DTR, and writes `observer-serial-<timestamp>.log`.
+4. Reproduce the problem, then press **Ctrl-C** to stop.
+5. Send us the `.log` file.
+
+## Notes
+
+- WiFi SSID/PSK and tokens are redacted automatically. Don't run any `get <secret>` command (e.g. `get guest_password`) while capturing.
+- Several devices plugged in? Add `--port COMx`.
+- Empty file? It auto-asserts DTR after 3s; if still empty the device isn't printing.


### PR DESCRIPTION
Closes #388. Documents the host-side serial-capture tool from #379.

New page `docs/serial-log-capture.md` — requirements, download link, run steps, redaction note, empty-file/port troubleshooting. Linked from `docs/index.md` ("Offband guides") so it's on the published docs site and searchable — a user can find it without being re-told. Content approved by Ben. App-side path is epic #384.