### PR TITLE
fix(#531): make reconciling_ std::atomic<bool> (cross-core memory ordering)

### DIFF
--- a/src/helpers/wifi_observer/MqttBrokerPool.h
+++ b/src/helpers/wifi_observer/MqttBrokerPool.h
@@ -8,6 +8,7 @@
 #include "WifiObserverConfig.h"
 #include "MqttBroker.h"
 #include "MqttRingLog.h"
+#include <atomic>   // #531: reconciling_ is a cross-task flag
 
 // #175: every broker slot is a ring reader, so the ring must have at least as
 // many cursors as there are broker slots. Caught at compile time rather than
@@ -159,7 +160,28 @@ private:
     // Per-slot guard: true while the lifecycle worker is creating/destroying
     // that slot's client. loopTask publish/status paths SKIP reconciling slots
     // so they never wait on the worker's blocking teardown (#53).
-    volatile bool reconciling_[OFFBAND_MAX_BROKERS] = {false};
+    // #531: cross-task guard -- written by the lifecycle worker (rotateTlsIfDue,
+    // workerLoop) and read by loopTask (drainBroker, the publish fan-outs, the
+    // status/[rot] enumerations). Was `volatile bool`, which forbids the compiler
+    // caching it in a register but is only a COMPILER barrier: it carries no
+    // memory-ordering or cross-core visibility guarantee, so on a dual-core ESP32
+    // there is no formal happens-before between the worker's write and loopTask's
+    // read. std::atomic (seq_cst by default) supplies that ordering and states the
+    // contract in the type.
+    //
+    // NOT a bug fix: correctness rests on the per-broker client_lock_ inside
+    // MqttBroker::publish(), which re-checks client_ != nullptr, so a mis-ordered
+    // read of this flag cannot produce a use-after-free. This flag is an
+    // optimization (skip slots mid-lifecycle instead of blocking on that lock).
+    // The value is making the contract self-enforcing for future code that touches
+    // a broker WITHOUT taking client_lock_ -- that is the change which would turn
+    // today's benign race into a real one.
+    // `= {}` value-initializes every element to false. std::atomic's default
+    // constructor is trivial in C++17 and leaves the value INDETERMINATE, so the
+    // initializer is required, not decorative -- the old `= {false}` on a plain
+    // volatile array was doing that job. begin() also assigns false per slot
+    // before the worker task starts; this covers any read before that.
+    std::atomic<bool> reconciling_[OFFBAND_MAX_BROKERS] = {};
 
 #if defined(ARDUINO) && defined(ESP_PLATFORM)
     // Lifecycle worker: owns ALL blocking esp_mqtt ops so loopTask never


### PR DESCRIPTION
## Summary
Closes #531. `MqttBrokerPool::reconciling_` — written by the lifecycle worker task, read by loopTask on a dual-core ESP32 — moves from `volatile bool` to `std::atomic<bool>`.

## Premise correction (recorded on #531)
The original review described a plain `bool` and a race where loopTask reads *"a stale value in a register"*. **That mechanism could not occur** — the field was `volatile`, which forbids register caching, and single-byte access on Xtensa is not torn.

The real gap is **ordering, not caching**: `volatile` is a *compiler* barrier only, with no memory-ordering or cross-core visibility guarantee, so there was no happens-before between the worker's write and loopTask's read. `std::atomic` (seq_cst) supplies it.

## Honest scope
**Not a live defect.** Correctness rests on the per-broker `client_lock_` inside `MqttBroker::publish()`, which re-checks `client_ != nullptr` — a mis-ordered read of this flag cannot produce a use-after-free today. The value is making the guard reliable *on its own*, so a future code path that touches a broker without taking that lock doesn't silently turn a benign race into a real one.

## Two things worth a reviewer's eye
1. **`= {}` is required, not cosmetic.** `std::atomic`'s default constructor is trivial in C++17 and leaves the value **indeterminate**. Dropping the old `= {false}` without replacing it would have introduced an uninitialized read — an easy miss on a "trivial" type swap.
2. **Lock-free verified, not assumed.** `nm` on `MqttBrokerPool.cpp.o` and on the linked image shows **zero `__atomic_*` symbols**, so accesses inline to native instructions with no libatomic locking on this toolchain.

## Verification
Build SUCCESS (`Heltec_v3_companion_observer_wifi`). **No hardware test** — this is a memory-ordering hardening with no observable runtime symptom to reproduce; a passing soak would not distinguish it from the old code. Saying so plainly rather than implying coverage.

## Review
Gemini 2.5-pro rated it **MAJOR** — *"a real, albeit latent, data race"*, and *"not cargo-culting; it is the correct C++ idiom"*. Confirmed the volatile-vs-ordering framing, the `= {}` initialization semantics, all 11 call sites (implicit load/store, no read-modify-write), and seq_cst as the right default. **Note:** the reviewer's MAJOR is a higher severity than this issue's `priority:P3` — flagging rather than re-labelling unilaterally, since board priority is yours.

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)
