### PR TITLE
task: button-action matrix dispatch + capability advertisement + per-sub-code 0xC5 gating

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1878,6 +1878,14 @@ void MyMesh::handleCmdFrame(size_t len) {
         _prefs.buzzer_quiet = (want == NOTIFY_SCOPE_NONE) ? 1 : 0;
         savePrefs();
       }
+      // #510: log the resulting state for the same reason the button path does -- a
+      // scope change over the wire must be as visible in caplog as one from a press,
+      // or the record depends on which route the user happened to take.
+      MESH_DEBUG_PRINTLN("[0xC5] notify scope -> %s (%d) via client",
+                         _prefs.notify_scope == NOTIFY_SCOPE_ALL  ? "ALL"  :
+                         _prefs.notify_scope == NOTIFY_SCOPE_SELF ? "SELF" : "NONE",
+                         (int)_prefs.notify_scope);
+
       // Apply to the HARDWARE unconditionally, even when the pref already matched.
       //
       // This line is the whole bug this handler shipped with: setting the scope over
@@ -1951,6 +1959,9 @@ void MyMesh::handleCmdFrame(size_t len) {
         _prefs.button_actions[seq] = action;
         savePrefs();
       }
+      // #509: a reassignment is a durable config change with no visible confirmation
+      // on a screenless board -- log it.
+      MESH_DEBUG_PRINTLN("[0xC5] button seq=%d -> action=%d", (int)seq, (int)action);
       out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
       out_frame[1] = sub;
       out_frame[2] = seq;

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1818,17 +1818,41 @@ void MyMesh::handleCmdFrame(size_t len) {
   // never advertises OFFBAND_CAP2_NOTIFY_SCOPE must not answer 0xC5 either.
   if (cmd_frame[0] == offband::CMD_OFFBAND_DEVICE_UI && len >= 2) {
     uint8_t sub = cmd_frame[1];
+    // #509: gate PER SUB-COMMAND, not for the whole command.
+    //
+    // This used to be one blanket `#ifndef PIN_BUZZER -> ERR_NO_BUZZER` covering the
+    // entire 0xC5 surface. That was right when 0xC5 only carried notification scope,
+    // and became wrong the moment it also carried the button matrix: a board with a
+    // button and no buzzer was refused a feature its hardware can do perfectly well
+    // (mapping "send advert" to double press needs nothing that makes noise).
+    //
+    // The two capabilities are independent and are advertised independently
+    // (OFFBAND_CAP2_NOTIFY_SCOPE on PIN_BUZZER, OFFBAND_CAP2_BUTTON_MATRIX on
+    // PIN_USER_BTN), so the command surface must match that split exactly.
+    const bool is_scope_sub  = (sub == offband::OFFBAND_UI_SCOPE_GET ||
+                                sub == offband::OFFBAND_UI_SCOPE_SET);
+    const bool is_matrix_sub = (sub == offband::OFFBAND_UI_MATRIX_GET ||
+                                sub == offband::OFFBAND_UI_MATRIX_SET);
 #ifndef PIN_BUZZER
-    // No buzzer on this board -> the whole surface is unsupported. Answer with the
-    // typed error carrying a REASON, not a bare ERR_CODE_ILLEGAL_ARG: the client is
-    // required to show the user WHY, and "this board has no buzzer" is a different
-    // answer from "unknown action".
-    out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
-    out_frame[1] = offband::OFFBAND_UI_ERR;
-    out_frame[2] = offband::OFFBAND_UI_ERR_NO_BUZZER;
-    _serial->writeFrame(out_frame, 3);
-    return;
-#else
+    if (is_scope_sub) {
+      out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+      out_frame[1] = offband::OFFBAND_UI_ERR;
+      out_frame[2] = offband::OFFBAND_UI_ERR_NO_BUZZER;
+      _serial->writeFrame(out_frame, 3);
+      return;
+    }
+#endif
+#ifndef PIN_USER_BTN
+    if (is_matrix_sub) {
+      out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+      out_frame[1] = offband::OFFBAND_UI_ERR;
+      out_frame[2] = offband::OFFBAND_UI_ERR_UNSUPPORTED_ACTION;
+      _serial->writeFrame(out_frame, 3);
+      return;
+    }
+#endif
+    (void)is_scope_sub; (void)is_matrix_sub;
+{
     if (sub == offband::OFFBAND_UI_SCOPE_GET) {
       out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
       out_frame[1] = sub;
@@ -1880,8 +1904,11 @@ void MyMesh::handleCmdFrame(size_t len) {
 #ifdef ENV_INCLUDE_GPS
       mask |= (1 << OFFBAND_UI_ACTION_GPS_TOGGLE);
 #endif
-      mask |= (1 << OFFBAND_UI_ACTION_CYCLE_SCOPE);   // buzzer present in this branch
+#ifdef PIN_BUZZER
+      // Both of these need a speaker: one cycles the sound mode, the other IS a sound.
+      mask |= (1 << OFFBAND_UI_ACTION_CYCLE_SCOPE);
       mask |= (1 << OFFBAND_UI_ACTION_BATTERY_BEEP);
+#endif
       out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
       out_frame[1] = sub;
       out_frame[2] = mask;
@@ -1937,7 +1964,7 @@ void MyMesh::handleCmdFrame(size_t len) {
     out_frame[2] = offband::OFFBAND_UI_ERR_MALFORMED;
     _serial->writeFrame(out_frame, 3);
     return;
-#endif  // PIN_BUZZER
+}
   }
   if (cmd_frame[0] == offband::CMD_OFFBAND_FEM_LNA && len >= 2) {
     uint8_t sub = cmd_frame[1];
@@ -2029,6 +2056,12 @@ void MyMesh::handleCmdFrame(size_t len) {
     // Gated on the hardware, same principle as OFFBAND_CAP_FEM_LNA above -- a client
     // must never render a control that cannot do anything on this board.
     offband_caps2 |= offband::OFFBAND_CAP2_NOTIFY_SCOPE;
+#endif
+#ifdef PIN_USER_BTN
+    // #509: button-action matrix. Gated on the BUTTON, not the buzzer -- reassigning
+    // a press needs something to press. These are independent capabilities and a
+    // board may have either without the other.
+    offband_caps2 |= offband::OFFBAND_CAP2_BUTTON_MATRIX;
 #endif
     out_frame[i++] = offband_caps2;          // v18+
     _serial->writeFrame(out_frame, i);

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -19,7 +19,7 @@
 // bumps the code even without a frame-layout change -- 17 was "+ caplog cap bit
 // (0x20)", 16 was "FEM LNA cap 0x04 / 0xC3". This change sets caps2 bit 0x01 and adds
 // the 0xC5 command, so it follows the same rule.
-#define FIRMWARE_VER_CODE 19   // #510 (PROVISIONAL, see above): + caps2 bit 0x01 NOTIFY_SCOPE, + 0xC5 device-UI command. Prior 18 (#508): second caps byte at frame offset 84. Prior 17 (#427): caplog cap bit 0x20
+#define FIRMWARE_VER_CODE 20   // #509: + caps2 bit 0x02 BUTTON_MATRIX (gated on PIN_USER_BTN). Prior 19 (#510): caps2 bit 0x01 NOTIFY_SCOPE + 0xC5. Prior 18 (#508): second caps byte at offset 84
 
 #ifndef FIRMWARE_BUILD_DATE
 #define FIRMWARE_BUILD_DATE "6 Jun 2026"

--- a/examples/companion_radio/OffbandConfigProtocol.h
+++ b/examples/companion_radio/OffbandConfigProtocol.h
@@ -211,7 +211,7 @@ enum MqttAuthType  : uint8_t { MQTT_AUTH_NONE = 0, MQTT_AUTH_BASIC = 1, MQTT_AUT
 //   bit  value  symbol                        state       issue
 //   ---  -----  ----------------------------  ----------  --------------------------
 //    0   0x01   OFFBAND_CAP2_NOTIFY_SCOPE     this change  #510
-//    1   0x02   -- free --                                (next: #509 button matrix set/get)
+//    1   0x02   OFFBAND_CAP2_BUTTON_MATRIX    this change  #509
 //    2-7 0x04.. -- free --
 // ===============================================================================
 // bit 0 (0x01): device notification scope ALL/SELF/NONE is supported and settable.
@@ -219,6 +219,11 @@ enum MqttAuthType  : uint8_t { MQTT_AUTH_NONE = 0, MQTT_AUTH_BASIC = 1, MQTT_AUT
 // as OFFBAND_CAP_FEM_LNA is gated on canControlLoRaFemLna(). A board with no buzzer
 // must not advertise it, or the client renders a control that does nothing.
 constexpr uint8_t OFFBAND_CAP2_NOTIFY_SCOPE = 0x01;
+// bit 1 (0x02): the button-action matrix is supported and settable.
+// Gated on PIN_USER_BTN, NOT PIN_BUZZER -- reassigning a press needs a button, not a
+// speaker. A board with a button and no buzzer can still map "send advert" to double
+// press, so gating this on the buzzer would refuse a feature the hardware can do.
+constexpr uint8_t OFFBAND_CAP2_BUTTON_MATRIX = 0x02;
 constexpr uint8_t OFFBAND_CAP_WIFI_OBSERVER = 0x01;  // bit 0: config backend (wifi_observer) compiled in
 constexpr uint8_t OFFBAND_CAP_BLOCK         = 0x02;  // bit 1: user-block list (BlockStore) compiled in (#241)
 constexpr uint8_t OFFBAND_CAP_FEM_LNA       = 0x04;  // bit 2: FEM LNA runtime control available (#298)

--- a/examples/companion_radio/ui-orig/UITask.cpp
+++ b/examples/companion_radio/ui-orig/UITask.cpp
@@ -362,7 +362,7 @@ void UITask::loop() {
 }
 
 void UITask::handleButtonAnyPress() {
-  MESH_DEBUG_PRINTLN("UITask: any press triggered");
+  MESH_DEBUG_PRINTLN("[btn] edge: a press was seen (count not yet resolved)");
   // called on any button press before other events, to wake up the display quickly
   // do not refresh the display here, as it may block the button handler
   if (_display != NULL) {
@@ -375,7 +375,6 @@ void UITask::handleButtonAnyPress() {
 }
 
 void UITask::handleButtonShortPress() {
-  MESH_DEBUG_PRINTLN("UITask: short press triggered");
   if (_display != NULL) {
     // Display housekeeping is NOT an assignable action -- it is how the screen
     // behaves, not what the button "does". Runs regardless of the assignment.
@@ -392,12 +391,11 @@ void UITask::handleButtonShortPress() {
   }
   // #509: single press is UNASSIGNED by default -- the owner requires it be opt-in,
   // never defaulted on. runButtonAction() no-ops on ACTION_NONE.
-  runButtonAction(_node_prefs->button_actions[OFFBAND_UI_SEQ_SINGLE]);
+  runButtonAction(OFFBAND_UI_SEQ_SINGLE, _node_prefs->button_actions[OFFBAND_UI_SEQ_SINGLE]);
 }
 
 void UITask::handleButtonDoublePress() {
-  MESH_DEBUG_PRINTLN("UITask: double press triggered");
-  runButtonAction(_node_prefs->button_actions[OFFBAND_UI_SEQ_DOUBLE]);
+  runButtonAction(OFFBAND_UI_SEQ_DOUBLE, _node_prefs->button_actions[OFFBAND_UI_SEQ_DOUBLE]);
 }
 
 // #509: THE BUTTON-ACTION DISPATCH TABLE.
@@ -414,11 +412,32 @@ void UITask::handleButtonDoublePress() {
 //
 // Actions unsupported by the hardware no-op safely here; the 0xC5 SET path is what
 // REFUSES them up front with a typed reason, so the client can say why.
-void UITask::runButtonAction(uint8_t action) {
-  // #509: record WHICH action a press resolved to. Without this, caplog shows that a
-  // press happened but not what it did -- and on a screenless board there is no other
-  // record, because _alert renders nowhere.
-  MESH_DEBUG_PRINTLN("[btn] action=%d dispatched", (int)action);
+static const char* seqName(uint8_t seq) {
+  switch (seq) {
+    case OFFBAND_UI_SEQ_SINGLE: return "SINGLE";
+    case OFFBAND_UI_SEQ_DOUBLE: return "DOUBLE";
+    case OFFBAND_UI_SEQ_TRIPLE: return "TRIPLE";
+    case OFFBAND_UI_SEQ_QUAD:   return "QUAD";
+    default:                    return "?";
+  }
+}
+static const char* actionName(uint8_t a) {
+  switch (a) {
+    case OFFBAND_UI_ACTION_NONE:         return "NONE";
+    case OFFBAND_UI_ACTION_ADVERT:       return "ADVERT";
+    case OFFBAND_UI_ACTION_GPS_TOGGLE:   return "GPS_TOGGLE";
+    case OFFBAND_UI_ACTION_CYCLE_SCOPE:  return "CYCLE_SCOPE";
+    case OFFBAND_UI_ACTION_BATTERY_BEEP: return "BATTERY_BEEP";
+    default:                             return "?";
+  }
+}
+
+void UITask::runButtonAction(uint8_t seq, uint8_t action) {
+  // #509: ONE line naming the press sequence AND what it resolved to, in words.
+  // "action=3 dispatched" could not answer the only question that matters when a
+  // press appears to do nothing: was it even detected as a TRIPLE? Now it says so.
+  MESH_DEBUG_PRINTLN("[btn] %s press -> %s (seq=%d action=%d)",
+                     seqName(seq), actionName(action), (int)seq, (int)action);
   switch (action) {
     case OFFBAND_UI_ACTION_NONE:
       break;                       // unassigned -- the default for single press
@@ -494,7 +513,6 @@ void UITask::runButtonAction(uint8_t action) {
 // #510: cycle notification scope ALL -> SELF -> NONE -> ALL. Extracted from the
 // triple-press handler so it can be ASSIGNED to any sequence, not just triple.
 void UITask::cycleNotifyScope() {
-  MESH_DEBUG_PRINTLN("UITask: triple press triggered");
   // #510: cycle notification scope ALL -> SELF -> NONE -> ALL.
   //
   // This replaces the old binary buzzer Off/On toggle, which had a real defect on a
@@ -556,17 +574,15 @@ void UITask::cycleNotifyScope() {
 }
 
 void UITask::handleButtonTriplePress() {
-  MESH_DEBUG_PRINTLN("UITask: triple press triggered");
-  runButtonAction(_node_prefs->button_actions[OFFBAND_UI_SEQ_TRIPLE]);
+  runButtonAction(OFFBAND_UI_SEQ_TRIPLE, _node_prefs->button_actions[OFFBAND_UI_SEQ_TRIPLE]);
 }
 
 void UITask::handleButtonQuadruplePress() {
-  MESH_DEBUG_PRINTLN("UITask: quad press triggered");
-  runButtonAction(_node_prefs->button_actions[OFFBAND_UI_SEQ_QUAD]);
+  runButtonAction(OFFBAND_UI_SEQ_QUAD, _node_prefs->button_actions[OFFBAND_UI_SEQ_QUAD]);
 }
 
 void UITask::handleButtonLongPress() {
-  MESH_DEBUG_PRINTLN("UITask: long press triggered");
+  MESH_DEBUG_PRINTLN("[btn] LONG press -> fixed (rescue/power-off, not assignable)");
   if (millis() - ui_started_at < 8000) {   // long press in first 8 seconds since startup -> CLI/rescue
     the_mesh.enterCLIRescue();
   } else {

--- a/examples/companion_radio/ui-orig/UITask.cpp
+++ b/examples/companion_radio/ui-orig/UITask.cpp
@@ -415,6 +415,10 @@ void UITask::handleButtonDoublePress() {
 // Actions unsupported by the hardware no-op safely here; the 0xC5 SET path is what
 // REFUSES them up front with a typed reason, so the client can say why.
 void UITask::runButtonAction(uint8_t action) {
+  // #509: record WHICH action a press resolved to. Without this, caplog shows that a
+  // press happened but not what it did -- and on a screenless board there is no other
+  // record, because _alert renders nowhere.
+  MESH_DEBUG_PRINTLN("[btn] action=%d dispatched", (int)action);
   switch (action) {
     case OFFBAND_UI_ACTION_NONE:
       break;                       // unassigned -- the default for single press
@@ -533,6 +537,14 @@ void UITask::cycleNotifyScope() {
         sprintf(_alert, "Notify: NONE");
         break;
     }
+
+    // #510: log the RESULTING state, not just that a change happened. The tone tells
+    // you something moved if you are listening; this tells you WHERE it landed, which
+    // is the only durable record on a device with no screen.
+    MESH_DEBUG_PRINTLN("[btn] notify scope -> %s (%d), buzzer quiet=%d",
+                       scope == NOTIFY_SCOPE_ALL  ? "ALL"  :
+                       scope == NOTIFY_SCOPE_SELF ? "SELF" : "NONE",
+                       (int)scope, buzzer.isQuiet() ? 1 : 0);
 
     // Keep the low-level mute flag consistent with the scope so a reboot restores the
     // same audible behaviour: NONE persists as quiet, ALL/SELF persist as un-quiet and

--- a/examples/companion_radio/ui-orig/UITask.cpp
+++ b/examples/companion_radio/ui-orig/UITask.cpp
@@ -377,13 +377,12 @@ void UITask::handleButtonAnyPress() {
 void UITask::handleButtonShortPress() {
   MESH_DEBUG_PRINTLN("UITask: short press triggered");
   if (_display != NULL) {
-    // Only clear message preview if display was already on before button press
+    // Display housekeeping is NOT an assignable action -- it is how the screen
+    // behaves, not what the button "does". Runs regardless of the assignment.
     if (_displayWasOn) {
-      // If display was on and showing message preview, clear it
       if (_origin[0] && _msg[0]) {
         clearMsgPreview();
       } else {
-        // Otherwise, refresh the display
         _need_refresh = true;
       }
     } else {
@@ -391,25 +390,106 @@ void UITask::handleButtonShortPress() {
     }
     // Note: Display turn-on and auto-off timer extension are handled by handleButtonAnyPress
   }
+  // #509: single press is UNASSIGNED by default -- the owner requires it be opt-in,
+  // never defaulted on. runButtonAction() no-ops on ACTION_NONE.
+  runButtonAction(_node_prefs->button_actions[OFFBAND_UI_SEQ_SINGLE]);
 }
 
 void UITask::handleButtonDoublePress() {
-  MESH_DEBUG_PRINTLN("UITask: double press triggered, sending advert");
-  // ADVERT
-  #ifdef PIN_BUZZER
-      notify(UIEventType::ack);
-  #endif
-  if (the_mesh.advert()) {
-    MESH_DEBUG_PRINTLN("Advert sent!");
-    sprintf(_alert, "Advert sent!");
-  } else {
-    MESH_DEBUG_PRINTLN("Advert failed!");
-    sprintf(_alert, "Advert failed..");
-  }
-  _need_refresh = true;
+  MESH_DEBUG_PRINTLN("UITask: double press triggered");
+  runButtonAction(_node_prefs->button_actions[OFFBAND_UI_SEQ_DOUBLE]);
 }
 
-void UITask::handleButtonTriplePress() {
+// #509: THE BUTTON-ACTION DISPATCH TABLE.
+//
+// Every press sequence resolves through here instead of doing a fixed thing, so a
+// sequence can be reassigned from the client (0xC5 matrix SET) without touching any
+// handler. Adding an action means adding one case; adding a device means reusing
+// this whole block. Previously each handler hardcoded its own behaviour, which is
+// what made the matrix unassignable.
+//
+// LONG PRESS IS DELIBERATELY ABSENT. It is the CLI-rescue / power-off escape hatch
+// and must never be remappable, or a bad assignment could leave a board with no way
+// back. handleButtonLongPress() keeps its fixed behaviour.
+//
+// Actions unsupported by the hardware no-op safely here; the 0xC5 SET path is what
+// REFUSES them up front with a typed reason, so the client can say why.
+void UITask::runButtonAction(uint8_t action) {
+  switch (action) {
+    case OFFBAND_UI_ACTION_NONE:
+      break;                       // unassigned -- the default for single press
+
+    case OFFBAND_UI_ACTION_ADVERT:
+      #ifdef PIN_BUZZER
+        notify(UIEventType::ack);
+      #endif
+      if (the_mesh.advert()) {
+        MESH_DEBUG_PRINTLN("Advert sent!");
+        sprintf(_alert, "Advert sent!");
+      } else {
+        MESH_DEBUG_PRINTLN("Advert failed!");
+        sprintf(_alert, "Advert failed..");
+      }
+      _need_refresh = true;
+      break;
+
+    case OFFBAND_UI_ACTION_GPS_TOGGLE:
+      if (_sensors != NULL) {
+        int num = _sensors->getNumSettings();
+        for (int i = 0; i < num; i++) {
+          if (strcmp(_sensors->getSettingName(i), "gps") == 0) {
+            if (strcmp(_sensors->getSettingValue(i), "1") == 0) {
+              _sensors->setSettingValue("gps", "0");
+              notify(UIEventType::ack);
+              sprintf(_alert, "GPS: Disabled");
+            } else {
+              _sensors->setSettingValue("gps", "1");
+              notify(UIEventType::ack);
+              sprintf(_alert, "GPS: Enabled");
+            }
+            break;
+          }
+        }
+      }
+      _need_refresh = true;
+      break;
+
+    case OFFBAND_UI_ACTION_CYCLE_SCOPE:
+      cycleNotifyScope();
+      break;
+
+    case OFFBAND_UI_ACTION_BATTERY_BEEP:
+      // Audible battery read for a screenless device: one chirp per 25%, so 4 chirps
+      // is full and 1 is nearly flat. Countable without looking at anything.
+      #ifdef PIN_BUZZER
+      {
+        uint16_t mv = getBattMilliVolts();
+        int pct = ((int)mv - BATT_MIN_MILLIVOLTS) * 100 / (BATT_MAX_MILLIVOLTS - BATT_MIN_MILLIVOLTS);
+        if (pct < 0) pct = 0;
+        if (pct > 100) pct = 100;
+        int chirps = (pct / 25) + 1;      // 1..5, never zero so "flat" is still audible
+        if (chirps > 4) chirps = 4;
+        for (int i = 0; i < chirps; i++) {
+          buzzer.play("bat:d=32,o=7,b=200:c");
+          uint32_t t0 = millis();
+          while (buzzer.isPlaying() && (millis() - t0) < 400) buzzer.loop();
+          delay(90);
+        }
+        sprintf(_alert, "Batt: %d%%", pct);
+        _need_refresh = true;
+      }
+      #endif
+      break;
+
+    default:
+      MESH_DEBUG_PRINTLN("UITask: unknown button action %d ignored", (int)action);
+      break;
+  }
+}
+
+// #510: cycle notification scope ALL -> SELF -> NONE -> ALL. Extracted from the
+// triple-press handler so it can be ASSIGNED to any sequence, not just triple.
+void UITask::cycleNotifyScope() {
   MESH_DEBUG_PRINTLN("UITask: triple press triggered");
   // #510: cycle notification scope ALL -> SELF -> NONE -> ALL.
   //
@@ -463,27 +543,14 @@ void UITask::handleButtonTriplePress() {
   #endif
 }
 
+void UITask::handleButtonTriplePress() {
+  MESH_DEBUG_PRINTLN("UITask: triple press triggered");
+  runButtonAction(_node_prefs->button_actions[OFFBAND_UI_SEQ_TRIPLE]);
+}
+
 void UITask::handleButtonQuadruplePress() {
   MESH_DEBUG_PRINTLN("UITask: quad press triggered");
-  if (_sensors != NULL) {
-    // toggle GPS onn/off
-    int num = _sensors->getNumSettings();
-    for (int i = 0; i < num; i++) {
-      if (strcmp(_sensors->getSettingName(i), "gps") == 0) {
-        if (strcmp(_sensors->getSettingValue(i), "1") == 0) {
-          _sensors->setSettingValue("gps", "0");
-          notify(UIEventType::ack);
-          sprintf(_alert, "GPS: Disabled");
-        } else {
-          _sensors->setSettingValue("gps", "1");
-          notify(UIEventType::ack);
-          sprintf(_alert, "GPS: Enabled");
-        }
-        break;
-      }
-    }
-  }
-  _need_refresh = true;
+  runButtonAction(_node_prefs->button_actions[OFFBAND_UI_SEQ_QUAD]);
 }
 
 void UITask::handleButtonLongPress() {

--- a/examples/companion_radio/ui-orig/UITask.h
+++ b/examples/companion_radio/ui-orig/UITask.h
@@ -71,7 +71,7 @@ public:
   // #509: button-action dispatch. Every press sequence resolves through
   // runButtonAction() against the stored matrix, so a sequence can be reassigned
   // from the client without editing a handler.
-  void runButtonAction(uint8_t action);
+  void runButtonAction(uint8_t seq, uint8_t action);
   void cycleNotifyScope();
   void loop() override;
 

--- a/examples/companion_radio/ui-orig/UITask.h
+++ b/examples/companion_radio/ui-orig/UITask.h
@@ -68,6 +68,11 @@ public:
   void newMsg(uint8_t path_len, const char* from_name, const char* text, int msgcount) override;
   void notify(UIEventType t = UIEventType::none) override;
   void applyBuzzerMute(bool quiet) override;
+  // #509: button-action dispatch. Every press sequence resolves through
+  // runButtonAction() against the stored matrix, so a sequence can be reassigned
+  // from the client without editing a handler.
+  void runButtonAction(uint8_t action);
+  void cycleNotifyScope();
   void loop() override;
 
   void shutdown(bool restart = false);


### PR DESCRIPTION
Closes #550. Part of epic #509 (and #510's dispatch surface). **Split out of `feat/509-button-dispatch`** so the protocol/contract work can land independently of the unfinished multi-press detection bug (#527) — the client half is built and waiting on these command bytes, and a second session (#542 Epic B) is blocked on the caps-byte allocation.

## What this does

**1. Button presses dispatch through a stored matrix, not hardcoded handlers.**
Every sequence resolves via `runButtonAction(seq, action)` against `NodePrefs.button_actions[]`, so a press can be reassigned from the client without editing a handler. Single press is **unassigned by default** — opt-in, never defaulted on, per the owner's requirement that nobody inherits a buzzer they can't turn off.

**2. `OFFBAND_CAP2_BUTTON_MATRIX` = caps byte 2, bit `0x02`**, gated on `PIN_USER_BTN`. `FIRMWARE_VER_CODE` 19 -> 20. Registry row recorded in `OffbandConfigProtocol.h` in this same PR, per the allocation discipline.

**3. `0xC5` gating split per sub-command.**
It used to be one blanket `#ifndef PIN_BUZZER -> ERR_NO_BUZZER` covering the whole command. That was right when `0xC5` only carried notification scope and became wrong the moment it also carried the button matrix:

- a board with a button and no buzzer was refused a feature its hardware does fine (mapping "send advert" to double-press needs nothing that makes noise)
- a Heltec V4 asking for a **display** setting got told it has no buzzer

Now scope (`0x01`/`0x02`) gates on `PIN_BUZZER` and matrix (`0x03`/`0x04`) on `PIN_USER_BTN`, matching how the two capabilities are advertised. This is also the structure #542 Epic B needs for its led/display sub-codes — coordinated with BrownHawk, who takes caps2 `0x04` and sub-codes `0x05`-`0x08`.

**4. caplog names what happened.** `[btn] TRIPLE press -> CYCLE_SCOPE (seq=2 action=3)` plus the resulting scope. On a screenless board caplog is the only record there is; `action=3 dispatched` couldn't answer whether a press was even detected as a triple.

## Verification

**Hardware, sensecap-t1000e-1:** the owner's serial capture shows `SINGLE press -> BATTERY_BEEP (seq=0 action=4)`. Single defaults to `NONE`, so that assignment came from the client — which proves the `0xC5` matrix SET, persistence to NodePrefs, and dispatch path end to end. `DOUBLE -> ADVERT` and `TRIPLE -> CYCLE_SCOPE` also observed, with scope cycling ALL -> SELF -> NONE and the buzzer quiet flag following it.

Not yet observed: `QUAD -> GPS_TOGGLE`.

**Builds:** `t1000e_companion_radio_ble` (buzzer + button), `heltec_v4_companion_radio_ble` (**no buzzer** — exercises the gate split), `RAK_3112_companion_radio_ble` (ESP32). All SUCCESS. Full matrix runs via `ci-green`.

**Review:** Gemini 2.5-pro reviewed the sibling #527 work; this half is contract/dispatch and was reviewed against the existing `0xC2`/`0xC3` sub-typed handlers for shape consistency.

## Not in scope

Multi-press *detection* reliability — presses still intermittently arriving as SINGLE — stays on #527 and its branch `feat/509-button-dispatch`. Nothing here depends on that fix.