### PR TITLE
bug: move per-message RSSI to reserved2/byte[3] — clear #429 outgoing-flag collision (#464)

### DIFF
--- a/docs/llm-consultations/2026-07-30-464-rssi-byte3-gemini-gemini-2.5-pro.log
+++ b/docs/llm-consultations/2026-07-30-464-rssi-byte3-gemini-gemini-2.5-pro.log
@@ -1,0 +1,5 @@
+Sound.
+
+1.  **L549-550, L662-663, L770-771**: **Sound**. Emit order is correct in all three frames: `out_frame[i++] = 0;` (for `reserved1`) is immediately followed by `out_frame[i++] = rssiToInt8(...)` (for `reserved2`), matching wire order. No swaps or duplications.
+2.  **L549, L662, L770**: **Sound**. `reserved1` is correctly set to 0 in all cases, appropriate for a received message (not outgoing). The synthesized message frame in `postSystemChannelText` (L733) is also consistent, setting `reserved1` to 0. No conflicting flag setting is clobbered.
+3.  **L549-550, L662-663, L770-771**: **Sound**. The fix is applied completely and correctly to all three specified frames. In each case, RSSI is now in `reserved2`, and no frame was missed or left with an incorrect value.

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -522,10 +522,12 @@ ContactInfo*  MyMesh::processAck(const uint8_t *data) {
   return checkConnectionsAck(data);
 }
 
-// #456: encode a received-packet RSSI (int dBm) into the int8 reserved1 byte of the
-// v3 msg/data-recv frames. Clamp to the int8 range first: LoRa RSSI can be weaker than
-// -128 dBm, and a raw (int8_t) cast of e.g. -130 would WRAP to a bogus positive value
-// (a false strong signal). 0 stays "no data" (a real RX RSSI is always negative).
+// #456/#464: encode a received-packet RSSI (int dBm) into the int8 reserved2 byte
+// (byte[3]) of the v3 msg/data-recv frames. NOTE the byte: reserved1 (byte[2]) is the
+// #429 device-composed outgoing flag (client parses its bit0) -- RSSI must go in
+// reserved2. Clamp to the int8 range first: LoRa RSSI can be weaker than -128 dBm, and
+// a raw (int8_t) cast of e.g. -130 would WRAP to a bogus positive value (a false strong
+// signal). 0 stays "no data" (a real RX RSSI is always negative).
 static inline int8_t rssiToInt8(int rssi_dbm) {
   if (rssi_dbm < -128) return -128;
   if (rssi_dbm >  127) return  127;
@@ -545,8 +547,8 @@ void MyMesh::queueMessage(const ContactInfo &from, uint8_t txt_type, mesh::Packe
   if (app_target_ver >= 3) {
     out_frame[i++] = RESP_CODE_CONTACT_MSG_RECV_V3;
     out_frame[i++] = (int8_t)(pkt->getSNR() * 4);
-    out_frame[i++] = rssiToInt8(_radio->getLastRSSI()); // #456: reserved1 = RX RSSI (int8 dBm). Built at receive time so this is THIS message's RSSI; frozen into the stored frame for sync replay. App gates on non-zero.
-    out_frame[i++] = 0; // reserved2
+    out_frame[i++] = 0; // reserved1 (byte[2]) = #429 device-composed outgoing flag; 0 for a received msg
+    out_frame[i++] = rssiToInt8(_radio->getLastRSSI()); // #464: reserved2 (byte[3]) = RX RSSI (int8 dBm). MUST be byte[3] -- the client parses reserved1 bit0 as #429's outgoing flag. Built at receive time (this msg's RSSI), frozen into the stored frame for sync replay. App gates on res2 != 0.
   } else {
     out_frame[i++] = RESP_CODE_CONTACT_MSG_RECV;
   }
@@ -658,8 +660,8 @@ void MyMesh::onChannelMessageRecv(const mesh::GroupChannel &channel, mesh::Packe
   if (app_target_ver >= 3) {
     out_frame[i++] = RESP_CODE_CHANNEL_MSG_RECV_V3;
     out_frame[i++] = (int8_t)(pkt->getSNR() * 4);
-    out_frame[i++] = rssiToInt8(_radio->getLastRSSI()); // #456: reserved1 = RX RSSI (int8 dBm), same as the contact frame.
-    out_frame[i++] = 0; // reserved2
+    out_frame[i++] = 0; // reserved1 (byte[2]) = #429 outgoing flag; 0 for received
+    out_frame[i++] = rssiToInt8(_radio->getLastRSSI()); // #464: reserved2 (byte[3]) = RX RSSI, same as the contact frame.
   } else {
     out_frame[i++] = RESP_CODE_CHANNEL_MSG_RECV;
   }
@@ -710,8 +712,8 @@ void MyMesh::onChannelMessageRecv(const mesh::GroupChannel &channel, mesh::Packe
 // Frame layout (v>=3):
 //   [0]  RESP_CODE_CHANNEL_MSG_RECV_V3 (17)
 //   [1]  snr*4 as int8_t (0 for synthesized)
-//   [2]  reserved1
-//   [3]  reserved2
+//   [2]  reserved1 -- #429 device-composed outgoing flag (bit0); 0 for received
+//   [3]  reserved2 -- #456/#464 RX RSSI (int8 dBm, clamped); 0 = no data
 //   [4]  channel_idx (kSystemChannelSlot)
 //   [5]  path_len (0xFF = no path, direct)
 //   [6]  TXT_TYPE_PLAIN
@@ -764,8 +766,8 @@ void MyMesh::onChannelDataRecv(const mesh::GroupChannel &channel, mesh::Packet *
   int i = 0;
   out_frame[i++] = RESP_CODE_CHANNEL_DATA_RECV;
   out_frame[i++] = (int8_t)(pkt->getSNR() * 4);
-  out_frame[i++] = rssiToInt8(_radio->getLastRSSI()); // #456: reserved1 = RX RSSI (int8 dBm), same as the msg-recv frames.
-  out_frame[i++] = 0; // reserved2
+  out_frame[i++] = 0; // reserved1 (byte[2]) = #429 outgoing flag; 0 for received
+  out_frame[i++] = rssiToInt8(_radio->getLastRSSI()); // #464: reserved2 (byte[3]) = RX RSSI, same as the msg-recv frames.
 
   uint8_t channel_idx = findChannelIdx(channel);
   out_frame[i++] = channel_idx;


### PR DESCRIPTION
Fixes **#464** — regression from #456 (PR #461).

## Bug
#461 wrote per-message RSSI into **reserved1 (byte[2])**, but the merged client parses byte[2] bit0 as **#429's device-composed outgoing flag** and expects RSSI in **byte[3]** (verified: `meshcore_connector.dart:5925-5934`, which documents `res1 = #429 outgoing / res2 = RSSI`). Result: received messages rendered as *sent-by-you* with garbage RSSI — a live two-way break on merged firmware.

## Fix
Move RSSI to **reserved2 (byte[3])** in all three v3 recv frames (contact-msg, channel-msg, channel-data); **reserved1 back to 0** (the #429 outgoing-flag slot). Encoding unchanged (clamped int8 dBm). Client gates on `res2 != 0`.

Documented the reserved-byte allocation in the frame-layout comment (res1 = #429 outgoing, res2 = #456 RSSI) — same split-allocation discipline as the cap-bit registry.

## Verification
Builds ESP32 (heltec_v4 BLE) + nRF52 (RAK_4631). Gemini-reviewed sound (byte order + no clobbered flag). BLE confirmation is the client's per-message-detail read once merged/flashed.

Root cause: built #456 to the issue prose, not the client's as-merged parse. Caught by the client agent before wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
