### PR TITLE
task(#508): add second offband_caps byte at device-info offset 84

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1674,6 +1674,23 @@ void MyMesh::handleCmdFrame(size_t len) {
     // stay fixed for a given version code; the cap bit above, not this byte's presence,
     // is what tells the client whether to show the control. Reads 0 when not capable.
     out_frame[i++] = board.isLoRaFemLnaEnabled() ? 1 : 0;   // v16+
+    // #508: SECOND capability byte. Byte 1 (offset 82) is exhausted -- see the
+    // canonical allocation table in OffbandConfigProtocol.h.
+    //
+    // POSITION IS DELIBERATE: this goes at the END of the frame, NOT adjacent to
+    // byte 1. The client reads both byte 1 and the FEM LNA state at FIXED absolute
+    // offsets (meshcore-client meshcore_connector.dart parseOffbandCaps -> frame[82],
+    // parseFemLnaState -> frame[83]). Inserting here-adjacent would shift the FEM
+    // state to 84 and every shipped client would read a capability bitmask as the
+    // LNA toggle state. Byte 1 stays at 82, FEM state stays at 83, byte 2 is 84.
+    //
+    // Appended UNCONDITIONALLY, same rule as the FEM byte above: the frame layout is
+    // fixed for a given version code, and capability is signalled by BITS, never by a
+    // byte's presence. Ships all-zero -- this change establishes the byte only; #509
+    // and #510 allocate the first bits from it. Pre-v18 clients read a shorter frame
+    // and never see it.
+    uint8_t offband_caps2 = 0;
+    out_frame[i++] = offband_caps2;          // v18+
     _serial->writeFrame(out_frame, i);
   } else if (cmd_frame[0] == CMD_APP_START &&
              len >= 8) { // sent when app establishes connection, respond with node ID

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -10,8 +10,10 @@
 // AT MERGE, not at branch time. Do not assume a code from an unmerged branch is yours
 // -- check what has actually merged (same split-allocation trap as the cap bits; see
 // the canonical table in OffbandConfigProtocol.h). In-flight claimants after 17:
-// #365 WIFI_COMPANION (0x08) -> 18, display-config (0x10) -> 19, in merge order.
-#define FIRMWARE_VER_CODE 17   // #427: + caplog cap bit (0x20) in device-info. Prior 16 (#298): FEM LNA cap 0x04 / 0xC3 / LNA state
+// #365 WIFI_COMPANION (0x08), display-config (0x10), and #508 (caps byte 2) are all
+// in flight; whichever merges first takes 18, and the others rebase. The value below
+// is PROVISIONAL for this branch -- reconcile it against firmware-base at merge.
+#define FIRMWARE_VER_CODE 18   // #508 (PROVISIONAL, see above): + second caps byte at frame offset 84. Prior 17 (#427): caplog cap bit 0x20. Prior 16 (#298): FEM LNA cap 0x04 / 0xC3 / LNA state
 
 #ifndef FIRMWARE_BUILD_DATE
 #define FIRMWARE_BUILD_DATE "6 Jun 2026"

--- a/examples/companion_radio/OffbandConfigProtocol.h
+++ b/examples/companion_radio/OffbandConfigProtocol.h
@@ -136,10 +136,33 @@ enum MqttAuthType  : uint8_t { MQTT_AUTH_NONE = 0, MQTT_AUTH_BASIC = 1, MQTT_AUT
 //    3   0x08   OFFBAND_CAP_WIFI_COMPANION    RESERVED    #365 (in-flight, unmerged) -- DO NOT REUSE
 //    4   0x10   (display-config)              RESERVED    owner, in-flight -- DO NOT REUSE
 //    5   0x20   OFFBAND_CAP_CAPLOG            this change  #427 (#396/#417)
-//    6   0x40   -- free --
-//    7   0x80   -- free --
+//    6   0x40   -- free --  (RESERVE for GPS, see note)
+//    7   0x80   -- free --  (last byte-1 bit: HEADROOM, do not spend casually)
 //   (GPS has NO bit: client uses a loose "any Offband v14+ radio speaks 0xC1"
 //    presence-gate until firmware defines one. If added, take 0x40.)
+//
+// === offband_caps BYTE 2 (#508) -- frame offset 84 =============================
+// Byte 1 above is effectively exhausted: one genuinely free bit (0x80) with two
+// reservations (0x08, 0x10) still unmerged. Rather than spend the last bit and force
+// the NEXT feature to extend the frame under pressure -- the condition that produced
+// the #427-vs-#365 0x08 double-claim -- byte 2 was added while nothing was blocked.
+//
+// ⚠ POSITION: byte 2 is at the END of the device-info frame (offset 84), NOT adjacent
+// to byte 1 (offset 82). The FEM LNA state byte sits at 83 and the client reads all of
+// these at FIXED ABSOLUTE OFFSETS (meshcore_connector.dart: parseOffbandCaps ->
+// frame[82], parseFemLnaState -> frame[83]). Inserting byte 2 adjacent to byte 1 would
+// shift the FEM state and every shipped client would misread a bitmask as the LNA
+// toggle. Client reads byte 2 as: frame.length >= 85 ? frame[84] : null.
+//
+// Same reservation discipline as byte 1 -- record the bit HERE with its issue in the
+// SAME PR, and Agent-Mail the reservation so parallel sessions see it. Grepping
+// firmware-base shows only MERGED bits; in-flight claims live on unmerged branches.
+//
+//   bit  value  symbol                        state       issue
+//   ---  -----  ----------------------------  ----------  --------------------------
+//    0   0x01   -- free --                                (first taker: #509 button matrix)
+//    1   0x02   -- free --                                (then: #510 notification scope)
+//    2-7 0x04.. -- free --
 // ===============================================================================
 constexpr uint8_t OFFBAND_CAP_WIFI_OBSERVER = 0x01;  // bit 0: config backend (wifi_observer) compiled in
 constexpr uint8_t OFFBAND_CAP_BLOCK         = 0x02;  // bit 1: user-block list (BlockStore) compiled in (#241)


### PR DESCRIPTION
Closes the caps-byte-exhaustion blocker for feature #507. Ships **all bits zero** — this establishes the byte only; #509 and #510 allocate the first bits.

## Why a whole byte instead of spending `0x80`

Byte 1 has one genuinely free bit. `0x40` is earmarked for GPS in the registry, and `0x08` (issue 365) + `0x10` (display-config) are reserved but unmerged. Spending `0x80` takes byte 1 to zero free bits with two claims still in flight, forcing the next feature to extend the frame mid-flight — the exact condition that produced the `0x08` double-claim between #427 and issue 365.

Owner decision, taken with both options on the table.

## ⚠ The part reviewers should check hardest — byte position

Byte 2 goes at the **end of the frame (offset 84)**, deliberately **not** adjacent to byte 1.

The caps byte is not the last field. The FEM LNA state byte follows it, and the client reads both at **fixed absolute offsets** (`meshcore-client :: lib/connector/meshcore_connector.dart:5009-5018`):

```dart
parseOffbandCaps  → frame.length >= 83 ? frame[82] : null
parseFemLnaState  → frame.length >= 84 ? frame[83] != femLnaBypass : null
```

Inserting byte 2 adjacent to byte 1 would shift FEM state to 84, and **every shipped client would read a capability bitmask as the LNA toggle state** — a wrong toggle on every connect, on firmware that looks correct. Byte 1 stays at 82, FEM state stays at 83, byte 2 is 84.

The original plan in #508 had this wrong; corrected during diagnosis, before code ([issue comment](https://github.com/OffbandMesh/meshcore-firmware/issues/508#issuecomment-5145757430)).

Appended **unconditionally**, matching the FEM byte rule: frame layout is fixed for a given version code, capability is signalled by bits and never by a byte's presence. Pre-v18 clients read a shorter frame and never see it.

## `FIRMWARE_VER_CODE` 17 → 18, marked PROVISIONAL

Issue 365 and display-config are also queued for 18; allocation is merge-ordered. **Verified at push time: all 87 remote branches scanned, zero claim 18.**

`firmware-base` protection is `strict: true` + `ci-green` + `enforce_admins`, so this PR cannot merge stale — a competing claim surfaces as a required rebase rather than two branches landing the same code. If issue 365 merges first, this rebases to 19.

## Verification

| Check | Result |
|---|---|
| `t1000e_companion_radio_ble` (nRF52) | SUCCESS |
| `Heltec_v3_companion_radio_ble` (ESP32) | SUCCESS |
| Frame size | 85 B vs `MAX_FRAME_SIZE` 176 and a 169 B BLE ATT floor |
| Gemini adversarial review | ran; independently recounted the frame and confirmed offset 84 |

Build results read from the per-env SUCCESS/FAILED table, not the exit code.

## Gemini findings — all dispositioned, none silently dismissed

Full table on [#508](https://github.com/OffbandMesh/meshcore-firmware/issues/508#issuecomment-5145849458).

- **Offsets / overflow / compatibility** — confirmed correct. (It assumed `MAX_FRAME_SIZE` 251; the real value is 176, `src/helpers/BaseSerialInterface.h:5`. Conclusion unchanged.)
- **"Provisional version code is not defensible"** — valid risk, kept, with the `strict` branch-protection mitigation it did not have. Residual hole stated: a textual rebase of `18` against `18` is not a conflict when comments differ.
- **"YAGNI, spend `0x80` instead"** — overridden, owner decision, recorded rather than dropped. Two of its premises were wrong: `0x80` is the *last* bit, not comfortable headroom; and its proposed alternative "a centralized registry" **is** the file whose weakness its own next finding identifies.
- **"Comment as a database is fragile"** — accepted, filed as **#514** (machine-checkable registry + `config-lint` enforcement).

## Not yet done

**No hardware test.** The meaningful test is backward compatibility — old client, new firmware, confirm the frame still parses and caps-gated features are unaffected. Best target is a **FEM-capable Heltec V4**, where a bad offset makes the LNA toggle visibly wrong; the T1000-E is LR1110 so its FEM byte reads 0 either way and would hide a shift.

That byte 2 is *readable* cannot be tested until a client reads offset 84 (#474/#475).

Human flash approval required before any device is touched.

Task: `Crosswire-ay2`. Parent: #507. Blocks #509, #510.
