### PR TITLE
feat(#350): land CrashLog decouple — relocate to diagnostics/, portable nRF52 core, companion wire-in, deferred re-dump

### DIFF
--- a/boards/nrf52840_s140_v6.ld
+++ b/boards/nrf52840_s140_v6.ld
@@ -33,6 +33,33 @@ SECTIONS
     KEEP(*(.fs_data))
     PROVIDE(__stop_fs_data = .);
   } > RAM
+
+  /* Offband #361 (Epic #350): retained RAM for the nRF52 crash breadcrumb.
+   *
+   * The Adafruit nRF52 core linker defines no .noinit section, and
+   * gcc_startup_nrf52840.S zeroes .bss (__STARTUP_CLEAR_BSS) on every reset,
+   * so an ordinary variable cannot survive a watchdog reboot. GPREGRET2 is not
+   * an alternative -- all 8 bits are allocated (SafeBoot owns bit 7 plus
+   * attempts/backoff/unclean; NRF52Board writes SHUTDOWN_REASON_* codes).
+   *
+   * NOLOAD: nothing is copied in from flash, so contents persist across a soft
+   * or watchdog reset. NOT retained across a power cut -- accepted trade.
+   *
+   * INSERT AFTER .data places this BEFORE .bss, i.e. outside
+   * __bss_start__..__bss_end__, which is what keeps the startup zero-loop off
+   * it -- the same reason .svc_data / .fs_data above survive.
+   *
+   * Lives in this repo-local override, never in the vendored PlatformIO core
+   * script: that copy is machine-local, unversioned, absent from CI, and is
+   * destroyed on package reinstall.
+   */
+  .noinit (NOLOAD) :
+  {
+    PROVIDE(__start_noinit = .);
+    KEEP(*(.noinit))
+    KEEP(*(.noinit.*))
+    PROVIDE(__stop_noinit = .);
+  } > RAM
 } INSERT AFTER .data;
 
 INCLUDE "nrf52_common.ld"

--- a/boards/nrf52840_s140_v6_extrafs.ld
+++ b/boards/nrf52840_s140_v6_extrafs.ld
@@ -33,6 +33,33 @@ SECTIONS
     KEEP(*(.fs_data))
     PROVIDE(__stop_fs_data = .);
   } > RAM
+
+  /* Offband #361 (Epic #350): retained RAM for the nRF52 crash breadcrumb.
+   *
+   * The Adafruit nRF52 core linker defines no .noinit section, and
+   * gcc_startup_nrf52840.S zeroes .bss (__STARTUP_CLEAR_BSS) on every reset,
+   * so an ordinary variable cannot survive a watchdog reboot. GPREGRET2 is not
+   * an alternative -- all 8 bits are allocated (SafeBoot owns bit 7 plus
+   * attempts/backoff/unclean; NRF52Board writes SHUTDOWN_REASON_* codes).
+   *
+   * NOLOAD: nothing is copied in from flash, so contents persist across a soft
+   * or watchdog reset. NOT retained across a power cut -- accepted trade.
+   *
+   * INSERT AFTER .data places this BEFORE .bss, i.e. outside
+   * __bss_start__..__bss_end__, which is what keeps the startup zero-loop off
+   * it -- the same reason .svc_data / .fs_data above survive.
+   *
+   * Lives in this repo-local override, never in the vendored PlatformIO core
+   * script: that copy is machine-local, unversioned, absent from CI, and is
+   * destroyed on package reinstall.
+   */
+  .noinit (NOLOAD) :
+  {
+    PROVIDE(__start_noinit = .);
+    KEEP(*(.noinit))
+    KEEP(*(.noinit.*))
+    PROVIDE(__stop_noinit = .);
+  } > RAM
 } INSERT AFTER .data;
 
 INCLUDE "nrf52_common.ld"

--- a/boards/nrf52840_s140_v7.ld
+++ b/boards/nrf52840_s140_v7.ld
@@ -33,6 +33,33 @@ SECTIONS
     KEEP(*(.fs_data))
     PROVIDE(__stop_fs_data = .);
   } > RAM
+
+  /* Offband #361 (Epic #350): retained RAM for the nRF52 crash breadcrumb.
+   *
+   * The Adafruit nRF52 core linker defines no .noinit section, and
+   * gcc_startup_nrf52840.S zeroes .bss (__STARTUP_CLEAR_BSS) on every reset,
+   * so an ordinary variable cannot survive a watchdog reboot. GPREGRET2 is not
+   * an alternative -- all 8 bits are allocated (SafeBoot owns bit 7 plus
+   * attempts/backoff/unclean; NRF52Board writes SHUTDOWN_REASON_* codes).
+   *
+   * NOLOAD: nothing is copied in from flash, so contents persist across a soft
+   * or watchdog reset. NOT retained across a power cut -- accepted trade.
+   *
+   * INSERT AFTER .data places this BEFORE .bss, i.e. outside
+   * __bss_start__..__bss_end__, which is what keeps the startup zero-loop off
+   * it -- the same reason .svc_data / .fs_data above survive.
+   *
+   * Lives in this repo-local override, never in the vendored PlatformIO core
+   * script: that copy is machine-local, unversioned, absent from CI, and is
+   * destroyed on package reinstall.
+   */
+  .noinit (NOLOAD) :
+  {
+    PROVIDE(__start_noinit = .);
+    KEEP(*(.noinit))
+    KEEP(*(.noinit.*))
+    PROVIDE(__stop_noinit = .);
+  } > RAM
 } INSERT AFTER .data;
 
 INCLUDE "nrf52_common.ld"

--- a/boards/nrf52840_s140_v7_extrafs.ld
+++ b/boards/nrf52840_s140_v7_extrafs.ld
@@ -33,6 +33,33 @@ SECTIONS
     KEEP(*(.fs_data))
     PROVIDE(__stop_fs_data = .);
   } > RAM
+
+  /* Offband #361 (Epic #350): retained RAM for the nRF52 crash breadcrumb.
+   *
+   * The Adafruit nRF52 core linker defines no .noinit section, and
+   * gcc_startup_nrf52840.S zeroes .bss (__STARTUP_CLEAR_BSS) on every reset,
+   * so an ordinary variable cannot survive a watchdog reboot. GPREGRET2 is not
+   * an alternative -- all 8 bits are allocated (SafeBoot owns bit 7 plus
+   * attempts/backoff/unclean; NRF52Board writes SHUTDOWN_REASON_* codes).
+   *
+   * NOLOAD: nothing is copied in from flash, so contents persist across a soft
+   * or watchdog reset. NOT retained across a power cut -- accepted trade.
+   *
+   * INSERT AFTER .data places this BEFORE .bss, i.e. outside
+   * __bss_start__..__bss_end__, which is what keeps the startup zero-loop off
+   * it -- the same reason .svc_data / .fs_data above survive.
+   *
+   * Lives in this repo-local override, never in the vendored PlatformIO core
+   * script: that copy is machine-local, unversioned, absent from CI, and is
+   * destroyed on package reinstall.
+   */
+  .noinit (NOLOAD) :
+  {
+    PROVIDE(__start_noinit = .);
+    KEEP(*(.noinit))
+    KEEP(*(.noinit.*))
+    PROVIDE(__stop_noinit = .);
+  } > RAM
 } INSERT AFTER .data;
 
 INCLUDE "nrf52_common.ld"

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -16,6 +16,14 @@
   #define CW_PHASE(name) ((void)0)
 #endif
 
+// #377 (Epic #350): boot-survival CrashLog on the nRF52 companion. The observer
+// path (ESP32) already wires CrashLog above; nRF52 companions are non-observer,
+// so include it here. Additive + nRF52-scoped -- does not touch the observer
+// blocks or the runtime-WiFi path.
+#if defined(NRF52_PLATFORM) && !defined(OFFBAND_OBSERVER)
+  #include "helpers/diagnostics/CrashLog.h"
+#endif
+
 // Believe it or not, this std C function is busted on some platforms!
 static uint32_t _atoi(const char* sp) {
   uint32_t n = 0;
@@ -190,6 +198,21 @@ void setup() {
              (unsigned long)board.getResetReason());
     Serial.println(rr);
   }
+#endif
+
+#if defined(NRF52_PLATFORM) && !defined(OFFBAND_OBSERVER)
+  // #377 (Epic #350): start the boot-survival breadcrumb on the nRF52 companion.
+  // Delegate the reset reason to the board (#376 decision 2) via a non-capturing
+  // lambda -- it references only the global `board`, so it converts to the
+  // ResetReasonHook function pointer. crashLogBegin() dumps a ring that survived
+  // the previous reset (retained .noinit, #361); the boot line records the reason
+  // AND keeps the ring referenced so ld-2.29 GC can't drop it (#363).
+  offband::crashLogSetResetReasonHook([]() -> const char* {
+    return board.getResetReasonString(board.getResetReason());
+  });
+  offband::crashLogBegin();
+  offband::crashLogf("[boot] nRF52 companion up; reset=%s",
+                     board.getResetReasonString(board.getResetReason()));
 #endif
 
 #ifdef DISPLAY_CLASS
@@ -415,6 +438,19 @@ void loop() {
 #if defined(NRF52_PLATFORM)
   board.feedWatchdog();  // #257: feed from the MAIN LOOP only -> a hung loop trips the WDT
   board.heartbeatTick(); // #275: loop-driven green-LED heartbeat (freezes if the loop hangs)
+  #if !defined(OFFBAND_OBSERVER)
+  {
+    // #377: periodic breadcrumb into the retained ring. Low cadence (30 s) so it
+    // does not evict real events from the 4 KB ring; records "up=Ns" so the boot
+    // after a hang shows how long this boot ran. Also keeps the ring referenced.
+    static uint32_t s_cl_last_ms = 0;
+    uint32_t now_ms = millis();
+    if (s_cl_last_ms == 0 || now_ms - s_cl_last_ms >= 30000u) {
+      s_cl_last_ms = now_ms;
+      offband::crashLogf("[hb] up=%us", (unsigned)(now_ms / 1000));
+    }
+  }
+  #endif
 #endif
 #ifdef OFFBAND_OBSERVER
   // CrashLog v6: per-sub-loop visit marking + heartbeat. Each sub-loop

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -445,6 +445,7 @@ void loop() {
     // after a hang shows how long this boot ran. Also keeps the ring referenced.
     static uint32_t s_cl_last_ms = 0;
     uint32_t now_ms = millis();
+    offband::crashLogTick(now_ms);  // #378: deferred previous-boot re-dump for late serial connect
     if (s_cl_last_ms == 0 || now_ms - s_cl_last_ms >= 30000u) {
       s_cl_last_ms = now_ms;
       offband::crashLogf("[hb] up=%us", (unsigned)(now_ms / 1000));

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -5,7 +5,7 @@
 
 #ifdef OFFBAND_OBSERVER
   #include "helpers/wifi_observer/WifiObserver.h"
-  #include "helpers/wifi_observer/CrashLog.h"
+  #include "helpers/diagnostics/CrashLog.h"
   #include "helpers/wifi_observer/ConfigSchema.h"   // #141: getDisplayAlwaysOn()
   #include "helpers/wifi_observer/ObserverCli.h"     // #141: setDisplayAlwaysOnApplier()
   // CW_PHASE: tracing macro for setup() crash localization. With

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -6,7 +6,7 @@
   #include <WiFi.h>
 #endif
 #ifdef OFFBAND_OBSERVER
-  #include <helpers/wifi_observer/CrashLog.h>
+  #include <helpers/diagnostics/CrashLog.h>
 #endif
 
 #ifndef AUTO_OFF_MILLIS

--- a/src/helpers/diagnostics/CrashLog.cpp
+++ b/src/helpers/diagnostics/CrashLog.cpp
@@ -1,4 +1,4 @@
-// src/helpers/wifi_observer/CrashLog.cpp
+// src/helpers/diagnostics/CrashLog.cpp
 //
 // Implementation of the RTC_NOINIT-backed crash log ring buffer.
 // See CrashLog.h for the full rationale.

--- a/src/helpers/diagnostics/CrashLog.cpp
+++ b/src/helpers/diagnostics/CrashLog.cpp
@@ -9,7 +9,7 @@
 #include <cstdio>
 #include <cstring>
 
-#ifdef ARDUINO
+#if defined(OFFBAND_CRASHLOG_ESP32)
   #include <Arduino.h>
   #include <Wire.h>          // i2cScan() bus probing
   #include <Preferences.h>   // NVS-backed boot counter
@@ -19,15 +19,21 @@
   #include <freertos/FreeRTOS.h>
   #include <freertos/portmacro.h>  // portENTER_CRITICAL
   #include <freertos/task.h> // uxTaskGetStackHighWaterMark()
+#elif defined(OFFBAND_CRASHLOG_NRF52)
+  #include <Arduino.h>       // Serial, millis(); .noinit ring from #361
 #endif
 
 namespace offband {
+
+// Reset-reason provider hook (#376). Board registers its decoder; unset is safe.
+static ResetReasonHook s_reset_reason_hook = nullptr;
+void crashLogSetResetReasonHook(ResetReasonHook hook) { s_reset_reason_hook = hook; }
 
 // ---------------------------------------------------------------------------
 // Reset-reason mapping
 // ---------------------------------------------------------------------------
 const char* resetReasonString(int reason) {
-#ifdef ARDUINO
+#if defined(OFFBAND_CRASHLOG_ESP32)
     switch ((esp_reset_reason_t)reason) {
         case ESP_RST_UNKNOWN:    return "UNKNOWN";
         case ESP_RST_POWERON:    return "POWERON";
@@ -42,6 +48,11 @@ const char* resetReasonString(int reason) {
         case ESP_RST_SDIO:       return "SDIO";
         default:                 return "UNKNOWN";
     }
+#elif defined(OFFBAND_CRASHLOG_NRF52)
+    // No esp_reset_reason enum on nRF52. Delegate to the board's decoder if it
+    // registered one (#376 decision 2); otherwise say so honestly.
+    (void)reason;
+    return s_reset_reason_hook ? s_reset_reason_hook() : "n/a";
 #else
     (void)reason;
     return "HOST_BUILD";
@@ -56,8 +67,8 @@ const char* resetReasonString(int reason) {
 // Total: 4096 B in RTC slow memory.
 
 static constexpr uint32_t kCrashLogMagic    = 0xCAFEF00DU;
-static constexpr size_t   kCrashLogTotal    = 4096;
-static constexpr size_t   kCrashLogDataSize = kCrashLogTotal - 16;  // 4080 B
+static constexpr size_t   kCrashLogTotal    = OFFBAND_CRASHLOG_RING_BYTES;  // #376: overridable
+static constexpr size_t   kCrashLogDataSize = kCrashLogTotal - 16;  // header is 16 B
 static constexpr size_t   kCrashLogLineMax  = 240;                  // truncation cap
 
 struct CrashLogHeader {
@@ -67,19 +78,33 @@ struct CrashLogHeader {
     uint32_t reserved;     // pad to 16 B
 };
 
-#ifdef ARDUINO
-// RTC_NOINIT_ATTR puts this in RTC slow memory, NOT cleared by soft reset.
-// The compiler does NOT initialize NOINIT variables; whatever was there
-// before the reset is what we see. That's the whole point.
-RTC_NOINIT_ATTR static CrashLogHeader s_header;
-RTC_NOINIT_ATTR static char           s_data[kCrashLogDataSize];
+// Retained storage. OFFBAND_RETAINED = RTC_NOINIT_ATTR (ESP32) / .noinit (nRF52)
+// / nothing (host). Contents are NOT zeroed by C-runtime startup, so a previous
+// boot's log survives a soft/watchdog reset. The compiler does not initialize
+// these; whatever survived the reset is what we read -- that is the point.
+OFFBAND_RETAINED static CrashLogHeader s_header;
+OFFBAND_RETAINED static char           s_data[kCrashLogDataSize];
 
-// Critical section spinlock for thread-safe writes.
-static portMUX_TYPE s_log_mux = portMUX_INITIALIZER_UNLOCKED;
+// Thread-safe write guard. ESP32 uses a portMUX spinlock; nRF52 (FreeRTOS via
+// the Adafruit core) masks interrupts around the short critical region; host is
+// single-threaded and needs neither.
+#if defined(OFFBAND_CRASHLOG_ESP32)
+  static portMUX_TYPE s_log_mux = portMUX_INITIALIZER_UNLOCKED;
+  static portMUX_TYPE s_hb_mux  = portMUX_INITIALIZER_UNLOCKED;
+  #define OFFBAND_CL_ENTER(mux) portENTER_CRITICAL(mux)
+  #define OFFBAND_CL_EXIT(mux)  portEXIT_CRITICAL(mux)
+#elif defined(OFFBAND_CRASHLOG_NRF52)
+  // Dummy mux tokens so shared call sites compile unchanged; the guard is a
+  // brief interrupt mask (writes are a memcpy of <=241 bytes).
+  static int s_log_mux = 0;
+  static int s_hb_mux  = 0;
+  #define OFFBAND_CL_ENTER(mux) do { (void)(mux); noInterrupts(); } while (0)
+  #define OFFBAND_CL_EXIT(mux)  do { (void)(mux); interrupts();   } while (0)
 #else
-// Host build: just provide stubs so the unit harness compiles.
-static CrashLogHeader s_header;
-static char           s_data[kCrashLogDataSize];
+  static int s_log_mux = 0;
+  static int s_hb_mux  = 0;
+  #define OFFBAND_CL_ENTER(mux) do { (void)(mux); } while (0)
+  #define OFFBAND_CL_EXIT(mux)  do { (void)(mux); } while (0)
 #endif
 
 static bool s_begin_called = false;
@@ -114,11 +139,22 @@ static void writeToRing(const char* src, size_t n) {
 // Public API
 // ---------------------------------------------------------------------------
 
+// Platform reset-reason code. ESP32 has the esp_reset_reason() enum; nRF52's
+// reason is carried by the board hook (its raw code is provider-defined, so 0
+// here and the string comes from resetReasonString via the hook).
+static int currentResetReasonCode() {
+#if defined(OFFBAND_CRASHLOG_ESP32)
+    return (int)esp_reset_reason();
+#else
+    return 0;
+#endif
+}
+
 void crashLogBegin() {
     if (s_begin_called) return;
     s_begin_called = true;
 
-#ifdef ARDUINO
+#ifndef OFFBAND_CRASHLOG_HOST
     // Was the previous boot's buffer valid?
     bool valid = (s_header.magic == kCrashLogMagic) &&
                  (s_header.write_index < kCrashLogDataSize);
@@ -126,10 +162,10 @@ void crashLogBegin() {
         // Dump previous-boot contents to serial.
         Serial.println();
         Serial.println("=========================================================");
-        Serial.println("=== CRASH LOG FROM PREVIOUS BOOT (RTC_NOINIT survived) ===");
+        Serial.println("=== CRASH LOG FROM PREVIOUS BOOT (retained RAM survived) =");
         Serial.printf("=== reset_reason=%d (%s), buffer wrapped=%u ===\n",
-                      (int)esp_reset_reason(),
-                      resetReasonString(esp_reset_reason()),
+                      currentResetReasonCode(),
+                      resetReasonString(currentResetReasonCode()),
                       (unsigned)s_header.wrapped);
         Serial.println("=========================================================");
 
@@ -156,19 +192,20 @@ void crashLogBegin() {
     // intentionally NOT cleared -- the wrap logic + start-from-write_index
     // handles "empty" correctly because write_index = 0 + wrapped = 0
     // means "print bytes [0..0)" = print nothing.
-    portENTER_CRITICAL(&s_log_mux);
+    OFFBAND_CL_ENTER(&s_log_mux);
     s_header.magic       = kCrashLogMagic;
     s_header.write_index = 0;
     s_header.wrapped     = 0;
     s_header.reserved    = 0;
-    portEXIT_CRITICAL(&s_log_mux);
+    OFFBAND_CL_EXIT(&s_log_mux);
 
     // v2: install hooks immediately so ESP-IDF logs from THIS boot onward
     // are captured, and any reset path triggers a last-gasp dump.
+    // (No-ops on nRF52: no ESP-IDF log stream, no shutdown-handler registry.)
     crashLogInstallEspLogHook();
     crashLogInstallShutdownHandler();
 
-    // v6: initialize boot counter + heartbeat state.
+    // v6: initialize boot counter + heartbeat state. (nRF52: minimal, see below.)
     heartbeatBegin();
 #endif
 }
@@ -182,7 +219,7 @@ void crashLogf(const char* fmt, ...) {
     char line[kCrashLogLineMax + 1];
     int  prefix_len = 0;
 
-#ifdef ARDUINO
+#ifndef OFFBAND_CRASHLOG_HOST
     // Auto-prepend "[<millis>] " for ordering context.
     prefix_len = snprintf(line, sizeof(line), "[%lu] ",
                           (unsigned long)millis());
@@ -209,16 +246,16 @@ void crashLogf(const char* fmt, ...) {
         line[total]   = '\0';
     }
 
-#ifdef ARDUINO
+#ifndef OFFBAND_CRASHLOG_HOST
     // Live monitoring path -- ALWAYS, even before begin() (the ring isn't ready
     // yet, but the line must not vanish).
     Serial.write((const uint8_t*)line, total);
 
     // Crash-survival ring -- only once begin() has initialized the header.
     if (s_begin_called) {
-        portENTER_CRITICAL(&s_log_mux);
+        OFFBAND_CL_ENTER(&s_log_mux);
         writeToRing(line, total);
-        portEXIT_CRITICAL(&s_log_mux);
+        OFFBAND_CL_EXIT(&s_log_mux);
     }
 #else
     // Host build: just write to stdout.
@@ -228,7 +265,7 @@ void crashLogf(const char* fmt, ...) {
 }
 
 void crashLogDump() {
-#ifdef ARDUINO
+#ifndef OFFBAND_CRASHLOG_HOST
     Serial.println("--- crashLogDump (current buffer) ---");
     size_t start = s_header.wrapped ? s_header.write_index : 0;
     size_t count = s_header.wrapped ? kCrashLogDataSize : s_header.write_index;
@@ -242,18 +279,25 @@ void crashLogDump() {
 }
 
 void crashLogClear() {
-    portENTER_CRITICAL(&s_log_mux);
+    OFFBAND_CL_ENTER(&s_log_mux);
     s_header.magic       = kCrashLogMagic;
     s_header.write_index = 0;
     s_header.wrapped     = 0;
-    portEXIT_CRITICAL(&s_log_mux);
+    OFFBAND_CL_EXIT(&s_log_mux);
 }
 
 // ---------------------------------------------------------------------------
 // CrashLog v2: ESP-IDF log capture + shutdown handler + heap stats
 // ---------------------------------------------------------------------------
+// ESP32-ONLY. These lean on ESP-IDF facilities with no nRF52 equivalent:
+// esp_log_set_vprintf (BT/Bluedroid log capture), esp_register_shutdown_handler,
+// NVS Preferences, ESP.getFreeHeap, uxTaskGetStackHighWaterMark. On nRF52 the
+// retained ring + crashLogf above are the breadcrumb substrate; the richer
+// sub-loop/heartbeat instrumentation is a later #350 increment. nRF52 + host
+// therefore share the stub set at the `#else` below.
+// ---------------------------------------------------------------------------
 
-#ifdef ARDUINO
+#if defined(OFFBAND_CRASHLOG_ESP32)
 
 // Recursion guard: if ESP_LOG is called from inside our handler (e.g., a
 // driver logs while we're writing to its serial), we'd loop forever.
@@ -363,10 +407,9 @@ struct BootCounterState {
 RTC_NOINIT_ATTR static BootCounterState s_boot_state;
 
 // Sub-loop visit tracking. Each sub-loop sets its bit on entry;
-// heartbeat reads + zeroes. portMUX serialization for thread safety.
+// heartbeat reads + zeroes. s_hb_mux (defined once, up top) serializes.
 static volatile uint8_t s_subloop_flags = 0;
 static volatile uint32_t s_loop_iter_delta = 0;
-static portMUX_TYPE s_hb_mux = portMUX_INITIALIZER_UNLOCKED;
 
 // Heartbeat timing
 static uint32_t s_last_hb_ms = 0;
@@ -581,7 +624,9 @@ void crashLogHeapStats(const char* tag) {
               phase);
 }
 
-#else  // !ARDUINO host build
+#else  // nRF52 + host: ESP-IDF extras are stubbed (see block header). The
+       // retained ring + crashLogf (above) are the working breadcrumb substrate
+       // on nRF52; sub-loop/heartbeat instrumentation is a later #350 increment.
 
 void crashLogInstallEspLogHook() {}
 void crashLogInstallShutdownHandler() {}

--- a/src/helpers/diagnostics/CrashLog.cpp
+++ b/src/helpers/diagnostics/CrashLog.cpp
@@ -150,6 +150,35 @@ static int currentResetReasonCode() {
 #endif
 }
 
+// Snapshot of the PREVIOUS boot's ring, captured at crashLogBegin() before this
+// boot overwrites it. Held so the dump can be re-emitted a few seconds later,
+// once a serial monitor plugged in AFTER the reset has had time to attach --
+// the boot-time print alone is lost to a not-yet-connected host (#378). Plain
+// static (not retained): it only needs to live for this boot.
+#ifndef OFFBAND_CRASHLOG_HOST
+static char   s_prev_snapshot[kCrashLogDataSize];
+static size_t s_prev_len     = 0;
+static bool   s_prev_pending = false;   // a deferred re-dump is still owed
+
+static void emitPreviousBootDump(const char* why) {
+    if (s_prev_len == 0) { return; }
+    Serial.println();
+    Serial.println("=========================================================");
+    Serial.printf ("=== CRASH LOG FROM PREVIOUS BOOT (%s) ===\n", why);
+    Serial.printf ("=== reset_reason=%d (%s) ===\n",
+                   currentResetReasonCode(),
+                   resetReasonString(currentResetReasonCode()));
+    Serial.println("=========================================================");
+    for (size_t i = 0; i < s_prev_len; ++i) {
+        char c = s_prev_snapshot[i];
+        if (c != '\0') Serial.write(c);
+    }
+    Serial.println();
+    Serial.println("=== END CRASH LOG ======================================");
+    Serial.println();
+}
+#endif
+
 void crashLogBegin() {
     if (s_begin_called) return;
     s_begin_called = true;
@@ -159,32 +188,22 @@ void crashLogBegin() {
     bool valid = (s_header.magic == kCrashLogMagic) &&
                  (s_header.write_index < kCrashLogDataSize);
     if (valid) {
-        // Dump previous-boot contents to serial.
-        Serial.println();
-        Serial.println("=========================================================");
-        Serial.println("=== CRASH LOG FROM PREVIOUS BOOT (retained RAM survived) =");
-        Serial.printf("=== reset_reason=%d (%s), buffer wrapped=%u ===\n",
-                      currentResetReasonCode(),
-                      resetReasonString(currentResetReasonCode()),
-                      (unsigned)s_header.wrapped);
-        Serial.println("=========================================================");
-
-        // Print the buffer in order: if wrapped, start at write_index
-        // (= oldest byte); else start at 0.
+        // Snapshot the previous-boot ring IN ORDER (oldest first) before this
+        // boot overwrites it, so it can be re-emitted later for a late-connecting
+        // monitor (#378). If wrapped, order starts at write_index; else at 0.
         size_t start = s_header.wrapped ? s_header.write_index : 0;
         size_t count = s_header.wrapped ? kCrashLogDataSize : s_header.write_index;
+        if (count > kCrashLogDataSize) count = kCrashLogDataSize;
         for (size_t i = 0; i < count; ++i) {
-            char c = s_data[(start + i) % kCrashLogDataSize];
-            if (c == '\0') continue;  // skip embedded nulls
-            Serial.write(c);
+            s_prev_snapshot[i] = s_data[(start + i) % kCrashLogDataSize];
         }
-        Serial.println();
-        Serial.println("=========================================================");
-        Serial.println("=== END CRASH LOG (this boot's writes start here)     ===");
-        Serial.println("=========================================================");
-        Serial.println();
+        s_prev_len     = count;
+        s_prev_pending = true;                 // a deferred re-dump is owed
+        emitPreviousBootDump("retained RAM survived");   // immediate (attached monitors)
     } else {
-        // Fresh power-on (or deep-sleep wake, or corrupted RTC memory).
+        // Fresh power-on (or brown-out / corrupted retained memory).
+        s_prev_len     = 0;
+        s_prev_pending = false;
         Serial.println("[CrashLog] fresh boot; no previous-boot log to recover.");
     }
 
@@ -284,6 +303,21 @@ void crashLogClear() {
     s_header.write_index = 0;
     s_header.wrapped     = 0;
     OFFBAND_CL_EXIT(&s_log_mux);
+}
+
+// #378: call once per loop. Re-emits the previous-boot crash dump ONE more time,
+// ~5 s after boot, so a serial monitor connected AFTER the reset (the normal
+// field case -- you plug in to a node you found wedged/rebooted) still sees it.
+// The boot-time print alone is lost to a host that has not attached yet.
+void crashLogTick(uint32_t now_ms) {
+#ifndef OFFBAND_CRASHLOG_HOST
+    if (s_prev_pending && now_ms >= 5000u) {
+        s_prev_pending = false;
+        emitPreviousBootDump("deferred re-dump for late serial connect");
+    }
+#else
+    (void)now_ms;
+#endif
 }
 
 // ---------------------------------------------------------------------------

--- a/src/helpers/diagnostics/CrashLog.h
+++ b/src/helpers/diagnostics/CrashLog.h
@@ -1,4 +1,4 @@
-// src/helpers/wifi_observer/CrashLog.h
+// src/helpers/diagnostics/CrashLog.h
 //
 // Panic-survival ring buffer using RTC_NOINIT memory on ESP32-S3.
 //
@@ -24,7 +24,9 @@
 //   inspect/clear it on demand.
 
 #pragma once
-#include "WifiObserverConfig.h"
+// NOTE (#350): CrashLog still depends on WifiObserverConfig.h. Breaking that
+// dependency is the next decoupling step -- this task is the move only.
+#include <helpers/wifi_observer/WifiObserverConfig.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/helpers/diagnostics/CrashLog.h
+++ b/src/helpers/diagnostics/CrashLog.h
@@ -127,6 +127,13 @@ void crashLogDump();
 // reads see nothing prior. CLI / settings command on demand.
 void crashLogClear();
 
+// Call once per loop iteration (pass millis()). Re-emits the previous-boot crash
+// dump ONE more time, ~5 s after boot, so a serial monitor connected AFTER the
+// reset -- the normal field case, you plug in to a node you found wedged or
+// rebooted -- still sees it. The boot-time print alone is lost to a host that
+// has not attached yet (#378). No-op after it has fired, and on a fresh boot.
+void crashLogTick(uint32_t now_ms);
+
 // ---------------------------------------------------------------------------
 // CrashLog v2 additions (SAFELANE "no silent failure" enforcement)
 // ---------------------------------------------------------------------------

--- a/src/helpers/diagnostics/CrashLog.h
+++ b/src/helpers/diagnostics/CrashLog.h
@@ -24,9 +24,6 @@
 //   inspect/clear it on demand.
 
 #pragma once
-// NOTE (#350): CrashLog still depends on WifiObserverConfig.h. Breaking that
-// dependency is the next decoupling step -- this task is the move only.
-#include <helpers/wifi_observer/WifiObserverConfig.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/helpers/diagnostics/CrashLog.h
+++ b/src/helpers/diagnostics/CrashLog.h
@@ -27,7 +27,58 @@
 #include <stddef.h>
 #include <stdint.h>
 
+// ---------------------------------------------------------------------------
+// Platform selector (#350 / #376)
+// ---------------------------------------------------------------------------
+// CrashLog was written ESP32-only, gated behind `#ifdef ARDUINO`. But ARDUINO
+// is defined on nRF52 too, so that guard is wrong for a role-neutral logger.
+// Select an EXPLICIT platform instead. ESP32 keeps every prior code path
+// byte-for-byte; nRF52 gets the portable core; anything else is the host build.
+#if defined(ARDUINO_ARCH_ESP32) || defined(ESP_PLATFORM)
+  #define OFFBAND_CRASHLOG_ESP32 1
+#elif defined(ARDUINO_ARCH_NRF52) || defined(NRF52) || defined(NRF52_PLATFORM)
+  #define OFFBAND_CRASHLOG_NRF52 1
+#else
+  #define OFFBAND_CRASHLOG_HOST 1
+#endif
+
+// Retained-memory placement. The ring + boot counter live here so they survive
+// a reset without being re-initialized by C-runtime startup.
+//   ESP32 : RTC slow memory (RTC_NOINIT_ATTR) -- separate from main RAM,
+//           survives deep sleep as well as soft/watchdog reset.
+//   nRF52 : the .noinit section added in #361 -- main SRAM, survives soft and
+//           watchdog reset but NOT a power cut. (Accepted trade, #350.)
+//           NB (ld 2.29, #363): .noinit is GC'd unless REFERENCED. The ring IS
+//           referenced by live code, so it is retained; do not add unreferenced
+//           retained globals without a `used` anchor.
+//   host  : plain static (tests only; no retention semantics).
+#if defined(OFFBAND_CRASHLOG_ESP32)
+  #include <esp_attr.h>
+  #define OFFBAND_RETAINED RTC_NOINIT_ATTR
+#elif defined(OFFBAND_CRASHLOG_NRF52)
+  #define OFFBAND_RETAINED __attribute__((section(".noinit")))
+#else
+  #define OFFBAND_RETAINED
+#endif
+
+// Ring size in bytes (header + data). 4 KB default; a RAM-tight variant may
+// override with -D OFFBAND_CRASHLOG_RING_BYTES=<n>. On nRF52840 (the whole
+// fleet) 4 KB is ~1.7% of app RAM; ~2% of a repeater's free RAM.
+#ifndef OFFBAND_CRASHLOG_RING_BYTES
+  #define OFFBAND_CRASHLOG_RING_BYTES 4096
+#endif
+
 namespace offband {
+
+// Reset-reason provider hook (#376, design decision 2: "delegate to the board").
+// CrashLog is board-agnostic, so instead of threading a board handle through the
+// API (which would ripple into integration code other sessions are editing), the
+// board registers its decoder here. When set, CrashLog reports the reset reason
+// via this hook; when null, it falls back to a built-in decode (ESP32) or "n/a"
+// (nRF52). The hook returns a short human-readable string; the raw code is
+// provider-defined. Wiring is a one-liner the board/example adds; unset is safe.
+typedef const char* (*ResetReasonHook)();
+void crashLogSetResetReasonHook(ResetReasonHook hook);
 
 // ---------------------------------------------------------------------------
 // Reset-reason string mapping (Stage A)

--- a/src/helpers/ui/SSD1306Display.cpp
+++ b/src/helpers/ui/SSD1306Display.cpp
@@ -1,7 +1,7 @@
 #include "SSD1306Display.h"
 
 #ifdef OFFBAND_OBSERVER
-  #include <helpers/wifi_observer/CrashLog.h>
+  #include <helpers/diagnostics/CrashLog.h>
 #endif
 
 bool SSD1306Display::i2c_probe(TwoWire& wire, uint8_t addr) {

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -6,7 +6,7 @@
   #include <Preferences.h>
   #if defined(ESP_PLATFORM)
     #include <nvs.h>        // #181: nvs_get_stats() -- write-failure diagnostic (real device only)
-    #include "CrashLog.h"   // #181: crashLogf() -- persistent + Serial failure log
+    #include <helpers/diagnostics/CrashLog.h>   // #181: crashLogf() -- persistent + Serial failure log
   #endif
 #else
   // Host build: provide a thin Preferences shim so the file compiles

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -4,7 +4,7 @@
 
 #include "MqttBrokerPool.h"
 #include "MqttPayload.h"
-#include "CrashLog.h"   // #181: crashLogf() -- worker has no user ACK channel
+#include <helpers/diagnostics/CrashLog.h>   // #181: crashLogf() -- worker has no user ACK channel
 #include <cstring>
 #include <cstdio>
 

--- a/src/helpers/wifi_observer/WifiObserver.cpp
+++ b/src/helpers/wifi_observer/WifiObserver.cpp
@@ -7,7 +7,7 @@
 
 #include "WifiObserver.h"
 #include "WifiBootstrap.h"
-#include "CrashLog.h"
+#include <helpers/diagnostics/CrashLog.h>
 #include "ObserverPipeline.h"
 
 #ifdef ARDUINO

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -439,3 +439,4 @@ build_src_filter =
   ${env:Heltec_v3_companion_radio_ble.build_src_filter}
   +<helpers/wifi_observer/*.cpp>
   +<helpers/config/*.cpp>            ; #364: shared role-agnostic config dispatch
+  +<helpers/diagnostics/*.cpp>   ; #350: CrashLog moved out of wifi_observer/

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -585,6 +585,7 @@ build_src_filter =
   ${env:heltec_v4_companion_radio_ble.build_src_filter}
   +<helpers/wifi_observer/*.cpp>
   +<helpers/config/*.cpp>            ; #364: shared role-agnostic config dispatch
+  +<helpers/diagnostics/*.cpp>   ; #350: CrashLog moved out of wifi_observer/
 [env:heltec_v4_kiss_modem]
 extends = Heltec_lora32_v4
 build_src_filter = ${Heltec_lora32_v4.build_src_filter}
@@ -615,6 +616,7 @@ build_src_filter =
   ${env:heltec_v4_tft_companion_radio_ble.build_src_filter}
   +<helpers/wifi_observer/*.cpp>
   +<helpers/config/*.cpp>            ; #364: shared role-agnostic config dispatch
+  +<helpers/diagnostics/*.cpp>   ; #350: CrashLog moved out of wifi_observer/
 lib_deps =
   ${env:heltec_v4_tft_companion_radio_ble.lib_deps}
   ${esp32_ble.lib_deps}

--- a/variants/rak3401/platformio.ini
+++ b/variants/rak3401/platformio.ini
@@ -31,6 +31,7 @@ build_src_filter = ${nrf52_base.build_src_filter}
   +<../variants/rak3401>
   +<helpers/sensors>
   +<helpers/ui/SSD1306Display.cpp>
+  +<helpers/diagnostics/*.cpp>   ; #376: CrashLog boot-survival diagnostics (nRF52 core)
   +<helpers/ui/MomentaryButton.cpp>
 lib_deps =
   ${nrf52_base.lib_deps}

--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -273,6 +273,7 @@ build_src_filter =
   ${env:Xiao_S3_WIO_companion_radio_ble.build_src_filter}
   +<helpers/wifi_observer/*.cpp>
   +<helpers/config/*.cpp>            ; #364: shared role-agnostic config dispatch
+  +<helpers/diagnostics/*.cpp>   ; #350: CrashLog moved out of wifi_observer/
 [env:Xiao_S3_WIO_kiss_modem]
 extends = Xiao_S3_WIO
 build_src_filter = ${Xiao_S3_WIO.build_src_filter}


### PR DESCRIPTION
Lands the **decouple foundation** of Epic #350 (CrashLog → role-neutral). Part of #350 — **does NOT close the epic** (it stays open for #472 uniform rollout + the parked #378 nRF52 retention limitation).

**Commits (all referenced issues closed):**
- #367 relocate CrashLog `wifi_observer/` → `helpers/diagnostics/`
- #369 drop the vestigial `WifiObserverConfig.h` dependency
- #376 portable core — CrashLog compiles + runs on nRF52
- #377 wire nRF52 CrashLog into the companion boot/loop
- #361 `.noinit` retained-RAM ldscript section (nRF52)
- #463 deferred re-dump (`crashLogTick`) — re-emit previous-boot log ~5s in for a late serial monitor

**Explicitly out of scope (tracked separately):**
- Uniform CrashLog across ALL roles → **#472** (the piece that gets CrashLog onto the sensor + repeater + room-server + ESP32 companion). This PR does NOT add those.
- nRF52 cross-reset retention (`.noinit` doesn't survive a watchdog reset on RAK) → **#378** (parked).

**Coordination:** resolves DarkLynx's #370 MAJOR-2 once landed — CrashLog now lives at `src/helpers/diagnostics/CrashLog.h`; #370's `DisplayConfigProvider.cpp` include moves to `../diagnostics/CrashLog.h`.

**Verification:** rebased clean onto `firmware-base` (a8fb77fa); builds green on `RAK_3401_companion_radio_usb` (nRF wire-in), `heltec_v4_companion_radio_usb` (ESP32 RTC_NOINIT), `heltec_v4_companion_observer_wifi` (CrashLog gone from wifi_observer/).