### PR TITLE
chore(#317): reseed default broker slots — OKIMesh mqtt2 in, LetsMesh out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,23 @@ prior to 0.13.0 predate it; see `git tag -l 'crosswire-v*'` and the tag
 annotations for that history (highlights: v0.12.0 NimBLE migration, v0.11.x
 Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
+## [Unreleased]
+
+### Changed
+- **Default broker slots reseated** — the OKI Mesh's own two brokers now hold slots 0
+  and 1: slot 0 `mqtt1.okimesh.org` (relabelled from "CoreScope Dayton", same host) and
+  slot 1 `mqtt2.okimesh.org` (new, same plaintext/anonymous/1883 config). MeshMapper and
+  eastme.sh swap to slots 2 and 3, Eastmesh.au moves 5 → 4, and slot 5 frees up for
+  operator use. **LetsMesh-US and LetsMesh-EU are no longer seeded** — both remain fully
+  supported and can be added by hand in any free slot (`gts-r4` still resolves). Every
+  seeded slot still ships disabled per #262. Because seeding is skip-if-present, this
+  only affects fresh-NVS devices; existing devices keep their current layout. (#317)
+
+### Fixed
+- **NVS round-trip test asserted a stale default** — the test still required slot 0 to
+  seed as *enabled*, which #262 changed to disabled on 2026-07-02 without updating the
+  assertion. Corrected alongside the #317 layout change. (#317)
+
 ## [1.2.0] - 2026-07-21
 
 Adds **MeshSmith Photon‑1W support** (both MCU flavors) on the **MeshCore 1.16.0** base, and **receive-sensitivity recovery on Heltec V4** (external FEM LNA control, which stock MeshCore leaves bypassed),

--- a/docs/observer-cli-commands.md
+++ b/docs/observer-cli-commands.md
@@ -134,16 +134,29 @@ mqtt status
   eastme.sh; some brokers expect a `v1_<pubkey>` prefix. If a wss slot won't
   authenticate, try the other form. (Defaulting this per broker is #95.)
 
-### Known broker values
+### Seeded broker slots (#317)
+
+| Slot | Broker | url | ca_cert | jwt_audience |
+|---|---|---|---|---|
+| 0 | OKIMesh mqtt1 | `mqtt://mqtt1.okimesh.org:1883` | — (tcp / anon) | — |
+| 1 | OKIMesh mqtt2 | `mqtt://mqtt2.okimesh.org:1883` | — (tcp / anon) | — |
+| 2 | MeshMapper | `wss://mqtt.meshmapper.net:443/mqtt` | `isrg-x2` | `mqtt.meshmapper.net` |
+| 3 | eastme.sh | `wss://mqtt.eastme.sh:443/mqtt` | `letsencrypt` | `mqtt.eastme.sh` |
+| 4 | Eastmesh.au | `wss://mqtt2.eastmesh.au:443/mqtt` | `letsencrypt` | `mqtt2.eastmesh.au` |
+| 5–9 | *(empty)* | — | — | — |
+
+**Every seeded slot ships disabled** (#262) — `mqtt enable <N>` to opt in.
+
+**LetsMesh is no longer seeded** (#317). To add it by hand in a free slot:
+
 | Broker | url | ca_cert | jwt_audience |
 |---|---|---|---|
-| CoreScope | `mqtt://mqtt.w8oof.net:1883` | — (tcp / anon) | — |
 | LetsMesh-US | `wss://mqtt-us-v1.letsmesh.net:443/mqtt` | `gts-r4` | `mqtt-us-v1.letsmesh.net` (bare) |
-| eastme.sh | `wss://mqtt.eastme.sh:443/mqtt` | `letsencrypt` | `mqtt.eastme.sh` |
+| LetsMesh-EU | `wss://mqtt-eu-v1.letsmesh.net:443/mqtt` | `gts-r4` | `mqtt-eu-v1.letsmesh.net` (bare) |
 
-The firmware also seeds **MeshMapper** (slot 3), **LetsMesh-EU** (slot 4), and
-**Eastmesh.au** (slot 5) as defaults — run `mqtt view 3` / `4` / `5` for their
-exact `url` / `ca_cert` / `jwt_audience`.
+> **Devices flashed before #317 keep their old layout.** Seeding is
+> skip-if-present, so a reorder never reshuffles a device that was already
+> seeded — run `mqtt view <N>` to see what a given slot actually holds.
 
 ## Gotchas
 

--- a/scripts/test_observer_nvs_round_trip.py
+++ b/scripts/test_observer_nvs_round_trip.py
@@ -150,11 +150,12 @@ int main() {
     // populateDefaultBrokers — Plan 2 v2 Task 3 Step 5
     // -----------------------------------------------------------------------
     // Slot 2 was just written above with a custom URL ("mqtt.example.org").
-    // Slots 0 + 1 + 3 are still virgin. populateDefaultBrokers should (#95):
-    //   - fill slot 0 with CoreScope (tcp/anon, the only default-ENABLED slot)
-    //   - fill slot 1 with LetsMesh-US (wss/jwt, disabled, BARE audience)
-    //   - fill slot 3 with MeshMapper (wss/jwt, disabled, isrg-x2 CA)
-    //   - LEAVE slot 2 alone (already has user-set URL)
+    // Slots 0 + 1 + 3 are still virgin. populateDefaultBrokers should (#317):
+    //   - fill slot 0 with OKIMesh mqtt1 (tcp/anon, disabled since #262)
+    //   - fill slot 1 with OKIMesh mqtt2 (tcp/anon, disabled)
+    //   - fill slot 3 with Eastme.sh (wss/jwt, disabled, letsencrypt CA)
+    //   - LEAVE slot 2 alone (already has user-set URL -- would otherwise be
+    //     MeshMapper under the #317 layout)
 
     populateDefaultBrokers();
 
@@ -164,7 +165,8 @@ int main() {
     if (!readBrokerConfig(2, slot2)) { puts("FAIL read slot 2"); return 1; }
     if (!readBrokerConfig(3, slot3)) { puts("FAIL read slot 3"); return 1; }
 
-    // Slot 0 = CoreScope: plaintext + anonymous, the ONLY default-enabled slot.
+    // Slot 0 = OKIMesh mqtt1: plaintext + anonymous. Ships DISABLED (#262 --
+    // a fresh flash must not auto-publish anywhere).
     if (strcmp(slot0.url, "mqtt://mqtt1.okimesh.org:1883") != 0) {  // #170: was mqtt.w8oof.net
         printf("FAIL slot 0 url after populate: '%s'\n", slot0.url);
         return 1;
@@ -177,48 +179,58 @@ int main() {
         printf("FAIL slot 0 auth_type: %d\n", (int)slot0.auth_type);
         return 1;
     }
-    if (!slot0.enabled) {
-        printf("FAIL slot 0 (CoreScope) should default to ENABLED\n");
+    if (slot0.enabled) {
+        printf("FAIL slot 0 (OKIMesh mqtt1) should default to DISABLED (#262)\n");
         return 1;
     }
 
-    // Slot 1 = LetsMesh-US (wss/jwt). Ships disabled; audience is the BARE
-    // host (#95 -- LetsMesh rejects the scheme-qualified "https://" form).
-    if (strcmp(slot1.url, "wss://mqtt-us-v1.letsmesh.net:443/mqtt") != 0) {
+    // Slot 1 = OKIMesh mqtt2 (#317): same plaintext/anon config as mqtt1,
+    // also disabled. Replaced LetsMesh-US, which is no longer seeded.
+    if (strcmp(slot1.url, "mqtt://mqtt2.okimesh.org:1883") != 0) {
         printf("FAIL slot 1 url after populate: '%s'\n", slot1.url);
         return 1;
     }
-    if (strcmp(slot1.jwt_audience, "mqtt-us-v1.letsmesh.net") != 0) {
-        printf("FAIL slot 1 jwt_audience (want bare host): '%s'\n", slot1.jwt_audience);
+    if (slot1.transport != BrokerTransport::Tcp) {
+        printf("FAIL slot 1 transport: %d\n", (int)slot1.transport);
         return 1;
     }
-    if (slot1.transport != BrokerTransport::Wss || slot1.auth_type != BrokerAuthType::Jwt) {
-        printf("FAIL slot 1 transport/auth: %d/%d\n", (int)slot1.transport, (int)slot1.auth_type);
+    if (slot1.auth_type != BrokerAuthType::None) {
+        printf("FAIL slot 1 auth_type: %d\n", (int)slot1.auth_type);
         return 1;
     }
     if (slot1.enabled) {
-        printf("FAIL slot 1 (wss/jwt) should default to disabled\n");
+        printf("FAIL slot 1 (OKIMesh mqtt2) should default to disabled\n");
+        return 1;
+    }
+
+    // Slot 3 = Eastme.sh (#317, moved from slot 2): wss/jwt, letsencrypt CA,
+    // BARE audience (#95 -- the scheme-qualified "https://" form is rejected
+    // by strict validators like LetsMesh).
+    if (strcmp(slot3.url, "wss://mqtt.eastme.sh:443/mqtt") != 0) {
+        printf("FAIL slot 3 url after populate: '%s'\n", slot3.url);
+        return 1;
+    }
+    if (strcmp(slot3.jwt_audience, "mqtt.eastme.sh") != 0) {
+        printf("FAIL slot 3 jwt_audience (want bare host): '%s'\n", slot3.jwt_audience);
+        return 1;
+    }
+    if (strcmp(slot3.ca_cert_name, "letsencrypt") != 0) {
+        printf("FAIL slot 3 ca_cert_name: '%s'\n", slot3.ca_cert_name);
+        return 1;
+    }
+    if (slot3.transport != BrokerTransport::Wss || slot3.auth_type != BrokerAuthType::Jwt) {
+        printf("FAIL slot 3 transport/auth: %d/%d\n", (int)slot3.transport, (int)slot3.auth_type);
+        return 1;
+    }
+    if (slot3.enabled) {
+        printf("FAIL slot 3 (wss/jwt) should default to disabled\n");
         return 1;
     }
     // #95: JWT identity claims are NOT seeded -- username auto-derives at
     // connect, and jwt_owner/jwt_email are the operator's claims.
-    if (slot1.jwt_owner[0] != '\0' || slot1.jwt_email[0] != '\0' || slot1.username[0] != '\0') {
-        printf("FAIL slot 1 identity claims should be empty: own='%s' eml='%s' usr='%s'\n",
-               slot1.jwt_owner, slot1.jwt_email, slot1.username);
-        return 1;
-    }
-
-    // Slot 3 = MeshMapper (#95 new slot): wss/jwt, isrg-x2 CA, bare audience.
-    if (strcmp(slot3.url, "wss://mqtt.meshmapper.net:443/mqtt") != 0) {
-        printf("FAIL slot 3 url after populate: '%s'\n", slot3.url);
-        return 1;
-    }
-    if (strcmp(slot3.jwt_audience, "mqtt.meshmapper.net") != 0) {
-        printf("FAIL slot 3 jwt_audience (want bare host): '%s'\n", slot3.jwt_audience);
-        return 1;
-    }
-    if (strcmp(slot3.ca_cert_name, "isrg-x2") != 0) {
-        printf("FAIL slot 3 ca_cert_name: '%s'\n", slot3.ca_cert_name);
+    if (slot3.jwt_owner[0] != '\0' || slot3.jwt_email[0] != '\0' || slot3.username[0] != '\0') {
+        printf("FAIL slot 3 identity claims should be empty: own='%s' eml='%s' usr='%s'\n",
+               slot3.jwt_owner, slot3.jwt_email, slot3.username);
         return 1;
     }
 

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -370,22 +370,30 @@ bool clearBrokerConfig(uint8_t slot) {
 // changing this layout does NOT re-shuffle slots on a device already seeded
 // under an older layout; it takes effect only on a fresh NVS.)
 //
-//   slot 0  CoreScope Dayton   mqtt://mqtt1.okimesh.org:1883    tcp / anon   disabled  (#262)
-//   slot 1  LetsMesh-US        wss://mqtt-us-v1.letsmesh.net    wss / jwt    disabled
-//   slot 2  Eastme.sh          wss://mqtt.eastme.sh             wss / jwt    disabled
-//   slot 3  MeshMapper         wss://mqtt.meshmapper.net        wss / jwt    disabled
-//   slot 4  LetsMesh-EU        wss://mqtt-eu-v1.letsmesh.net    wss / jwt    disabled
-//   slot 5  Eastmesh.au        wss://mqtt2.eastmesh.au          wss / jwt    disabled
-//   slots 6-9  (MQTT Custom)   left empty for the operator to fill
+//   slot 0  OKIMesh mqtt1      mqtt://mqtt1.okimesh.org:1883    tcp / anon   disabled  (#262)
+//   slot 1  OKIMesh mqtt2      mqtt://mqtt2.okimesh.org:1883    tcp / anon   disabled  (#317)
+//   slot 2  MeshMapper         wss://mqtt.meshmapper.net        wss / jwt    disabled
+//   slot 3  Eastme.sh          wss://mqtt.eastme.sh             wss / jwt    disabled
+//   slot 4  Eastmesh.au        wss://mqtt2.eastmesh.au          wss / jwt    disabled
+//   slots 5-9  (MQTT Custom)   left empty for the operator to fill
+//
+// #317 reseat: the OKI Mesh's own two brokers now hold slots 0-1 (mqtt1 was
+// formerly labelled "CoreScope Dayton"; mqtt2 is new and shares mqtt1's
+// plaintext/anon/1883 config). LetsMesh-US and LetsMesh-EU were DROPPED from
+// the seed to make room -- they remain fully supported for operators who add
+// them by hand ("gts-r4" still resolves in lookupCaCertPem(), and the bare-host
+// audience note below still applies). MeshMapper and Eastme.sh swapped to 2/3;
+// Eastmesh.au moved 5 -> 4.
 //
 // As of #262 NO slot is enabled by default -- a fresh flash must not
-// auto-publish to any upstream broker. CoreScope (slot 0, plaintext + anon,
-// no TLS cert / no JWT; validated live on HV3 -- #42/#48) was formerly the
-// sole default-enabled slot, which made out-of-region fresh flashes feed
+// auto-publish to any upstream broker. Slot 0 (plaintext + anon, no TLS cert /
+// no JWT; validated live on HV3 -- #42/#48) was formerly the sole
+// default-enabled slot, which made out-of-region fresh flashes feed
 // OKIMesh CoreScope tagged as Dayton/HAO.
 // The wss brokers stay disabled until the operator opts in; their ca_cert
-// names ("gts-r4", "letsencrypt", "isrg-x2") all resolve in MqttBroker.cpp's
-// lookupCaCertPem(), and while disabled they never connect anyway.
+// names ("letsencrypt", "isrg-x2" -- plus "gts-r4" for a hand-added LetsMesh)
+// all resolve in MqttBroker.cpp's lookupCaCertPem(), and while disabled they
+// never connect anyway.
 //
 // JWT identity (#95 / #63 / #68) -- the seed deliberately leaves username,
 // jwt_owner, jwt_email EMPTY; the connect-time auth layer fills what it can:
@@ -419,14 +427,13 @@ struct DefaultBrokerSpec {
     const char*      ca_cert_name;   // "" when no TLS cert (tcp)
 };
 
-// Slots 0-5. Slots 6-9 (MQTT Custom) are intentionally absent so they stay empty.
+// Slots 0-4. Slots 5-9 (MQTT Custom) are intentionally absent so they stay empty.
 // jwt_audience is the BARE host (#95); ca_cert names resolve in MqttBroker.cpp.
 constexpr DefaultBrokerSpec kDefaultBrokerSpecs[] = {
     {false, "mqtt://mqtt1.okimesh.org:1883",          BrokerTransport::Tcp, 1883, BrokerAuthType::None, "",                        ""},
-    {false, "wss://mqtt-us-v1.letsmesh.net:443/mqtt", BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt-us-v1.letsmesh.net", "gts-r4"},
-    {false, "wss://mqtt.eastme.sh:443/mqtt",          BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt.eastme.sh",          "letsencrypt"},
+    {false, "mqtt://mqtt2.okimesh.org:1883",          BrokerTransport::Tcp, 1883, BrokerAuthType::None, "",                        ""},
     {false, "wss://mqtt.meshmapper.net:443/mqtt",     BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt.meshmapper.net",     "isrg-x2"},
-    {false, "wss://mqtt-eu-v1.letsmesh.net:443/mqtt", BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt-eu-v1.letsmesh.net", "gts-r4"},
+    {false, "wss://mqtt.eastme.sh:443/mqtt",          BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt.eastme.sh",          "letsencrypt"},
     {false, "wss://mqtt2.eastmesh.au:443/mqtt",       BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt2.eastmesh.au",       "letsencrypt"},
 };
 constexpr uint8_t kNumDefaultBrokers =


### PR DESCRIPTION
Closes #317
Sub-issue #390 (code-landing task) closed on push.

Agent: GreenCave (session 8fe5f971)

## What this does

Reseats the seeded MQTT broker registry in `populateDefaultBrokers()` so the OKI Mesh's own two brokers occupy slots 0–1, and the remaining public brokers compact upward.

| Slot | Before | After |
|---|---|---|
| 0 | CoreScope Dayton (`mqtt1.okimesh.org`) | **OKIMesh mqtt1** (relabelled, same host) |
| 1 | LetsMesh-US | **OKIMesh mqtt2** (`mqtt2.okimesh.org`, new) |
| 2 | Eastme.sh | **MeshMapper** |
| 3 | MeshMapper | **Eastme.sh** |
| 4 | LetsMesh-EU | **Eastmesh.au** |
| 5 | Eastmesh.au | *(empty)* |

`mqtt2.okimesh.org` is plaintext TCP / 1883 / anonymous — identical to `mqtt1`.

## On-record decisions (from #317)

- **Dropping LetsMesh-US + LetsMesh-EU from the seed is deliberate** (owner-approved), traded for the second OKIMesh broker. Both stay fully supported for hand-config — `gts-r4` still resolves in `lookupCaCertPem()`, and the docs now show the exact `set` values.
- **`mqtt2.okimesh.org` config is owner-supplied** (same as mqtt1 / the retired w8oof), not independently verified against the broker.
- **MeshMapper may be dropped later** once OKI Mesh feeds upstream from its own MQTT — out of scope here.

## Fresh-flash only

`populateDefaultBrokers()` is skip-if-present: it never overwrites a slot that already has a URL. Devices already in the field keep their current layout, so both orderings will coexist. Docs call this out and point users at `mqtt view <N>`. Every seeded slot still ships **disabled** (#262).

## Also fixed (pre-existing)

The host round-trip test still asserted slot 0 seeds **enabled**, which #262 changed to disabled on 2026-07-02 without updating the test. `origin/firmware-base` fails this test today; this PR makes it pass.

> ⚠ Root cause of why that went 26 days undetected: **`scripts/test_observer_nvs_round_trip.py` is not wired into any CI workflow.** Filing separately — it's outside this PR's scope.

## Verification

- `python scripts/test_observer_nvs_round_trip.py` → `OK: NVS round-trip + clamp tests pass.` (exit 0), on the rebased tree.
- Confirmed the same test **fails on `origin/firmware-base`** before this change.
- Gemini adversarial review: **LGTM, 0 blocker / 0 major / 0 minor.**

## Files

- `src/helpers/wifi_observer/ConfigSchema.cpp` — seed table + comment block
- `scripts/test_observer_nvs_round_trip.py` — slot assertions + stale-default fix
- `docs/observer-cli-commands.md` — seeded-slots table (also drops the retired `mqtt.w8oof.net`)
- `CHANGELOG.md` — `[Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)