### PR TITLE
task: ESP32 runtime WatchDog — board-layer plumbing + sensor activation (#518, #519)

### DIFF
--- a/examples/simple_sensor/main.cpp
+++ b/examples/simple_sensor/main.cpp
@@ -121,10 +121,27 @@ void setup() {
 #if ENABLE_ADVERT_ON_BOOT == 1
   the_mesh.sendSelfAdvertisement(16000, false);
 #endif
+
+  // #446/#519: arm the runtime WatchDog now that init has succeeded (a failed
+  // radio_init/store halts before this point, so a bad boot never WDT-loops).
+  // Feed from loop() only -> a hung loop trips it -> auto-reset. startWatchdog is
+  // a MainBoard virtual: ESP32/nRF52 override, no-op on other platforms.
+  board.startWatchdog(30);
+#if defined(NRF52_PLATFORM)
+  // #275: the nRF52 WDT counts during sleep (CONFIG.SLEEP=Run), so it MUST be paired
+  // with the ~10 Hz loop-wake heartbeat -- otherwise an RF-silent nap starves the feed
+  // and false-trips the WDT (the repeater/companion do the same). ESP32 doesn't need
+  // this: ESP32Board::sleep() feeds on entry and light-sleep pauses the task tick.
+  board.startHeartbeat();
+#endif
 }
 
 void loop() {
   offband::crashLogStandardTick(millis());  // #472: deferred previous-boot re-dump for late serial connect
+  board.feedWatchdog();                     // #446/#519: keep the runtime WatchDog fed; a hung loop trips it -> auto-reset
+#if defined(NRF52_PLATFORM)
+  board.heartbeatTick();                    // #275: loop-driven heartbeat + wake so idle naps still service the WDT
+#endif
 
   int len = strlen(command);
   while (Serial.available() && len < sizeof(command)-1) {

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -119,6 +119,13 @@ public:
   virtual uint8_t getShutdownReason() const { return 0; }
   virtual const char* getShutdownReasonString(uint8_t reason) { return "Not available"; }
 
+  // Runtime watchdog (#446 / mirrors nRF52 #257). startWatchdog() once after
+  // begin(); feedWatchdog() from the MAIN LOOP each iteration, so a hung loop
+  // trips it -> auto-reset. Default no-op; boards with a runtime watchdog
+  // (nRF52, ESP32) override these.
+  virtual void startWatchdog(uint32_t timeout_secs) { (void)timeout_secs; }
+  virtual void feedWatchdog() { }
+
   // External LoRa FEM LNA control (boards with a controllable FEM override these).
   // Default: not supported (boards without an external FEM, or without a controllable LNA path).
   virtual bool setLoRaFemLnaEnabled(bool enable) { return false; }

--- a/src/helpers/ESP32Board.h
+++ b/src/helpers/ESP32Board.h
@@ -14,11 +14,13 @@
 #include <Wire.h>
 #include "soc/rtc.h"
 #include "esp_system.h"
+#include "esp_task_wdt.h"
 
 class ESP32Board : public mesh::MainBoard {
 protected:
   uint8_t startup_reason;
   bool inhibit_sleep = false;
+  bool _wdt_started = false;   // #446: runtime task watchdog armed
   static inline portMUX_TYPE sleepMux = portMUX_INITIALIZER_UNLOCKED;
 
 public:
@@ -66,7 +68,53 @@ public:
     return P_LORA_DIO_1; // default for SX1262
   }
 
+  // #446: runtime watchdog via the ESP-IDF Task WDT. startWatchdog() once after
+  // begin(); feedWatchdog() from the MAIN LOOP each iteration, so a hung loop
+  // trips it -> panic-reset (esp_reset_reason() == ESP_RST_TASK_WDT next boot).
+  // The Arduino core pre-inits the TWDT (panic on) but only watches the idle
+  // task(s); we (re)apply our timeout and subscribe the loop task.
+  void startWatchdog(uint32_t timeout_secs) override {
+    if (_wdt_started) return;
+    esp_err_t err;
+#if ESP_IDF_VERSION_MAJOR >= 5
+    esp_task_wdt_config_t cfg = {};
+    cfg.timeout_ms     = timeout_secs * 1000;
+    cfg.idle_core_mask = (1 << portNUM_PROCESSORS) - 1;  // keep idle-task monitoring
+    cfg.trigger_panic  = true;                            // reset on timeout
+    err = esp_task_wdt_init(&cfg);
+    if (err == ESP_ERR_INVALID_STATE) {
+      err = esp_task_wdt_reconfigure(&cfg);   // already inited by the Arduino core
+    }
+#else
+    // IDF 4.x: init-or-update. When the TWDT is already initialized this updates
+    // the timeout + panic config in place (per esp_task_wdt.h).
+    err = esp_task_wdt_init(timeout_secs, true);
+#endif
+    // Degrade gracefully: if configuration failed (e.g. ESP_ERR_NO_MEM), leave the
+    // watchdog DISARMED rather than falsely reporting it armed. Not ESP_ERROR_CHECK()
+    // -- that aborts on error, which would turn a reliability primitive into a crash.
+    if (err != ESP_OK) {
+      MESH_DEBUG_PRINTLN("WDT: init failed (err=%d); NOT armed", (int)err);
+      return;
+    }
+    // Subscribe the current (main loop) task. ESP_ERR_INVALID_ARG == already
+    // subscribed by the Arduino core, which is fine; any other error is a failure.
+    err = esp_task_wdt_add(NULL);
+    if (err != ESP_OK && err != ESP_ERR_INVALID_ARG) {
+      MESH_DEBUG_PRINTLN("WDT: loop-task subscribe failed (err=%d); NOT armed", (int)err);
+      return;
+    }
+    _wdt_started = true;
+  }
+
+  void feedWatchdog() override {
+    if (_wdt_started) esp_task_wdt_reset();
+  }
+
   void sleep(uint32_t secs) override {
+    // #446: feed on the way into (light) sleep so a long sleep window is not
+    // mistaken for a hung loop.
+    if (_wdt_started) esp_task_wdt_reset();
     // Skip if not allow to sleep
     if (inhibit_sleep) {
       delay(1); // Give MCU to OTA to run

--- a/src/helpers/NRF52Board.h
+++ b/src/helpers/NRF52Board.h
@@ -65,8 +65,9 @@ public:
   // #257: hardware watchdog (independent of NRF52_POWER_MANAGEMENT).
   // startWatchdog() once at boot; feedWatchdog() from the MAIN LOOP only, so a
   // hung loop trips it -> auto-reboot + RESETREAS=DOG ("Watchdog") at next boot.
-  void startWatchdog(uint32_t timeout_secs);
-  void feedWatchdog();
+  // #446: now overrides the MainBoard runtime-watchdog interface.
+  void startWatchdog(uint32_t timeout_secs) override;
+  void feedWatchdog() override;
 
   // #275 (P0): true, ungated green-LED heartbeat. startHeartbeat() once at boot;
   // heartbeatTick() from the MAIN LOOP only. The LED toggle is loop-driven (so a hung


### PR DESCRIPTION
## What
ESP32 **runtime WatchDog** (auto-recovery on a hung loop), mirroring the nRF52 hardware watchdog. Part of epic #446. Two increments, both here:

- **#518 — board-layer plumbing:** `startWatchdog(uint32_t)`/`feedWatchdog()` promoted to `MainBoard` virtuals (no-op default); `NRF52Board` now overrides them; new `ESP32Board` impl via the ESP-IDF **Task WDT** — version-guarded for IDF 4.4 (`init` updates in place) and 5.x (`init`/`reconfigure` + config struct), panic→reset, subscribes the loop task, feeds at sleep entry, and **degrades gracefully** (disarmed, not aborted) on config failure.
- **#519 — sensor activation (sensor-first):** `simple_sensor` arms `startWatchdog(30)` at end of `setup()` (after init, so a bad boot halts rather than WDT-loops) and feeds in `loop()`. nRF52 is paired with the #275 heartbeat (its WDT counts during sleep, so the ~10 Hz idle-wake keeps it fed — the proven repeater pattern). ESP32 is safe standalone.

Repeater/companion ESP32 activation is **deferred** — their burst-WiFi/OTA legitimately blocks >30 s; a later increment adds a relax window.

## Verification
- **Builds green** across the toolchains: IDF 4.4 (`heltec_v4_sensor`), IDF 5.x (`meshsmith_photon_esp32c6`), nRF52 (`RAK_3401`), STM32 (`wio-e5-mini`, base no-op); native test suites pass.
- **Gemini 2.5-pro reviewed** both increments — caught + fixed a HIGH (#518 unchecked `esp_task_wdt` returns) and a CRITICAL (#519 nRF52 idle false-reset from arming the WDT without the heartbeat).
- **Hardware-validated — #520 PASS** on `Offband-Sensor01` (Heltec V4 / ESP32-S3): forced a loop hang → Task WDT reset → node auto-recovered and responded to CLI.

## Scope
3 board files (`MeshCore.h`, `NRF52Board.h`, `ESP32Board.h`) + 1 example (`simple_sensor/main.cpp`). Zero behavior change on non-sensor roles (base no-op; nothing else calls it yet).

Delivers #518, #519 (closed). Validated by #520. Epic #446 stays open (repeater/companion wiring + burst-relax remain).