### PR TITLE
feat(#536): make the MqttBrokerPool + #175 scheduler engine reusable from the repeater

### DIFF
--- a/src/helpers/wifi_observer/WifiObserverConfig.h
+++ b/src/helpers/wifi_observer/WifiObserverConfig.h
@@ -10,9 +10,14 @@
 
 #pragma once
 
-#ifndef OFFBAND_OBSERVER
-  #error "WifiObserverConfig.h included without OFFBAND_OBSERVER defined. \
-          Check env build_flags or remove the include."
+// #536: the broker-pool engine (MqttBrokerPool/MqttBroker) legitimately needs
+// the engine tunables below (OFFBAND_MAX_BROKERS / OFFBAND_MAX_LIVE_TLS /
+// OFFBAND_TLS_HEAP_FLOOR_BYTES) on the REPEATER too, without the observer
+// pipeline. Accept OFFBAND_MQTT_POOL as an alternative gate. The AP-SSID / CLI-
+// rescue tunables further down are observer-only but harmless to the repeater.
+#if !defined(OFFBAND_OBSERVER) && !defined(OFFBAND_MQTT_POOL)
+  #error "WifiObserverConfig.h needs OFFBAND_OBSERVER or OFFBAND_MQTT_POOL \
+          (the broker-pool engine, #536) defined. Check env build_flags."
 #endif
 
 // ---------------------------------------------------------------------------

--- a/src/helpers/wifi_telemetry/RepeaterMqttPool.cpp
+++ b/src/helpers/wifi_telemetry/RepeaterMqttPool.cpp
@@ -1,0 +1,73 @@
+// src/helpers/wifi_telemetry/RepeaterMqttPool.cpp — see header (#536 / #302).
+
+#include "RepeaterMqttPool.h"
+
+#if defined(OFFBAND_MQTT_POOL)
+
+// Impl-only include of the shared engine so the observer surface stays out of
+// the telemetry public header.
+#include "helpers/wifi_observer/MqttBrokerPool.h"
+
+namespace offband {
+namespace {
+// One long-lived pool instance, mirroring the observer's static pool. Held here
+// (not as a class member) so the observer type never appears in the header.
+MqttBrokerPool& thePool() {
+    static MqttBrokerPool pool;
+    return pool;
+}
+}  // namespace
+
+void RepeaterMqttPool::begin(const mesh::LocalIdentity& identity,
+                             const char* device_id,
+                             const char* node_name,
+                             const char* firmware_version,
+                             const char* model) {
+#ifdef ARDUINO
+    // The repeater carries a single firmware string; the engine's begin() splits
+    // client_version vs firmware_version (an observer distinction) — pass the
+    // one repeater FW string for both.
+    thePool().begin(identity, device_id, node_name,
+                    firmware_version, firmware_version, model);
+    started_ = true;
+#else
+    (void)identity; (void)device_id; (void)node_name;
+    (void)firmware_version; (void)model;
+#endif
+}
+
+void RepeaterMqttPool::loop(uint32_t now_ms) {
+    if (started_) thePool().loop(now_ms);
+}
+
+uint8_t RepeaterMqttPool::publish(const uint8_t* payload, size_t len) {
+    return started_ ? thePool().publishPacket(payload, len) : 0;
+}
+
+void RepeaterMqttPool::shutdown() {
+    if (started_) {
+        thePool().shutdown();
+        started_ = false;
+    }
+}
+
+}  // namespace offband
+
+#ifdef ARDUINO
+// #536 link-proof: force the linker to resolve the full engine symbol set in the
+// repeater image, catching any observer-pipeline dependency the engine still
+// carries. `used` keeps this past --gc-sections; it is NEVER called, so the pool
+// never actually starts here (that wiring is #537). If the engine had an
+// unresolved observer-only symbol, THIS is where the repeater link would fail.
+#include "MeshCore.h"  // mesh::LocalIdentity full type for the dummy instance
+__attribute__((used)) static void _repeaterMqttPoolLinkProof() {
+    static offband::RepeaterMqttPool pool;
+    static mesh::LocalIdentity identity;
+    pool.begin(identity, "", "", "", "");
+    pool.loop(0);
+    (void)pool.publish(nullptr, 0);
+    pool.shutdown();
+}
+#endif  // ARDUINO
+
+#endif  // OFFBAND_MQTT_POOL

--- a/src/helpers/wifi_telemetry/RepeaterMqttPool.h
+++ b/src/helpers/wifi_telemetry/RepeaterMqttPool.h
@@ -1,0 +1,63 @@
+// src/helpers/wifi_telemetry/RepeaterMqttPool.h
+//
+// #536 (Epic #302) — role-neutral reuse surface for the merged multi-broker
+// pool + #175 round-robin TLS scheduler engine on the REPEATER telemetry path.
+//
+// The engine (MqttBrokerPool + MqttBroker + MqttAuth + MqttRingLog, all under
+// helpers/wifi_observer/) is already role-neutral in its API — it takes a mesh
+// identity + device strings and fans a pre-built payload out to every live
+// broker, rotating TLS slots within a heap-derived budget. This adapter is the
+// thin owner the repeater drives from its main loop, exactly as WifiObserver
+// does on the observer side, WITHOUT pulling the observer pipeline
+// (WifiObserver/ObserverCli/ObserverPipeline) into the repeater build.
+//
+// It deliberately keeps the observer engine headers out of this PUBLIC header
+// (impl-only include in the .cpp) so telemetry translation units don't inherit
+// the whole wifi_observer surface.
+//
+// Gated behind OFFBAND_MQTT_POOL (set on the repeater telemetry env). Actual
+// routing of repeater telemetry through the pool is #537; this task only proves
+// the engine compiles + links + is callable from here.
+
+#pragma once
+
+#if defined(OFFBAND_MQTT_POOL)
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace mesh { class LocalIdentity; }
+
+namespace offband {
+
+class RepeaterMqttPool {
+public:
+    // Bring the pool up: seeds default broker slots (idempotent), reads each
+    // slot's config, and connects enabled brokers within the #175 heap budget.
+    // The string args must outlive the pool (typical: static/global storage).
+    void begin(const mesh::LocalIdentity& identity,
+               const char* device_id,
+               const char* node_name,
+               const char* firmware_version,
+               const char* model);
+
+    // Drive the pool once per main-loop iteration (schedules connects, dwell
+    // rotation, periodic status). No-op until begin() has run.
+    void loop(uint32_t now_ms);
+
+    // Fan a pre-built payload out to every enabled + live broker. Returns the
+    // number of brokers published to (0 if not started).
+    uint8_t publish(const uint8_t* payload, size_t len);
+
+    // Tear the pool down. Idempotent.
+    void shutdown();
+
+    bool started() const { return started_; }
+
+private:
+    bool started_ = false;
+};
+
+}  // namespace offband
+
+#endif  // OFFBAND_MQTT_POOL

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -169,8 +169,22 @@ build_flags =
   ; env's build_flags block, or undefine via -U CMD_TRANSPORT_HTTP in the
   ; child env.
   -D CMD_TRANSPORT_HTTP=1
+  ; #536: opt the repeater into the shared multi-broker pool + #175 scheduler
+  ; engine (engine ONLY -- not the observer pipeline). Telemetry routing through
+  ; it is #537; this env compiles + links the engine to prove reuse.
+  -D OFFBAND_MQTT_POOL=1
+  ; #536: the pool's JWT auth (MqttAuth) needs JwtHelper, gated by WITH_MQTT_UPLINK.
+  -D WITH_MQTT_UPLINK=1
 build_src_filter = ${env:heltec_v4_repeater.build_src_filter}
   +<helpers/wifi_telemetry/*.cpp>
+  ; #536: merged broker-pool engine files only. The observer PIPELINE
+  ; (WifiObserver/ObserverCli/ObserverPipeline) stays excluded.
+  +<helpers/wifi_observer/MqttBrokerPool.cpp>
+  +<helpers/wifi_observer/MqttBroker.cpp>
+  +<helpers/wifi_observer/MqttAuth.cpp>
+  +<helpers/wifi_observer/MqttPayload.cpp>
+  +<helpers/wifi_observer/ConfigSchema.cpp>
+  +<helpers/wifi_observer/JwtHelper.cpp>
 lib_deps =
   ${env:heltec_v4_repeater.lib_deps}
   knolleary/PubSubClient @ ^2.8


### PR DESCRIPTION
## What
Child of #302. Makes the merged observer multi-broker pool + #175 round-robin TLS scheduler engine compile + link into the **repeater telemetry** build, without the observer pipeline (WifiObserver/ObserverCli/ObserverPipeline). Telemetry *routing* through the pool is #537; this PR proves reuse (compile + link + a clean adapter surface).

## Changes
- **`variants/heltec_v4/platformio.ini`** (`heltec_v4_repeater_telemetry`): add the 6 engine `.cpp` files (MqttBrokerPool, MqttBroker, MqttAuth, MqttPayload, ConfigSchema, JwtHelper) to `build_src_filter`; define `OFFBAND_MQTT_POOL=1` and `WITH_MQTT_UPLINK=1` (the latter gates `JwtHelper` for the pool's JWT auth — verified used only in `JwtHelper.{h,cpp}`).
- **`WifiObserverConfig.h`**: `#error` guard now accepts `OFFBAND_MQTT_POOL` as an alternative to `OFFBAND_OBSERVER`, so the engine pulls its tunables (heap floor / max brokers / live-TLS cap) on the repeater. Backward-compatible with observer builds.
- **`RepeaterMqttPool.{h,cpp}`** (new): thin role-neutral adapter owning a file-static `MqttBrokerPool` (`begin/loop/publish/shutdown`); keeps observer headers out of the telemetry public header. Includes an `__attribute__((used))` link-proof that forces the linker to resolve the full engine symbol set.

## Test
- `heltec_v4_repeater_telemetry` compiles + **links** the engine (Flash 21.5%).
- `Heltec_v3_companion_observer_wifi` + `heltec_v4_companion_observer_wifi` — **no regression** from the guard change.
- `heltec_v4_repeater_telemetry_stp` builds.
- Full ci-green matrix runs here.

## Review
Gemini 2.5-pro reviewed — **no blocker**. The one MAJOR (pool seeds *observer* default brokers via `populateDefaultBrokers()`) is deferred to #538 (repeater broker-config surface + defaults), as planned.

Closes #536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
