### PR TITLE
fix(#506): cap MQTT keepalive at 60s (broker max_keepalive rejects k120 as CONNACK 0x02)

### DIFF
--- a/src/helpers/wifi_observer/MqttBroker.cpp
+++ b/src/helpers/wifi_observer/MqttBroker.cpp
@@ -154,8 +154,16 @@ bool MqttBroker::begin(uint8_t slot, const BrokerConfig& cfg,
 
 #if defined(ESP_PLATFORM)
     esp_mqtt_client_config_t mqcfg = {};
+    // #506: esp-mqtt defaults the MQTT keepalive to 120 s, but a broker can cap it
+    // via max_keepalive and REJECT an over-limit CONNECT with a MISLEADING CONNACK
+    // 0x02 "identifier rejected" (confirmed live against mqtt2.okimesh.org, which
+    // sets max_keepalive 60 -- a paho client is accepted at k=60, rejected at k=120,
+    // identical to this firmware). 60 s is accepted by capped brokers and by
+    // uncapped ones. #516 makes this per-broker configurable.
+    const int keepalive_sec = 60;
 #if ESP_IDF_VERSION_MAJOR >= 5
     mqcfg.broker.address.uri = cfg_.url;
+    mqcfg.session.keepalive = keepalive_sec;
     if (cfg_.transport == BrokerTransport::Tls ||
         cfg_.transport == BrokerTransport::Wss) {
         const char* pem = lookupCaCertPem(cfg_.ca_cert_name);
@@ -163,6 +171,7 @@ bool MqttBroker::begin(uint8_t slot, const BrokerConfig& cfg,
     }
 #else
     mqcfg.uri = cfg_.url;
+    mqcfg.keepalive = keepalive_sec;
     if (cfg_.transport == BrokerTransport::Tls ||
         cfg_.transport == BrokerTransport::Wss) {
         const char* pem = lookupCaCertPem(cfg_.ca_cert_name);
@@ -435,17 +444,38 @@ void MqttBroker::eventHandler(void* handler_args,
             break;
         case MQTT_EVENT_ERROR: {
             BrokerErrorClass err = BrokerErrorClass::Other;
-            if (event != nullptr && event->error_handle != nullptr) {
+            const esp_mqtt_error_codes_t* eh =
+                (event != nullptr) ? event->error_handle : nullptr;
+            if (eh != nullptr) {
                 // Classify by error_type. Connection refused is auth-y;
                 // TLS errors get their own class.
-                if (event->error_handle->error_type == MQTT_ERROR_TYPE_CONNECTION_REFUSED) {
+                if (eh->error_type == MQTT_ERROR_TYPE_CONNECTION_REFUSED) {
                     err = BrokerErrorClass::Auth;
-                } else if (event->error_handle->esp_tls_last_esp_err != 0 ||
-                           event->error_handle->esp_tls_stack_err != 0) {
+                } else if (eh->esp_tls_last_esp_err != 0 ||
+                           eh->esp_tls_stack_err != 0) {
                     err = BrokerErrorClass::Tls;
-                } else if (event->error_handle->esp_transport_sock_errno != 0) {
+                } else if (eh->esp_transport_sock_errno != 0) {
                     err = BrokerErrorClass::Tcp;
                 }
+                // SAFELANE no-silent-failure: surface the ACTUAL reason
+                // esp-mqtt/esp-tls reported, not just the coarse class.
+                //   sock_errno   -> ECONNREFUSED(111)=refused, EHOSTUNREACH(113/118)
+                //                   =unreachable, ETIMEDOUT(110)=timeout (TCP layer)
+                //   tls_stack_err+cert_flags -> mbedTLS rejected the chain
+                //   connack      -> MQTT CONNACK refusal code (a max_keepalive-exceeded
+                //                   rejection also surfaces here as connack=2, #506)
+                Serial.printf(
+                    "[mqtt-err] s%u type=%d sock_errno=%d tls_esp_err=0x%X "
+                    "tls_stack_err=-0x%04X cert_flags=0x%08X connack=%d -> class=%d\n",
+                    (unsigned)self->slot_, (int)eh->error_type,
+                    eh->esp_transport_sock_errno,
+                    (unsigned)eh->esp_tls_last_esp_err,
+                    (unsigned)(-eh->esp_tls_stack_err),
+                    (unsigned)eh->esp_tls_cert_verify_flags,
+                    (int)eh->connect_return_code, (int)err);
+            } else {
+                Serial.printf("[mqtt-err] s%u (no error_handle)\n",
+                              (unsigned)self->slot_);
             }
             self->onError(now_ms, err);
             break;


### PR DESCRIPTION
## Summary
Fixes #506 — the companion-observer's MQTT CONNECT to a broker with `max_keepalive 60` (mqtt2.okimesh.org) was rejected with a misleading CONNACK `0x02`. esp-mqtt defaults keepalive to 120; this caps it at 60.

## Root cause (confirmed)
Controlled paho test against the broker: keepalive=60 → accepted (rc0), keepalive=120 → rejected (rc2), identical to the firmware. mosquitto reports a max-keepalive-exceeded rejection as "0x02 identifier rejected" — which is why this masqueraded as a client_id bug the whole way. Not client_id, not cert. Full diagnosis trail on #506.

## Change (1 file)
- `MqttBroker::begin()`: `mqcfg.session.keepalive = 60` (IDF≥5) / `mqcfg.keepalive = 60` (IDF4).
- `MQTT_EVENT_ERROR` handler: `[mqtt-err]` log surfacing the full esp-mqtt/esp-tls error struct (sock_errno / tls errs / cert_flags / connack) — no-silent-failure; this is what made #506 diagnosable.

## Test (hardware)
Flashed HV3 (`hv3-bench`, MAC-verified). Result: slot 1 `wss://mqtt2.okimesh.org:9002` → `state=up`; broker log shows `Received PUBLISH … Sending PUBACK rc0`. No more `bad socket read/write: Invalid input` / `connack=2`.

## Review
Gemini adversarial review: clean. 1 MINOR (assert keepalive at the JWT-refresh config sites) dispositioned to #516.

## Follow-ups
- #516 — per-broker configurable keepalive (firmware)
- OffbandMesh/meshcore-client#490 — client keepalive UI

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)
