### PR TITLE
refactor(#370): split wifi.*/display.* into shared config providers

### DIFF
--- a/src/helpers/config/DisplayConfigProvider.cpp
+++ b/src/helpers/config/DisplayConfigProvider.cpp
@@ -1,0 +1,239 @@
+// src/helpers/config/DisplayConfigProvider.cpp
+//
+// #370: the shared `display.*` config provider. See DisplayConfigProvider.h.
+//
+// The NVS accessors + handlers are relocated VERBATIM from ConfigSchema.cpp and
+// ObserverCli.cpp (byte-identical reply strings + identical NVS keys/namespace,
+// so no wire-contract or on-flash change). The private write-failure diagnostic
+// and the `offband_ui` constants are carried here too, so this file does NOT
+// depend on ConfigSchema.
+
+#include "DisplayConfigProvider.h"
+#include "ConfigDispatch.h"
+#include <cstdio>
+#include <cstring>
+
+#ifdef ARDUINO
+  #include <Arduino.h>
+  #include <Preferences.h>
+  #ifdef ESP_PLATFORM
+    #include <nvs.h>                          // nvs_get_stats() -- write-failure diagnostic
+    #include <helpers/diagnostics/CrashLog.h> // crashLogf() -- shared role-neutral diagnostic (relocated here by #350)
+  #endif
+#endif
+
+namespace offband {
+
+// offband_ui NVS keys (relocated from ConfigSchema -- fork-branded namespace so a
+// future upstream NVS namespace can never clash).
+namespace {
+constexpr const char* kNvsOffbandUi       = "offband_ui";
+constexpr const char* kKeyDisplayAlwaysOn = "always_on";   // bool; default false (#141)
+constexpr const char* kKeyDisplayRotation = "rotation";    // uint8 0/180; default 0 (#148)
+
+// #181: surface an NVS write failure to the persistent crash log + Serial. Real
+// device only; a no-op on host/non-ESP builds. Copied from ConfigSchema so the
+// display accessors carry their own diagnostic and stay decoupled.
+#if defined(ARDUINO) && defined(ESP_PLATFORM)
+void logCfgWriteFailure(const char* where, const char* ns) {
+    nvs_stats_t st;
+    if (nvs_get_stats(NULL, &st) == ESP_OK) {
+        crashLogf("[cfg] %s WRITE FAILED ns=%s nvs[used=%u free=%u total=%u]", where, ns,
+                  (unsigned)st.used_entries, (unsigned)st.free_entries, (unsigned)st.total_entries);
+    } else {
+        crashLogf("[cfg] %s WRITE FAILED ns=%s (nvs_get_stats unavailable)", where, ns);
+    }
+}
+#else
+void logCfgWriteFailure(const char*, const char*) {}
+#endif
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Display-preference persistence (relocated from ConfigSchema.cpp -- unchanged)
+// ---------------------------------------------------------------------------
+bool getDisplayAlwaysOn() {
+#ifdef ARDUINO
+    Preferences p;
+    p.begin(kNvsOffbandUi, /*readOnly=*/true);
+    bool v = p.getBool(kKeyDisplayAlwaysOn, false);
+    p.end();
+    return v;
+#else
+    return false;
+#endif
+}
+
+bool setDisplayAlwaysOn(bool on) {
+#ifdef ARDUINO
+    Preferences p;
+    if (!p.begin(kNvsOffbandUi, /*readOnly=*/false)) {
+        logCfgWriteFailure("setDisplayAlwaysOn.begin", kNvsOffbandUi);
+        return false;
+    }
+    size_t wrote = p.putBool(kKeyDisplayAlwaysOn, on);
+    p.end();
+    if (wrote != sizeof(uint8_t)) {     // putBool stores 1 byte; 0 on failure
+        logCfgWriteFailure("setDisplayAlwaysOn.putBool", kNvsOffbandUi);
+        return false;
+    }
+    return true;
+#else
+    (void)on;
+    return true;
+#endif
+}
+
+uint8_t getDisplayRotation() {
+#ifdef ARDUINO
+    Preferences p;
+    p.begin(kNvsOffbandUi, /*readOnly=*/true);
+    uint8_t v = p.getUChar(kKeyDisplayRotation, 0);
+    p.end();
+    return (v == 180) ? 180 : 0;
+#else
+    return 0;
+#endif
+}
+
+bool setDisplayRotation(uint8_t deg) {
+#ifdef ARDUINO
+    Preferences p;
+    if (!p.begin(kNvsOffbandUi, /*readOnly=*/false)) {
+        logCfgWriteFailure("setDisplayRotation.begin", kNvsOffbandUi);
+        return false;
+    }
+    size_t wrote = p.putUChar(kKeyDisplayRotation, (deg == 180) ? 180 : 0);
+    p.end();
+    if (wrote != sizeof(uint8_t)) {     // putUChar stores 1 byte; 0 on failure
+        logCfgWriteFailure("setDisplayRotation.putUChar", kNvsOffbandUi);
+        return false;
+    }
+    return true;
+#else
+    (void)deg;
+    return true;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Appliers + handlers (relocated from ObserverCli.cpp -- bodies unchanged)
+// ---------------------------------------------------------------------------
+static void (*s_display_always_on_applier)(bool) = nullptr;
+
+void setDisplayAlwaysOnApplier(void (*fn)(bool)) {
+    s_display_always_on_applier = fn;
+}
+
+bool handleDisplayAlwaysOn(char* reply, size_t reply_size, bool on) {
+    // #181: if persistence fails, surface it and do NOT apply to the live display
+    // -- applying a setting that won't survive a reboot would mislead the user
+    // about what's actually stored (SAFELANE 6: state must match the ACK).
+    if (!setDisplayAlwaysOn(on)) {                                     // persist (offband_ui NVS)
+        snprintf(reply, reply_size, "ERROR: failed to save display setting (NVS write failed)\n");
+        return true;
+    }
+    if (s_display_always_on_applier) s_display_always_on_applier(on);  // apply to the live display
+    snprintf(reply, reply_size,
+             on ? "display: always on (screen stays lit)\n"
+                : "display: normal (blanks after 15 s)\n");
+    return true;
+}
+
+static void (*s_display_rotation_applier)(uint8_t) = nullptr;
+
+void setDisplayRotationApplier(void (*fn)(uint8_t)) {
+    s_display_rotation_applier = fn;
+}
+
+static bool (*s_display_rotation_supported)() = nullptr;
+
+void setDisplayRotationSupportedQuery(bool (*fn)()) {
+    s_display_rotation_supported = fn;
+}
+
+// In-session cache of the current rotation so `display flip` toggles reliably
+// from RAM instead of a write-then-read NVS round-trip (a fresh read-only
+// handle may not observe a just-committed write). Lazily seeded from NVS;
+// updated on every rotate/flip. NVS stays the persistence layer (#148).
+static int s_rotation_cache = -1;   // -1 = not yet loaded
+
+bool handleDisplayRotate(char* reply, size_t reply_size, uint8_t deg) {
+    // #148: gate to drivers with a verified runtime-rotation override (SSD1306
+    // OLED). Others report unsupported rather than silently no-op'ing; the TFT
+    // (ST7789) override is not yet hardware-verified and is tracked separately.
+    // Deny-by-default: if the capability query was never registered, treat the
+    // display as unsupported (don't fall through to a silent no-op) -- per Gemini review.
+    if (!s_display_rotation_supported || !s_display_rotation_supported()) {
+        snprintf(reply, reply_size, "display: rotation not supported on this display\n");
+        return true;
+    }
+    // #181: persist first; on NVS failure surface it and leave the cache + live
+    // display untouched, so RAM state, NVS, and the ACK all stay consistent.
+    if (!setDisplayRotation(deg)) {                                           // persist (offband_ui NVS)
+        snprintf(reply, reply_size, "ERROR: failed to save display rotation (NVS write failed)\n");
+        return true;
+    }
+    s_rotation_cache = deg;                                                   // keep the in-session cache current
+    if (s_display_rotation_applier) s_display_rotation_applier(deg);          // apply to the live display
+    snprintf(reply, reply_size,
+             deg == 180 ? "display: rotation 180 (flipped)\n"
+                        : "display: rotation 0 (default)\n");
+    return true;
+}
+
+bool handleDisplayFlip(char* reply, size_t reply_size) {
+    // Toggle from the in-session cache (seeded from NVS on first use), so flip
+    // always inverts 0<->180 without depending on a read-after-write.
+    if (s_rotation_cache < 0) s_rotation_cache = getDisplayRotation();
+    uint8_t other = (s_rotation_cache == 180) ? 0 : 180;
+    return handleDisplayRotate(reply, reply_size, other);
+}
+
+// ---------------------------------------------------------------------------
+// Provider set/get -- relocated verbatim from observerConfigSet/Get's display
+// branches.
+// ---------------------------------------------------------------------------
+namespace {
+
+bool displayConfigSet(const char* key, const char* value, char* reply, size_t reply_size) {
+    if (key == nullptr || value == nullptr || reply == nullptr || reply_size == 0) return false;
+
+    if (config::strEq(key, "display.always_on")) {
+        bool on;
+        if (!config::parseBool(value, on)) { snprintf(reply, reply_size, "ERROR: display.always_on expects 0|1\n"); return true; }
+        return handleDisplayAlwaysOn(reply, reply_size, on);
+    }
+    if (config::strEq(key, "display.rotation")) {
+        if (config::strEq(value, "0"))   return handleDisplayRotate(reply, reply_size, 0);
+        if (config::strEq(value, "180")) return handleDisplayRotate(reply, reply_size, 180);
+        snprintf(reply, reply_size, "ERROR: display.rotation expects 0|180\n");
+        return true;
+    }
+    return false;  // not a display key
+}
+
+bool displayConfigGet(const char* key, char* reply, size_t reply_size) {
+    if (key == nullptr || reply == nullptr || reply_size == 0) return false;
+
+    if (config::strEq(key, "display.always_on")) {
+        snprintf(reply, reply_size, "display.always_on = %d\n", getDisplayAlwaysOn() ? 1 : 0);
+        return true;
+    }
+    if (config::strEq(key, "display.rotation")) {
+        snprintf(reply, reply_size, "display.rotation = %u\n", (unsigned)getDisplayRotation());
+        return true;
+    }
+    return false;  // not a display key
+}
+
+// #366: this provider owns exactly the `display.` prefix.
+const char* const kDisplayPrefixes[] = { "display." };
+
+__attribute__((used)) config::ProviderRegistrar _display_config_provider(
+    &displayConfigSet, &displayConfigGet, "display",
+    kDisplayPrefixes, (int)(sizeof(kDisplayPrefixes) / sizeof(kDisplayPrefixes[0])));
+
+}  // namespace
+
+}  // namespace offband

--- a/src/helpers/config/DisplayConfigProvider.h
+++ b/src/helpers/config/DisplayConfigProvider.h
@@ -1,0 +1,48 @@
+// src/helpers/config/DisplayConfigProvider.h
+//
+// Epic #300 item 1 / #370: the shared `display.*` config provider.
+//
+// Owner Option A (2026-07-29): `display.*` is its OWN provider + its OWN
+// capability bit (0x10, reserved in the canonical map; the constant + advertise
+// land under #365's caps-byte surface, NOT here), separate from `wifi.*`, so the
+// two are independently advertisable.
+//
+// This file also OWNS the display-preference NVS accessors (`getDisplayAlwaysOn`
+// etc.), relocated out of wifi_observer/ConfigSchema. They are pure `Preferences`
+// wrappers on the `offband_ui` namespace with zero broker/mqtt/observer coupling
+// -- role-neutral, so any role with a screen links them without dragging the
+// observer config schema. (This is the "decouple display" half of #370 -- owner
+// said do it now since every display-capable role needs it. WiFi's WifiBootstrap
+// coupling is deliberately NOT decoupled here; that's #365's call.)
+//
+// Keys: `display.always_on` (0|1), `display.rotation` (0|180). Persistence:
+// `offband_ui` NVS namespace. Applied live via app-registered raw function
+// pointers (no heap on tight-RAM boards).
+//
+// Handlers are exposed (not file-static) because the observer's `_sys` CLI
+// (dispatchObserverCli, in ObserverCli.cpp) calls them too. The provider
+// self-registers during static init.
+
+#pragma once
+#include <stddef.h>
+#include <stdint.h>
+
+namespace offband {
+
+// --- display-preference persistence (offband_ui NVS; relocated from ConfigSchema) ---
+bool    getDisplayAlwaysOn();
+bool    setDisplayAlwaysOn(bool on);       // #181: false on NVS failure (logged)
+uint8_t getDisplayRotation();              // clamped to {0,180}
+bool    setDisplayRotation(uint8_t deg);   // #181: false on NVS failure (logged)
+
+// --- live-apply appliers the app registers at boot (raw fn ptr, no heap) ---
+void setDisplayAlwaysOnApplier(void (*fn)(bool));            // #141
+void setDisplayRotationApplier(void (*fn)(uint8_t));         // #148
+void setDisplayRotationSupportedQuery(bool (*fn)());         // #148: refuse rotate on unsupported drivers
+
+// --- handlers (also called by the observer _sys CLI) ---
+bool handleDisplayAlwaysOn(char* reply, size_t reply_size, bool on);
+bool handleDisplayRotate(char* reply, size_t reply_size, uint8_t deg);
+bool handleDisplayFlip(char* reply, size_t reply_size);
+
+}  // namespace offband

--- a/src/helpers/config/WifiConfigProvider.cpp
+++ b/src/helpers/config/WifiConfigProvider.cpp
@@ -1,0 +1,205 @@
+// src/helpers/config/WifiConfigProvider.cpp
+//
+// #370: the shared `wifi.*` config provider. See WifiConfigProvider.h.
+//
+// Handler bodies are relocated VERBATIM from ObserverCli.cpp (byte-identical
+// reply strings; the only change is `eq(...)` -> `config::strEq(...)`, which is
+// behaviourally identical -- both are NULL-safe strcmp==0, proven by the #364
+// host parity harness). This keeps the firmware<->client wire contract
+// (#143/#160) unchanged.
+
+#include "WifiConfigProvider.h"
+#include "ConfigDispatch.h"
+#include "../wifi_observer/WifiBootstrap.h"   // wifi.status reads WifiBootstrap
+                                              // (observer bring-up; see header --
+                                              // #365 supplies its own off-observer)
+#include <cstdio>
+#include <cstring>
+
+#ifdef ARDUINO
+  #include <Preferences.h>
+  #include <WiFi.h>   // WiFi.localIP() for wifi.status
+#endif
+
+namespace offband {
+
+// ---------------------------------------------------------------------------
+// Handlers (relocated from ObserverCli.cpp -- bodies unchanged)
+// ---------------------------------------------------------------------------
+
+bool handleSetWifiField(char* reply, size_t reply_size,
+                        const char* field, const char* value) {
+    if (field == nullptr || value == nullptr) {
+        snprintf(reply, reply_size,
+                 "ERROR: usage: set wifi.ssid <s> | set wifi.pwd <s>\n");
+        return true;
+    }
+    if (!config::strEq(field, "ssid") && !config::strEq(field, "pwd")) {
+        snprintf(reply, reply_size,
+                 "ERROR: unknown wifi field '%s' "
+                 "(supported: ssid, pwd)\n", field);
+        return true;
+    }
+    // Reject empty values: an empty SSID is never useful and would
+    // collide with the no-creds detection in WifiBootstrap::begin.
+    if (value[0] == '\0') {
+        snprintf(reply, reply_size,
+                 "ERROR: empty value for wifi.%s\n", field);
+        return true;
+    }
+#ifdef ARDUINO
+    Preferences p;
+    if (!p.begin("wifi", /*readOnly=*/false)) {
+        snprintf(reply, reply_size,
+                 "ERROR: cannot open NVS namespace 'wifi'\n");
+        return true;
+    }
+    p.putString(field, value);
+    p.end();
+#endif
+    if (config::strEq(field, "pwd")) {
+        // Never echo the PSK in any code path.
+        snprintf(reply, reply_size,
+                 "wifi.pwd set (%u chars entered). Reboot or run "
+                 "'wifi status' after STA retry.\n",
+                 (unsigned)strlen(value));
+    } else {
+        snprintf(reply, reply_size, "wifi.ssid = %s\n", value);
+    }
+    return true;
+}
+
+bool handleGetWifi(char* reply, size_t reply_size, const char* field) {
+    if (field == nullptr) {
+        snprintf(reply, reply_size,
+                 "ERROR: usage: get wifi.ssid | wifi status\n");
+        return true;
+    }
+    if (config::strEq(field, "pwd")) {
+        // Refuse to ever read the PSK back. There is no legitimate
+        // workflow where surfacing the saved PSK to a remote caller
+        // is the right answer.
+        snprintf(reply, reply_size,
+                 "ERROR: wifi.pwd is write-only\n");
+        return true;
+    }
+    if (config::strEq(field, "ssid")) {
+#ifdef ARDUINO
+        Preferences p;
+        if (!p.begin("wifi", /*readOnly=*/true)) {
+            snprintf(reply, reply_size,
+                     "ERROR: cannot open NVS namespace 'wifi'\n");
+            return true;
+        }
+        String s = p.getString("ssid", "");
+        p.end();
+        snprintf(reply, reply_size, "wifi.ssid = %s\n",
+                 s.isEmpty() ? "(unset)" : s.c_str());
+#else
+        snprintf(reply, reply_size, "wifi.ssid = (host build)\n");
+#endif
+        return true;
+    }
+    if (config::strEq(field, "status")) {
+#ifdef ARDUINO
+        // Reach into the WifiBootstrap state via the singleton.
+        // Render a single human-readable line summarizing the
+        // current STA state + IP when connected.
+        auto state = wifiBootstrap().state();
+        const char* st = "?";
+        switch (state) {
+            case WifiBootstrapState::Boot:          st = "Boot";          break;
+            case WifiBootstrapState::CliRescue:     st = "CliRescue";     break;
+            case WifiBootstrapState::ApMode:        st = "AwaitingSetup"; break;
+            case WifiBootstrapState::StaConnecting: st = "StaConnecting"; break;
+            case WifiBootstrapState::StaConnected:  st = "StaConnected";  break;
+            case WifiBootstrapState::StaFailed:     st = "StaFailed";     break;
+        }
+        if (state == WifiBootstrapState::StaConnected) {
+            snprintf(reply, reply_size, "wifi.status = %s ip=%s\n",
+                     st, WiFi.localIP().toString().c_str());
+        } else {
+            snprintf(reply, reply_size, "wifi.status = %s\n", st);
+        }
+#else
+        snprintf(reply, reply_size, "wifi.status = (host build)\n");
+#endif
+        return true;
+    }
+    snprintf(reply, reply_size,
+             "ERROR: unknown wifi field '%s' (supported: ssid, status)\n",
+             field);
+    return true;
+}
+
+bool handleSetWifiEnabled(char* reply, size_t reply_size, bool enabled) {
+#ifdef ARDUINO
+    Preferences p;
+    if (!p.begin("wifi", /*readOnly=*/false)) {
+        snprintf(reply, reply_size, "ERROR: cannot open NVS namespace 'wifi'\n");
+        return true;
+    }
+    p.putBool("enabled", enabled);
+    p.end();
+#endif
+    snprintf(reply, reply_size, "wifi.enabled = %d (reboot to apply)\n",
+             enabled ? 1 : 0);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Provider set/get -- relocated verbatim from observerConfigSet/Get's wifi
+// branches. Key ORDER is load-bearing: exact `wifi.enabled` MUST be tested
+// before the generic `wifi.` prefix, else the boolean is written to NVS as a
+// wifi field literally named "enabled".
+// ---------------------------------------------------------------------------
+namespace {
+
+bool wifiConfigSet(const char* key, const char* value, char* reply, size_t reply_size) {
+    if (key == nullptr || value == nullptr || reply == nullptr || reply_size == 0) return false;
+
+    if (config::strEq(key, "wifi.enabled")) {
+        bool on;
+        if (!config::parseBool(value, on)) { snprintf(reply, reply_size, "ERROR: wifi.enabled expects 0|1\n"); return true; }
+        return handleSetWifiEnabled(reply, reply_size, on);
+    }
+    if (strncmp(key, "wifi.", 5) == 0)            // wifi.ssid / wifi.pwd
+        return handleSetWifiField(reply, reply_size, key + 5, value);
+
+    return false;  // not a wifi key
+}
+
+bool wifiConfigGet(const char* key, char* reply, size_t reply_size) {
+    if (key == nullptr || reply == nullptr || reply_size == 0) return false;
+
+    if (config::strEq(key, "wifi.enabled")) {
+#ifdef ARDUINO
+        Preferences p; bool en = true;
+        if (p.begin("wifi", /*readOnly=*/true)) { en = p.getBool("enabled", true); p.end(); }
+        snprintf(reply, reply_size, "wifi.enabled = %d\n", en ? 1 : 0);
+#else
+        snprintf(reply, reply_size, "wifi.enabled = (host build)\n");
+#endif
+        return true;
+    }
+    if (strncmp(key, "wifi.", 5) == 0)             // wifi.ssid (wifi.pwd -> write-only error)
+        return handleGetWifi(reply, reply_size, key + 5);
+
+    return false;  // not a wifi key
+}
+
+// #366: this provider owns exactly the `wifi.` prefix. The overlap detector
+// fires at registration if another provider also claims it (e.g. a second role
+// registering `wifi.mode` under `wifi.` -- #301's exact hazard).
+const char* const kWifiPrefixes[] = { "wifi." };
+
+// Self-register during static init (POD table in .bss -> link-order safe; see
+// ConfigDispatch.h). __attribute__((used)) is free insurance against a future
+// toolchain dropping the registrar object (#364 review BLOCKER-1).
+__attribute__((used)) config::ProviderRegistrar _wifi_config_provider(
+    &wifiConfigSet, &wifiConfigGet, "wifi",
+    kWifiPrefixes, (int)(sizeof(kWifiPrefixes) / sizeof(kWifiPrefixes[0])));
+
+}  // namespace
+
+}  // namespace offband

--- a/src/helpers/config/WifiConfigProvider.h
+++ b/src/helpers/config/WifiConfigProvider.h
@@ -1,0 +1,46 @@
+// src/helpers/config/WifiConfigProvider.h
+//
+// Epic #300 item 1 / #370: the shared `wifi.*` config provider.
+//
+// Extracted from wifi_observer/ObserverCli.cpp so ANY WiFi-capable role
+// (observer, companion #365, repeater #301) registers the SAME provider for the
+// `wifi.` key space instead of the observer owning the prefix. Single ownership
+// dissolves the first-provider-wins shadowing hazard (#366) for `wifi.*`.
+//
+// Keys: `wifi.ssid`, `wifi.pwd` (write-only on GET), `wifi.enabled`, and the
+// read-only `wifi.status`. Persistence is the `"wifi"` NVS namespace via
+// Preferences (role-neutral) -- NOT a NodePrefs/DataStore offset.
+//
+// KNOWN COUPLING (deliberate, deferred to #365): the `wifi.status` GET reads the
+// observer's `WifiBootstrap` state machine. That is the observer's STA/AP
+// bring-up; a non-observer companion's runtime-WiFi path (#325/#365) has its own
+// bring-up, so what `wifi.status` means off-observer is a #365 design decision,
+// not a mechanical move. This provider keeps the WifiBootstrap dependency for the
+// observer; #365 wires its own status source when it lands. (Owner call
+// 2026-07-29: #370 relocates + decouples DISPLAY, leaves WiFi's WifiBootstrap
+// coupling to #365.)
+//
+// The handlers are exposed here (not file-static) because the observer's `_sys`
+// string CLI (dispatchObserverCli, still in ObserverCli.cpp) calls them too --
+// one implementation, two callers (the CLI grammar and the wire dispatcher).
+// The provider self-registers during static init; nothing to call from main().
+
+#pragma once
+#include <stddef.h>
+
+namespace offband {
+
+// wifi.ssid / wifi.pwd setter. `field` is the part after "wifi." ("ssid"|"pwd").
+// PSK never echoed (pwd ACK reports length only). Reply is NUL-terminated human
+// text; returns true when handled (incl. an ERROR reply).
+bool handleSetWifiField(char* reply, size_t reply_size,
+                        const char* field, const char* value);
+
+// wifi.ssid / wifi.status getter. `field` is the part after "wifi.". wifi.pwd is
+// write-only and returns an ERROR here.
+bool handleGetWifi(char* reply, size_t reply_size, const char* field);
+
+// wifi.enabled policy flag (NVS "wifi"/"enabled", default true; reboot-to-apply).
+bool handleSetWifiEnabled(char* reply, size_t reply_size, bool enabled);
+
+}  // namespace offband

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -124,54 +124,11 @@ bool writeStatusIntervalSec(uint16_t seconds) {
     return true;
 }
 
-// #141: display always-on toggle, in the fork-branded "offband_ui" namespace.
-bool getDisplayAlwaysOn() {
-    Preferences p;
-    p.begin(kNvsOffbandUi, /*readOnly=*/true);
-    bool v = p.getBool(kKeyDisplayAlwaysOn, false);
-    p.end();
-    return v;
-}
-
-bool setDisplayAlwaysOn(bool on) {
-    Preferences p;
-    if (!p.begin(kNvsOffbandUi, /*readOnly=*/false)) {
-        logCfgWriteFailure("setDisplayAlwaysOn.begin", kNvsOffbandUi);
-        return false;
-    }
-    size_t wrote = p.putBool(kKeyDisplayAlwaysOn, on);
-    p.end();
-    if (wrote != sizeof(uint8_t)) {     // putBool stores 1 byte; 0 on failure
-        logCfgWriteFailure("setDisplayAlwaysOn.putBool", kNvsOffbandUi);
-        return false;
-    }
-    return true;
-}
-
-// #148: display rotation (0/180) in the "offband_ui" namespace. Clamped to the
-// supported set on both read and write.
-uint8_t getDisplayRotation() {
-    Preferences p;
-    p.begin(kNvsOffbandUi, /*readOnly=*/true);
-    uint8_t v = p.getUChar(kKeyDisplayRotation, 0);
-    p.end();
-    return (v == 180) ? 180 : 0;
-}
-
-bool setDisplayRotation(uint8_t deg) {
-    Preferences p;
-    if (!p.begin(kNvsOffbandUi, /*readOnly=*/false)) {
-        logCfgWriteFailure("setDisplayRotation.begin", kNvsOffbandUi);
-        return false;
-    }
-    size_t wrote = p.putUChar(kKeyDisplayRotation, (deg == 180) ? 180 : 0);
-    p.end();
-    if (wrote != sizeof(uint8_t)) {     // putUChar stores 1 byte; 0 on failure
-        logCfgWriteFailure("setDisplayRotation.putUChar", kNvsOffbandUi);
-        return false;
-    }
-    return true;
-}
+// #370: the display.* NVS accessors (getDisplayAlwaysOn / setDisplayAlwaysOn /
+// getDisplayRotation / setDisplayRotation) moved to
+// src/helpers/config/DisplayConfigProvider.cpp. They were role-neutral
+// "offband_ui" Preferences wrappers with no broker/mqtt coupling, so they belong
+// with the display provider where any role can link them without this schema.
 
 // #182: broker config is stored as individual per-key NVS entries. The #181
 // single-blob attempt was reverted: a ~1.1KB blob needs one large contiguous

--- a/src/helpers/wifi_observer/ConfigSchema.h
+++ b/src/helpers/wifi_observer/ConfigSchema.h
@@ -21,7 +21,7 @@ namespace offband {
 constexpr const char* kNvsWifi      = "wifi";      // Plan 1
 constexpr const char* kNvsMqtt      = "mqtt";      // global mqtt keys (iata, status_interval)
 constexpr const char* kNvsObserver  = "observer";  // ring buffer size etc.
-constexpr const char* kNvsOffbandUi = "offband_ui"; // #141: fork UI prefs (display.always_on). Fork-branded so a future upstream NVS namespace can never clash.
+// #370: kNvsOffbandUi + the display keys moved to config/DisplayConfigProvider.cpp.
 
 // Per-broker namespace is generated at runtime: "mqtt_b0".."mqtt_b5".
 // 15-char ceiling tolerates "mqtt_b<digit>" comfortably.
@@ -38,11 +38,6 @@ constexpr uint16_t kDefaultStatusIntervalSec = 30;
 constexpr uint16_t kMinStatusIntervalSec     = 10;
 constexpr uint16_t kMaxStatusIntervalSec     = 3600;
 
-// ---------------------------------------------------------------------------
-// Offband UI keys (in "offband_ui" namespace)
-// ---------------------------------------------------------------------------
-constexpr const char* kKeyDisplayAlwaysOn = "always_on";  // bool; default false (#141)
-constexpr const char* kKeyDisplayRotation = "rotation";   // uint8 0/180; default 0 (#148)
 
 // ---------------------------------------------------------------------------
 // Per-broker keys (in per-broker "mqtt_bN" namespace)
@@ -91,14 +86,9 @@ bool writeGlobalIata(const char* iata);
 uint16_t readStatusIntervalSec();
 bool     writeStatusIntervalSec(uint16_t seconds);
 
-// #141: display always-on toggle. When true, UITask never auto-blanks the
-// screen. Stored in the fork-branded "offband_ui" NVS namespace.
-bool getDisplayAlwaysOn();
-bool setDisplayAlwaysOn(bool on);   // #181: false on NVS failure (logged)
-
-// #148: display rotation in degrees (0 or 180). Stored in "offband_ui".
-uint8_t getDisplayRotation();
-bool    setDisplayRotation(uint8_t deg);   // #181: false on NVS failure (logged)
+// #370: display.* accessors (getDisplayAlwaysOn / setDisplayAlwaysOn /
+// getDisplayRotation / setDisplayRotation) moved to
+// src/helpers/config/DisplayConfigProvider.h -- role-neutral, no schema coupling.
 
 // Broker-slot accessors. Slot range [0, OFFBAND_MAX_BROKERS).
 // Returns sensible defaults on read-miss (e.g., empty url, enabled=false,

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -4,11 +4,9 @@
 
 #include "ObserverCli.h"
 #include "ConfigSchema.h"
-#include "WifiBootstrap.h"   // Plan 3 Task 10: get wifi.status walks
-                             // WifiBootstrap::state()
-#include "../config/ConfigDispatch.h"   // #364: role-agnostic config dispatch --
-                                        // this file registers the observer's
-                                        // provider at the bottom.
+#include "../config/ConfigDispatch.h"          // #364: role-agnostic config dispatch
+#include "../config/WifiConfigProvider.h"      // #370: wifi.* handlers (moved out of this file)
+#include "../config/DisplayConfigProvider.h"   // #370: display.* handlers + NVS accessors (moved out)
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
@@ -371,125 +369,6 @@ static bool handleSetBrokerField(char* reply, size_t reply_size,
     return true;
 }
 
-// "set wifi.ssid <s>"  / "set wifi.pwd <s>"  / "get wifi.ssid"
-// / "get wifi.status" -- Plan 3 Task 10 (Strycher/LoRa#272).
-//
-// First-contact WiFi setup is driven through the BLE system channel
-// (SystemChannelCli) by typing CLI commands as channel messages.
-// Those commands route through the cliPassthrough allowlist into
-// dispatchObserverCli, which is this function. Both set and get
-// halves write/read NVS namespace "wifi" with keys ssid + pwd; the
-// status reply enumerates WifiBootstrapState so the user can confirm
-// state after a set sequence.
-//
-// PSK redacted from reply per CLAUDE.md security note: the set-pwd
-// branch acknowledges "wifi.pwd = (set, length=N)" without echoing
-// the value, and get-pwd is unsupported.
-static bool handleSetWifiField(char* reply, size_t reply_size,
-                               const char* field, const char* value) {
-    if (field == nullptr || value == nullptr) {
-        snprintf(reply, reply_size,
-                 "ERROR: usage: set wifi.ssid <s> | set wifi.pwd <s>\n");
-        return true;
-    }
-    if (!eq(field, "ssid") && !eq(field, "pwd")) {
-        snprintf(reply, reply_size,
-                 "ERROR: unknown wifi field '%s' "
-                 "(supported: ssid, pwd)\n", field);
-        return true;
-    }
-    // Reject empty values: an empty SSID is never useful and would
-    // collide with the no-creds detection in WifiBootstrap::begin.
-    if (value[0] == '\0') {
-        snprintf(reply, reply_size,
-                 "ERROR: empty value for wifi.%s\n", field);
-        return true;
-    }
-#ifdef ARDUINO
-    Preferences p;
-    if (!p.begin("wifi", /*readOnly=*/false)) {
-        snprintf(reply, reply_size,
-                 "ERROR: cannot open NVS namespace 'wifi'\n");
-        return true;
-    }
-    p.putString(field, value);
-    p.end();
-#endif
-    if (eq(field, "pwd")) {
-        // Never echo the PSK in any code path.
-        snprintf(reply, reply_size,
-                 "wifi.pwd set (%u chars entered). Reboot or run "
-                 "'wifi status' after STA retry.\n",
-                 (unsigned)strlen(value));
-    } else {
-        snprintf(reply, reply_size, "wifi.ssid = %s\n", value);
-    }
-    return true;
-}
-
-static bool handleGetWifi(char* reply, size_t reply_size, const char* field) {
-    if (field == nullptr) {
-        snprintf(reply, reply_size,
-                 "ERROR: usage: get wifi.ssid | wifi status\n");
-        return true;
-    }
-    if (eq(field, "pwd")) {
-        // Refuse to ever read the PSK back. There is no legitimate
-        // workflow where surfacing the saved PSK to a remote caller
-        // is the right answer.
-        snprintf(reply, reply_size,
-                 "ERROR: wifi.pwd is write-only\n");
-        return true;
-    }
-    if (eq(field, "ssid")) {
-#ifdef ARDUINO
-        Preferences p;
-        if (!p.begin("wifi", /*readOnly=*/true)) {
-            snprintf(reply, reply_size,
-                     "ERROR: cannot open NVS namespace 'wifi'\n");
-            return true;
-        }
-        String s = p.getString("ssid", "");
-        p.end();
-        snprintf(reply, reply_size, "wifi.ssid = %s\n",
-                 s.isEmpty() ? "(unset)" : s.c_str());
-#else
-        snprintf(reply, reply_size, "wifi.ssid = (host build)\n");
-#endif
-        return true;
-    }
-    if (eq(field, "status")) {
-#ifdef ARDUINO
-        // Reach into the WifiBootstrap state via the singleton.
-        // Render a single human-readable line summarizing the
-        // current STA state + IP when connected.
-        auto state = wifiBootstrap().state();
-        const char* st = "?";
-        switch (state) {
-            case WifiBootstrapState::Boot:          st = "Boot";          break;
-            case WifiBootstrapState::CliRescue:     st = "CliRescue";     break;
-            case WifiBootstrapState::ApMode:        st = "AwaitingSetup"; break;
-            case WifiBootstrapState::StaConnecting: st = "StaConnecting"; break;
-            case WifiBootstrapState::StaConnected:  st = "StaConnected";  break;
-            case WifiBootstrapState::StaFailed:     st = "StaFailed";     break;
-        }
-        if (state == WifiBootstrapState::StaConnected) {
-            snprintf(reply, reply_size, "wifi.status = %s ip=%s\n",
-                     st, WiFi.localIP().toString().c_str());
-        } else {
-            snprintf(reply, reply_size, "wifi.status = %s\n", st);
-        }
-#else
-        snprintf(reply, reply_size, "wifi.status = (host build)\n");
-#endif
-        return true;
-    }
-    snprintf(reply, reply_size,
-             "ERROR: unknown wifi field '%s' (supported: ssid, status)\n",
-             field);
-    return true;
-}
-
 // "set web.allow_initial <on|off>" -- recovery override that re-allows
 // the derived initial password even after the user has set their own.
 // Cleared automatically after the next successful login via
@@ -521,27 +400,6 @@ static bool handleSetWebAllowInitial(char* reply, size_t reply_size,
 // ---------------------------------------------------------------------------
 // Top-level dispatch
 // ---------------------------------------------------------------------------
-
-// "wifi enable" / "wifi disable" -- #45. Persists an NVS
-// policy flag in namespace "wifi" (key "enabled", default true) that
-// WifiBootstrap::begin() honors at boot. Reboot-to-apply by design: we do
-// NOT tear down a live STA here, because the observer's MQTT uplink and this
-// very _sys channel ride that WiFi link -- the flag only gates the next
-// boot's STA attempt.
-static bool handleSetWifiEnabled(char* reply, size_t reply_size, bool enabled) {
-#ifdef ARDUINO
-    Preferences p;
-    if (!p.begin("wifi", /*readOnly=*/false)) {
-        snprintf(reply, reply_size, "ERROR: cannot open NVS namespace 'wifi'\n");
-        return true;
-    }
-    p.putBool("enabled", enabled);
-    p.end();
-#endif
-    snprintf(reply, reply_size, "wifi.enabled = %d (reboot to apply)\n",
-             enabled ? 1 : 0);
-    return true;
-}
 
 // "get mqtt.broker.<N>.<key>" -- #45: symmetric read for the
 // existing "set mqtt.broker.<N>.<key>". Key vocabulary mirrors
@@ -643,90 +501,6 @@ static bool handleClearBroker(char* reply, size_t reply_size,
              "mqtt slot %d cleared. Default slots re-seed at next reboot; "
              "custom slots stay empty.\n", slot);
     return true;
-}
-
-// ---------------------------------------------------------------------------
-// #141: display always-on toggle (`display always on` / `display always off`).
-// Persists to the fork-branded "offband_ui" NVS namespace, then applies the
-// change to the live display via an applier the app registers at boot (a raw
-// function pointer -- not std::function -- to avoid heap on tight-RAM boards).
-// ---------------------------------------------------------------------------
-static void (*s_display_always_on_applier)(bool) = nullptr;
-
-void setDisplayAlwaysOnApplier(void (*fn)(bool)) {
-    s_display_always_on_applier = fn;
-}
-
-static bool handleDisplayAlwaysOn(char* reply, size_t reply_size, bool on) {
-    // #181: if persistence fails, surface it and do NOT apply to the live display
-    // -- applying a setting that won't survive a reboot would mislead the user
-    // about what's actually stored (SAFELANE 6: state must match the ACK).
-    if (!setDisplayAlwaysOn(on)) {                                     // persist (offband_ui NVS)
-        snprintf(reply, reply_size, "ERROR: failed to save display setting (NVS write failed)\n");
-        return true;
-    }
-    if (s_display_always_on_applier) s_display_always_on_applier(on);  // apply to the live display
-    snprintf(reply, reply_size,
-             on ? "display: always on (screen stays lit)\n"
-                : "display: normal (blanks after 15 s)\n");
-    return true;
-}
-
-// ---------------------------------------------------------------------------
-// #148: display rotation (0/180). Persists to offband_ui; applies live via a
-// raw-fn-pointer applier the app registers at boot (parallel to the always-on
-// applier above).
-// ---------------------------------------------------------------------------
-static void (*s_display_rotation_applier)(uint8_t) = nullptr;
-
-void setDisplayRotationApplier(void (*fn)(uint8_t)) {
-    s_display_rotation_applier = fn;
-}
-
-// #148: capability query (parallel to the applier) so we can refuse rotation on
-// displays whose driver has no verified runtime-rotation override.
-static bool (*s_display_rotation_supported)() = nullptr;
-
-void setDisplayRotationSupportedQuery(bool (*fn)()) {
-    s_display_rotation_supported = fn;
-}
-
-// In-session cache of the current rotation so `display flip` toggles reliably
-// from RAM instead of a write-then-read NVS round-trip (a fresh read-only
-// handle may not observe a just-committed write). Lazily seeded from NVS;
-// updated on every rotate/flip. NVS stays the persistence layer (#148).
-static int s_rotation_cache = -1;   // -1 = not yet loaded
-
-static bool handleDisplayRotate(char* reply, size_t reply_size, uint8_t deg) {
-    // #148: gate to drivers with a verified runtime-rotation override (SSD1306
-    // OLED). Others report unsupported rather than silently no-op'ing; the TFT
-    // (ST7789) override is not yet hardware-verified and is tracked separately.
-    // Deny-by-default: if the capability query was never registered, treat the
-    // display as unsupported (don't fall through to a silent no-op) -- per Gemini review.
-    if (!s_display_rotation_supported || !s_display_rotation_supported()) {
-        snprintf(reply, reply_size, "display: rotation not supported on this display\n");
-        return true;
-    }
-    // #181: persist first; on NVS failure surface it and leave the cache + live
-    // display untouched, so RAM state, NVS, and the ACK all stay consistent.
-    if (!setDisplayRotation(deg)) {                                           // persist (offband_ui NVS)
-        snprintf(reply, reply_size, "ERROR: failed to save display rotation (NVS write failed)\n");
-        return true;
-    }
-    s_rotation_cache = deg;                                                   // keep the in-session cache current
-    if (s_display_rotation_applier) s_display_rotation_applier(deg);          // apply to the live display
-    snprintf(reply, reply_size,
-             deg == 180 ? "display: rotation 180 (flipped)\n"
-                        : "display: rotation 0 (default)\n");
-    return true;
-}
-
-static bool handleDisplayFlip(char* reply, size_t reply_size) {
-    // Toggle from the in-session cache (seeded from NVS on first use), so flip
-    // always inverts 0<->180 without depending on a read-after-write.
-    if (s_rotation_cache < 0) s_rotation_cache = getDisplayRotation();
-    uint8_t other = (s_rotation_cache == 180) ? 0 : 180;
-    return handleDisplayRotate(reply, reply_size, other);
 }
 
 bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
@@ -981,25 +755,9 @@ static bool observerConfigSet(const char* key, const char* value, char* reply, s
     if (eq(key, "mqtt.iata"))            return handleSetIata(reply, reply_size, value);
     if (eq(key, "mqtt.status_interval")) return handleSetStatusInterval(reply, reply_size, value);
 
-    if (eq(key, "display.always_on")) {
-        bool on;
-        if (!parseConfigBool(value, on)) { snprintf(reply, reply_size, "ERROR: display.always_on expects 0|1\n"); return true; }
-        return handleDisplayAlwaysOn(reply, reply_size, on);
-    }
-    if (eq(key, "display.rotation")) {
-        if (eq(value, "0"))   return handleDisplayRotate(reply, reply_size, 0);
-        if (eq(value, "180")) return handleDisplayRotate(reply, reply_size, 180);
-        snprintf(reply, reply_size, "ERROR: display.rotation expects 0|180\n");
-        return true;
-    }
-
-    if (eq(key, "wifi.enabled")) {
-        bool on;
-        if (!parseConfigBool(value, on)) { snprintf(reply, reply_size, "ERROR: wifi.enabled expects 0|1\n"); return true; }
-        return handleSetWifiEnabled(reply, reply_size, on);
-    }
-    if (strncmp(key, "wifi.", 5) == 0)            // wifi.ssid / wifi.pwd
-        return handleSetWifiField(reply, reply_size, key + 5, value);
+    // #370: display.* and wifi.* moved to their own providers
+    // (config/DisplayConfigProvider, config/WifiConfigProvider). The shared
+    // dispatcher routes those key spaces there; this provider owns only mqtt.*.
 
     {
         int slot; const char* field;
@@ -1038,18 +796,7 @@ static bool observerConfigGet(const char* key, char* reply, size_t reply_size) {
     if (key == nullptr || reply == nullptr || reply_size == 0) return false;
     reply[0] = '\0';
 
-    if (eq(key, "wifi.enabled")) {
-#ifdef ARDUINO
-        Preferences p; bool en = true;
-        if (p.begin("wifi", /*readOnly=*/true)) { en = p.getBool("enabled", true); p.end(); }
-        snprintf(reply, reply_size, "wifi.enabled = %d\n", en ? 1 : 0);
-#else
-        snprintf(reply, reply_size, "wifi.enabled = (host build)\n");
-#endif
-        return true;
-    }
-    if (strncmp(key, "wifi.", 5) == 0)             // wifi.ssid (wifi.pwd -> write-only error)
-        return handleGetWifi(reply, reply_size, key + 5);
+    // #370: wifi.* and display.* GETs are served by their own providers now.
 
     if (eq(key, "mqtt.iata")) {
         char iata[8] = {0};
@@ -1059,14 +806,6 @@ static bool observerConfigGet(const char* key, char* reply, size_t reply_size) {
     }
     if (eq(key, "mqtt.status_interval")) {
         snprintf(reply, reply_size, "mqtt.status_interval = %u\n", (unsigned)readStatusIntervalSec());
-        return true;
-    }
-    if (eq(key, "display.always_on")) {
-        snprintf(reply, reply_size, "display.always_on = %d\n", getDisplayAlwaysOn() ? 1 : 0);
-        return true;
-    }
-    if (eq(key, "display.rotation")) {
-        snprintf(reply, reply_size, "display.rotation = %u\n", (unsigned)getDisplayRotation());
         return true;
     }
 
@@ -1168,28 +907,26 @@ size_t configRenderBrokerSlot(uint8_t slot, char* out, size_t out_size,
 // ---------------------------------------------------------------------------
 // __attribute__((used)): belt-and-braces against the compiler/linker dropping an
 // object whose only purpose is its constructor's side effect. NOT a fix for an
-// observed defect -- verified present on the linked ESP32-S3 image (#364 review,
-// BLOCKER-1): .init_array entry 6 == _GLOBAL__sub_I_...setDisplayAlwaysOnApplier,
-// whose whole body is one call to config::registerProvider. ESP-IDF's linker
-// script KEEPs .init_array, and this TU is always pulled in (dispatchObserverCli
-// / configBrokerSlotCount are referenced elsewhere), so it cannot be dropped as
-// an unextracted archive member either. Kept as free insurance against a future
+// observed defect -- the #364 review (BLOCKER-1) verified the registrar's
+// static-init ctor is present in .init_array on the linked ESP32-S3 image, its
+// whole body one call to config::registerProvider. ESP-IDF's linker script KEEPs
+// .init_array, and this TU is always pulled in (dispatchObserverCli /
+// configBrokerSlotCount are referenced elsewhere), so it cannot be dropped as an
+// unextracted archive member either. Kept as free insurance against a future
 // toolchain/flag change, since the failure mode -- every config key answering
-// "unknown config key" on a deployed fleet -- is severe.
+// "unknown config key" on a deployed fleet -- is severe. (#370: the wifi/display
+// providers carry the same `used` insurance in their own TUs.)
 // #366: the observer's key-space manifest, for registration-time overlap
 // detection. Must mirror what observerConfigSet/observerConfigGet actually
-// claim (see the if-chain above): exact leaf keys verbatim, plus the two BROAD
-// prefixes it owns -- `wifi.` (wifi.ssid/wifi.pwd; also covers wifi.enabled)
-// and `mqtt.broker.`. The `wifi.` entry is exactly the shadow the repeater's
-// `wifi.mode` would hit (#301) -- the detector fires on that at registration.
+// claim (see the if-chain above). #370: the observer now owns ONLY `mqtt.*`;
+// `wifi.` moved to WifiConfigProvider and `display.` to DisplayConfigProvider,
+// each declaring its own prefix. The overlap detector fires if any two
+// providers claim the same key space (e.g. #301's `wifi.mode` under `wifi.`).
 // Keep this in sync when adding/removing an observer config key.
 static const char* const kObserverConfigPrefixes[] = {
     "mqtt.iata",
     "mqtt.status_interval",
     "mqtt.broker.",
-    "display.always_on",
-    "display.rotation",
-    "wifi.",
 };
 
 static __attribute__((used)) config::ProviderRegistrar _observer_config_provider(

--- a/src/helpers/wifi_observer/ObserverCli.h
+++ b/src/helpers/wifi_observer/ObserverCli.h
@@ -79,17 +79,17 @@ size_t configRenderBrokerSlot(uint8_t slot, char* out, size_t out_size,
                               const BrokerRuntimeState* rt = nullptr,
                               const char* owner_default_hex = nullptr);
 
-// #141: register a callback the app provides so a `display always on/off`
-// command applies to the live UITask immediately (no reboot). Raw function
-// pointer (not std::function) to avoid heap on tight-RAM boards.
-void setDisplayAlwaysOnApplier(void (*fn)(bool));
-
-// #148: register the applier for `display rotate`/`display flip` (degrees 0/180).
-void setDisplayRotationApplier(void (*fn)(uint8_t));
-
-// #148: register a query so `display rotate`/`flip` can report "not supported on
-// this display" (instead of a silent no-op) when the live driver has no verified
-// runtime-rotation override (TFT variants, e-ink).
-void setDisplayRotationSupportedQuery(bool (*fn)());
+// #370: the display appliers (setDisplayAlwaysOnApplier / setDisplayRotationApplier
+// / setDisplayRotationSupportedQuery) and the display.* NVS accessors moved to
+// config/DisplayConfigProvider.h. Included below so existing includers of this
+// header (e.g. examples/companion_radio/main.cpp) keep resolving them unchanged.
 
 }  // namespace offband
+
+// #370: forward ONLY the display header, so legacy includers of ObserverCli.h
+// (examples/companion_radio/main.cpp) keep resolving the display appliers +
+// display.* NVS accessors unchanged -- that is the only cross-TU surface they
+// used from this header. The wifi.* handlers are NOT forwarded: the sole caller
+// is ObserverCli.cpp's dispatchObserverCli, which includes WifiConfigProvider.h
+// directly. (Gemini #370 review MINOR-3: keep the transitive surface minimal.)
+#include "../config/DisplayConfigProvider.h"


### PR DESCRIPTION
Closes #370. **Epic #300.** Builds on #364 (merged wire dispatcher).

**Pure internal refactor — no behavior change, wire contract byte-compatible.**

## What this does

Splits the `wifi.*` and `display.*` config surface out of the observer into their own **role-agnostic providers**, so any WiFi/display-capable role uses **one** set of config keys — not a reinvented-per-role set. Observer keeps `mqtt.*`.

```
ObserverCli.cpp (was: wifi + display + mqtt handlers, observer-only)
   ├─► config/WifiConfigProvider.{h,cpp}     prefix "wifi."
   ├─► config/DisplayConfigProvider.{h,cpp}  prefix "display."  (+ display NVS accessors, decoupled from ConfigSchema)
   └─► ObserverCli.cpp  keeps mqtt.* + broker enum + the _sys CLI
```

- Each provider self-registers with the #364 dispatcher and declares its own #366 key-prefix manifest; the observer's manifest drops `wifi.`/`display.`, so the registration-time overlap detector guards the split.
- `dispatchObserverCli` (the observer `_sys` string CLI) still calls the moved handlers via the new headers — one implementation, two callers.
- **Display decoupled ("1.5", owner-approved):** the 4 display NVS accessors (`getDisplayAlwaysOn` etc.) moved out of `wifi_observer/ConfigSchema` — they were role-neutral `offband_ui` `Preferences` wrappers with no broker/mqtt coupling, so any display role links them without the observer schema.
- **WiFi keeps its `WifiBootstrap` dependency** (only `wifi.status` uses it). What `wifi.status` means on a non-observer node is #365's design call — deliberately deferred.

## Scope boundary (owner)

Unify the **shared config** commands (wifi/MQTT/display) across roles — **not** a full-CLI merge. Role-specific commands stay role-specific. See #462.

## Deliberately NOT in this PR
- The display cap bit (`0x10`) definition + device-info advertise + `FIRMWARE_VER_CODE` bump — that's #365's caps-byte surface (seam confirmed with the #365 owner + TopazHill). This PR touches no wire-protocol header.
- The string-CLI-verb → config-dispatch bridge for non-observer roles → **#462**.
- `main.cpp` / `MyMesh.cpp` / `platformio.ini` / `OffbandConfigProtocol.h` — untouched.

## Verification (all this session, on the rebased branch)

| Gate | Result |
|---|---|
| Client-visible reply strings | **141 = 141, byte-identical** before vs after (device-side `[cfg]` crashlog strings excluded — proven never written to a client `reply`) |
| Builds | **5/5 SUCCESS** — `heltec_v4` / `Heltec_v3` / `heltec_v4_tft` / `Xiao_S3_WIO` observer envs + `RAK_4631_companion_radio_usb` (nRF52) |
| nRF52 no-leak | the new providers correctly **not** compiled into the nRF52 build |
| Base | rebased onto current `firmware-base` (`a569b468`); no file overlap with intervening commits; audit + builds re-run **after** rebase |

## Gemini adversarial review — 0 blocker, adjudicated

Log: `docs/llm-consultations/2026-07-29-370-wifi-display-providers-review-gemini-gemini-2.5-pro.log` (untracked, per repo convention).

- **MAJOR-1** silent NVS-read default → **pre-existing Offband bug** (verbatim relocation; `wifi_observer` doesn't exist upstream, so it's ours not stock). Fixing it changes failure-path reply text → not byte-compat. Filed **#457** (P2), lands right after this.
- **MAJOR-2** `DisplayConfigProvider` includes `wifi_observer/CrashLog.h` → CrashLog is a shared diagnostic already in companion builds; its relocation is **#350** (documented there + to the #350 owner). Not a #370 change.
- **MAJOR-3** string-CLI grammar not shared → real, and foundational to the combined observer-repeater role (#297). Filed **#462**, scope-bounded (shared config commands only, not a full-CLI merge). Not #370's backend scope.
- **MINOR-1** duplicated `logCfgWriteFailure`/constants → deliberate (decouple), internal linkage, no ODR. Kept.
- **MINOR-2** `wifi.status` portability → the documented #365 deferred seam.
- **MINOR-3** transitive include → **fixed** — `ObserverCli.h` now forwards only the display header.

## Not done — still gating #301
Observer **behavioural** no-regression on real hardware against the currently-released app (Epic #300 item 3). Build + string-level checks are not that gate; #366's overlap detector runs at runtime (boot-log check). Needs bench time.

**Merge gate (#477):** `firmware-base` requires the **`ci-green`** check (full matrix incl. nRF52 + room_server), so auto-merge waits for the matrix — it does **not** merge on push. Auto-merge (`--auto --rebase`) enabled; this PR lands only when `ci-green` passes. Not marking #370 done until `state=MERGED`.

**Base note:** rebased onto `d4dc4444`; nRF52 companion link is green thanks to #475 (`arduino_base` now compiles `helpers/diagnostics/*` everywhere) — the regression I flagged during review, now fixed by RubyDog.

Agent: DarkLynx (session 17550faa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
