### PR TITLE
feat(#366): registration-time config-provider key-space overlap detector

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -220,5 +220,6 @@ build_src_filter =
   -<*>
   +<../src/Utils.cpp>
   +<../src/CaptureRing.cpp>
+  +<../src/helpers/config/ConfigDispatch.cpp>
 lib_deps =
   google/googletest @ 1.17.0

--- a/src/helpers/config/ConfigDispatch.cpp
+++ b/src/helpers/config/ConfigDispatch.cpp
@@ -40,22 +40,41 @@ bool g_warned_empty;
 // correct build this is 0 forever.
 int g_overlap_count;
 
-// Two key-prefixes "collide" if one is a prefix of the other -- i.e. there is at
-// least one key string both would claim. Equal strings collide (min length is
-// their shared length). Empty strings are treated as non-colliding: a "" prefix
-// would claim everything, which is never a legitimate manifest entry, so we do
-// not let it force-collide with all keys.
+// Manifest-entry convention (#366 review MINOR-3): an entry ENDING in '.' is a
+// PREFIX (claims every key starting with it, e.g. "wifi." -> wifi.ssid/wifi.pwd);
+// an entry NOT ending in '.' is an EXACT leaf key (e.g. "mqtt.iata"). Two entries
+// collide iff some key string would be claimed by both:
+//   - prefix P vs anything X : collide iff X starts with P
+//   - leaf  L vs leaf L2      : collide iff L == L2
+// This avoids the false positive of a leaf "mqtt.iata" shadowing an unrelated
+// "mqtt.iata_x". Empty strings never collide (a "" prefix would claim all keys,
+// which is never a legitimate manifest entry).
 bool prefixesCollide(const char* a, const char* b) {
     if (a == nullptr || b == nullptr || a[0] == '\0' || b[0] == '\0') return false;
     size_t la = strlen(a), lb = strlen(b);
-    size_t n = la < lb ? la : lb;
-    return strncmp(a, b, n) == 0;
+    bool a_prefix = a[la - 1] == '.';
+    bool b_prefix = b[lb - 1] == '.';
+    if (a_prefix && strncmp(b, a, la) == 0) return true;   // b starts with prefix a
+    if (b_prefix && strncmp(a, b, lb) == 0) return true;   // a starts with prefix b
+    if (!a_prefix && !b_prefix) return strcmp(a, b) == 0;  // leaf vs leaf: exact only
+    return false;
 }
 
-// #366: on registration, warn LOUDLY (every target) if the incoming provider's
-// prefixes overlap any already-registered provider's -- the silent
-// first-provider-wins shadow otherwise. Diagnostic only; registration proceeds.
-void warnOnOverlap(const char* new_role,
+// #366: detected collisions are STORED here and printed LAZILY at first dispatch
+// (review BLOCKER-1). registerProvider runs during static init -- before
+// Serial.begin() -- so printing there is unreliable/lost on ESP32 + nRF52. The
+// count still increments at registration (so a host test can assert immediately);
+// the human-visible diagnostic is flushed once, on the first dispatchSet/Get,
+// when Serial is up. Same deferral pattern as warnIfNoProvider below.
+const int kMaxStoredOverlaps = 4;
+struct OverlapRecord { const char* role_a; const char* pfx_a;
+                       const char* role_b; const char* pfx_b; };
+OverlapRecord g_overlaps[kMaxStoredOverlaps];
+int  g_overlaps_stored = 0;
+bool g_overlaps_flushed = false;
+
+// Called from registration (static-init safe: only touches ints/pointers).
+void detectOverlap(const char* new_role,
                    const char* const* new_prefixes, int new_count) {
     if (new_prefixes == nullptr || new_count <= 0) return;
     for (int i = 0; i < new_count; ++i) {
@@ -65,19 +84,40 @@ void warnOnOverlap(const char* new_role,
                 const char* ep = g_providers[p].prefixes[j];
                 if (!prefixesCollide(np, ep)) continue;
                 ++g_overlap_count;
-                const char* er = g_providers[p].role ? g_providers[p].role : "?";
-                const char* nr = new_role ? new_role : "?";
-#ifdef ARDUINO
-                Serial.printf("ERROR: config key-space OVERLAP: '%s' (role %s) "
-                              "collides with '%s' (role %s) -- one silently "
-                              "shadows the other (#366)\n", np, nr, ep, er);
-#else
-                fprintf(stderr, "ERROR: config key-space OVERLAP: '%s' (role %s) "
-                        "collides with '%s' (role %s) -- one silently shadows "
-                        "the other (#366)\n", np, nr, ep, er);
-#endif
+                if (g_overlaps_stored < kMaxStoredOverlaps) {
+                    g_overlaps[g_overlaps_stored++] = {
+                        new_role ? new_role : "?", np,
+                        g_providers[p].role ? g_providers[p].role : "?", ep };
+                }
             }
         }
+    }
+}
+
+// Flush stored overlap diagnostics once, at runtime (Serial up). Latched.
+void flushOverlapWarnings() {
+    if (g_overlaps_flushed || g_overlap_count == 0) return;
+    g_overlaps_flushed = true;
+    for (int i = 0; i < g_overlaps_stored; ++i) {
+        const OverlapRecord& o = g_overlaps[i];
+#ifdef ARDUINO
+        Serial.printf("ERROR: config key-space OVERLAP: '%s' (role %s) collides "
+                      "with '%s' (role %s) -- one silently shadows the other "
+                      "(#366)\n", o.pfx_a, o.role_a, o.pfx_b, o.role_b);
+#else
+        fprintf(stderr, "ERROR: config key-space OVERLAP: '%s' (role %s) collides "
+                "with '%s' (role %s) -- one silently shadows the other (#366)\n",
+                o.pfx_a, o.role_a, o.pfx_b, o.role_b);
+#endif
+    }
+    if (g_overlap_count > g_overlaps_stored) {
+#ifdef ARDUINO
+        Serial.printf("ERROR: config overlap: %d more collision(s) not shown "
+                      "(#366)\n", g_overlap_count - g_overlaps_stored);
+#else
+        fprintf(stderr, "ERROR: config overlap: %d more collision(s) not shown "
+                "(#366)\n", g_overlap_count - g_overlaps_stored);
+#endif
     }
 }
 
@@ -103,8 +143,10 @@ bool registerProvider(SetFn set_fn, GetFn get_fn, const char* role_name,
                       const char* const* key_prefixes, int prefix_count) {
     if (set_fn == nullptr && get_fn == nullptr) return false;
     // #366: check overlap against already-registered providers BEFORE adding
-    // this one, so it never compares against itself.
-    warnOnOverlap(role_name, key_prefixes, prefix_count);
+    // this one, so it never compares against itself. Stores records + bumps the
+    // count here (static-init safe); the human-visible diagnostic is flushed at
+    // first dispatch (Serial up).
+    detectOverlap(role_name, key_prefixes, prefix_count);
     if (g_count >= kMaxProviders) {
         // Loud on every target: a role silently dropped here loses its whole
         // config surface (#364 review MAJOR-1).
@@ -135,6 +177,7 @@ bool dispatchSet(const char* key, const char* value, char* reply, size_t reply_s
     if (key == nullptr || value == nullptr || reply == nullptr || reply_size == 0) return false;
     reply[0] = '\0';
     warnIfNoProvider("set");
+    flushOverlapWarnings();   // #366: emit any registration-time collisions now (Serial up)
     for (int i = 0; i < g_count; ++i) {
         if (g_providers[i].set_fn == nullptr) continue;
         if (g_providers[i].set_fn(key, value, reply, reply_size)) return true;
@@ -146,6 +189,7 @@ bool dispatchGet(const char* key, char* reply, size_t reply_size) {
     if (key == nullptr || reply == nullptr || reply_size == 0) return false;
     reply[0] = '\0';
     warnIfNoProvider("get");
+    flushOverlapWarnings();   // #366: emit any registration-time collisions now (Serial up)
     for (int i = 0; i < g_count; ++i) {
         if (g_providers[i].get_fn == nullptr) continue;
         if (g_providers[i].get_fn(key, reply, reply_size)) return true;

--- a/src/helpers/config/ConfigDispatch.cpp
+++ b/src/helpers/config/ConfigDispatch.cpp
@@ -18,9 +18,11 @@ namespace config {
 namespace {
 
 struct Provider {
-    SetFn       set_fn;
-    GetFn       get_fn;
-    const char* role;
+    SetFn              set_fn;
+    GetFn              get_fn;
+    const char*        role;
+    const char* const* prefixes;      // static array; not owned, not copied
+    int                prefix_count;
 };
 
 // POD with static storage duration -> zero-initialised in .bss during static
@@ -32,6 +34,52 @@ int      g_count;
 // Latched so a client polling config cannot turn this into a log flood
 // (SAFELANE 11 rule 10: diagnostics must not become the outage).
 bool g_warned_empty;
+
+// #366: count of key-space collisions detected across all registrations. Lets a
+// host regression test assert the detector fired without scraping stderr. In a
+// correct build this is 0 forever.
+int g_overlap_count;
+
+// Two key-prefixes "collide" if one is a prefix of the other -- i.e. there is at
+// least one key string both would claim. Equal strings collide (min length is
+// their shared length). Empty strings are treated as non-colliding: a "" prefix
+// would claim everything, which is never a legitimate manifest entry, so we do
+// not let it force-collide with all keys.
+bool prefixesCollide(const char* a, const char* b) {
+    if (a == nullptr || b == nullptr || a[0] == '\0' || b[0] == '\0') return false;
+    size_t la = strlen(a), lb = strlen(b);
+    size_t n = la < lb ? la : lb;
+    return strncmp(a, b, n) == 0;
+}
+
+// #366: on registration, warn LOUDLY (every target) if the incoming provider's
+// prefixes overlap any already-registered provider's -- the silent
+// first-provider-wins shadow otherwise. Diagnostic only; registration proceeds.
+void warnOnOverlap(const char* new_role,
+                   const char* const* new_prefixes, int new_count) {
+    if (new_prefixes == nullptr || new_count <= 0) return;
+    for (int i = 0; i < new_count; ++i) {
+        const char* np = new_prefixes[i];
+        for (int p = 0; p < g_count; ++p) {
+            for (int j = 0; j < g_providers[p].prefix_count; ++j) {
+                const char* ep = g_providers[p].prefixes[j];
+                if (!prefixesCollide(np, ep)) continue;
+                ++g_overlap_count;
+                const char* er = g_providers[p].role ? g_providers[p].role : "?";
+                const char* nr = new_role ? new_role : "?";
+#ifdef ARDUINO
+                Serial.printf("ERROR: config key-space OVERLAP: '%s' (role %s) "
+                              "collides with '%s' (role %s) -- one silently "
+                              "shadows the other (#366)\n", np, nr, ep, er);
+#else
+                fprintf(stderr, "ERROR: config key-space OVERLAP: '%s' (role %s) "
+                        "collides with '%s' (role %s) -- one silently shadows "
+                        "the other (#366)\n", np, nr, ep, er);
+#endif
+            }
+        }
+    }
+}
 
 // SAFELANE 6: an unregistered config surface must not silently masquerade as
 // "unknown config key" to the client. Report it once, visibly.
@@ -51,8 +99,12 @@ void warnIfNoProvider(const char* op) {
 
 }  // namespace
 
-bool registerProvider(SetFn set_fn, GetFn get_fn, const char* role_name) {
+bool registerProvider(SetFn set_fn, GetFn get_fn, const char* role_name,
+                      const char* const* key_prefixes, int prefix_count) {
     if (set_fn == nullptr && get_fn == nullptr) return false;
+    // #366: check overlap against already-registered providers BEFORE adding
+    // this one, so it never compares against itself.
+    warnOnOverlap(role_name, key_prefixes, prefix_count);
     if (g_count >= kMaxProviders) {
         // Loud on every target: a role silently dropped here loses its whole
         // config surface (#364 review MAJOR-1).
@@ -66,14 +118,18 @@ bool registerProvider(SetFn set_fn, GetFn get_fn, const char* role_name) {
 #endif
         return false;
     }
-    g_providers[g_count].set_fn = set_fn;
-    g_providers[g_count].get_fn = get_fn;
-    g_providers[g_count].role   = role_name;
+    g_providers[g_count].set_fn       = set_fn;
+    g_providers[g_count].get_fn       = get_fn;
+    g_providers[g_count].role         = role_name;
+    g_providers[g_count].prefixes     = key_prefixes;
+    g_providers[g_count].prefix_count = prefix_count;
     ++g_count;
     return true;
 }
 
 int providerCount() { return g_count; }
+
+int overlapWarningCount() { return g_overlap_count; }
 
 bool dispatchSet(const char* key, const char* value, char* reply, size_t reply_size) {
     if (key == nullptr || value == nullptr || reply == nullptr || reply_size == 0) return false;

--- a/src/helpers/config/ConfigDispatch.h
+++ b/src/helpers/config/ConfigDispatch.h
@@ -70,22 +70,24 @@ static const int kMaxProviders = 4;
 
 // Register a role's provider.
 //   role_name    : static string, diagnostics only.
-//   key_prefixes : static array of the key strings/prefixes this provider's
-//                  if-chain claims (e.g. observer = {"mqtt.iata","mqtt.broker.",
-//                  "wifi.", ...}). A key is "claimed" if it starts with any
-//                  entry. Exact leaf keys are given verbatim (safe as prefixes:
-//                  dotted config keys are never strict extensions of a leaf).
+//   key_prefixes : static array of the keys this provider claims. CONVENTION:
+//                  an entry ENDING in '.' is a PREFIX ("wifi." claims wifi.ssid,
+//                  wifi.pwd, ...); an entry NOT ending in '.' is an EXACT leaf
+//                  key ("mqtt.iata"). See prefixesCollide in the .cpp.
 //   prefix_count : entries in key_prefixes (0 + nullptr allowed, but then this
 //                  provider is EXEMPT from overlap detection -- discouraged).
 // Returns false if the table is full (SAFELANE 6: the caller must not ignore).
 //
-// OVERLAP DETECTION (#366): at registration, every prefix is checked against
-// each already-registered provider's prefixes. If one is a prefix of the other
-// (i.e. some key would be claimed by both), a LOUD diagnostic naming both roles
-// and the colliding entries is emitted on every target (Serial / stderr). This
-// converts the silent first-provider-wins shadow (the `wifi.` vs `wifi.mode`
-// trap #301 would hit) into a visible boot-time error. Registration still
-// proceeds -- the diagnostic is the signal; it does not change dispatch.
+// OVERLAP DETECTION (#366): at registration, this provider's entries are checked
+// against each already-registered provider's. A collision (some key both would
+// claim -- e.g. observer's `wifi.` prefix vs a repeater's `wifi.mode` leaf, the
+// #301 trap) bumps overlapWarningCount() immediately AND stores a record. The
+// human-visible LOUD diagnostic (Serial / stderr, naming both roles + entries)
+// is emitted LAZILY on the first dispatchSet/dispatchGet -- NOT at registration,
+// which runs during static init before Serial.begin() (review BLOCKER-1). This
+// converts the silent first-provider-wins shadow into a visible error without
+// depending on unready hardware. Registration still proceeds; dispatch is
+// unchanged -- the diagnostic is only a signal.
 bool registerProvider(SetFn set_fn, GetFn get_fn, const char* role_name,
                       const char* const* key_prefixes, int prefix_count);
 

--- a/src/helpers/config/ConfigDispatch.h
+++ b/src/helpers/config/ConfigDispatch.h
@@ -68,13 +68,33 @@ typedef bool (*GetFn)(const char* key, char* reply, size_t reply_size);
 // precedent in ObserverCli.h).
 static const int kMaxProviders = 4;
 
-// Register a role's provider. `role_name` is a static string used only in
-// diagnostics. Returns false if the table is full (SAFELANE 6: the caller must
-// not ignore this).
-bool registerProvider(SetFn set_fn, GetFn get_fn, const char* role_name);
+// Register a role's provider.
+//   role_name    : static string, diagnostics only.
+//   key_prefixes : static array of the key strings/prefixes this provider's
+//                  if-chain claims (e.g. observer = {"mqtt.iata","mqtt.broker.",
+//                  "wifi.", ...}). A key is "claimed" if it starts with any
+//                  entry. Exact leaf keys are given verbatim (safe as prefixes:
+//                  dotted config keys are never strict extensions of a leaf).
+//   prefix_count : entries in key_prefixes (0 + nullptr allowed, but then this
+//                  provider is EXEMPT from overlap detection -- discouraged).
+// Returns false if the table is full (SAFELANE 6: the caller must not ignore).
+//
+// OVERLAP DETECTION (#366): at registration, every prefix is checked against
+// each already-registered provider's prefixes. If one is a prefix of the other
+// (i.e. some key would be claimed by both), a LOUD diagnostic naming both roles
+// and the colliding entries is emitted on every target (Serial / stderr). This
+// converts the silent first-provider-wins shadow (the `wifi.` vs `wifi.mode`
+// trap #301 would hit) into a visible boot-time error. Registration still
+// proceeds -- the diagnostic is the signal; it does not change dispatch.
+bool registerProvider(SetFn set_fn, GetFn get_fn, const char* role_name,
+                      const char* const* key_prefixes, int prefix_count);
 
 // Number of registered providers (diagnostics / tests).
 int providerCount();
+
+// #366: total key-space collisions detected across all registerProvider calls.
+// 0 in a correct build. Lets a regression test assert the detector fired.
+int overlapWarningCount();
 
 // Walk providers in registration order; first to claim `key` wins.
 // Returns false if NO provider claimed the key.
@@ -109,8 +129,9 @@ bool parseIndexedKey(const char* key, const char* prefix, int max_index,
 // regardless of translation-unit link order -- and it removes the "a new role
 // forgot to call registerProvider()" failure mode entirely.
 struct ProviderRegistrar {
-    ProviderRegistrar(SetFn set_fn, GetFn get_fn, const char* role_name) {
-        registerProvider(set_fn, get_fn, role_name);
+    ProviderRegistrar(SetFn set_fn, GetFn get_fn, const char* role_name,
+                      const char* const* key_prefixes, int prefix_count) {
+        registerProvider(set_fn, get_fn, role_name, key_prefixes, prefix_count);
     }
 };
 

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -1176,7 +1176,25 @@ size_t configRenderBrokerSlot(uint8_t slot, char* out, size_t out_size,
 // an unextracted archive member either. Kept as free insurance against a future
 // toolchain/flag change, since the failure mode -- every config key answering
 // "unknown config key" on a deployed fleet -- is severe.
+// #366: the observer's key-space manifest, for registration-time overlap
+// detection. Must mirror what observerConfigSet/observerConfigGet actually
+// claim (see the if-chain above): exact leaf keys verbatim, plus the two BROAD
+// prefixes it owns -- `wifi.` (wifi.ssid/wifi.pwd; also covers wifi.enabled)
+// and `mqtt.broker.`. The `wifi.` entry is exactly the shadow the repeater's
+// `wifi.mode` would hit (#301) -- the detector fires on that at registration.
+// Keep this in sync when adding/removing an observer config key.
+static const char* const kObserverConfigPrefixes[] = {
+    "mqtt.iata",
+    "mqtt.status_interval",
+    "mqtt.broker.",
+    "display.always_on",
+    "display.rotation",
+    "wifi.",
+};
+
 static __attribute__((used)) config::ProviderRegistrar _observer_config_provider(
-    &observerConfigSet, &observerConfigGet, "observer");
+    &observerConfigSet, &observerConfigGet, "observer",
+    kObserverConfigPrefixes,
+    (int)(sizeof(kObserverConfigPrefixes) / sizeof(kObserverConfigPrefixes[0])));
 
 }  // namespace offband

--- a/test/test_config_overlap/test_config_overlap.cpp
+++ b/test/test_config_overlap/test_config_overlap.cpp
@@ -1,0 +1,48 @@
+// Native regression test for the config-provider key-space overlap detector
+// (#366). Proves that the silent first-provider-wins shadow — specifically the
+// observer's `wifi.` prefix vs a repeater's `wifi.mode` (the #301 trap) — is
+// detected at registration instead of silently swallowing the second provider.
+//
+// The provider table is a process-global that only accumulates (no reset API in
+// production code, by design). So the whole scenario runs as ONE ordered test
+// in its own binary: fresh process => all counters start at zero.
+
+#include <gtest/gtest.h>
+#include "helpers/config/ConfigDispatch.h"
+
+using namespace offband::config;
+
+// Stub set/get: overlap is decided from the declared manifest at registration,
+// not from these, so they only need to be valid pointers.
+static bool stubSet(const char*, const char*, char*, size_t) { return false; }
+static bool stubGet(const char*, char*, size_t) { return false; }
+
+TEST(ConfigOverlap, DetectsWifiPrefixShadowAtRegistration) {
+  // Fresh process: nothing registered, no overlaps.
+  EXPECT_EQ(0, providerCount());
+  EXPECT_EQ(0, overlapWarningCount());
+
+  // 1) First provider (observer-like), incl. the broad `wifi.` claim.
+  static const char* const kObserver[] = {"mqtt.iata", "mqtt.broker.", "wifi."};
+  ASSERT_TRUE(registerProvider(&stubSet, &stubGet, "observer", kObserver, 3));
+  EXPECT_EQ(1, providerCount());
+  EXPECT_EQ(0, overlapWarningCount());   // first provider: nothing to collide with
+
+  // 2) A disjoint provider must NOT trip the detector (no false positive).
+  static const char* const kDisjoint[] = {"display.", "gps."};
+  ASSERT_TRUE(registerProvider(&stubSet, &stubGet, "other", kDisjoint, 2));
+  EXPECT_EQ(2, providerCount());
+  EXPECT_EQ(0, overlapWarningCount());
+
+  // 3) The concrete #301 case: repeater declares `wifi.mode`, which the
+  //    observer's `wifi.` prefix would silently shadow. Detector must fire.
+  static const char* const kRepeater[] = {"wifi.mode", "cmd."};
+  ASSERT_TRUE(registerProvider(&stubSet, &stubGet, "repeater", kRepeater, 2));
+  EXPECT_EQ(3, providerCount());
+  EXPECT_GT(overlapWarningCount(), 0);   // `wifi.mode` vs `wifi.` detected
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## What
Mechanical **registration-time overlap detector** for the config-dispatch component. The #364 dispatcher short-circuits on the first provider to claim a key, so a later provider is silently shadowed for any key both would claim. Live trap for #301: the observer claims the whole `wifi.` prefix, so a repeater's `wifi.mode` would be unreachable with no diagnostic. #364 mitigated by documentation only; this makes it mechanical.

## How (owner-approved approach (a))
- `registerProvider`/`ProviderRegistrar` take a **key-prefix manifest** (static, no heap; pointers to literals). Convention: entry ending `.` = prefix (`wifi.`), else exact leaf (`mqtt.iata`).
- At registration, each entry is checked against every already-registered provider's; a collision bumps `overlapWarningCount()` and stores a record.
- The **loud diagnostic is deferred to first `dispatchSet/Get`** (Serial up), not registration — registration runs during static init before `Serial.begin()`. Same lazy pattern as the existing `warnIfNoProvider`.
- Observer declares its actual manifest: `mqtt.iata`, `mqtt.status_interval`, `mqtt.broker.`, `display.always_on`, `display.rotation`, `wifi.`.

**Cost:** a few pointer slots per provider (`kMaxProviders`=4) — tens of bytes RAM, always-on. Accepted: silent config loss on a combined repeater+observer build (#297) is severe enough to warrant an unconditional guard.

## Verification
- **Native regression test** `test_config_overlap` PASSES — detects `wifi.mode` vs `wifi.`, no false positive on disjoint providers.
- Builds clean: **ESP32** `heltec_v4_companion_observer_wifi` · **nRF52** `RAK_4631_companion_radio_usb`.

## Adversarial review (standards#145)
Gemini v1: 1 BLOCKER / 1 MAJOR / 2 MINOR. Dispositions:
- **BLOCKER** (Serial during static init) — **fixed**: diagnostic deferred to first dispatch; count still increments at registration for the test.
- **MINOR-3** (leaf vs prefix ambiguity) — **fixed**: trailing-dot-aware `prefixesCollide`.
- **MAJOR** (manifest can drift from the if-chain) — real but distinct from overlap detection; manifest is verified-accurate for the current keys. Deferred → **#429**.
- **MINOR-4** (remove test `main()`) — **rejected**: codebase convention is per-file `main()`, one binary per test dir; no multi-main conflict.

Gemini **re-review of v2: all findings resolved, no new issues, PROCEED.**

Logs: `docs/llm-consultations/2026-07-28-366-overlap-detector-review-*.log` (+ `-rereview-`).

Closes #366. Follow-up: #429. Unblocks #301.

Agent: CloudyCliff (session 83c8582b)
