### PR TITLE
feat(#462): role-agnostic string-CLI config bridge (config::dispatchCliLine)

### DIFF
--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -14,6 +14,15 @@
   #include "wifi_observer/WifiObserver.h"  // wifiObserverPool() accessor
 #endif
 
+// #462: role-agnostic shared config-CLI bridge. Any role that compiles
+// helpers/config AND defines OFFBAND_CONFIG_CLI routes generic `set/get <key>`
+// through the shared dispatcher here. NOT defined on observer envs -- observer
+// keeps dispatchObserverCli's richer grammar and stays byte-identical (see #462;
+// unifying observer onto the bridge is deferred to #511).
+#if defined(OFFBAND_CONFIG_CLI)
+  #include "config/ConfigDispatch.h"
+#endif
+
 // #200 / LoRa-wek: embed the Offband identity blob in .rodata so the
 // flash-history parser (scripts/firmware_identity.py) can recover BUILD-time
 // identity by scanning the firmware binary, rather than re-running git at
@@ -1462,6 +1471,13 @@ void CommonCLI::handleRegionCmd(char* command, char* reply) {
                                             offband::wifiObserverPool())) {
     // handled by Plan 2 v2 observer CLI (mqtt status / enable / disable /
     // set mqtt.iata / set mqtt.status_interval / set mqtt.broker.<N>.*).
+#endif
+#if defined(OFFBAND_CONFIG_CLI)
+  } else if (offband::config::dispatchCliLine(command, reply, /*reply_size=*/1024)) {
+    // #462: shared config-CLI bridge -- generic `set <key> <value>` / `get <key>`
+    // routed to the registered config providers. Runs AFTER the observer CLI so
+    // a combined build lets the observer's richer grammar win first; on a
+    // non-observer role this is the whole config CLI surface.
 #endif
   } else {
     strcpy(reply, "Err - ??");

--- a/src/helpers/config/ConfigDispatch.cpp
+++ b/src/helpers/config/ConfigDispatch.cpp
@@ -197,6 +197,43 @@ bool dispatchGet(const char* key, char* reply, size_t reply_size) {
     return false;   // no role claims this key
 }
 
+// #462: string-CLI bridge -- parse a generic `set <key> <value>` / `get <key>`
+// line and route to dispatchSet/dispatchGet. See ConfigDispatch.h. The `set`
+// value is the remainder after the FIRST space, taken verbatim (a value may
+// contain spaces, e.g. a WiFi PSK) -- matching the wire OCFG_SET split; a `set`
+// with a key but no value passes "" so the provider emits its own field error.
+bool dispatchCliLine(const char* cmd, char* reply, size_t reply_size) {
+    if (cmd == nullptr || reply == nullptr || reply_size == 0) return false;
+
+    const char* rest = nullptr;
+    bool is_set = false;
+    if (strncmp(cmd, "set ", 4) == 0)      { rest = cmd + 4; is_set = true;  }
+    else if (strncmp(cmd, "get ", 4) == 0) { rest = cmd + 4; is_set = false; }
+    else return false;                     // not a config CLI verb -- not ours
+
+    while (*rest == ' ') ++rest;           // skip spaces before the key
+    if (*rest == '\0') return false;       // no key -- not ours
+
+    // key = up to the first space.
+    char key[64];
+    size_t ki = 0;
+    while (*rest && *rest != ' ' && ki + 1 < sizeof(key)) key[ki++] = *rest++;
+    key[ki] = '\0';
+
+    // #462 review MAJOR-1: if the key hit the buffer limit (next char is neither a
+    // space nor end-of-string), it was TRUNCATED. Reject rather than route a
+    // truncated key -- a truncation could prefix-match a provider and set the
+    // WRONG field. An over-long key is not a valid config key anyway.
+    if (*rest != '\0' && *rest != ' ') return false;
+
+    if (!is_set)
+        return dispatchGet(key, reply, reply_size);   // get: trailing args ignored
+
+    // set: value = remainder after exactly ONE delimiter space (verbatim); "" if none.
+    const char* value = (*rest == ' ') ? rest + 1 : "";
+    return dispatchSet(key, value, reply, reply_size);
+}
+
 // ---------------------------------------------------------------------------
 // Shared parse helpers
 // ---------------------------------------------------------------------------

--- a/src/helpers/config/ConfigDispatch.h
+++ b/src/helpers/config/ConfigDispatch.h
@@ -103,6 +103,26 @@ int overlapWarningCount();
 bool dispatchSet(const char* key, const char* value, char* reply, size_t reply_size);
 bool dispatchGet(const char* key, char* reply, size_t reply_size);
 
+// #462: role-agnostic string-CLI bridge. Parses a generic
+//   set <key> <value>   -> dispatchSet(key, value, ...)
+//   get <key>           -> dispatchGet(key, ...)
+// and routes to the registered providers, so ANY role's CommonCLI fall-through
+// can expose the SAME shared config commands (wifi.*/mqtt.*/display.*) the wire
+// path (CMD_OFFBAND_CONFIG) exposes -- no per-role grammar duplication.
+//
+// This is the string-CLI counterpart of dispatchSet/dispatchGet, which already
+// route the WIRE path. `set` splits on the FIRST space (value = remainder
+// verbatim, matching the wire's OCFG_SET); `get` takes the key token only
+// (trailing args ignored). Returns true iff a provider handled the key (incl. an
+// "ERROR: ..." reply); false if the line is not a config verb OR no provider
+// claims the key -- the caller then falls through to its own unknown-command path.
+//
+// Callers gate the call behind `#if defined(OFFBAND_CONFIG_CLI)` so envs that do
+// not compile helpers/config don't reference this symbol. Deliberately NOT
+// enabled on observer envs (they keep dispatchObserverCli's richer grammar);
+// unifying the observer onto this bridge is #511. See #462.
+bool dispatchCliLine(const char* cmd, char* reply, size_t reply_size);
+
 // ---------------------------------------------------------------------------
 // Shared, role-agnostic parse helpers (moved verbatim in behaviour from
 // ObserverCli.cpp so every role parses config values identically).


### PR DESCRIPTION
Closes #462. **Epic #300.** Builds on #364 (wire dispatcher, merged).

Adds a **role-agnostic string-CLI → config bridge** so any role's `CommonCLI` can expose the same shared config commands the wire path already does — the string-CLI counterpart of `config::dispatchSet`/`dispatchGet`.

## What this does

New `config::dispatchCliLine(cmd, reply, size)` in `helpers/config/ConfigDispatch`:
- `set <key> <value>` → `dispatchSet(key, value, …)` (value = remainder after the first space, **verbatim** — matches the wire OCFG_SET split; a value may contain spaces, e.g. a PSK)
- `get <key>` → `dispatchGet(key, …)` (key token only; trailing args ignored)
- returns false if the line isn't a config verb, the key is over-long/truncated, or no provider claims it — caller then falls through to its own unknown-command path

Wired into `CommonCLI`'s command fall-through behind `#if defined(OFFBAND_CONFIG_CLI)`, placed **after** the observer CLI so a combined build lets the observer's richer grammar win first.

## Scope boundary (owner-pinned)

Unifies the **shared config commands only** (wifi/mqtt/display keys). **NOT a full-CLI merge** — role-specific verbs (observer's `mqtt status`, `display flip`, `wifi enable`, …) are untouched and stay role-specific.

## Observer stays byte-identical (this version)

`OFFBAND_CONFIG_CLI` is **not defined on any shipping env** in this PR — observer keeps `dispatchObserverCli`'s grammar. Byte-identical is **structural**: only 3 files change (`ConfigDispatch.{h,cpp}`, `CommonCLI.cpp`), **none under `wifi_observer/`**; the guarded CommonCLI block doesn't compile for observer, and the new function is uncalled there (`--gc-sections`-droppable). Unifying the observer onto the bridge is deferred to **#511** (documented there: re-enable the flag on observer, re-prove byte-compat, re-run the #488 gate).

## Verification

- **Host test** of `dispatchCliLine` — 19 checks (set/get split, value-with-spaces preserved, key-no-value → empty value, trailing get args ignored, leading spaces, non-verb → false, unknown key → false, over-long key → false, malformed → false, null) — **0 failures**.
- **5/5 envs build** flag-off (4 observer + `RAK_4631` nRF52).
- **Observer-off + config-on compiles + links** (built a non-observer ESP32 env with the flag + the bridge TU) — confirms the `#if OFFBAND_CONFIG_CLI` guarded `else if` is well-formed and `dispatchCliLine` links off-observer.

## Gemini adversarial review — adjudicated

Log: `docs/llm-consultations/2026-07-31-462-config-cli-bridge-review-gemini-gemini-2.5-pro.log`.

- **BLOCKER-1** "dangling `else if` when observer off / config-cli on" → **REFUTED by build.** Built exactly that combination; `CommonCLI.cpp` compiled clean. The guard's leading `}` closes the preceding `list` branch body correctly; no dangling else.
- **MAJOR-1** over-long key truncated then prefix-matched → **ACCEPTED, FIXED.** `dispatchCliLine` now returns false if the key hit the `key[64]` boundary (truncation), rather than routing a truncated key. Host-tested (70-char key under a claimed prefix → rejected).
- **MINOR-1** hardcoded `1024` → kept: matches the adjacent existing `dispatchObserverCli` call; `reply` is a `char*` param here so `sizeof` can't apply, and `1024` is CommonCLI's documented reply size.
- **MINOR-2** byte-identical not binary-proven → acknowledged; claim softened to *structural* (no `wifi_observer/` file touched, guarded-off + uncalled). A binary diff would be overkill for an uncalled function.
- **MINOR-3** accept tabs as delimiter → **rejected**: space-delimited matches the wire OCFG_SET contract and CommonCLI convention; accepting tabs would make the CLI accept inputs the wire rejects — the exact wire/CLI asymmetry this bridge exists to avoid.

## ⚠ Dependency for the first non-observer consumer (not a #462 defect)

A non-observer role that enables `OFFBAND_CONFIG_CLI` must compile `helpers/config` — but the **`*.cpp` glob currently also sweeps `WifiConfigProvider.cpp`, which includes observer-only `WifiObserverConfig.h`** (via `WifiBootstrap.h`) and `#error`s without `OFFBAND_OBSERVER`. That is the #370-deferred WiFi-provider portability coupling, owned by **#365** (WifiBootstrap decouple). So the bridge is sound and merges now, but the first non-observer role (#301/#365) must either selectively compile `ConfigDispatch.cpp` + its own portable provider, or land #365's decouple first. Flagged so nobody flips the flag on a repeater and hits the `#error`.

⚠ Merge gate (#477): `ci-green` required matrix. Auto-merge waits for it.

Agent: DarkLynx (session 17550faa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
