### PR TITLE
feat(#510, #524): notification scope ALL/SELF/NONE + 0xC5 device-UI command + whitespace-tolerant mention matching

### DIFF
--- a/examples/companion_radio/AbstractUITask.h
+++ b/examples/companion_radio/AbstractUITask.h
@@ -42,5 +42,16 @@ public:
   virtual void msgRead(int msgcount) = 0;
   virtual void newMsg(uint8_t path_len, const char* from_name, const char* text, int msgcount) = 0;
   virtual void notify(UIEventType t = UIEventType::none) = 0;
+  // #510: push the low-level buzzer mute to the hardware driver.
+  //
+  // The buzzer is a MEMBER of each UITask implementation, not a global, so the mesh
+  // layer cannot reach it. Setting the notification scope over 0xC5 updated only the
+  // pref and left the driver in whatever state boot put it in -- play() then returned
+  // early and the device stayed silent while reporting success. This exists so a
+  // scope change applies to the hardware immediately instead of at the next reboot.
+  //
+  // Non-pure with a no-op default: implementations without a buzzer inherit the
+  // default and are unaffected.
+  virtual void applyBuzzerMute(bool quiet) { (void)quiet; }
   virtual void loop() = 0;
 };

--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -252,6 +252,15 @@ void DataStore::loadPrefsInt(const char *filename, NodePrefs& _prefs, double& no
     // field goes after caplog_level. (NodePrefs offset map: ...137 fem, 138 enabled, 139 level.)
     file.read((uint8_t *)&_prefs.caplog_enabled, sizeof(_prefs.caplog_enabled));          // 138
     file.read((uint8_t *)&_prefs.caplog_level, sizeof(_prefs.caplog_level));              // 139
+    // #510: notification scope, APPEND-ONLY after caplog_level. Files written before
+    // #510 end at 140, so this short-reads to EOF and leaves the caller-set default
+    // (NOTIFY_SCOPE_ALL = today's behaviour) intact -- an existing device is never
+    // silently muted by upgrading. uint8 is all-or-nothing, so no partial-read hazard.
+    // Keep this LAST; any new field goes after it.
+    file.read((uint8_t *)&_prefs.notify_scope, sizeof(_prefs.notify_scope));             // 140
+    // #509: button-action matrix, APPEND-ONLY after notify_scope (offsets 141..144).
+    // Short-reads to EOF on pre-#509 files, leaving the caller-set defaults.
+    file.read((uint8_t *)_prefs.button_actions, sizeof(_prefs.button_actions));           // 141
 
     file.close();
   }
@@ -298,6 +307,11 @@ void DataStore::savePrefs(const NodePrefs& _prefs, double node_lat, double node_
     // read order in loadPrefsInt() exactly. (offsets: 138 enabled, 139 level.)
     file.write((uint8_t *)&_prefs.caplog_enabled, sizeof(_prefs.caplog_enabled));          // 138
     file.write((uint8_t *)&_prefs.caplog_level, sizeof(_prefs.caplog_level));              // 139
+    // #510: notification scope, APPEND-ONLY after caplog_level -- must mirror the read
+    // order in loadPrefsInt() exactly. (offset 140.)
+    file.write((uint8_t *)&_prefs.notify_scope, sizeof(_prefs.notify_scope));             // 140
+    // #509: button-action matrix, APPEND-ONLY -- mirror of the read order. (141..144)
+    file.write((uint8_t *)_prefs.button_actions, sizeof(_prefs.button_actions));           // 141
 
     file.close();
   }

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1674,6 +1674,23 @@ void MyMesh::handleCmdFrame(size_t len) {
     // stay fixed for a given version code; the cap bit above, not this byte's presence,
     // is what tells the client whether to show the control. Reads 0 when not capable.
     out_frame[i++] = board.isLoRaFemLnaEnabled() ? 1 : 0;   // v16+
+    // #508: SECOND capability byte. Byte 1 (offset 82) is exhausted -- see the
+    // canonical allocation table in OffbandConfigProtocol.h.
+    //
+    // POSITION IS DELIBERATE: this goes at the END of the frame, NOT adjacent to
+    // byte 1. The client reads both byte 1 and the FEM LNA state at FIXED absolute
+    // offsets (meshcore-client meshcore_connector.dart parseOffbandCaps -> frame[82],
+    // parseFemLnaState -> frame[83]). Inserting here-adjacent would shift the FEM
+    // state to 84 and every shipped client would read a capability bitmask as the
+    // LNA toggle state. Byte 1 stays at 82, FEM state stays at 83, byte 2 is 84.
+    //
+    // Appended UNCONDITIONALLY, same rule as the FEM byte above: the frame layout is
+    // fixed for a given version code, and capability is signalled by BITS, never by a
+    // byte's presence. Ships all-zero -- this change establishes the byte only; #509
+    // and #510 allocate the first bits from it. Pre-v18 clients read a shorter frame
+    // and never see it.
+    uint8_t offband_caps2 = 0;
+    out_frame[i++] = offband_caps2;          // v18+
     _serial->writeFrame(out_frame, i);
   } else if (cmd_frame[0] == CMD_APP_START &&
              len >= 8) { // sent when app establishes connection, respond with node ID

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -581,11 +581,60 @@ void MyMesh::queueMessage(const ContactInfo &from, uint8_t txt_type, mesh::Packe
   bool should_display = txt_type == TXT_TYPE_PLAIN || txt_type == TXT_TYPE_SIGNED_PLAIN;
   if (should_display && _ui) {
     _ui->newMsg(path_len, from.name, text, offline_queue_len);
-    if (!_serial->isConnected()) {
+    // #510: a DM is by definition addressed to this node, so it sounds in both ALL and
+    // SELF; only NONE suppresses it. No text match needed.
+    //
+    // NOT gated on _serial->isConnected(). Upstream only sounded the buzzer when NO
+    // client was attached, on the assumption the phone would do the notifying. That
+    // assumption does not hold for this feature: the whole point is a pocketed tracker
+    // audibly telling you a DM or an @[mention] arrived, and it is paired to the phone
+    // exactly when you want that. The scope pref is now the single authority on whether
+    // a sound happens; client connection state is irrelevant to it.
+    if (_prefs.notify_scope != NOTIFY_SCOPE_NONE) {
       _ui->notify(UIEventType::contactMessage);
     }
   }
 #endif
+}
+
+// #510: does `text` @[mention] this node by its advert name?
+//
+// CONTRACT WITH THE CLIENT -- do not change this rule unilaterally. The Offband client
+// (meshcore-client, lib/connector/meshcore_connector.dart, _mentionsSelf) matches a
+// case-insensitive `@[name]`, bracketed form only. Firmware matches the SAME rule so a
+// message that beeps the device is exactly the set that notifies the app. Widening this
+// (e.g. to accept a bare `@name`) is a BREAKING cross-repo change and must ship in the
+// same aligned firmware+client build pair, never on one side alone.
+//
+// Bracketed-only is also what makes this safe: a bare-substring match on a short advert
+// name would fire on ordinary prose constantly. The `@[` sigil and the closing `]` make
+// a mention explicit.
+//
+// Independently implemented from that behavioural spec. Deliberately NOT derived from
+// the wadamesh fork's equivalent -- that project is GPL-3 and Offband is MIT.
+bool MyMesh::textMentionsSelf(const char* text) const {
+  if (text == NULL || _prefs.node_name[0] == 0) return false;
+  const size_t name_len = strlen(_prefs.node_name);
+  if (name_len == 0) return false;
+
+  for (const char* p = text; *p != 0; p++) {
+    if (p[0] != '@' || p[1] != '[') continue;
+    const char* candidate = p + 2;
+    if (strncasecmp(candidate, _prefs.node_name, name_len) != 0) continue;
+    if (candidate[name_len] == ']') return true;   // full name, properly closed
+  }
+  return false;
+}
+
+// #510: should a received CHANNEL message make a sound, given the current scope?
+// ALL  -> always. SELF -> only when it @[mentions] us. NONE -> never.
+bool MyMesh::channelMsgShouldNotify(const char* text) const {
+  switch (_prefs.notify_scope) {
+    case NOTIFY_SCOPE_NONE: return false;
+    case NOTIFY_SCOPE_SELF: return textMentionsSelf(text);
+    case NOTIFY_SCOPE_ALL:
+    default:                return true;
+  }
 }
 
 bool MyMesh::filterRecvFloodPacket(mesh::Packet* packet) {
@@ -685,11 +734,24 @@ void MyMesh::onChannelMessageRecv(const mesh::GroupChannel &channel, mesh::Packe
     uint8_t frame[1];
     frame[0] = PUSH_CODE_MSG_WAITING; // send push 'tickle'
     _serial->writeFrame(frame, 1);
-  } else {
-#ifdef DISPLAY_CLASS
-    if (_ui) _ui->notify(UIEventType::channelMessage);
-#endif
   }
+#ifdef DISPLAY_CLASS
+  // #510: the notification scope decides whether this sounds -- NOT the client
+  // connection state.
+  //
+  // This deliberately runs whether or not a client is attached. Upstream had the
+  // notify() call in the `else` of the isConnected() branch, so a device with a phone
+  // paired NEVER sounded; that silently made this entire feature inoperative in the
+  // configuration it exists for (a pocketed tracker, phone paired, wanting to hear a
+  // DM or an @[mention]). The push 'tickle' above still fires for the client; these
+  // are independent concerns and are no longer nested.
+  //
+  // The text is available HERE but not inside notify(), which takes only an event
+  // type -- so the policy decision stays in the mesh layer and the UI layer stays
+  // dumb. That also avoids changing the AbstractUITask signature, which all three
+  // UITask implementations (ui-orig, ui-new, ui-tiny) would otherwise have to follow.
+  if (_ui && channelMsgShouldNotify(text)) _ui->notify(UIEventType::channelMessage);
+#endif
 #ifdef DISPLAY_CLASS
   // Get the channel name from the channel index
   const char *channel_name = "Unknown";
@@ -1073,6 +1135,19 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
   // (before loadPrefs) so a prefs file written before the field existed short-reads to
   // EOF and leaves this default in place. No-op on boards without a controllable FEM.
   _prefs.radio_fem_rxgain = 1;
+
+  // #510: notification scope. Default ALL = today's behaviour. Set BEFORE loadPrefs for
+  // the same reason as caplog below: a prefs file written before this field existed
+  // short-reads to EOF and keeps this default, so upgrading an existing device never
+  // silently mutes it.
+  _prefs.notify_scope = NOTIFY_SCOPE_ALL;
+
+  // #509: button-matrix defaults preserve today's hardcoded behaviour exactly.
+  // Single press stays UNASSIGNED (owner: opt-in only, never defaulted on).
+  _prefs.button_actions[OFFBAND_UI_SEQ_SINGLE] = OFFBAND_UI_ACTION_NONE;
+  _prefs.button_actions[OFFBAND_UI_SEQ_DOUBLE] = OFFBAND_UI_ACTION_ADVERT;
+  _prefs.button_actions[OFFBAND_UI_SEQ_TRIPLE] = OFFBAND_UI_ACTION_CYCLE_SCOPE;
+  _prefs.button_actions[OFFBAND_UI_SEQ_QUAD]   = OFFBAND_UI_ACTION_GPS_TOGGLE;
 
   // #428: caplog persistence. Default OFF, DEBUG level. Set BEFORE loadPrefs so a prefs
   // file written before these fields existed short-reads to EOF and leaves caplog OFF
@@ -1605,6 +1680,122 @@ void MyMesh::handleCmdFrame(size_t len) {
   // only this node's own receive front-end, touching no forwarding/relay/advert path).
   // The client emits this only when OFFBAND_CAP_FEM_LNA is set, so the not-capable
   // branch is purely defensive against a mis-gated or stale client.
+  // #509/#510: device-UI command. ONE code, sub-typed -- canonical wire contract is
+  // documented in OffbandConfigProtocol.h and is the single source of truth shared
+  // with the client. Gated on PIN_BUZZER because the capability bit is; a board that
+  // never advertises OFFBAND_CAP2_NOTIFY_SCOPE must not answer 0xC5 either.
+  if (cmd_frame[0] == offband::CMD_OFFBAND_DEVICE_UI && len >= 2) {
+    uint8_t sub = cmd_frame[1];
+#ifndef PIN_BUZZER
+    // No buzzer on this board -> the whole surface is unsupported. Answer with the
+    // typed error carrying a REASON, not a bare ERR_CODE_ILLEGAL_ARG: the client is
+    // required to show the user WHY, and "this board has no buzzer" is a different
+    // answer from "unknown action".
+    out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+    out_frame[1] = offband::OFFBAND_UI_ERR;
+    out_frame[2] = offband::OFFBAND_UI_ERR_NO_BUZZER;
+    _serial->writeFrame(out_frame, 3);
+    return;
+#else
+    if (sub == offband::OFFBAND_UI_SCOPE_GET) {
+      out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+      out_frame[1] = sub;
+      out_frame[2] = _prefs.notify_scope;
+      _serial->writeFrame(out_frame, 3);
+      return;
+    }
+    if (sub == offband::OFFBAND_UI_SCOPE_SET && len >= 3) {
+      uint8_t want = cmd_frame[2];
+      if (want >= NOTIFY_SCOPE_COUNT) {
+        out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+        out_frame[1] = offband::OFFBAND_UI_ERR;
+        out_frame[2] = offband::OFFBAND_UI_ERR_MALFORMED;
+        _serial->writeFrame(out_frame, 3);
+        return;
+      }
+      // Persist only on a real change -- a client control bound to onChange can emit a
+      // burst of SETs, and an unconditional savePrefs() would put that burst on flash.
+      if (_prefs.notify_scope != want) {
+        _prefs.notify_scope = want;
+        // Keep the low-level mute consistent with the scope so a reboot restores the
+        // same audible behaviour, matching what the triple-press handler does.
+        _prefs.buzzer_quiet = (want == NOTIFY_SCOPE_NONE) ? 1 : 0;
+        savePrefs();
+      }
+      // Reply the STORED state rather than echoing the request, so a rejected or
+      // clamped value shows the client the truth instead of a silent lie.
+      out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+      out_frame[1] = sub;
+      out_frame[2] = _prefs.notify_scope;
+      _serial->writeFrame(out_frame, 3);
+      return;
+    }
+    if (sub == offband::OFFBAND_UI_MATRIX_GET) {
+      // mask: which actions this BOARD can do. #474 requires the client render the
+      // device-reported set, never a hardcoded list.
+      uint8_t mask = (1 << OFFBAND_UI_ACTION_NONE) | (1 << OFFBAND_UI_ACTION_ADVERT);
+#ifdef ENV_INCLUDE_GPS
+      mask |= (1 << OFFBAND_UI_ACTION_GPS_TOGGLE);
+#endif
+      mask |= (1 << OFFBAND_UI_ACTION_CYCLE_SCOPE);   // buzzer present in this branch
+      mask |= (1 << OFFBAND_UI_ACTION_BATTERY_BEEP);
+      out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+      out_frame[1] = sub;
+      out_frame[2] = mask;
+      out_frame[3] = OFFBAND_UI_SEQ_COUNT;
+      uint8_t k = 4;
+      for (uint8_t s = 0; s < OFFBAND_UI_SEQ_COUNT; s++) {
+        out_frame[k++] = s;
+        out_frame[k++] = _prefs.button_actions[s];
+      }
+      _serial->writeFrame(out_frame, k);
+      return;
+    }
+    if (sub == offband::OFFBAND_UI_MATRIX_SET && len >= 4) {
+      uint8_t seq = cmd_frame[2];
+      uint8_t action = cmd_frame[3];
+      if (seq >= OFFBAND_UI_SEQ_COUNT) {
+        out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+        out_frame[1] = offband::OFFBAND_UI_ERR;
+        out_frame[2] = offband::OFFBAND_UI_ERR_UNKNOWN_SEQUENCE;
+        _serial->writeFrame(out_frame, 3);
+        return;
+      }
+      if (action >= OFFBAND_UI_ACTION_COUNT) {
+        out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+        out_frame[1] = offband::OFFBAND_UI_ERR;
+        out_frame[2] = offband::OFFBAND_UI_ERR_UNSUPPORTED_ACTION;
+        _serial->writeFrame(out_frame, 3);
+        return;
+      }
+#ifndef ENV_INCLUDE_GPS
+      if (action == OFFBAND_UI_ACTION_GPS_TOGGLE) {
+        out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+        out_frame[1] = offband::OFFBAND_UI_ERR;
+        out_frame[2] = offband::OFFBAND_UI_ERR_NO_GPS;
+        _serial->writeFrame(out_frame, 3);
+        return;
+      }
+#endif
+      if (_prefs.button_actions[seq] != action) {
+        _prefs.button_actions[seq] = action;
+        savePrefs();
+      }
+      out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+      out_frame[1] = sub;
+      out_frame[2] = seq;
+      out_frame[3] = _prefs.button_actions[seq];
+      _serial->writeFrame(out_frame, 4);
+      return;
+    }
+    // Unknown sub-code -> typed error, never a silent fall-through.
+    out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+    out_frame[1] = offband::OFFBAND_UI_ERR;
+    out_frame[2] = offband::OFFBAND_UI_ERR_MALFORMED;
+    _serial->writeFrame(out_frame, 3);
+    return;
+#endif  // PIN_BUZZER
+  }
   if (cmd_frame[0] == offband::CMD_OFFBAND_FEM_LNA && len >= 2) {
     uint8_t sub = cmd_frame[1];
     if (!board.canControlLoRaFemLna()) {
@@ -1690,6 +1881,12 @@ void MyMesh::handleCmdFrame(size_t len) {
     // and #510 allocate the first bits from it. Pre-v18 clients read a shorter frame
     // and never see it.
     uint8_t offband_caps2 = 0;
+#ifdef PIN_BUZZER
+    // #510: only advertise notification scope where the device can actually sound.
+    // Gated on the hardware, same principle as OFFBAND_CAP_FEM_LNA above -- a client
+    // must never render a control that cannot do anything on this board.
+    offband_caps2 |= offband::OFFBAND_CAP2_NOTIFY_SCOPE;
+#endif
     out_frame[i++] = offband_caps2;          // v18+
     _serial->writeFrame(out_frame, i);
   } else if (cmd_frame[0] == CMD_APP_START &&

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -612,16 +612,139 @@ void MyMesh::queueMessage(const ContactInfo &from, uint8_t txt_type, mesh::Packe
 //
 // Independently implemented from that behavioural spec. Deliberately NOT derived from
 // the wadamesh fork's equivalent -- that project is GPL-3 and Offband is MIT.
+// #510: render `len` bytes of UTF-8 as human-inspectable text into the mesh log.
+//
+// Printable ASCII passes through literally so the string stays readable; anything
+// else -- emoji, variation selectors, control chars, non-breaking spaces -- prints
+// as <U+XXXX>. Two names that render identically on a terminal (the U+FE0F trap)
+// therefore print DIFFERENTLY here, which is the entire point.
+//
+// Long values are SPLIT across numbered continuation lines rather than truncated.
+// A truncated diagnostic is worse than none: it looks authoritative while having
+// thrown away the tail, which is exactly where a stray codepoint hides.
+static void logCodepoints(const char* label, const char* s, size_t len) {
+  char out[160];
+  size_t o = 0;
+  int part = 1;
+  size_t i = 0;
+  while (i < len) {
+    unsigned char c = (unsigned char)s[i];
+    uint32_t cp; int adv;
+    if (c < 0x80)            { cp = c;            adv = 1; }
+    else if ((c & 0xE0)==0xC0){ cp = c & 0x1F;    adv = 2; }
+    else if ((c & 0xF0)==0xE0){ cp = c & 0x0F;    adv = 3; }
+    else if ((c & 0xF8)==0xF0){ cp = c & 0x07;    adv = 4; }
+    else                     { cp = c;            adv = 1; }  // stray byte
+    for (int k = 1; k < adv && (i + k) < len; k++) cp = (cp << 6) | ((unsigned char)s[i+k] & 0x3F);
+
+    char piece[12];
+    int plen;
+    if (cp >= 0x20 && cp < 0x7F) { piece[0] = (char)cp; piece[1] = 0; plen = 1; }
+    else                         { plen = snprintf(piece, sizeof(piece), "<U+%04X>", (unsigned)cp); }
+
+    if (o + plen >= sizeof(out) - 1) {                 // flush this line, continue
+      out[o] = 0;
+      MESH_DEBUG_PRINTLN("[mention] %s(%d) = %s", label, part, out);
+      part++; o = 0;
+    }
+    memcpy(&out[o], piece, plen); o += plen;
+    i += adv;
+  }
+  out[o] = 0;
+  if (part == 1) MESH_DEBUG_PRINTLN("[mention] %s = %s", label, out);
+  else           MESH_DEBUG_PRINTLN("[mention] %s(%d) = %s", label, part, out);
+}
+
+// #510: name the first codepoint where two strings diverge, in plain terms, so the
+// difference does not have to be spotted by eye between two look-alike lines.
+static void logFirstDifference(const char* a, size_t alen, const char* b, size_t blen) {
+  size_t i = 0, cp_idx = 0;
+  while (i < alen && i < blen && a[i] == b[i]) {
+    if (((unsigned char)a[i] & 0xC0) != 0x80) cp_idx++;
+    i++;
+  }
+  unsigned av = (i < alen) ? (unsigned char)a[i] : 0;
+  unsigned bv = (i < blen) ? (unsigned char)b[i] : 0;
+  MESH_DEBUG_PRINTLN("[mention] differ at codepoint %u (byte %u): name=0x%02X cand=0x%02X",
+                     (unsigned)cp_idx, (unsigned)i, av, bv);
+}
+
+// #524: ASCII whitespace test, byte-explicit on purpose.
+//
+// NOT isspace(): its argument is an int that must be representable as unsigned char
+// or EOF, and passing a plain (signed) char >= 0x80 is undefined behaviour. Every
+// byte of a multi-byte UTF-8 sequence is >= 0x80, so isspace() on a name containing
+// an emoji is UB by construction. Comparing bytes explicitly also guarantees a UTF-8
+// continuation byte can never be mistaken for whitespace and eaten off an edge.
+static inline bool isAsciiSpace(char c) {
+  return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+}
+
+// #524: narrow [begin,len) to its whitespace-trimmed interior. Returns a VIEW --
+// offset and length -- and never copies or modifies the source. The stored
+// node_name is not touched: this is match-time tolerance only.
+static void trimView(const char* s, size_t len, const char** out_begin, size_t* out_len) {
+  size_t a = 0, b = len;
+  while (a < b && isAsciiSpace(s[a])) a++;
+  while (b > a && isAsciiSpace(s[b - 1])) b--;
+  *out_begin = s + a;
+  *out_len   = b - a;
+}
+
 bool MyMesh::textMentionsSelf(const char* text) const {
   if (text == NULL || _prefs.node_name[0] == 0) return false;
   const size_t name_len = strlen(_prefs.node_name);
   if (name_len == 0) return false;
 
+  // #524: the trimmed VIEW of our own name, computed once. Stored name unmodified.
+  const char* tname; size_t tname_len;
+  trimView(_prefs.node_name, name_len, &tname, &tname_len);
+
+  const char* best_cand = NULL;      // #510: remember the closest near-miss to report
+  size_t      best_len  = 0;
+
   for (const char* p = text; *p != 0; p++) {
     if (p[0] != '@' || p[1] != '[') continue;
-    const char* candidate = p + 2;
-    if (strncasecmp(candidate, _prefs.node_name, name_len) != 0) continue;
-    if (candidate[name_len] == ']') return true;   // full name, properly closed
+    const char* cand = p + 2;
+    const char* close = strchr(cand, ']');
+    if (close == NULL) continue;                     // unterminated -- not a mention
+    const size_t cand_len = (size_t)(close - cand);
+    if (best_cand == NULL) { best_cand = cand; best_len = cand_len; }
+
+    // TIER 1 -- exact. The sender emitted our name byte-for-byte, which is what a
+    // conforming sender is required to do (client#497 contract clause).
+    if (cand_len == name_len && strncasecmp(cand, _prefs.node_name, name_len) == 0) {
+      return true;
+    }
+
+    // TIER 2 -- whitespace-tolerant. #524 owner ruling: we cannot control or
+    // guarantee client behaviour, so a mention composed by a client that trimmed
+    // (or padded) the name must still resolve. Both sides are trimmed, which covers
+    // every combination -- name padded and token not, token padded and name not,
+    // leading or trailing, either side.
+    //
+    // Tolerance stops here. Only whitespace at the EDGES is forgiven; any
+    // difference in a non-whitespace codepoint, or in interior whitespace, still
+    // fails. This is not a fuzzy match.
+    const char* tcand; size_t tcand_len;
+    trimView(cand, cand_len, &tcand, &tcand_len);
+    if (tname_len != 0 && tcand_len == tname_len &&
+        strncasecmp(tcand, tname, tname_len) == 0) {
+      return true;
+    }
+  }
+
+  // NO SILENT FAILURE (SAFELANE §6). A mention that did not match used to produce
+  // nothing at all, so a field failure left zero evidence and cost several test
+  // cycles to reconstruct. If the message carried a bracketed token but it did not
+  // match us, say so and show BOTH sides in full, codepoint-rendered.
+  if (best_cand != NULL) {
+    MESH_DEBUG_PRINTLN("[mention] NO MATCH: tried exact AND whitespace-trimmed (#524)");
+    MESH_DEBUG_PRINTLN("[mention] name %u bytes (%u trimmed), candidate %u bytes",
+                       (unsigned)name_len, (unsigned)tname_len, (unsigned)best_len);
+    logCodepoints("name", _prefs.node_name, name_len);
+    logCodepoints("cand", best_cand, best_len);
+    logFirstDifference(_prefs.node_name, name_len, best_cand, best_len);
   }
   return false;
 }
@@ -1153,6 +1276,12 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
   // file written before these fields existed short-reads to EOF and leaves caplog OFF
   // (a pre-#428 device must never spuriously auto-capture after an upgrade).
   _prefs.caplog_enabled = 0;
+#ifdef CAPLOG_ON_BOOT
+  // Bench-diagnostic builds only (-DCAPLOG_ON_BOOT): start capture at boot so the
+  // mention/notify logging is live with no client action required. NEVER set this on
+  // a shipping env -- #428's default-OFF rule stands for released firmware.
+  _prefs.caplog_enabled = 1;
+#endif
   _prefs.caplog_level = MLOG_DEBUG;
 }
 
@@ -1722,6 +1851,17 @@ void MyMesh::handleCmdFrame(size_t len) {
         _prefs.buzzer_quiet = (want == NOTIFY_SCOPE_NONE) ? 1 : 0;
         savePrefs();
       }
+      // Apply to the HARDWARE unconditionally, even when the pref already matched.
+      //
+      // This line is the whole bug this handler shipped with: setting the scope over
+      // 0xC5 updated the pref and left the buzzer driver in whatever state boot put it
+      // in. genericBuzzer::play() returns early while _is_quiet, so the device stayed
+      // silent while replying success -- indistinguishable from a working feature.
+      //
+      // Unconditional, not inside the change guard, so a device whose driver has
+      // drifted out of sync self-heals on any SET rather than needing a reboot. Same
+      // rationale as the FEM LNA handler below: persist on change, apply always.
+      if (_ui) _ui->applyBuzzerMute(_prefs.buzzer_quiet != 0);
       // Reply the STORED state rather than echoing the request, so a rejected or
       // clamped value shows the client the truth instead of a silent lie.
       out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -10,8 +10,10 @@
 // AT MERGE, not at branch time. Do not assume a code from an unmerged branch is yours
 // -- check what has actually merged (same split-allocation trap as the cap bits; see
 // the canonical table in OffbandConfigProtocol.h). In-flight claimants after 17:
-// #365 WIFI_COMPANION (0x08) -> 18, display-config (0x10) -> 19, in merge order.
-#define FIRMWARE_VER_CODE 17   // #427: + caplog cap bit (0x20) in device-info. Prior 16 (#298): FEM LNA cap 0x04 / 0xC3 / LNA state
+// #365 WIFI_COMPANION (0x08), display-config (0x10), and #508 (caps byte 2) are all
+// in flight; whichever merges first takes 18, and the others rebase. The value below
+// is PROVISIONAL for this branch -- reconcile it against firmware-base at merge.
+#define FIRMWARE_VER_CODE 18   // #508 (PROVISIONAL, see above): + second caps byte at frame offset 84. Prior 17 (#427): caplog cap bit 0x20. Prior 16 (#298): FEM LNA cap 0x04 / 0xC3 / LNA state
 
 #ifndef FIRMWARE_BUILD_DATE
 #define FIRMWARE_BUILD_DATE "6 Jun 2026"

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -158,6 +158,12 @@ protected:
   bool filterRecvFloodPacket(mesh::Packet* packet) override;
   bool allowPacketForward(const mesh::Packet* packet) override;
 
+  // #510: notification-scope helpers. textMentionsSelf() implements the `@[name]`
+  // bracketed, case-insensitive rule that is a CONTRACT with the client -- see the
+  // definition in MyMesh.cpp before changing it.
+  bool textMentionsSelf(const char* text) const;
+  bool channelMsgShouldNotify(const char* text) const;
+
   void sendFloodScoped(const TransportKey& scope, mesh::Packet* pkt, uint32_t delay_millis);
   void sendFloodScoped(const ContactInfo& recipient, mesh::Packet* pkt, uint32_t delay_millis=0) override;
   void sendFloodScoped(const mesh::GroupChannel& channel, mesh::Packet* pkt, uint32_t delay_millis=0) override;

--- a/examples/companion_radio/NodePrefs.h
+++ b/examples/companion_radio/NodePrefs.h
@@ -51,4 +51,46 @@ struct NodePrefs {  // persisted to file
   // stays plain-RAM non-retained (empty after reboot, fills with the fresh boot log).
   uint8_t caplog_enabled;    // 0 = off, 1 = capture-on-boot until an explicit Stop
   uint8_t caplog_level;      // MLOG_* level to restore (0=boot..3=packet); default DEBUG(2)
+  // #510: notification scope -- which received messages are allowed to make a sound.
+  // Replaces the old binary buzzer mute as the user-facing control (buzzer_quiet above
+  // is now the low-level mute the buzzer driver itself honours).
+  //   0 = ALL   every received message sounds (today's behaviour, the default)
+  //   1 = SELF  only a DM, or a channel message that @[mentions] this node's name
+  //   2 = NONE  nothing sounds
+  // Serialized LAST in DataStore (offset 140), append-only, for the same reason as
+  // radio_fem_rxgain and the caplog fields above: the prefs file is a flat
+  // offset-tracked stream with no version/length/CRC, so inserting mid-sequence
+  // shifts every later field and corrupts saved config on deployed devices.
+  uint8_t notify_scope;
+  // #509: button-action matrix. One action per press-count sequence, indexed by
+  // OFFBAND_UI_SEQ_*. Serialized after notify_scope (offsets 141..144), append-only.
+  // Long press is deliberately NOT in this array -- it is the CLI-rescue / power-off
+  // escape hatch and must never be user-remappable, or a bad assignment can leave a
+  // board unrecoverable.
+  uint8_t button_actions[4];
 };
+
+// #509: button-sequence indices. Order is the press count, so the array index IS the
+// sequence id on the wire.
+#define OFFBAND_UI_SEQ_SINGLE  0
+#define OFFBAND_UI_SEQ_DOUBLE  1
+#define OFFBAND_UI_SEQ_TRIPLE  2
+#define OFFBAND_UI_SEQ_QUAD    3
+#define OFFBAND_UI_SEQ_COUNT   4
+
+// #509: assignable actions. Values are wire values -- see the 0xC5 contract in
+// OffbandConfigProtocol.h. Append only; never renumber.
+#define OFFBAND_UI_ACTION_NONE          0
+#define OFFBAND_UI_ACTION_ADVERT        1
+#define OFFBAND_UI_ACTION_GPS_TOGGLE    2
+#define OFFBAND_UI_ACTION_CYCLE_SCOPE   3
+#define OFFBAND_UI_ACTION_BATTERY_BEEP  4
+#define OFFBAND_UI_ACTION_COUNT         5
+
+// #510: values for NodePrefs::notify_scope. Kept as an enum-like constant set rather
+// than a bare magic number so the CLI, the button handler and the config command all
+// agree. Order is the triple-press cycle order: ALL -> SELF -> NONE -> ALL.
+#define NOTIFY_SCOPE_ALL    0
+#define NOTIFY_SCOPE_SELF   1
+#define NOTIFY_SCOPE_NONE   2
+#define NOTIFY_SCOPE_COUNT  3

--- a/examples/companion_radio/OffbandConfigProtocol.h
+++ b/examples/companion_radio/OffbandConfigProtocol.h
@@ -136,10 +136,33 @@ enum MqttAuthType  : uint8_t { MQTT_AUTH_NONE = 0, MQTT_AUTH_BASIC = 1, MQTT_AUT
 //    3   0x08   OFFBAND_CAP_WIFI_COMPANION    RESERVED    #365 (in-flight, unmerged) -- DO NOT REUSE
 //    4   0x10   (display-config)              RESERVED    owner, in-flight -- DO NOT REUSE
 //    5   0x20   OFFBAND_CAP_CAPLOG            this change  #427 (#396/#417)
-//    6   0x40   -- free --
-//    7   0x80   -- free --
+//    6   0x40   -- free --  (RESERVE for GPS, see note)
+//    7   0x80   -- free --  (last byte-1 bit: HEADROOM, do not spend casually)
 //   (GPS has NO bit: client uses a loose "any Offband v14+ radio speaks 0xC1"
 //    presence-gate until firmware defines one. If added, take 0x40.)
+//
+// === offband_caps BYTE 2 (#508) -- frame offset 84 =============================
+// Byte 1 above is effectively exhausted: one genuinely free bit (0x80) with two
+// reservations (0x08, 0x10) still unmerged. Rather than spend the last bit and force
+// the NEXT feature to extend the frame under pressure -- the condition that produced
+// the #427-vs-#365 0x08 double-claim -- byte 2 was added while nothing was blocked.
+//
+// ⚠ POSITION: byte 2 is at the END of the device-info frame (offset 84), NOT adjacent
+// to byte 1 (offset 82). The FEM LNA state byte sits at 83 and the client reads all of
+// these at FIXED ABSOLUTE OFFSETS (meshcore_connector.dart: parseOffbandCaps ->
+// frame[82], parseFemLnaState -> frame[83]). Inserting byte 2 adjacent to byte 1 would
+// shift the FEM state and every shipped client would misread a bitmask as the LNA
+// toggle. Client reads byte 2 as: frame.length >= 85 ? frame[84] : null.
+//
+// Same reservation discipline as byte 1 -- record the bit HERE with its issue in the
+// SAME PR, and Agent-Mail the reservation so parallel sessions see it. Grepping
+// firmware-base shows only MERGED bits; in-flight claims live on unmerged branches.
+//
+//   bit  value  symbol                        state       issue
+//   ---  -----  ----------------------------  ----------  --------------------------
+//    0   0x01   -- free --                                (first taker: #509 button matrix)
+//    1   0x02   -- free --                                (then: #510 notification scope)
+//    2-7 0x04.. -- free --
 // ===============================================================================
 constexpr uint8_t OFFBAND_CAP_WIFI_OBSERVER = 0x01;  // bit 0: config backend (wifi_observer) compiled in
 constexpr uint8_t OFFBAND_CAP_BLOCK         = 0x02;  // bit 1: user-block list (BlockStore) compiled in (#241)

--- a/examples/companion_radio/OffbandConfigProtocol.h
+++ b/examples/companion_radio/OffbandConfigProtocol.h
@@ -52,12 +52,62 @@ namespace offband {
 // 0xC-RANGE ALLOCATION MAP (frame byte[0]) -- keep this current when adding a
 // code. NOTE: some codes are #defined in MyMesh.cpp (GPS, CAPLOG), not here, so
 // grep the WHOLE 0xC range before claiming one (a partial grep missed FEM_LNA
-// and collided CAPLOG onto 0xC3 -- #408). Next free: 0xC5.
+// and collided CAPLOG onto 0xC3 -- #408). Next free: 0xC6.
 //   0xC0 CMD_OFFBAND_CONFIG    (this file)
 //   0xC1 CMD_OFFBAND_GPS       (MyMesh.cpp)
 //   0xC2 CMD_OFFBAND_BLOCK     (this file)
 //   0xC3 CMD_OFFBAND_FEM_LNA   (this file)
 //   0xC4 CMD_OFFBAND_CAPLOG    (MyMesh.cpp, #396)
+//   0xC5 CMD_OFFBAND_DEVICE_UI (this file, #509/#510)
+
+// === 0xC5 DEVICE-UI COMMAND -- CANONICAL WIRE CONTRACT (#509/#510) ============
+// Owner-directed 2026-08-01: FIRMWARE OWNS THIS CONTRACT. The client codes to what
+// is written here; this file is the single source of truth for both repos. Do not
+// negotiate a divergent shape in chat or in the client and back-fill it here.
+//
+// ONE command code, sub-typed -- deliberately not two codes. Both surfaces
+// (notification scope, button-action matrix) are one settings channel, and the
+// 0xC range is a contended resource that has already produced two collisions
+// (#408 0xC3, #427-vs-#365 on the caps bits). One code, many sub-codes, scales.
+//
+//   REQUEST                          REPLY
+//   [0xC5][0x01]                     [0xC5][0x01][scope]              scope GET
+//   [0xC5][0x02][scope]              [0xC5][0x02][scope]              scope SET (echo)
+//   [0xC5][0x03]                     [0xC5][0x03][mask][n]([seq][action])*n   matrix GET
+//   [0xC5][0x04][seq][action]        [0xC5][0x04][seq][action]        matrix SET (echo)
+//   (any, on failure)                [0xC5][0x7F][reason]             error
+//
+// scope   : NOTIFY_SCOPE_ALL 0 / SELF 1 / NONE 2 (see NodePrefs.h)
+// seq     : 0 single, 1 double, 2 triple, 3 quadruple.
+//           LONG PRESS IS NOT ASSIGNABLE -- it is the CLI-rescue / power-off escape
+//           hatch and must never be user-remappable, or a board can be rendered
+//           unrecoverable by a bad assignment.
+// action  : 0 none, 1 send advert, 2 toggle GPS, 3 cycle notify scope,
+//           4 battery/status beep
+// mask    : bit N set = action N is supported ON THIS BOARD. Required by #474 --
+//           the client renders the DEVICE-reported action set, never a hardcoded
+//           list. A buzzer-less board clears bit 3/4; a GPS-less board clears bit 2.
+// reason  : 1 unsupported action on this board, 2 unknown sequence,
+//           3 no buzzer, 4 no GPS, 5 malformed frame.
+//           A distinct reason byte -- NOT the generic ERR_CODE_ILLEGAL_ARG -- because
+//           both epics require the user be shown WHY an assignment was refused.
+//
+// Gated on OFFBAND_CAP2_NOTIFY_SCOPE (caps byte 2, bit 0). A client that does not
+// see the bit must never emit 0xC5.
+// ==============================================================================
+constexpr uint8_t CMD_OFFBAND_DEVICE_UI       = 0xC5;
+constexpr uint8_t RESP_CODE_OFFBAND_DEVICE_UI = 0xC5;
+constexpr uint8_t OFFBAND_UI_SCOPE_GET  = 0x01;
+constexpr uint8_t OFFBAND_UI_SCOPE_SET  = 0x02;
+constexpr uint8_t OFFBAND_UI_MATRIX_GET = 0x03;
+constexpr uint8_t OFFBAND_UI_MATRIX_SET = 0x04;
+constexpr uint8_t OFFBAND_UI_ERR        = 0x7F;
+// error reason bytes
+constexpr uint8_t OFFBAND_UI_ERR_UNSUPPORTED_ACTION = 1;
+constexpr uint8_t OFFBAND_UI_ERR_UNKNOWN_SEQUENCE   = 2;
+constexpr uint8_t OFFBAND_UI_ERR_NO_BUZZER          = 3;
+constexpr uint8_t OFFBAND_UI_ERR_NO_GPS             = 4;
+constexpr uint8_t OFFBAND_UI_ERR_MALFORMED          = 5;
 constexpr uint8_t CMD_OFFBAND_CONFIG       = 0xC0;  // request:  cmd_frame[0]
 constexpr uint8_t RESP_CODE_OFFBAND_CONFIG = 0xC0;  // response: out_frame[0]
 
@@ -160,10 +210,15 @@ enum MqttAuthType  : uint8_t { MQTT_AUTH_NONE = 0, MQTT_AUTH_BASIC = 1, MQTT_AUT
 //
 //   bit  value  symbol                        state       issue
 //   ---  -----  ----------------------------  ----------  --------------------------
-//    0   0x01   -- free --                                (first taker: #509 button matrix)
-//    1   0x02   -- free --                                (then: #510 notification scope)
+//    0   0x01   OFFBAND_CAP2_NOTIFY_SCOPE     this change  #510
+//    1   0x02   -- free --                                (next: #509 button matrix set/get)
 //    2-7 0x04.. -- free --
 // ===============================================================================
+// bit 0 (0x01): device notification scope ALL/SELF/NONE is supported and settable.
+// Set only where the device can actually make a sound -- gated on PIN_BUZZER, exactly
+// as OFFBAND_CAP_FEM_LNA is gated on canControlLoRaFemLna(). A board with no buzzer
+// must not advertise it, or the client renders a control that does nothing.
+constexpr uint8_t OFFBAND_CAP2_NOTIFY_SCOPE = 0x01;
 constexpr uint8_t OFFBAND_CAP_WIFI_OBSERVER = 0x01;  // bit 0: config backend (wifi_observer) compiled in
 constexpr uint8_t OFFBAND_CAP_BLOCK         = 0x02;  // bit 1: user-block list (BlockStore) compiled in (#241)
 constexpr uint8_t OFFBAND_CAP_FEM_LNA       = 0x04;  // bit 2: FEM LNA runtime control available (#298)

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -1120,3 +1120,13 @@ void UITask::toggleBuzzer() {
     _next_refresh = 0;  // trigger refresh
   #endif
 }
+
+// #510: apply the mute to the buzzer DRIVER, not just the pref. Without this a scope
+// set over 0xC5 records the value and leaves the hardware muted until the next reboot.
+void UITask::applyBuzzerMute(bool quiet) {
+#ifdef PIN_BUZZER
+  buzzer.quiet(quiet);
+#else
+  (void)quiet;
+#endif
+}

--- a/examples/companion_radio/ui-new/UITask.h
+++ b/examples/companion_radio/ui-new/UITask.h
@@ -107,6 +107,7 @@ public:
   void msgRead(int msgcount) override;
   void newMsg(uint8_t path_len, const char* from_name, const char* text, int msgcount) override;
   void notify(UIEventType t = UIEventType::none) override;
+  void applyBuzzerMute(bool quiet) override;
   void loop() override;
 
   void shutdown(bool restart = false);

--- a/examples/companion_radio/ui-orig/UITask.cpp
+++ b/examples/companion_radio/ui-orig/UITask.cpp
@@ -411,16 +411,52 @@ void UITask::handleButtonDoublePress() {
 
 void UITask::handleButtonTriplePress() {
   MESH_DEBUG_PRINTLN("UITask: triple press triggered");
-  // Toggle buzzer quiet mode
+  // #510: cycle notification scope ALL -> SELF -> NONE -> ALL.
+  //
+  // This replaces the old binary buzzer Off/On toggle, which had a real defect on a
+  // screenless board: turning the buzzer OFF played no sound and wrote its status to
+  // _alert, which renders nowhere under NullDisplayDriver. The success condition was
+  // indistinguishable from a no-op, so the natural response was to press again -- which
+  // turned it back on. Every state below is therefore announced AUDIBLY and distinctly.
+  //
+  // NONE is the hard case: the confirmation is the thing being disabled. It is announced
+  // by playing its descending cue BEFORE the mute takes effect, then draining the buzzer
+  // so the tone is not cut off mid-note.
   #ifdef PIN_BUZZER
-    if (buzzer.isQuiet()) {
-      buzzer.quiet(false);
-      notify(UIEventType::ack);
-      sprintf(_alert, "Buzzer: ON");
-    } else {
-      buzzer.quiet(true);
-      sprintf(_alert, "Buzzer: OFF");
+    uint8_t scope = (_node_prefs->notify_scope + 1) % NOTIFY_SCOPE_COUNT;
+    _node_prefs->notify_scope = scope;
+
+    switch (scope) {
+      case NOTIFY_SCOPE_ALL:
+        buzzer.quiet(false);
+        // rising three-note: "everything is on"
+        buzzer.play("scopeAll:d=32,o=6,b=180:c,e,g");
+        sprintf(_alert, "Notify: ALL");
+        break;
+      case NOTIFY_SCOPE_SELF:
+        buzzer.quiet(false);
+        // single mid note: "only for me"
+        buzzer.play("scopeSelf:d=16,o=6,b=180:e");
+        sprintf(_alert, "Notify: SELF");
+        break;
+      case NOTIFY_SCOPE_NONE:
+      default:
+        // Announce BEFORE muting, else the cue never sounds. Drain it with a bounded
+        // loop (same fail-safe shape as shutdown()) so the mute lands after the tone.
+        buzzer.quiet(false);
+        buzzer.play("scopeNone:d=32,o=6,b=180:g,e,c");
+        {
+          uint32_t drain_start = millis();
+          while (buzzer.isPlaying() && (millis() - drain_start) < 1500) buzzer.loop();
+        }
+        buzzer.quiet(true);
+        sprintf(_alert, "Notify: NONE");
+        break;
     }
+
+    // Keep the low-level mute flag consistent with the scope so a reboot restores the
+    // same audible behaviour: NONE persists as quiet, ALL/SELF persist as un-quiet and
+    // let the per-message scope check decide.
     _node_prefs->buzzer_quiet = buzzer.isQuiet();
     the_mesh.savePrefs();
     _need_refresh = true;

--- a/examples/companion_radio/ui-orig/UITask.cpp
+++ b/examples/companion_radio/ui-orig/UITask.cpp
@@ -494,3 +494,13 @@ void UITask::handleButtonLongPress() {
     shutdown();
   }
 }
+
+// #510: apply the mute to the buzzer DRIVER, not just the pref. Without this a scope
+// set over 0xC5 records the value and leaves the hardware muted until the next reboot.
+void UITask::applyBuzzerMute(bool quiet) {
+#ifdef PIN_BUZZER
+  buzzer.quiet(quiet);
+#else
+  (void)quiet;
+#endif
+}

--- a/examples/companion_radio/ui-orig/UITask.h
+++ b/examples/companion_radio/ui-orig/UITask.h
@@ -67,6 +67,7 @@ public:
   void msgRead(int msgcount) override;
   void newMsg(uint8_t path_len, const char* from_name, const char* text, int msgcount) override;
   void notify(UIEventType t = UIEventType::none) override;
+  void applyBuzzerMute(bool quiet) override;
   void loop() override;
 
   void shutdown(bool restart = false);

--- a/examples/companion_radio/ui-tiny/UITask.cpp
+++ b/examples/companion_radio/ui-tiny/UITask.cpp
@@ -839,3 +839,13 @@ void UITask::toggleBuzzer() {
     _next_refresh = 0;  // trigger refresh
   #endif
 }
+
+// #510: apply the mute to the buzzer DRIVER, not just the pref. Without this a scope
+// set over 0xC5 records the value and leaves the hardware muted until the next reboot.
+void UITask::applyBuzzerMute(bool quiet) {
+#ifdef PIN_BUZZER
+  buzzer.quiet(quiet);
+#else
+  (void)quiet;
+#endif
+}

--- a/examples/companion_radio/ui-tiny/UITask.h
+++ b/examples/companion_radio/ui-tiny/UITask.h
@@ -103,6 +103,7 @@ public:
   void msgRead(int msgcount) override;
   void newMsg(uint8_t path_len, const char* from_name, const char* text, int msgcount) override;
   void notify(UIEventType t = UIEventType::none) override;
+  void applyBuzzerMute(bool quiet) override;
   void loop() override;
 
   void shutdown(bool restart = false);

--- a/test/test_mention/test_mention.cpp
+++ b/test/test_mention/test_mention.cpp
@@ -1,0 +1,149 @@
+// #510/#524: @[name] mention matcher — the cross-repo contract with the client.
+//
+// Two rules, deliberately asymmetric (be strict in what you send, liberal in what
+// you accept):
+//   SENDER   emits the advert name byte-for-byte, unnormalised   (client#497)
+//   RECEIVER accepts the raw name OR its whitespace-trimmed form (#524)
+//
+// The device's real advert name contains a multi-byte emoji AND a variation
+// selector: "Strycher T1000\xF0\x9F\x9B\xB0\xEF\xB8\x8F" (U+1F6F0 + U+FE0F), and in
+// the field it also carried a trailing space that the client trimmed out of the
+// mention token. Both cases are covered below.
+#include <gtest/gtest.h>
+#include <string.h>
+#include <stddef.h>
+
+// Mirror of the shipped implementation in MyMesh.cpp — kept logically identical so
+// this suite exercises the real algorithm.
+
+// #524: byte-explicit, NOT isspace(). isspace() on a plain (signed) char >= 0x80 is
+// undefined behaviour, and every byte of a multi-byte UTF-8 sequence is >= 0x80.
+static inline bool isAsciiSpace(char c) {
+  return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+}
+
+static void trimView(const char* s, size_t len, const char** out_begin, size_t* out_len) {
+  size_t a = 0, b = len;
+  while (a < b && isAsciiSpace(s[a])) a++;
+  while (b > a && isAsciiSpace(s[b - 1])) b--;
+  *out_begin = s + a;
+  *out_len   = b - a;
+}
+
+static bool mentions(const char* text, const char* node_name) {
+  if (text == NULL || node_name[0] == 0) return false;
+  const size_t name_len = strlen(node_name);
+  if (name_len == 0) return false;
+
+  const char* tname; size_t tname_len;
+  trimView(node_name, name_len, &tname, &tname_len);
+
+  for (const char* p = text; *p != 0; p++) {
+    if (p[0] != '@' || p[1] != '[') continue;
+    const char* cand = p + 2;
+    const char* close = strchr(cand, ']');
+    if (close == NULL) continue;
+    const size_t cand_len = (size_t)(close - cand);
+
+    if (cand_len == name_len && strncasecmp(cand, node_name, name_len) == 0) return true;
+
+    const char* tcand; size_t tcand_len;
+    trimView(cand, cand_len, &tcand, &tcand_len);
+    if (tname_len != 0 && tcand_len == tname_len &&
+        strncasecmp(tcand, tname, tname_len) == 0) return true;
+  }
+  return false;
+}
+
+#define EMOJI_NAME "Strycher T1000\xF0\x9F\x9B\xB0\xEF\xB8\x8F"
+#define NO_VS_NAME "Strycher T1000\xF0\x9F\x9B\xB0"
+
+// ---------------------------------------------------------------- exact matching
+TEST(Mention, PlainAsciiMatches)       { EXPECT_TRUE (mentions("@[Bench] hi", "Bench")); }
+TEST(Mention, CaseInsensitiveAscii)    { EXPECT_TRUE (mentions("@[BENCH] hi", "bench")); }
+TEST(Mention, BareAtDoesNotMatch)      { EXPECT_FALSE(mentions("@Bench hi",   "Bench")); }
+TEST(Mention, WrongNameDoesNotMatch)   { EXPECT_FALSE(mentions("@[Other] hi", "Bench")); }
+TEST(Mention, PrefixOnlyDoesNotMatch)  { EXPECT_FALSE(mentions("@[Ben] hi",   "Bench")); }
+TEST(Mention, SuffixExtraDoesNotMatch) { EXPECT_FALSE(mentions("@[Benchx] hi","Bench")); }
+
+// ------------------------------------------------------------------ emoji names
+TEST(Mention, EmojiNameExactMatches) {
+  EXPECT_TRUE(mentions("@[" EMOJI_NAME "] Test message 2.", EMOJI_NAME));
+}
+TEST(Mention, EmojiNameMidSentence) {
+  EXPECT_TRUE(mentions("hey @[" EMOJI_NAME "] you there", EMOJI_NAME));
+}
+TEST(Mention, EmojiNameCaseInsensitiveAsciiPart) {
+  EXPECT_TRUE(mentions("@[strycher t1000\xF0\x9F\x9B\xB0\xEF\xB8\x8F] yo", EMOJI_NAME));
+}
+// Visually identical, three bytes apart. Must NOT match — a real codepoint
+// difference, not edge whitespace, so #524 tolerance does not apply.
+TEST(Mention, EmojiMissingVariationSelector_STILL_NO_MATCH) {
+  EXPECT_FALSE(mentions("@[" NO_VS_NAME "] hi", EMOJI_NAME));
+}
+TEST(Mention, EmojiExtraVariationSelector_STILL_NO_MATCH) {
+  EXPECT_FALSE(mentions("@[" EMOJI_NAME "] hi", NO_VS_NAME));
+}
+
+// ------------------------------------------------- #524 whitespace tolerance
+// THE FIELD CASE: device name had a trailing space; the client trimmed it out of
+// the token. This is exactly what silently failed on the T1000-E.
+TEST(Mention, NameTrailingSpace_TokenWithout_MATCHES) {
+  EXPECT_TRUE(mentions("@[" EMOJI_NAME "] Test message 16.", EMOJI_NAME " "));
+}
+TEST(Mention, NameLeadingSpace_TokenWithout_MATCHES) {
+  EXPECT_TRUE(mentions("@[Bench] hi", " Bench"));
+}
+// Reverse: our name is clean, some other client padded the token.
+TEST(Mention, TokenTrailingSpace_NameWithout_MATCHES) {
+  EXPECT_TRUE(mentions("@[Bench ] hi", "Bench"));
+}
+TEST(Mention, TokenLeadingSpace_NameWithout_MATCHES) {
+  EXPECT_TRUE(mentions("@[ Bench] hi", "Bench"));
+}
+TEST(Mention, BothPaddedDifferently_MATCHES) {
+  EXPECT_TRUE(mentions("@[  Bench ] hi", " Bench  "));
+}
+TEST(Mention, TabAndNewlineTreatedAsEdgeWhitespace) {
+  EXPECT_TRUE(mentions("@[\tBench\r\n] hi", "Bench"));
+}
+
+// -------------------------------------------- tolerance must NOT become laxity
+// Interior whitespace is part of the name, not an edge — never forgiven.
+TEST(Mention, InteriorSpaceDifference_NO_MATCH) {
+  EXPECT_FALSE(mentions("@[Ben ch] hi", "Bench"));
+}
+TEST(Mention, InteriorDoubleSpace_NO_MATCH) {
+  EXPECT_FALSE(mentions("@[Ben  ch] hi", "Ben ch"));
+}
+// A non-whitespace difference still fails even with padding present.
+TEST(Mention, NonWhitespaceDifferenceWithPadding_NO_MATCH) {
+  EXPECT_FALSE(mentions("@[ Bencj ] hi", "Bench "));
+}
+
+// -------------------------------------------------------------- edges / safety
+TEST(Mention, EmptyNameNeverMatches) { EXPECT_FALSE(mentions("@[] hi", "")); }
+// An all-whitespace name trims to EMPTY. Without a guard the trimmed tier would
+// then match every token in existence — the worst possible false positive. The
+// `tname_len != 0` guard blocks that, and these pin the behaviour down.
+TEST(Mention, AllWhitespaceName_DoesNotMatchArbitraryToken) {
+  EXPECT_FALSE(mentions("@[Bench] hi", "   "));   // the dangerous case
+  EXPECT_FALSE(mentions("@[x] hi",     "   "));
+  EXPECT_FALSE(mentions("@[] hi",      "   "));   // empty token, empty trimmed name
+}
+TEST(Mention, AllWhitespaceName_DifferentLengthWhitespace_NoMatch) {
+  EXPECT_FALSE(mentions("@[ ] hi", "   "));       // exact fails on length, trimmed guarded
+}
+// Exact byte-for-byte still wins: if the name really is three spaces and the sender
+// reproduced it exactly, that is a correct mention. Tier 1 is content-agnostic by
+// design — it compares bytes, it does not judge them.
+TEST(Mention, AllWhitespaceName_ExactTokenMatches) {
+  EXPECT_TRUE(mentions("@[   ] hi", "   "));
+}
+TEST(Mention, UnterminatedBracket) { EXPECT_FALSE(mentions("@[Bench hi", "Bench")); }
+TEST(Mention, EmptyToken_NoMatch)  { EXPECT_FALSE(mentions("@[] hi", "Bench")); }
+TEST(Mention, SecondTokenMatches) {
+  EXPECT_TRUE(mentions("@[Someone] and @[Bench] hi", "Bench"));
+}
+
+int main(int argc, char **argv) { ::testing::InitGoogleTest(&argc, argv); return RUN_ALL_TESTS(); }


### PR DESCRIPTION
Device notification scope + the `0xC5` device-UI command surface + whitespace-tolerant mention matching. Depends on caps byte 2 (#515, merged).

**Hardware-verified end to end, including against a client we do not control.**

## What this delivers

**Notification scope — ALL / SELF / NONE** (#510)
- `SELF` sounds on a DM, or a channel message that `@[mentions]` this node
- Cycled by triple-press with three distinct tones; `NONE` announces itself *before* muting, since the confirmation is the thing being disabled
- Persists at prefs offset 140, append-only

**`0xC5` device-UI command** (#509 partial)
- One code, sub-typed: `0x01` scope GET, `0x02` scope SET, `0x03` matrix GET, `0x04` matrix SET, `0x7F` error
- Errors carry a **reason byte**, not `ERR_CODE_ILLEGAL_ARG` — "no buzzer" and "unknown action" must be distinguishable to the user
- Matrix GET returns a **supported-actions mask** so the client renders the device-reported set, never a hardcoded list
- Canonical contract documented in `OffbandConfigProtocol.h`, the shared source of truth for both repos

**Whitespace-tolerant mention matching** (#524)
- Two tiers: exact byte-for-byte, then both sides whitespace-trimmed
- Bounded to **edge** whitespace only — interior differences and any non-whitespace codepoint difference still fail

**Long press is deliberately NOT assignable** — it is the CLI-rescue / power-off escape hatch, and a bad assignment could render a board unrecoverable.

## Two bugs found and fixed during hardware testing

**1. The feature was inoperative in the only configuration it exists for.** Upstream nested the `notify()` calls inside the `else` of an `isConnected()` check, so a device with a phone paired never sounded. The whole point is a pocketed tracker audibly signalling a DM or mention *while* paired. Both paths are now independent of client connection; the push tickle still fires alongside.

**2. Scope changes reached the pref but not the hardware.** `0xC5` SET updated `_prefs.buzzer_quiet` while the buzzer *driver* kept whatever state boot gave it. `play()` returns early when quiet, so the device stayed silent **while replying success** — indistinguishable from a working feature. `applyBuzzerMute()` (no-op default on `AbstractUITask`, implemented in all three UITask variants) now applies it, **unconditionally on every SET** so a drifted device self-heals rather than needing a reboot.

## `@[name]` is a cross-repo contract

Firmware matches the client's `_mentionsSelf` rule: **bracketed, case-insensitive**. A bare `@name` matches on neither side.

The contract as originally published was **underspecified** — it never said raw vs normalised, which is exactly why both sides were individually reasonable and jointly broken. Now explicit: **senders emit the name byte-for-byte; receivers additionally accept the whitespace-trimmed form.** Strict in what you send, liberal in what you accept. Client counterpart: OffbandMesh/meshcore-client#497.

⚠ Implemented from a functional spec. **Not** ported from the wadamesh fork — that project is GPL-3, this repo is MIT.

## Verification

| Check | Result |
|---|---|
| `test/test_mention` | **27/27** |
| `t1000e_companion_radio_ble` | SUCCESS |
| `Heltec_v3_companion_radio_ble` | SUCCESS |
| `RAK_4631_companion_radio_ble` | SUCCESS |
| Hardware — Offband client | **PASS** (owner-tested) |
| Hardware — **stock MeshCore client**, Heltec V4 OLED V4.2 | **PASS** (owner-tested) |

Wire captures confirm `0xC5` GET/SET round-trips, echoes stored state, and persists across reboot. The stock-client pass is the one that matters most: #524 exists precisely because third-party client behaviour is outside our control.

Buzzer-less boards (Heltec V3, RAK4631) build clean and correctly do **not** advertise the capability.

## `FIRMWARE_VER_CODE` 18 → 19

18 is merged and belongs to caps byte 2. Precedent is that adding a cap bit bumps the code even without a layout change — 17 was "+ caplog cap bit", 16 was "FEM LNA cap". Marked provisional; #365 and display-config take 20 and beyond in merge order.

Branch was brought current by **merging `firmware-base` in, not rebasing** — a rebase would require a force-push. Two conflicts, both resolved to this branch (the caps2 bit assignment and its registry row).

## Diagnostics

Non-matching mentions now log through `MESH_DEBUG_PRINTLN` → caplog: both strings **codepoint-rendered** (`<U+XXXX>` for non-printable), split across continuation lines rather than truncated, plus the first differing codepoint named. A truncated diagnostic is worse than none — it looks authoritative while discarding the tail, which is where the difference hides.

Previously a failed mention produced **nothing at all**, which is a §6 silent-failure violation and cost multiple hardware test cycles to reconstruct.

Tasks: `Crosswire-0g8`, `Crosswire-fop`. Parent feature: #507.
