### PR TITLE
feat(#538): repeater broker-config CLI — serial + client-over-RemoteCommand

### DIFF
--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -706,6 +706,21 @@ public:
     void logSafetyEvent(uint8_t event_type, const char* detail) override {
         board.appendSafetyEvent(event_type, detail);
     }
+
+    // #538: route an authenticated CLI line to the mesh CLI (CommonCLI ->
+    // dispatchObserverCli), the same entry point the serial admin uses -- this is
+    // how the client configures the repeater's brokers over RemoteCommand. Copy
+    // into a mutable buffer first: handleCommand may tokenize the command
+    // in place. CommonCLI sizes its own 1024-byte reply, so `reply` must be >=1024.
+    bool runCli(const char* cmd, char* reply, size_t reply_size) override {
+        if (cmd == nullptr || reply == nullptr || reply_size == 0) return false;
+        reply[0] = '\0';
+        char cmdbuf[192];
+        strncpy(cmdbuf, cmd, sizeof(cmdbuf) - 1);
+        cmdbuf[sizeof(cmdbuf) - 1] = '\0';
+        the_mesh.handleCommand(0, cmdbuf, reply);
+        return true;
+    }
 };
 
 // publishResponseShim: function-pointer adapter so RemoteCommandHandler can

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -9,8 +9,14 @@
 // Plan 2 v2 Task 11: ObserverCli dispatcher hooked into handleCommand's
 // fall-through. Compiles in only when OFFBAND_OBSERVER is defined
 // (observer envs); other envs have zero impact.
-#ifdef OFFBAND_OBSERVER
+// #538: dispatchObserverCli (the broker-config CLI) is reused on the repeater
+// under OFFBAND_MQTT_POOL. ObserverCli.h declares BOTH dispatchObserverCli and
+// wifiObserverPool(); the observer pipeline header (WifiObserver.h) stays
+// observer-only. The observer keeps both includes (byte-identical).
+#if defined(OFFBAND_OBSERVER) || defined(OFFBAND_MQTT_POOL)
   #include "wifi_observer/ObserverCli.h"
+#endif
+#ifdef OFFBAND_OBSERVER
   #include "wifi_observer/WifiObserver.h"  // wifiObserverPool() accessor
 #endif
 
@@ -1466,11 +1472,13 @@ void CommonCLI::handleRegionCmd(char* command, char* reply) {
     if (len == 0) {
       strcpy(reply, "-none-");
     }
-#ifdef OFFBAND_OBSERVER
+#if defined(OFFBAND_OBSERVER) || defined(OFFBAND_MQTT_POOL)
   } else if (offband::dispatchObserverCli(command, reply, /*reply_size=*/1024,
                                             offband::wifiObserverPool())) {
-    // handled by Plan 2 v2 observer CLI (mqtt status / enable / disable /
+    // handled by the broker-config CLI (mqtt status / enable / disable /
     // set mqtt.iata / set mqtt.status_interval / set mqtt.broker.<N>.*).
+    // #538: also active on the repeater under OFFBAND_MQTT_POOL, operating on
+    // the repeater's pool via its wifiObserverPool() accessor.
 #endif
 #if defined(OFFBAND_CONFIG_CLI)
   } else if (offband::config::dispatchCliLine(command, reply, /*reply_size=*/1024)) {

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -1,12 +1,26 @@
 // src/helpers/wifi_observer/ObserverCli.cpp
 //
 // Plan 2 v2 Task 10.
+//
+// #538 (Option A): this file provides CLI verbs for BOTH the observer and the
+// repeater. The BROKER verbs (mqtt.* / set|get mqtt.broker.*), the typed config
+// providers (observerConfigSet/Get), and the broker enumeration are common to
+// both roles and stay unguarded. The observer-only verbs (wifi.*, display.*,
+// web.*) pull the observer's wifiBootstrap + config providers and are guarded
+// behind OFFBAND_OBSERVER, so the repeater compiles this file for the broker
+// verbs alone, without that observer-pipeline dependency.
 
 #include "ObserverCli.h"
 #include "ConfigSchema.h"
 #include "../config/ConfigDispatch.h"          // #364: role-agnostic config dispatch
+// #538 (Option A): the wifi.*/display.* handlers pull the observer's WiFi
+// bootstrap (wifiBootstrap), which the repeater has no equivalent for. Their CLI
+// verbs are guarded behind OFFBAND_OBSERVER below, so the repeater compiles this
+// file for the BROKER verbs only and never links the wifi/display providers.
+#ifdef OFFBAND_OBSERVER
 #include "../config/WifiConfigProvider.h"      // #370: wifi.* handlers (moved out of this file)
 #include "../config/DisplayConfigProvider.h"   // #370: display.* handlers + NVS accessors (moved out)
+#endif
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
@@ -369,6 +383,7 @@ static bool handleSetBrokerField(char* reply, size_t reply_size,
     return true;
 }
 
+#ifdef OFFBAND_OBSERVER
 // "set web.allow_initial <on|off>" -- recovery override that re-allows
 // the derived initial password even after the user has set their own.
 // Cleared automatically after the next successful login via
@@ -396,6 +411,7 @@ static bool handleSetWebAllowInitial(char* reply, size_t reply_size,
     snprintf(reply, reply_size, "web.allow_initial = %s\n", value);
     return true;
 }
+#endif  // OFFBAND_OBSERVER (web handler -- observer-only, #538 Option A)
 
 // ---------------------------------------------------------------------------
 // Top-level dispatch
@@ -560,6 +576,7 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
         return true;
     }
 
+#ifdef OFFBAND_OBSERVER   // #538 (Option A): display/wifi verbs are observer-only
     // "display ..." commands -- #141: display always-on toggle.
     const char* disp_rest = skipPrefix(cmd, "display");
     if (disp_rest != nullptr) {
@@ -598,6 +615,7 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
                  "ERROR: unknown wifi subcommand (status | enable | disable)\n");
         return true;
     }
+#endif  // OFFBAND_OBSERVER (display/wifi verbs -- #538 Option A)
 
     // "get wifi.<field>" -- Plan 3 Task 10 (Strycher/LoRa#272). This
     // is the first `get` verb the observer CLI handles; all earlier
@@ -607,6 +625,7 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
     // allowlist surface.
     rest = skipPrefix(cmd, "get");
     if (rest != nullptr) {
+#ifdef OFFBAND_OBSERVER   // #538 (Option A): get wifi.* is observer-only
         if (strncmp(rest, "wifi.", 5) == 0) {
             const char* field = rest + 5;
             // Extract just the field name; ignore any trailing args
@@ -620,6 +639,7 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
             fbuf[fi] = '\0';
             return handleGetWifi(reply, reply_size, fbuf);
         }
+#endif  // OFFBAND_OBSERVER (get wifi.* -- #538 Option A)
         // "get mqtt.broker.<N>.<key>" -- #45 symmetric read (mirrors the
         // "set mqtt.broker.<N>.<key>" parse below).
         if (strncmp(rest, "mqtt.broker.", 12) == 0) {
@@ -666,6 +686,7 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
         while (*v == ' ') v++;
         return handleSetStatusInterval(reply, reply_size, v);
     }
+#ifdef OFFBAND_OBSERVER   // #538 (Option A): set web.*/wifi.* are observer-only
     if (strncmp(rest, "web.allow_initial", 17) == 0) {
         const char* v = rest + 17;
         while (*v == ' ') v++;
@@ -683,6 +704,7 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
         while (*p == ' ') ++p;   // value starts here
         return handleSetWifiField(reply, reply_size, field, p);
     }
+#endif  // OFFBAND_OBSERVER (set web.*/wifi.* -- #538 Option A)
     if (strncmp(rest, "mqtt.broker.", 12) == 0) {
         const char* p = rest + 12;
         int slot = parseSlot(p);

--- a/src/helpers/wifi_observer/ObserverCli.h
+++ b/src/helpers/wifi_observer/ObserverCli.h
@@ -46,6 +46,12 @@ namespace offband {
 bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
                          MqttBrokerPool& pool);
 
+// The pool accessor dispatchObserverCli reads live state from (and that CommonCLI
+// passes as the `pool` arg). Each role provides one definition: the observer via
+// its pipeline (WifiObserver), the repeater via RepeaterMqttPool (#538). Declared
+// here so CommonCLI sees it on both roles.
+MqttBrokerPool& wifiObserverPool();
+
 // Epic F (#165): typed config dispatch -- the wire path's set/get backend.
 // A config key routes straight to the same handlers the _sys CLI uses (above),
 // WITHOUT re-parsing a CLI string. Consumed by the companion-API config command

--- a/src/helpers/wifi_telemetry/RemoteCommand.cpp
+++ b/src/helpers/wifi_telemetry/RemoteCommand.cpp
@@ -39,6 +39,7 @@ const uint32_t RemoteCommandHandler::kRateLimitMs[kRateLimitSlots] = {
     60 * 1000,       // WIFI_KEEPALIVE    - 1 min
     60 * 1000,       // REBOOT            - 1 min
     30 * 1000,       // SAFETY_LOG_DUMP   - 30 sec (read-only, lighter rate-limit)
+    1000,            // CLI (#538)        - 1 sec; allows a config sequence, blocks flooding
 };
 
 // ---------------------------------------------------------------------------
@@ -71,6 +72,7 @@ static RemoteCmd parseActionString(const char* s)
     if (strcmp(s, "wifi_keepalive")  == 0) return RemoteCmd::WIFI_KEEPALIVE;
     if (strcmp(s, "reboot")          == 0) return RemoteCmd::REBOOT;
     if (strcmp(s, "safety_log_dump") == 0) return RemoteCmd::SAFETY_LOG_DUMP;
+    if (strcmp(s, "cli")             == 0) return RemoteCmd::CLI;
     return RemoteCmd::UNKNOWN;
 }
 
@@ -83,6 +85,7 @@ static const char* actionToString(RemoteCmd a)
         case RemoteCmd::WIFI_KEEPALIVE:  return "wifi_keepalive";
         case RemoteCmd::REBOOT:          return "reboot";
         case RemoteCmd::SAFETY_LOG_DUMP: return "safety_log_dump";
+        case RemoteCmd::CLI:             return "cli";
         default:                         return "unknown";
     }
 }
@@ -237,6 +240,19 @@ bool RemoteCommandHandler::parseFromJson(JsonObject cmd_obj, RemoteCommandReques
     } else if (!cmd_obj["window_sec"].isNull()) {
         out.window_sec = cmd_obj["window_sec"].as<unsigned long>();
     }
+
+    // #538: CLI line for RemoteCmd::CLI -- prefer params.cmd, fall back to a
+    // top-level cmd for flattened senders. Empty for every other action.
+    out.cli_cmd[0] = '\0';
+    const char* cli = nullptr;
+    if (!params.isNull() && params.is<JsonObject>()) {
+        cli = params.as<JsonObject>()["cmd"];
+    }
+    if (cli == nullptr) cli = cmd_obj["cmd"];
+    if (cli != nullptr) {
+        strncpy(out.cli_cmd, cli, sizeof(out.cli_cmd) - 1);
+        out.cli_cmd[sizeof(out.cli_cmd) - 1] = '\0';
+    }
     return true;
 }
 
@@ -292,6 +308,14 @@ bool RemoteCommandHandler::parse(const uint8_t* payload, size_t len,
     // clamping in onMessage().
     uint32_t window_default = 600;
     out.window_sec = doc["window_sec"] | window_default;
+
+    // #538: CLI line for RemoteCmd::CLI (flat MQTT shape). Empty otherwise.
+    out.cli_cmd[0] = '\0';
+    const char* cli = doc["cmd"];
+    if (cli != nullptr) {
+        strncpy(out.cli_cmd, cli, sizeof(out.cli_cmd) - 1);
+        out.cli_cmd[sizeof(out.cli_cmd) - 1] = '\0';
+    }
 
     // auth not extracted here - re-extracted in onMessage for the
     // constant-time compare. Keeping the auth handling localized makes
@@ -464,6 +488,42 @@ void RemoteCommandHandler::dispatch(const RemoteCommandRequest& req,
             strcpy(data_json, "{}");
         } else {
             strcpy(message, "Safety log dump");
+        }
+        break;
+    }
+    case RemoteCmd::CLI: {
+        // #538: run the CLI line (post-auth) via the callback -> MyMesh::
+        // handleCommand -> the broker-config CLI. The reply may contain newlines
+        // and quotes, so it goes into `data.reply` through ArduinoJson (RFC-8259
+        // escaped), exactly like SAFETY_LOG_DUMP; `message` stays a short,
+        // control-char-free summary (it is snprintf'd UNescaped below).
+        if (req.cli_cmd[0] == '\0') {
+            action_ok = false;
+            strcpy(status_str, "error");
+            strcpy(message, "cli: empty command");
+            break;
+        }
+        static char cli_reply[1024];   // static (BSS): loopTask stack budget, #206
+        cli_reply[0] = '\0';
+        if (!_callbacks.runCli(req.cli_cmd, cli_reply, sizeof(cli_reply))) {
+            action_ok = false;
+            strcpy(status_str, "error");
+            strcpy(message, "cli: not available on this build");
+            break;
+        }
+        bool truncated = false;
+        if (strlen(cli_reply) > 400) { cli_reply[400] = '\0'; truncated = true; }
+        JsonDocument doc;
+        doc["reply"] = cli_reply;
+        if (truncated) doc["truncated"] = true;
+        size_t n = serializeJson(doc, data_json, sizeof(data_json));
+        if (n == 0) {
+            action_ok = false;
+            strcpy(status_str, "error");
+            strcpy(message, "cli reply serialization overflowed");
+            strcpy(data_json, "{}");
+        } else {
+            strcpy(message, "cli executed");
         }
         break;
     }

--- a/src/helpers/wifi_telemetry/RemoteCommand.h
+++ b/src/helpers/wifi_telemetry/RemoteCommand.h
@@ -47,6 +47,9 @@ enum class RemoteCmd : uint8_t {
     WIFI_KEEPALIVE   = 4,    // wifi_on (no ota_start); window_sec required
     REBOOT           = 5,    // calls reboot after a brief response-publish delay
     SAFETY_LOG_DUMP  = 6,    // read-only; returns full safety log text
+    CLI              = 7,    // #538: run a CLI line (params.cmd) via handleCommand;
+                             // post-auth like every action. Used for repeater
+                             // broker config (`set mqtt.broker.N.*`, `mqtt enable`).
 };
 
 // ---------------------------------------------------------------------------
@@ -60,6 +63,8 @@ struct RemoteCommandRequest {
     uint32_t  cmd_id;                  // HTTP path: server-assigned cmd_id for response
                                        // correlation. MQTT path: 0 (no correlation needed).
                                        // Included in response payload when nonzero.
+    char      cli_cmd[192];            // #538: CLI line for RemoteCmd::CLI (from
+                                       // params.cmd); empty for every other action.
 };
 
 // ---------------------------------------------------------------------------
@@ -108,6 +113,16 @@ public:
 
     // Read full safety log text into buf. Truncates if log exceeds buflen.
     virtual void getSafetyLog(char* buf, size_t buflen) = 0;
+
+    // #538: run a CLI line (post-auth) and write its human reply into `reply`.
+    // Returns true if executed. Default no-op (false) so non-repeater callback
+    // implementations don't have to provide it. The repeater routes this to
+    // MyMesh::handleCommand, which reaches the broker-config CLI.
+    virtual bool runCli(const char* cmd, char* reply, size_t reply_size) {
+        (void)cmd;
+        if (reply != nullptr && reply_size > 0) reply[0] = '\0';
+        return false;
+    }
 
     // Log an event to the persistent safety log. Used by RemoteCommandHandler
     // for forensic record of every accept and reject. The detail string is
@@ -199,7 +214,7 @@ private:
 
     // Per-action last-accept timestamps for rate limiting.
     // Index by static_cast<uint8_t>(RemoteCmd). Slot 0 (UNKNOWN) unused.
-    static constexpr size_t kRateLimitSlots = 7;
+    static constexpr size_t kRateLimitSlots = 8;   // #538: +1 for RemoteCmd::CLI
     uint32_t _last_accept_ms[kRateLimitSlots];
 
     // Per-action minimum interval between accepts (milliseconds).

--- a/src/helpers/wifi_telemetry/RepeaterMqttPool.cpp
+++ b/src/helpers/wifi_telemetry/RepeaterMqttPool.cpp
@@ -73,6 +73,17 @@ RepeaterMqttPool& repeaterMqttPool() {
     return inst;
 }
 
+#ifndef OFFBAND_OBSERVER
+// #538: ObserverCli (the broker-config CLI, reused on the repeater) both takes a
+// MqttBrokerPool& param AND calls offband::wifiObserverPool() internally for
+// live-state reads. On the repeater (no observer pipeline) point that accessor
+// at the SAME pool this adapter drives, so `mqtt status` / `set mqtt.broker.N.*`
+// operate on the repeater's brokers. The observer defines its own
+// wifiObserverPool() elsewhere; repeater builds never define OFFBAND_OBSERVER,
+// so there is no double-definition.
+MqttBrokerPool& wifiObserverPool() { return thePool(); }
+#endif
+
 }  // namespace offband
 
 #ifdef ARDUINO

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -185,6 +185,13 @@ build_src_filter = ${env:heltec_v4_repeater.build_src_filter}
   +<helpers/wifi_observer/MqttPayload.cpp>
   +<helpers/wifi_observer/ConfigSchema.cpp>
   +<helpers/wifi_observer/JwtHelper.cpp>
+  ; #538 (Option A): broker-config CLI. dispatchObserverCli's wifi/display/web
+  ; verbs are guarded behind OFFBAND_OBSERVER, so the repeater gets broker verbs
+  ; only and does NOT pull WifiConfigProvider/DisplayConfigProvider (which need
+  ; the observer's wifiBootstrap). ConfigDispatch.cpp backs the typed broker
+  ; config providers' static registration.
+  +<helpers/wifi_observer/ObserverCli.cpp>
+  +<helpers/config/ConfigDispatch.cpp>
 lib_deps =
   ${env:heltec_v4_repeater.lib_deps}
   knolleary/PubSubClient @ ^2.8


### PR DESCRIPTION
## What
Child of #302. Makes the repeater's multi-broker pool (#536/#537) **configurable via serial CLI AND via the client**, so the #537 mesh-packet feed becomes operator-usable. Owner **Option A**: the client drives config over the authenticated **RemoteCommand (#86)** channel — no BLE. HA-slot unification deferred → #547.

## Serial CLI — reuse ObserverCli's broker verbs on the repeater
- `CommonCLI.cpp`: open the `dispatchObserverCli` fall-through gate from `OFFBAND_OBSERVER` to `OFFBAND_OBSERVER || OFFBAND_MQTT_POOL`.
- `ObserverCli.cpp`: guard the **wifi/display/web** verbs (they pull the observer's `wifiBootstrap` via `WifiConfigProvider`) behind `OFFBAND_OBSERVER`. The **broker** verbs + the typed config providers (broker-only) + broker enumeration stay unguarded → the repeater compiles this file for the broker verbs with **no wifiBootstrap dependency**. **Observer byte-identical** (it defines `OFFBAND_OBSERVER`).
- `RepeaterMqttPool.cpp`: define `offband::wifiObserverPool()` → the repeater's pool (guarded `!OFFBAND_OBSERVER`, no double-def) so ObserverCli's live-state reads hit it.
- `platformio.ini`: repeater telemetry env adds `ObserverCli.cpp` + `ConfigDispatch.cpp` (NOT the wifi/display providers).

## Client — new authenticated RemoteCommand `cli` action
- `RemoteCommand.{h,cpp}`: whitelisted `RemoteCmd::CLI` (+rate-limit slot, 1 s). `parse`/`parseFromJson` pull `params.cmd` → `req.cli_cmd[192]`. The dispatch case runs it via the new `runCli` callback (default-false so non-repeater impls are unaffected) and escapes the reply into `data.reply` via ArduinoJson (mirrors `SAFETY_LOG_DUMP`), truncated to 400 B. **Runs only via `executeAuthenticated`** — same shared-secret gate as every #86 action.
- `main.cpp`: `PatioRemoteCallbacks::runCli` copies into a mutable buffer (handleCommand tokenizes in place) → `the_mesh.handleCommand` → the broker CLI.

## Test
- `heltec_v4_repeater_telemetry` + `_stp` compile + link (Flash 22.7%).
- `Heltec_v3_companion_observer_wifi` + `heltec_v4_companion_observer_wifi` — **no regression** (guards additive under `OFFBAND_OBSERVER`).
- Full ci-green matrix runs here. End-to-end runtime (config a broker → #537 feed publishes) is #539's HW-verify scope.

## Review
Gemini 2.5-pro — **no blocker/major**: observer byte-identical, repeater falls through cleanly for observer-only verbs, `wifiObserverPool()` safe, `cli` action robustly post-auth with correct JSON escaping + bounds, rate-limit table correct.

Closes #538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
