### PR TITLE
fix(#532): re-assert keepalive on every mqcfg rebuild (JWT refresh paths)

### DIFF
--- a/src/helpers/wifi_observer/MqttBroker.cpp
+++ b/src/helpers/wifi_observer/MqttBroker.cpp
@@ -89,6 +89,46 @@ const char* lookupCaCertPem(const char* name) {
 }
 
 // ---------------------------------------------------------------------------
+// populateBaseConfig -- the ONE place transport-level esp_mqtt fields are set.
+// ---------------------------------------------------------------------------
+// #506: esp-mqtt defaults the MQTT keepalive to 120 s, but a broker can cap it
+// via max_keepalive and REJECT an over-limit CONNECT with a MISLEADING CONNACK
+// 0x02 "identifier rejected" (confirmed live against a broker with
+// max_keepalive 60 -- a paho client is accepted at k=60, rejected at k=120,
+// identical to this firmware). 60 s is accepted by capped and uncapped brokers
+// alike; OWNER RULING 2026-08-02: it stays a FIXED 60 (#516, per-broker
+// configurability, is deferred and must not be gated on).
+//
+// #532: this is called from ALL THREE config build sites -- begin() and the two
+// JWT-refresh paths in tryConnect()/loop(). The refresh paths previously set
+// only uri+cert and pushed that through esp_mqtt_set_config(), leaving keepalive
+// at the 120 default, so a JWT broker behind a cap silently reverted after a
+// token refresh. Any new field that must survive a refresh belongs HERE, not in
+// an individual call site.
+#if defined(ARDUINO) && defined(ESP_PLATFORM)
+void MqttBroker::populateBaseConfig(esp_mqtt_client_config_t& mqcfg) const {
+    const int keepalive_sec = 60;
+#if ESP_IDF_VERSION_MAJOR >= 5
+    mqcfg.broker.address.uri = cfg_.url;
+    mqcfg.session.keepalive  = keepalive_sec;
+    if (cfg_.transport == BrokerTransport::Tls ||
+        cfg_.transport == BrokerTransport::Wss) {
+        const char* pem = lookupCaCertPem(cfg_.ca_cert_name);
+        if (pem != nullptr) mqcfg.broker.verification.certificate = pem;
+    }
+#else
+    mqcfg.uri       = cfg_.url;
+    mqcfg.keepalive = keepalive_sec;
+    if (cfg_.transport == BrokerTransport::Tls ||
+        cfg_.transport == BrokerTransport::Wss) {
+        const char* pem = lookupCaCertPem(cfg_.ca_cert_name);
+        if (pem != nullptr) mqcfg.cert_pem = pem;
+    }
+#endif
+}
+#endif
+
+// ---------------------------------------------------------------------------
 // Lifecycle
 // ---------------------------------------------------------------------------
 MqttBroker::~MqttBroker() {
@@ -169,30 +209,7 @@ bool MqttBroker::begin(uint8_t slot, const BrokerConfig& cfg,
 
 #if defined(ESP_PLATFORM)
     esp_mqtt_client_config_t mqcfg = {};
-    // #506: esp-mqtt defaults the MQTT keepalive to 120 s, but a broker can cap it
-    // via max_keepalive and REJECT an over-limit CONNECT with a MISLEADING CONNACK
-    // 0x02 "identifier rejected" (confirmed live against mqtt2.okimesh.org, which
-    // sets max_keepalive 60 -- a paho client is accepted at k=60, rejected at k=120,
-    // identical to this firmware). 60 s is accepted by capped brokers and by
-    // uncapped ones. #516 makes this per-broker configurable.
-    const int keepalive_sec = 60;
-#if ESP_IDF_VERSION_MAJOR >= 5
-    mqcfg.broker.address.uri = cfg_.url;
-    mqcfg.session.keepalive = keepalive_sec;
-    if (cfg_.transport == BrokerTransport::Tls ||
-        cfg_.transport == BrokerTransport::Wss) {
-        const char* pem = lookupCaCertPem(cfg_.ca_cert_name);
-        if (pem != nullptr) mqcfg.broker.verification.certificate = pem;
-    }
-#else
-    mqcfg.uri = cfg_.url;
-    mqcfg.keepalive = keepalive_sec;
-    if (cfg_.transport == BrokerTransport::Tls ||
-        cfg_.transport == BrokerTransport::Wss) {
-        const char* pem = lookupCaCertPem(cfg_.ca_cert_name);
-        if (pem != nullptr) mqcfg.cert_pem = pem;
-    }
-#endif
+    populateBaseConfig(mqcfg);   // #532: uri + keepalive + CA cert
 
     // Apply auth strategy (sets username + password/token fields).
     if (!auth_->apply(mqcfg, /*now_ms=*/0)) {
@@ -294,21 +311,10 @@ bool MqttBroker::tryConnect(uint32_t now_ms, bool tls_budget_ok) {
     // time and the token may have aged out before first connect attempt.
     if (auth_ != nullptr && auth_->needsRefresh(now_ms)) {
         esp_mqtt_client_config_t mqcfg = {};
-#if ESP_IDF_VERSION_MAJOR >= 5
-        mqcfg.broker.address.uri = cfg_.url;
-        if (cfg_.transport == BrokerTransport::Tls ||
-            cfg_.transport == BrokerTransport::Wss) {
-            const char* pem = lookupCaCertPem(cfg_.ca_cert_name);
-            if (pem != nullptr) mqcfg.broker.verification.certificate = pem;
-        }
-#else
-        mqcfg.uri = cfg_.url;
-        if (cfg_.transport == BrokerTransport::Tls ||
-            cfg_.transport == BrokerTransport::Wss) {
-            const char* pem = lookupCaCertPem(cfg_.ca_cert_name);
-            if (pem != nullptr) mqcfg.cert_pem = pem;
-        }
-#endif
+        // #532: MUST include keepalive -- this config is pushed via
+        // esp_mqtt_set_config() below, and omitting it reverted a capped broker
+        // to esp-mqtt's default 120 (-> CONNACK 0x02, #506).
+        populateBaseConfig(mqcfg);
         if (!auth_->apply(mqcfg, now_ms)) {
             rt_.state = BrokerState::Backoff;
             rt_.retry_count++;
@@ -364,21 +370,10 @@ void MqttBroker::loop(uint32_t now_ms) {
     if (rt_.state == BrokerState::Up && client_ != nullptr) {
         if (auth_->needsRefresh(now_ms)) {
             esp_mqtt_client_config_t mqcfg = {};
-#if ESP_IDF_VERSION_MAJOR >= 5
-            mqcfg.broker.address.uri = cfg_.url;
-            if (cfg_.transport == BrokerTransport::Tls ||
-                cfg_.transport == BrokerTransport::Wss) {
-                const char* pem = lookupCaCertPem(cfg_.ca_cert_name);
-                if (pem != nullptr) mqcfg.broker.verification.certificate = pem;
-            }
-#else
-            mqcfg.uri = cfg_.url;
-            if (cfg_.transport == BrokerTransport::Tls ||
-                cfg_.transport == BrokerTransport::Wss) {
-                const char* pem = lookupCaCertPem(cfg_.ca_cert_name);
-                if (pem != nullptr) mqcfg.cert_pem = pem;
-            }
-#endif
+            // #532: same reassert requirement as the tryConnect() path -- this is
+            // the mid-session JWT refresh, where a silent revert to 120 would only
+            // surface on the NEXT reconnect, making it especially hard to trace.
+            populateBaseConfig(mqcfg);
             if (auth_->apply(mqcfg, now_ms)) {
                 esp_mqtt_set_config(client_, &mqcfg);
             }

--- a/src/helpers/wifi_observer/MqttBroker.h
+++ b/src/helpers/wifi_observer/MqttBroker.h
@@ -134,6 +134,18 @@ public:
     bool                       isConfigured() const { return slot_ != 0xFF; }
 
 private:
+#if defined(ARDUINO) && defined(ESP_PLATFORM)
+    // #532: fill the transport-level fields of an esp_mqtt config -- uri,
+    // keepalive, and CA cert. The config is rebuilt in THREE places (begin() and
+    // the two JWT-refresh paths in tryConnect()/loop()), and the refresh paths
+    // used to set only uri+cert. esp_mqtt_set_config() would then leave keepalive
+    // at esp-mqtt's default 120, so a JWT broker behind a max_keepalive cap
+    // silently reverted after a token refresh and drew the misleading CONNACK
+    // 0x02 diagnosed in #506. Centralizing it makes every build site identical.
+    // Auth is applied by the caller AFTER this (auth_->apply()).
+    void populateBaseConfig(esp_mqtt_client_config_t& mqcfg) const;
+#endif
+
     uint8_t              slot_  = 0xFF;
     BrokerConfig         cfg_;
     BrokerRuntimeState   rt_;


### PR DESCRIPTION
## Summary
Fixes #532. `keepalive` was set only in `begin()`, not on the two JWT-refresh paths that rebuild the esp-mqtt config and push it via `esp_mqtt_set_config()`. A JWT broker behind a `max_keepalive` cap could therefore revert to esp-mqtt's default 120 after a token refresh and get the misleading CONNACK 0x02 root-caused in #506.

Split out of #516 by owner decision — **#516 (per-broker configurable keepalive) stays deferred; keepalive remains a FIXED 60.** This fix asserts that fixed value everywhere.

## Change (2 files)
New private `MqttBroker::populateBaseConfig()` sets uri + keepalive + CA cert for both IDF branches, called from all three config build sites (`begin()`, `tryConnect()`, `loop()`) before `auth_->apply()`. `keepalive` no longer appears outside the helper, so a future build site can't silently omit it.

Pure refactor on the first-connect path; the behaviour change is confined to the two refresh paths, which now stage the correct keepalive for the next CONNECT.

## Why it matters now
Latent for the observer (the one known capped broker is anonymous, so it never takes the refresh path), but flagged by DarkLynx as biting **repeater rotation** (#302), where JWT brokers reconnect frequently — an intermittent, hard-to-trace failure.

## Verification
- `Heltec_v3_companion_observer_wifi` build **SUCCESS**.
- **No hardware test.** Reproducing this needs a JWT broker that caps `max_keepalive` below 120; none is available on the bench. The known capped broker (`max_keepalive 60`) is anonymous and cannot exercise the JWT-refresh path. Stating this plainly rather than implying coverage that doesn't exist.

## Review
Gemini 2.5-pro. Confirmed the load-bearing question — `esp_mqtt_set_config()` stages the value for the *next* CONNECT, which is precisely the defect. Both IDF branches, `const`, and first-connect behaviour all confirmed correct. Its one MAJOR (guard mismatch) was **refuted with evidence** — all three call sites are already inside `ARDUINO`, and every env is `framework = arduino`; disposition recorded on #532.

Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)
