### PR TITLE
chore(#477): CI matrix becomes a required merge gate (ci-green aggregator + room_server coverage)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,14 @@ jobs:
           - meshsmith_photon_esp32c6_e22p_30dbm_companion_radio_ble   # MeshSmith Photon-1W (ESP32-C6 + E22 1W) coverage -- #193
           - meshsmith_photon_esp32c6_e22p_30dbm_repeater   # Photon-1W repeater (its primary "ridge repeater" role) -- #193
           - meshsmith_photon_nrf52_e22p_30dbm_repeater   # Photon-1W nRF52 repeater coverage -- #194
+          # #477: room_server role was previously built NOWHERE in CI -- caplog-era
+          # cross-role changes could compile-break it invisibly. One env per MCU
+          # family/flavor in active use.
+          - Heltec_v3_room_server
+          - heltec_v4_room_server
+          - RAK_3401_room_server
+          - RAK_4631_room_server
+          - Xiao_S3_room_server
     steps:
       - uses: actions/checkout@v5
 
@@ -116,3 +124,23 @@ jobs:
             .pio/build/${{ matrix.env }}/firmware.uf2
           if-no-files-found: warn
           retention-days: 90
+
+  # #477: single required-status aggregation point. Branch protection on
+  # firmware-base requires ONLY this check -- so matrix edits can never
+  # silently un-require an env, and `gh pr merge --auto` genuinely waits for
+  # the full curated matrix. `needs.build.result` is `success` only when EVERY
+  # matrix leg succeeded (fail-fast is off, so all legs always report).
+  # `if: always()` makes this job run -- and FAIL -- even when a dependency
+  # failed; without it a red build would leave ci-green skipped, and a skipped
+  # required check blocks the PR with no explanation instead of a red X.
+  ci-green:
+    runs-on: ubuntu-latest
+    needs: [config-lint, build]
+    if: always()
+    steps:
+      - name: All required CI jobs green
+        run: |
+          echo "config-lint: ${{ needs.config-lint.result }}"
+          echo "build (all matrix legs): ${{ needs.build.result }}"
+          test "${{ needs.config-lint.result }}" = "success"
+          test "${{ needs.build.result }}" = "success"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,11 @@ jobs:
           - RAK_3401_room_server
           - RAK_4631_room_server
           - Xiao_S3_room_server
+          # #477: tracker variants ship in every release but were built nowhere
+          # in CI -- variant-specific code (GPS/eink/button paths) was blind.
+          # Owner has bench devices for both as of 2026-07-31.
+          - t1000e_companion_radio_ble
+          - WioTrackerL1_companion_radio_ble
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
           # Owner has bench devices for both as of 2026-07-31.
           - t1000e_companion_radio_ble
           - WioTrackerL1_companion_radio_ble
+          - SenseCap_Solar_repeater   # fleet-deployed fixed solar nodes (owner, 2026-07-31)
     steps:
       - uses: actions/checkout@v5
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,12 @@ Device inventory, RF chain (FEM / TX power), per-device MACs/roles, slot/pin map
 
 - **Release approval gate** — never push a release tag (`-rc` or stable) without first posting a concise **release preview** (version, `-rc`/stable, the CHANGELOG entry, any user-facing string change) and getting an explicit human "ship it." Validation/feedback ("it works" / "happy with it") is **not** release authorization. Scale the preview to the change — keep it light, not ceremony. Full rationale + format in [`VERSIONING.md`](VERSIONING.md) ("Release approval gate").
 
+## PR definition-of-done (#477 — CI matrix is a required merge gate)
+
+- `firmware-base` branch protection requires the **`ci-green`** check (aggregates `config-lint` + the FULL curated build matrix, incl. nRF52 + room_server envs). `gh pr merge --auto --rebase` therefore **waits for the matrix** — enabling auto-merge is no longer merging.
+- **A PR task is NOT complete — and must not be closed in Citadel — until `gh pr view <n> --json state` reports `MERGED`.** A red matrix leaves the PR sitting unmerged; closing the task anyway is the SAFELANE §5 "declaring success without the artifact" violation. If `ci-green` fails, fixing the build (all matrix envs, not just the ones you tested on — the #350/#463 lesson) is part of the same task.
+- Do not shrink or bypass the matrix to get green; matrix changes are owner-approved only.
+
 ## Follow-ups (bootstrap gaps to close)
 
 - `/work` slash command + `session-state.py` compaction-recovery hook: **now published canonically** (standards @27b3ec7 — `/work` #112, `session-state.py` #107). `/work` auto-syncs into `.claude/commands/` via preflight; `session-state.py` is a hook copy-in (not auto-synced). Port deferred by owner — do when picked up.


### PR DESCRIPTION
Implements the owner-approved #477 plan, steps 1-3:

1. **`ci-green` aggregator** — `needs: [config-lint, build]`, `if: always()`, fails on any non-success dependency result. Branch protection will require ONLY this one stable check: matrix edits can never silently un-require an env, and `gh pr merge --auto --rebase` genuinely waits for the full matrix. (`if: always()` specifically prevents the skipped-required-check deadlock.)
2. **Matrix +5** — room_server was built nowhere in CI: `Heltec_v3_room_server`, `heltec_v4_room_server`, `RAK_3401_room_server`, `RAK_4631_room_server`, `Xiao_S3_room_server` (names are the literal case-sensitive env IDs from `variants/*/platformio.ini` — the case mix is upstream naming, per Gemini's only MINOR).
3. **CLAUDE.md definition-of-done** — a PR task isn't closeable until the PR reports MERGED; red matrix = fix all envs as part of the same task (#350/#463 lesson).

Step 4 (branch protection: require `ci-green` + strict up-to-date, preserving existing settings) is applied via `gh api` **after** this merges — the check must exist on the base branch first. Rollback for everything is documented on #477.

Verified: YAML parses (3 jobs, 21 matrix envs); Gemini adversarial review **0 BLOCKER / 0 MAJOR** (`docs/llm-consultations/2026-07-30-477-ci-gate-review-gemini-gemini-2.5-pro.log`); this PR's own run is the first live exercise of `ci-green`.

Refs #477. Agent: WhiteFalcon (session cb12cdd2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)