### PR TITLE
fix(#475): compile CrashLog everywhere via arduino_base src-filter (nRF52 companion regression)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -65,6 +65,7 @@ build_flags = -w -DNDEBUG -DRADIOLIB_STATIC_ONLY=1 -DRADIOLIB_GODMODE=1
 build_src_filter =
   +<*.cpp>
   +<helpers/*.cpp>
+  +<helpers/diagnostics/*.cpp>   ; #475: CrashLog (moved here in #350) -- compile everywhere; --gc-sections drops it where uncalled
   +<helpers/radiolib/*.cpp>
   +<helpers/bridges/BridgeBase.cpp>
   +<helpers/ui/MomentaryButton.cpp>


### PR DESCRIPTION
Fixes the #350 regression found by DarkLynx (while verifying #370): #350 moved `CrashLog.cpp` to `helpers/diagnostics/` and #377 wired `crashLog*` into the companion boot/loop for all nRF52 companions, but the `+<helpers/diagnostics/*.cpp>` src-filter add only reached `rak3401` + the ESP32 observer variants — so ~33 nRF52 companion variants failed to link.

**One-line fix:** add `+<helpers/diagnostics/*.cpp>` to `arduino_base.build_src_filter` — the common root (`esp32_base`/`nrf52_base`/`rp2040_base`/`stm32_base` all `extends = arduino_base`). CrashLog compiles in every env; `--gc-sections` drops it where uncalled (no forcing constructor → zero cost on non-using envs).

**Verified across every chip family (11 envs):** ESP32-S3/C3/C6/classic, nRF52 (direct + intermediate-base: RAK_4631, GAT562, ikoka, meshsmith_photon), RP2040 (RAK_11310), STM32 (wio-e5-mini) — including the two confirmed-broken envs DarkLynx hit.

Not a #370 issue — #370's base is clean once this lands. Closes the regression bug #475 (already closed). Does not touch the #350 epic (stays open for #472).