### PR TITLE
feat(#472): uniform CrashLog boot-survival across all roles

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -16,12 +16,11 @@
   #define CW_PHASE(name) ((void)0)
 #endif
 
-// #377 (Epic #350): boot-survival CrashLog on the nRF52 companion. The observer
-// path (ESP32) already wires CrashLog above; nRF52 companions are non-observer,
-// so include it here. Additive + nRF52-scoped -- does not touch the observer
-// blocks or the runtime-WiFi path.
-#if defined(NRF52_PLATFORM) && !defined(OFFBAND_OBSERVER)
-  #include "helpers/diagnostics/CrashLog.h"
+// #472 (was #377, nRF52-only): uniform boot-survival CrashLog for ALL non-observer
+// companions (ESP32 + nRF52). The observer path includes CrashLog above; every other
+// companion gets it here via the shared helper (which also re-exposes crashLogf).
+#if !defined(OFFBAND_OBSERVER)
+  #include "helpers/diagnostics/CrashLogStandard.h"
 #endif
 
 // Believe it or not, this std C function is busted on some platforms!
@@ -200,19 +199,12 @@ void setup() {
   }
 #endif
 
-#if defined(NRF52_PLATFORM) && !defined(OFFBAND_OBSERVER)
-  // #377 (Epic #350): start the boot-survival breadcrumb on the nRF52 companion.
-  // Delegate the reset reason to the board (#376 decision 2) via a non-capturing
-  // lambda -- it references only the global `board`, so it converts to the
-  // ResetReasonHook function pointer. crashLogBegin() dumps a ring that survived
-  // the previous reset (retained .noinit, #361); the boot line records the reason
-  // AND keeps the ring referenced so ld-2.29 GC can't drop it (#363).
-  offband::crashLogSetResetReasonHook([]() -> const char* {
-    return board.getResetReasonString(board.getResetReason());
-  });
-  offband::crashLogBegin();
-  offband::crashLogf("[boot] nRF52 companion up; reset=%s",
-                     board.getResetReasonString(board.getResetReason()));
+#if !defined(OFFBAND_OBSERVER)
+  // #472 (was #377, nRF52-only): uniform boot-survival CrashLog for ALL non-observer
+  // companions (ESP32 + nRF52). Wires the board reset-reason into CrashLog, dumps a
+  // ring that survived the previous reset, records a boot breadcrumb. The observer
+  // path wires CrashLog via wifiObserverBegin() above.
+  offband::crashLogStandardInit(board, "companion");
 #endif
 
 #ifdef DISPLAY_CLASS
@@ -435,6 +427,9 @@ void setup() {
 }
 
 void loop() {
+#if !defined(OFFBAND_OBSERVER)
+  offband::crashLogStandardTick(millis());  // #472: deferred previous-boot re-dump (all non-observer companions)
+#endif
 #if defined(NRF52_PLATFORM)
   board.feedWatchdog();  // #257: feed from the MAIN LOOP only -> a hung loop trips the WDT
   board.heartbeatTick(); // #275: loop-driven green-LED heartbeat (freezes if the loop hangs)
@@ -445,7 +440,7 @@ void loop() {
     // after a hang shows how long this boot ran. Also keeps the ring referenced.
     static uint32_t s_cl_last_ms = 0;
     uint32_t now_ms = millis();
-    offband::crashLogTick(now_ms);  // #378: deferred previous-boot re-dump for late serial connect
+    // (deferred re-dump now runs uniformly at loop top via crashLogStandardTick; #472)
     if (s_cl_last_ms == 0 || now_ms - s_cl_last_ms >= 30000u) {
       s_cl_last_ms = now_ms;
       offband::crashLogf("[hb] up=%us", (unsigned)(now_ms / 1000));

--- a/examples/kiss_modem/main.cpp
+++ b/examples/kiss_modem/main.cpp
@@ -4,6 +4,7 @@
 #include <helpers/IdentityStore.h>
 #include <SafeBoot.h>
 #include "KissModem.h"
+#include "helpers/diagnostics/CrashLogStandard.h"   // #472: uniform boot-survival CrashLog
 
 #if defined(NRF52_PLATFORM)
   #include <InternalFileSystem.h>
@@ -83,6 +84,8 @@ void setup() {
 
   board.begin();
 
+  offband::crashLogStandardInit(board, "kiss-modem");   // #472: uniform CrashLog (after board.begin() for reset reason)
+
   if (!radio_init()) {
     halt();
   }
@@ -131,6 +134,7 @@ void setup() {
 }
 
 void loop() {
+  offband::crashLogStandardTick(millis());  // #472: deferred previous-boot re-dump for late serial connect
   modem->loop();
 
   if (!modem->isActuallyTransmitting()) {

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -3,6 +3,7 @@
 #include <SafeBoot.h>
 
 #include "MyMesh.h"
+#include "helpers/diagnostics/CrashLogStandard.h"   // #472: uniform boot-survival CrashLog
 
 #ifdef PIN_STATUS_LED
   // Repeater heartbeat status LED (#9). Active-high default;
@@ -869,6 +870,8 @@ void setup() {
 
   board.begin();
 
+  offband::crashLogStandardInit(board, "repeater");   // #472: uniform CrashLog (after board.begin() for reset reason)
+
 #ifdef PIN_STATUS_LED
   pinMode(PIN_STATUS_LED, OUTPUT);
   digitalWrite(PIN_STATUS_LED, !LED_STATE_ON);   // start off
@@ -968,6 +971,7 @@ void setup() {
 }
 
 void loop() {
+  offband::crashLogStandardTick(millis());  // #472: deferred previous-boot re-dump for late serial connect
 #if defined(NRF52_PLATFORM)
   board.feedWatchdog();  // #266: feed from the MAIN LOOP only -> a hung loop trips the WDT
   board.heartbeatTick(); // #275: loop-driven, ungated green-LED heartbeat (freezes on hang)

--- a/examples/simple_room_server/main.cpp
+++ b/examples/simple_room_server/main.cpp
@@ -3,6 +3,7 @@
 #include <SafeBoot.h>
 
 #include "MyMesh.h"
+#include "helpers/diagnostics/CrashLogStandard.h"   // #472: uniform boot-survival CrashLog
 
 #ifdef DISPLAY_CLASS
   #include "UITask.h"
@@ -27,6 +28,9 @@ void setup() {
   SafeBoot::checkAndMaybeSleep();
 
   board.begin();
+
+  // #472: uniform CrashLog boot-survival (after board.begin() so the reset reason is cached).
+  offband::crashLogStandardInit(board, "room-server");
 
 #ifdef DISPLAY_CLASS
   if (display.begin()) {
@@ -89,6 +93,8 @@ void setup() {
 }
 
 void loop() {
+  offband::crashLogStandardTick(millis());  // #472: deferred previous-boot re-dump for late serial connect
+
   int len = strlen(command);
   while (Serial.available() && len < sizeof(command)-1) {
     char c = Serial.read();

--- a/examples/simple_secure_chat/main.cpp
+++ b/examples/simple_secure_chat/main.cpp
@@ -1,6 +1,7 @@
 #include <Arduino.h>   // needed for PlatformIO
 #include <Mesh.h>
 #include <SafeBoot.h>
+#include "helpers/diagnostics/CrashLogStandard.h"   // #472: uniform boot-survival CrashLog
 
 #if defined(NRF52_PLATFORM)
   #include <InternalFileSystem.h>
@@ -564,6 +565,8 @@ void setup() {
 
   board.begin();
 
+  offband::crashLogStandardInit(board, "secure-chat");   // #472: uniform CrashLog (after board.begin() for reset reason)
+
   if (!radio_init()) { halt(); }
 
   fast_rng.begin(radio_driver.getRngSeed());
@@ -593,6 +596,7 @@ void setup() {
 }
 
 void loop() {
+  offband::crashLogStandardTick(millis());  // #472: deferred previous-boot re-dump for late serial connect
   the_mesh.loop();
   rtc_clock.tick();
 }

--- a/examples/simple_sensor/main.cpp
+++ b/examples/simple_sensor/main.cpp
@@ -1,5 +1,6 @@
 #include "SensorMesh.h"
 #include <SafeBoot.h>
+#include "helpers/diagnostics/CrashLogStandard.h"   // #472: uniform boot-survival CrashLog
 
 #ifdef DISPLAY_CLASS
   #include "UITask.h"
@@ -62,6 +63,8 @@ void setup() {
 
   board.begin();
 
+  offband::crashLogStandardInit(board, "sensor");   // #472: uniform CrashLog (after board.begin() for reset reason)
+
 #ifdef DISPLAY_CLASS
   if (display.begin()) {
     display.startFrame();
@@ -121,6 +124,8 @@ void setup() {
 }
 
 void loop() {
+  offband::crashLogStandardTick(millis());  // #472: deferred previous-boot re-dump for late serial connect
+
   int len = strlen(command);
   while (Serial.available() && len < sizeof(command)-1) {
     char c = Serial.read();

--- a/src/helpers/diagnostics/CrashLogStandard.cpp
+++ b/src/helpers/diagnostics/CrashLogStandard.cpp
@@ -1,0 +1,39 @@
+// src/helpers/diagnostics/CrashLogStandard.cpp -- see CrashLogStandard.h (#472 / Epic #350)
+#include "CrashLogStandard.h"
+#include "CrashLog.h"          // board-agnostic core + OFFBAND_CRASHLOG_HOST selector
+#include "../../MeshCore.h"    // MainBoard: getResetReason() / getResetReasonString()
+
+namespace offband {
+
+#if !defined(OFFBAND_CRASHLOG_DISABLED) && !defined(OFFBAND_CRASHLOG_HOST)
+
+// The board is held statically so the reset-reason hook can be a plain
+// (non-capturing) function pointer -- CrashLog's ResetReasonHook is
+// `const char* (*)()`. One board per node, set once in init.
+namespace {
+mesh::MainBoard* s_board = nullptr;
+const char* resetReasonProvider() {
+  if (!s_board) return "n/a";
+  return s_board->getResetReasonString(s_board->getResetReason());
+}
+}  // namespace
+
+void crashLogStandardInit(mesh::MainBoard& board, const char* role_tag) {
+  s_board = &board;
+  crashLogSetResetReasonHook(&resetReasonProvider);
+  crashLogBegin();  // dumps a ring that survived the previous reset, if any
+  crashLogf("[boot] %s up; reset=%s", role_tag ? role_tag : "node", resetReasonProvider());
+}
+
+void crashLogStandardTick(uint32_t now_ms) {
+  crashLogTick(now_ms);
+}
+
+#else  // host build or explicit per-board opt-out -> no-ops
+
+void crashLogStandardInit(mesh::MainBoard&, const char*) {}
+void crashLogStandardTick(uint32_t) {}
+
+#endif
+
+}  // namespace offband

--- a/src/helpers/diagnostics/CrashLogStandard.h
+++ b/src/helpers/diagnostics/CrashLogStandard.h
@@ -1,0 +1,40 @@
+// src/helpers/diagnostics/CrashLogStandard.h
+//
+// Uniform, role-agnostic CrashLog bring-up (#472 / Epic #350).
+//
+// CrashLog itself (CrashLog.h) is deliberately board-agnostic -- it takes a
+// reset-reason *hook* rather than a board handle. This thin wrapper binds a
+// role's MainBoard-derived `board` to that hook and gives every role an
+// IDENTICAL one-line bring-up, so boot-survival is standard across ALL roles
+// instead of hand-wired (and unevenly) per example.
+//
+// Usage (every role's main.cpp):
+//   setup():  offband::crashLogStandardInit(board, "repeater");
+//   loop():   offband::crashLogStandardTick(millis());
+//
+// Default-ON. Compiles to a no-op on the host build and when a board opts out
+// with -D OFFBAND_CRASHLOG_DISABLED (reserved for boards that fail hardware
+// testing -- per the #472 owner decision: on everywhere unless a tested board
+// proves it can't). Platform storage (ESP32 RTC_NOINIT / nRF52 .noinit) and the
+// nRF52 cross-reset retention caveat (#378) are handled/known inside CrashLog.
+#pragma once
+#include <stdint.h>
+#include "CrashLog.h"   // superset header: also exposes the core API (crashLogf, crashLogBegin, ...)
+
+namespace mesh { class MainBoard; }  // fwd; full definition in MeshCore.h
+
+namespace offband {
+
+// Call once at the TOP of setup(), after Serial.begin() and before any
+// high-current peripheral rail / filesystem write. Wires
+// board.getResetReasonString(board.getResetReason()) into CrashLog, dumps any
+// previous-boot ring that survived a reset, and records a role-tagged boot
+// breadcrumb. Idempotent (CrashLog's begin is idempotent).
+void crashLogStandardInit(mesh::MainBoard& board, const char* role_tag);
+
+// Call once per loop() iteration with millis(). Drives the deferred re-dump
+// (#463) so a serial monitor that connects AFTER the reset still sees the
+// previous-boot crash log.
+void crashLogStandardTick(uint32_t now_ms);
+
+}  // namespace offband


### PR DESCRIPTION
Implements #472's per-example wiring — the remaining half of the uniform-CrashLog rollout (the src-filter half already landed globally via the #475 `arduino_base` fix). Part of epic #350.

**Wires the shared `crashLogStandardInit`/`Tick` helper into every role example** so boot-survival CrashLog is default-ON everywhere, not just observer + nRF52 companion:
- `simple_repeater`, `simple_room_server`, `simple_sensor`, `simple_secure_chat`, `kiss_modem` — each gets the include + `crashLogStandardInit(board, "<role>")` after `board.begin()` + `crashLogStandardTick(millis())` in `loop()`.
- `companion_radio` — the nRF52-only block (was #377) is extended to **all non-observer companions**, so the **ESP32 companion** finally gets CrashLog (the gap that started this). Observer keeps its existing `wifiObserverBegin()` path.
- Helper (`CrashLogStandard.{h,cpp}`): fixed to `mesh::MainBoard` and made a superset header (re-exposes `crashLogf`). Default-ON; no-op on host / behind `-D OFFBAND_CRASHLOG_DISABLED`.

**Verified — 15 envs green:** every role on ESP32 (`heltec_v4`) + nRF52 (`rak4631`), companion USB/BLE on both, observer no-break.

**#472 stays OPEN after merge** — its closure gate is hardware verification (CrashLog dump on a *preserving* reset, `esp_restart()`, on one ESP32 + one nRF52 role). Does **not** close #350.