### PR TITLE
chore(#437): gitignore debug_logs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ platformio.local.ini
 *.elf
 *.map
 build-logs/
+debug_logs/
 
 # Python bytecode (host tests + script imports under scripts/)
 __pycache__/


### PR DESCRIPTION
One-line addition: `debug_logs/` next to the already-ignored `build-logs/`. Keeps per-host serial/diagnostic capture dumps (which can carry device identifiers) out of `git status` and out of accidental commits.

Verified: `git check-ignore -v debug_logs/` → matches `.gitignore:30`. No code, no build impact.

Refs #437. Agent: WhiteFalcon (session cb12cdd2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)