### PR TITLE
fix(#534): allocate the esp_mqtt client on promotion, not at configure time

### DIFF
--- a/src/helpers/wifi_observer/MqttBroker.cpp
+++ b/src/helpers/wifi_observer/MqttBroker.cpp
@@ -185,7 +185,8 @@ void MqttBroker::shutdown() {
 
 #ifdef ARDUINO
 bool MqttBroker::begin(uint8_t slot, const BrokerConfig& cfg,
-                       const mesh::LocalIdentity& identity) {
+                       const mesh::LocalIdentity& identity,
+                       bool may_alloc_client) {
 #if defined(ARDUINO) && defined(ESP_PLATFORM)
     ClientLockGuard _g(client_lock_);
 #endif
@@ -200,6 +201,19 @@ bool MqttBroker::begin(uint8_t slot, const BrokerConfig& cfg,
     // Enabling later routes through reloadSlot()->begin() which creates it.
     if (!cfg.enabled) {
         rt_ = BrokerRuntimeState{};
+        return true;
+    }
+    // #534: TLS/wss allocation admission. When the pool already holds its full
+    // quota of TLS clients, store the config and stay CONFIGURED BUT CLIENT-LESS
+    // rather than allocating a ~18KB client this broker cannot use. HeldNoHeap
+    // marks it as deferred-not-failed (same semantics tryConnect uses), so the
+    // pool's re-drive promotes it via reconcileSlot() once budget frees. NOT a
+    // failure: return true. tcp brokers hold no mbedTLS context and are exempt.
+    if (!may_alloc_client &&
+        (cfg.transport == BrokerTransport::Tls ||
+         cfg.transport == BrokerTransport::Wss)) {
+        rt_ = BrokerRuntimeState{};
+        rt_.state = BrokerState::HeldNoHeap;
         return true;
     }
     auth_ = makeAuth(cfg, identity);

--- a/src/helpers/wifi_observer/MqttBroker.h
+++ b/src/helpers/wifi_observer/MqttBroker.h
@@ -65,9 +65,24 @@ public:
     // Bind slot to config. Allocates esp_mqtt_client + MqttAuth.
     // Does NOT start the connection; pool decides via tryConnect().
     // Returns false if cfg is invalid (empty URL, unknown auth, etc.).
+    //
+    // #534: may_alloc_client is the pool's ALLOCATION admission for TLS/wss
+    // slots -- REQUIRED (no default, mirroring tryConnect's tls_budget_ok #171)
+    // so no caller can silently bypass it. false means the pool already holds
+    // OFFBAND_MAX_LIVE_TLS TLS clients, so this slot stores its config and stays
+    // CONFIGURED BUT CLIENT-LESS -- the same state releaseClient() leaves a
+    // rotated-out broker in (#175). Previously every enabled slot allocated a
+    // client at configure time, so brokers parked at HeldNoHeap still held a
+    // ~18KB client they could not use; on HV3 that pushed free heap below
+    // OFFBAND_TLS_HEAP_FLOOR_BYTES and deadlocked the pool -- admission fired
+    // only AFTER the cost was paid. The pool promotes a client-less broker via
+    // the existing reconcileSlot() -> begin(..., true) path once budget frees.
+    // Ignored for tcp brokers (they hold no mbedTLS context) and for disabled
+    // slots (they never allocate).
 #ifdef ARDUINO
     bool begin(uint8_t slot, const BrokerConfig& cfg,
-               const mesh::LocalIdentity& identity);
+               const mesh::LocalIdentity& identity,
+               bool may_alloc_client);
 #else
     bool begin(uint8_t slot, const BrokerConfig& cfg);  // host stub (no identity needed)
 #endif

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -70,11 +70,19 @@ void MqttBrokerPool::begin(const mesh::LocalIdentity& identity,
     // Initialize each configured slot. begin() stores config always and
     // creates a live client ONLY if the slot is enabled (#53); disabled or
     // url-empty slots stay client-less.
+    //
+    // #534: TLS/wss slots additionally pass the pool's ALLOCATION admission.
+    // The metric is clients already ALLOCATED (tlsClientsAllocated()), not
+    // connections live -- at boot nothing is Up/Connecting yet, so a live-based
+    // check would admit every slot and allocate a client for each, which is the
+    // deadlock this fixes. Surplus TLS slots stay configured-but-client-less and
+    // are promoted later by the re-drive's reconcileSlot() path.
     for (uint8_t slot = 0; slot < OFFBAND_MAX_BROKERS; ++slot) {
         BrokerConfig cfg;
         if (!readBrokerConfig(slot, cfg)) continue;
         if (cfg.url[0] == '\0') continue;  // skip unused slots
-        brokers_[slot].begin(slot, cfg, identity);
+        brokers_[slot].begin(slot, cfg, identity,
+                             tlsClientsAllocated() < OFFBAND_MAX_LIVE_TLS);
     }
 
 #if defined(ARDUINO) && defined(ESP_PLATFORM)
@@ -379,12 +387,35 @@ void MqttBrokerPool::reconcileSlot(uint8_t slot) {
     // rt_.state as evidence. begin() returns false on bad auth / client-init OOM;
     // a DISABLED slot returns true with no client (expected, not a failure).
     // URL is omitted from the log -- a broker URL may carry inline credentials.
-    if (!brokers_[slot].begin(slot, cfg, *identity_) && cfg.enabled) {
+    // #534: allocation admission. This slot's own client (if any) is destroyed by
+    // begin()'s shutdown() before reallocation, so exclude it from the count --
+    // otherwise a plain reload of an already-allocated slot would count itself
+    // and refuse to re-allocate.
+    const bool may_alloc =
+        (tlsClientsAllocated() - (brokers_[slot].hasClient() ? 1u : 0u))
+            < OFFBAND_MAX_LIVE_TLS;
+    if (!brokers_[slot].begin(slot, cfg, *identity_, may_alloc) && cfg.enabled) {
         crashLogf("[pool] reconcileSlot %u begin FAILED state=%d err_class=%d",
                   (unsigned)slot,
                   (int)brokers_[slot].runtime().state,
                   (int)brokers_[slot].runtime().last_error_class);
     }
+}
+
+// #534: count TLS/wss brokers holding an allocated esp_mqtt client. See the
+// header for why allocation admission counts CLIENTS, not live connections.
+uint8_t MqttBrokerPool::tlsClientsAllocated() const {
+    uint8_t n = 0;
+    for (uint8_t s = 0; s < OFFBAND_MAX_BROKERS; ++s) {
+        const MqttBroker& b = brokers_[s];
+        if (!b.isConfigured()) continue;
+        const BrokerConfig& c = b.config();
+        if ((c.transport == BrokerTransport::Tls ||
+             c.transport == BrokerTransport::Wss) && b.hasClient()) {
+            n++;
+        }
+    }
+    return n;
 }
 
 namespace {

--- a/src/helpers/wifi_observer/MqttBrokerPool.h
+++ b/src/helpers/wifi_observer/MqttBrokerPool.h
@@ -134,6 +134,15 @@ private:
     // Drain one broker's backlog to its transport. Returns messages published.
     uint8_t drainBroker(uint8_t slot);
 
+    // #534: how many TLS/wss brokers currently hold an allocated esp_mqtt client.
+    // This -- not the count of LIVE (Up/Connecting) connections -- is the correct
+    // admission metric for ALLOCATION: at boot nothing is live yet, so a
+    // live-based check would admit every slot and allocate a client for each,
+    // which is exactly the heap deadlock #534 fixes. Cheap: an O(slots) scan of
+    // hasClient(), no locking (client_ transitions are already serialized by the
+    // reconciling_ guard + the per-broker client_lock_).
+    uint8_t tlsClientsAllocated() const;
+
     // #175: TLS rotation. When more TLS brokers are enabled than the heap-derived
     // budget allows, the live set is rotated on a dwell timer so every feed gets
     // serviced. Degenerates to a no-op when the budget covers every enabled TLS


### PR DESCRIPTION
## Summary
Fixes #534. Parked (`HeldNoHeap`) TLS brokers still held an allocated `esp_mqtt` client they could not use. Admission ran in `tryConnect()`, but allocation had already happened in `begin()` — the guard fired *after* the heap cost was paid. On HV3 that deadlocked the pool entirely.

## Before → after, on the board that deadlocked (HV3)

| | Before | After |
|---|---|---|
| Free heap (2 wss configured) | 76,924 — **below** the 81,920 floor | one client only; recovers to 84K+ between rotations |
| Brokers promoted | **0** — both stuck `HeldNoHeap` | s1 and s2 both reach `Up` |
| Rotations in capture | **0** (8 min) | **4**, strict s1↔s2 alternation |
| Parked broker | held a ~18 KB unusable client | holds **no** client |

Alternation is genuine, not one broker reclaiming: `s1:HH s2:UP/55s` → later `s1:UP/13s s2:DN`. Heap after each teardown: 84,140 / 90,468 / 80,180 / 83,356 — flat, no leak.

## Change (4 files)
- `MqttBroker::begin()` takes a **required** `may_alloc_client` (no default — mirrors `tryConnect`'s `tls_budget_ok` from #171 so no caller can silently bypass it). A denied TLS slot stores config, marks `HeldNoHeap`, returns **true** without allocating client or auth.
- New `MqttBrokerPool::tlsClientsAllocated()`. **Admission counts allocated clients, not live connections** — at boot nothing is `Up`/`Connecting`, so a live-based check would admit every slot and reproduce the deadlock. This is the load-bearing design decision.
- `reconcileSlot()` subtracts the slot's own client from the count (`begin()` destroys it before reallocating), so a reload doesn't count itself and refuse.
- Promotion reuses the existing re-drive path — `!hasClient() && budget_ok → reconcileSlot()` — no new machinery.

Also makes the invariant consistent: after #175 a *rotated-out* broker holds no client; now a *never-promoted* one doesn't either. Same logical state, same footprint.

## Review
Gemini 2.5-pro: **"No issues found."** Explicitly PASSed starvation/liveness, the self-count off-by-one, `HeldNoHeap` reuse for a second condition, concurrency of the unlocked `hasClient()` scan, tcp/single-wss regression, and `begin()`'s new true-return (correctly avoids a false `crashLogf`).

## Impact beyond HV3
Resolves the remaining half of #521 — HV3 is a viable rotating observer at budget 1, not a board to drop. Flagged to DarkLynx for #302: the repeater has ~196 KB headroom so it never deadlocked, but the same per-parked-client cost limited how many brokers could be configured.

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)
