### PR TITLE
feat(#537): repeater mesh-packet feed into the multi-broker pool (parallel to observer)

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -1,5 +1,8 @@
 #include "MyMesh.h"
 #include <algorithm>
+// #537: mesh-packet feed into the shared broker pool (self-guards on
+// OFFBAND_MQTT_POOL; a no-op include otherwise).
+#include "helpers/wifi_telemetry/RepeaterMqttPool.h"
 
 /* ------------------------------ Config -------------------------------- */
 
@@ -470,6 +473,12 @@ void MyMesh::logRxRaw(float snr, float rssi, const uint8_t raw[], int len) {
   mesh::Utils::printHex(Serial, raw, len);
   Serial.println();
 #endif
+#ifdef OFFBAND_MQTT_POOL
+  // #537: tee every raw RX into the broker pool (/raw), parallel to the
+  // observer's logRxRaw hook. Non-blocking (ring-log enqueue); inert until the
+  // pool is started + brokers configured.
+  offband::repeaterMqttPool().publishRaw(raw, (size_t)len, rssi, snr);
+#endif
 }
 
 void MyMesh::logRx(mesh::Packet *pkt, int len, float score) {
@@ -496,6 +505,19 @@ void MyMesh::logRx(mesh::Packet *pkt, int len, float score) {
       f.close();
     }
   }
+#ifdef OFFBAND_MQTT_POOL
+  // #537: tee the PARSED packet into the pool (/packets, the CoreScope-ingested
+  // topic), parallel to the observer's logRx hook. rssi/snr/airtime are valid
+  // here (same checkRecv iteration); score is scaled to MeshCore's milli
+  // convention. Non-blocking; inert until the pool is started + configured.
+  if (pkt != nullptr) {
+    int   rssi        = (int)_radio->getLastRSSI();
+    float snr         = _radio->getLastSNR();
+    int   score_milli = (int)(score * 1000.0f);
+    int   duration    = (int)_radio->getEstAirtimeFor(len);
+    offband::repeaterMqttPool().publishParsed(*pkt, rssi, snr, score_milli, duration);
+  }
+#endif
 }
 
 void MyMesh::logTx(mesh::Packet *pkt, int len) {

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -29,6 +29,7 @@
 #include "../../src/helpers/wifi_telemetry/WifiTelemetry.h"
 #include "../../src/helpers/wifi_telemetry/WifiMqttTransport.h"
 #include "../../src/helpers/wifi_telemetry/RemoteCommand.h"  // issue #86 - remote OTA trigger
+#include "../../src/helpers/wifi_telemetry/RepeaterMqttPool.h"  // #537 - multi-broker mesh-packet feed (self-guards on OFFBAND_MQTT_POOL)
 
 #ifndef FIRMWARE_HW_MODEL
 #define FIRMWARE_HW_MODEL "Heltec V4"
@@ -166,6 +167,18 @@ static void wifi_telemetry_setup() {
         FIRMWARE_BUILD_DATE,
         FIRMWARE_HW_MODEL
     );
+
+#ifdef OFFBAND_MQTT_POOL
+    // #537: bring up the shared multi-broker pool (mesh-packet feed -> CoreScope
+    // /map sinks), PARALLEL to the HA telemetry above. Seeded broker slots are
+    // disabled by default, so this is inert until brokers are configured (#538);
+    // the RX hooks (MyMesh::logRxRaw/logRx) enqueue to the pool's ring-log, which
+    // drains per-broker once brokers are enabled + WiFi is up. self_id is loaded
+    // before this runs.
+    offband::repeaterMqttPool().begin(the_mesh.self_id, WIFI_TELEMETRY_NODE_ID,
+                                      WIFI_TELEMETRY_FRIENDLY_NAME,
+                                      FIRMWARE_VERSION, FIRMWARE_HW_MODEL);
+#endif
 
     g_tel_reset_reason = board.getResetReasonString(board.getResetReason());
 
@@ -350,6 +363,18 @@ static void wifi_telemetry_loop() {
     // the issue-#86 remote command callback to fire when persistent-mode WiFi
     // is up. No-op when transport not ready.
     if (g_tel_transport) g_tel_transport->loop();
+#ifdef OFFBAND_MQTT_POOL
+    // #537: drive the multi-broker pool (per-broker connects, dwell rotation,
+    // ring-log drain) ONLY while WiFi is up. The repeater duty-cycles WiFi
+    // (burst mode); the pool engine has no WiFi.status() gate of its own (the
+    // observer's WiFi is persistent, so it never needed one), and running its
+    // connect/rotation logic with WiFi down would churn esp-mqtt reconnects and
+    // risk heap fragmentation (Gemini review MAJOR). RX packets still enqueue to
+    // the ring-log via the logRx hooks regardless of WiFi; the pool drains them
+    // once WiFi returns. (Sustaining wss brokers realistically needs persistent
+    // WiFi mode -- a #539 verification point.)
+    if (WiFi.status() == WL_CONNECTED) offband::repeaterMqttPool().loop(millis());
+#endif
 
     // Issue #86: deferred reboot check. Set by PatioRemoteCallbacks::rebootAfter
     // (called from REBOOT command dispatch). Honored regardless of telemetry

--- a/src/helpers/wifi_telemetry/RepeaterMqttPool.cpp
+++ b/src/helpers/wifi_telemetry/RepeaterMqttPool.cpp
@@ -44,11 +44,33 @@ uint8_t RepeaterMqttPool::publish(const uint8_t* payload, size_t len) {
     return started_ ? thePool().publishPacket(payload, len) : 0;
 }
 
+void RepeaterMqttPool::publishRaw(const uint8_t* raw, size_t len, float rssi, float snr) {
+#ifdef ARDUINO
+    if (started_) thePool().publishRawFromBytes(raw, len, rssi, snr);
+#else
+    (void)raw; (void)len; (void)rssi; (void)snr;
+#endif
+}
+
+void RepeaterMqttPool::publishParsed(const mesh::Packet& packet, int rssi, float snr,
+                                     int score, int duration) {
+#ifdef ARDUINO
+    if (started_) thePool().publishParsedPacket(packet, rssi, snr, score, duration);
+#else
+    (void)packet; (void)rssi; (void)snr; (void)score; (void)duration;
+#endif
+}
+
 void RepeaterMqttPool::shutdown() {
     if (started_) {
         thePool().shutdown();
         started_ = false;
     }
+}
+
+RepeaterMqttPool& repeaterMqttPool() {
+    static RepeaterMqttPool inst;
+    return inst;
 }
 
 }  // namespace offband

--- a/src/helpers/wifi_telemetry/RepeaterMqttPool.h
+++ b/src/helpers/wifi_telemetry/RepeaterMqttPool.h
@@ -26,7 +26,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-namespace mesh { class LocalIdentity; }
+namespace mesh { class LocalIdentity; class Packet; }
 
 namespace offband {
 
@@ -49,6 +49,14 @@ public:
     // number of brokers published to (0 if not started).
     uint8_t publish(const uint8_t* payload, size_t len);
 
+    // #537: mesh-packet feed — tee the traffic the repeater HEARS into the pool,
+    // parallel to the observer's logRxRaw/logRx hooks. Both no-op until started.
+    //   publishRaw    — pre-parse raw bytes  -> the /raw topic.
+    //   publishParsed — post-parse Packet    -> the /packets topic (CoreScope).
+    void publishRaw(const uint8_t* raw, size_t len, float rssi, float snr);
+    void publishParsed(const mesh::Packet& packet, int rssi, float snr,
+                       int score, int duration);
+
     // Tear the pool down. Idempotent.
     void shutdown();
 
@@ -57,6 +65,10 @@ public:
 private:
     bool started_ = false;
 };
+
+// Process-wide singleton so the RX hooks (MyMesh::logRxRaw/logRx) and the
+// lifecycle driver (wifi_telemetry setup/loop) share one pool.
+RepeaterMqttPool& repeaterMqttPool();
 
 }  // namespace offband
 


### PR DESCRIPTION
## What
Child of #302. Gives the repeater an **observer-style mesh-packet feed** into the merged multi-broker pool (#536), **parallel to** its single-broker Home Assistant telemetry (which is untouched). Broker config is #538 — the pool is **inert until brokers are enabled**.

## Changes
- **`RepeaterMqttPool.{h,cpp}`**: add `publishRaw`/`publishParsed` (delegate to the pool's `publishRawFromBytes`/`publishParsedPacket`) + a process-wide singleton `repeaterMqttPool()` so the RX hooks and the lifecycle driver share one pool.
- **`simple_repeater/MyMesh.cpp`**: `logRxRaw` → `publishRaw` (`/raw`); `logRx` → derive rssi/snr/score_milli/duration (mirroring the observer's `logRx`) → `publishParsed` (`/packets`, the CoreScope-ingested topic). Both gated on `OFFBAND_MQTT_POOL`.
- **`simple_repeater/main.cpp`**: `pool.begin()` in `wifi_telemetry_setup()` (inert at boot — seeded slots disabled + lazy client creation #534); `pool.loop()` driven **only while `WiFi.status()==WL_CONNECTED`** (burst-mode reconnect-churn guard).

HA telemetry (`WifiTelemetry`/`WifiMqttTransport`) is unchanged — a repeater still feeds its one HA.

## Test
- `heltec_v4_repeater_telemetry` + `heltec_v4_repeater_telemetry_stp` compile + **link** (Flash 22.5%).
- Only the telemetry-repeater envs are touched (no observer/shared files) — no observer regression.
- Full ci-green matrix runs here.
- End-to-end runtime (packets reaching a broker) needs configured brokers (#538) and is the HW-verify scope of **#539** — burst-mode WiFi is the top verification priority.

## Review
Gemini 2.5-pro — **no blocker**. RX-path non-blocking confirmed (`MqttRingLog` is a drop-on-full overwrite ring); burst-mode WiFi connect-churn addressed via the `WiFi.status()` loop gate.

Closes #537.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
