### PR TITLE
chore(#479): add Heltec T096 to CI matrix (repeater + BLE companion)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,11 @@ jobs:
           - t1000e_companion_radio_ble
           - WioTrackerL1_companion_radio_ble
           - SenseCap_Solar_repeater   # fleet-deployed fixed solar nodes (owner, 2026-07-31)
+          # #479: Heltec T096 (nRF52) -- in active use; repeater-improvement work
+          # incoming, so its primary role + BLE companion must build in CI.
+          # (No observer env exists: observer is ESP32/WiFi-only.)
+          - Heltec_t096_repeater
+          - Heltec_t096_companion_radio_ble
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
Adds `Heltec_t096_repeater` (primary role per owner) + `Heltec_t096_companion_radio_ble` — board is in active use with repeater-focused improvement work incoming. Observer role doesn't exist for this nRF52 board. Matrix: 26 envs. First PR through the #477 ci-green gate — auto-merge enabled, lands only when the full matrix is green. Refs #479. Agent: WhiteFalcon (session cb12cdd2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)