### PR TITLE
fix: ui-orig Button drops presses — rework to timestamped edge capture (T1000-E)

### DIFF
--- a/examples/companion_radio/ui-orig/Button.cpp
+++ b/examples/companion_radio/ui-orig/Button.cpp
@@ -1,111 +1,172 @@
 #include "Button.h"
+#include <MeshCore.h>
 
-Button::Button(uint8_t pin, bool activeState) 
+// -----------------------------------------------------------------------------------
+// #527: edge capture
+//
+// Arduino's attachInterrupt() on both nRF52 and ESP32 takes a bare function pointer, so
+// there is no way to hand it a `this`. The usual workaround is a fixed table of static
+// trampolines, one per attachable instance, each holding the instance it belongs to.
+// ui-orig creates at most two Buttons (digital + analog), and the analog one cannot use
+// an interrupt at all, so two slots is one more than is reachable.
+// -----------------------------------------------------------------------------------
+
+#ifdef BUTTON_IRQ_CAPTURE
+
+#ifndef BUTTON_IRQ_SLOTS
+#define BUTTON_IRQ_SLOTS 2
+#endif
+
+// ESP32 requires ISR code to be resident in IRAM: a handler in flash can fault if the
+// interrupt lands while the flash cache is disabled (during an SPI flash write). Other
+// targets have no such attribute.
+#ifdef ESP32
+  #define BUTTON_ISR_ATTR IRAM_ATTR
+#else
+  #define BUTTON_ISR_ATTR
+#endif
+
+static Button* s_irq_owner[BUTTON_IRQ_SLOTS] = { nullptr, nullptr };
+
+static void BUTTON_ISR_ATTR button_isr_0() { if (s_irq_owner[0]) s_irq_owner[0]->captureEdgeFromISR(); }
+static void BUTTON_ISR_ATTR button_isr_1() { if (s_irq_owner[1]) s_irq_owner[1]->captureEdgeFromISR(); }
+
+static void (*const s_irq_trampoline[BUTTON_IRQ_SLOTS])() = { button_isr_0, button_isr_1 };
+
+#endif  // BUTTON_IRQ_CAPTURE
+
+Button::Button(uint8_t pin, bool activeState)
     : _pin(pin), _activeState(activeState), _isAnalog(false), _analogThreshold(20) {
-    _currentState = false;  // Initialize as not pressed
-    _lastState = _currentState;
 }
 
 Button::Button(uint8_t pin, bool activeState, bool isAnalog, uint16_t analogThreshold)
     : _pin(pin), _activeState(activeState), _isAnalog(isAnalog), _analogThreshold(analogThreshold) {
-    _currentState = false;  // Initialize as not pressed
-    _lastState = _currentState;
 }
 
 void Button::begin() {
-    _currentState = readButton();
-    _lastState = _currentState;
+    _seq.reset();
+    // Seed the producer's notion of the current level so a button already held at boot
+    // does not synthesise a phantom press on the first poll.
+    _produced_level = readButton();
+
+#ifdef BUTTON_IRQ_CAPTURE
+    // Analog "buttons" are read through the ADC and have no digital edge to interrupt on.
+    if (!_isAnalog) {
+        for (int8_t i = 0; i < BUTTON_IRQ_SLOTS; i++) {
+            if (s_irq_owner[i] == nullptr) {
+                s_irq_owner[i] = this;
+                _irq_slot = i;
+                attachInterrupt(digitalPinToInterrupt(_pin), s_irq_trampoline[i], CHANGE);
+                MESH_DEBUG_PRINTLN("[btn] edge capture armed on pin %d (slot %d)", (int)_pin, (int)i);
+                break;
+            }
+        }
+        // SAFELANE §6: if every slot is taken, say so. The polled producer still runs,
+        // so the button keeps working -- just without interrupt-grade capture.
+        if (_irq_slot < 0) {
+            MESH_DEBUG_PRINTLN("[btn] WARNING no IRQ slot free for pin %d, polling only", (int)_pin);
+        }
+    }
+#endif
+}
+
+bool Button::readButton() const {
+    if (_isAnalog) {
+        return (analogRead(_pin) < _analogThreshold);
+    }
+    return (digitalRead(_pin) == _activeState);
+}
+
+// Producer side. Safe to call from an ISR: it only advances _q_head, which no other
+// context writes.
+void Button::pushEdge(uint32_t ms, bool pressed) {
+    uint8_t head = _q_head;
+    uint8_t next = (uint8_t)((head + 1) % BUTTON_EDGE_QUEUE_LEN);
+    if (next == _q_tail) {
+        _dropped++;                  // full -- record the loss rather than hide it
+        return;
+    }
+    _queue[head].ms = ms;
+    _queue[head].pressed = pressed;
+    _q_head = next;                  // publish only after the slot is fully written
+    _produced_level = pressed;
+}
+
+// Consumer side. Only ever called from update().
+bool Button::popEdge(Edge& out) {
+    uint8_t tail = _q_tail;
+    if (tail == _q_head) return false;
+    out.ms = _queue[tail].ms;
+    out.pressed = _queue[tail].pressed;
+    _q_tail = (uint8_t)((tail + 1) % BUTTON_EDGE_QUEUE_LEN);
+    return true;
+}
+
+void Button::captureEdgeFromISR() {
+#ifdef BUTTON_IRQ_CAPTURE
+    // CHANGE gives no direction, so read the level. Contact bounce can make this
+    // disagree with the edge that actually fired; that is fine -- the sequencer
+    // debounces on timestamps and ignores anything that is not a transition.
+    bool pressed = (digitalRead(_pin) == _activeState);
+    if (pressed == _produced_level) return;   // nothing new to record
+    pushEdge(millis(), pressed);
+#endif
 }
 
 void Button::update() {
     uint32_t now = millis();
-    
-    // Read button at specified interval
-    if (now - _lastReadTime < BUTTON_READ_INTERVAL_MS) {
-        return;
-    }
-    _lastReadTime = now;
-    
-    bool newState = readButton();
-    
-    // Check if state has changed
-    if (newState != _lastState) {
-        _stateChangeTime = now;
-    }
-    
-    // Debounce check
-    if ((now - _stateChangeTime) > BUTTON_DEBOUNCE_TIME_MS) {
-        if (newState != _currentState) {
-            _currentState = newState;
-            handleStateChange();
+
+    // Polled producer. Under BUTTON_IRQ_CAPTURE this is a backstop: the ISR has usually
+    // already published the edge and _produced_level matches, so this adds nothing. It
+    // still runs, so a missed or unattachable interrupt degrades to the old sampling
+    // behaviour instead of a dead button.
+    if ((uint32_t)(now - _lastReadTime) >= BUTTON_READ_INTERVAL_MS) {
+        _lastReadTime = now;
+        bool level = readButton();
+        if (level != _produced_level) {
+            pushEdge(now, level);
         }
     }
-    
-    _lastState = newState;
-    
-    // Handle multi-click timeout
-    if (_state == WAITING_FOR_MULTI_CLICK && (now - _releaseTime) > BUTTON_CLICK_TIMEOUT_MS) {
-        // Timeout reached, process the clicks
-        if (_clickCount == 1) {
-            triggerEvent(SHORT_PRESS);
-        } else if (_clickCount == 2) {
-            triggerEvent(DOUBLE_PRESS);
-        } else if (_clickCount == 3) {
-            triggerEvent(TRIPLE_PRESS);
-        } else if (_clickCount >= 4) {
-            triggerEvent(QUADRUPLE_PRESS);
+
+    // Consumer. Drain everything captured since the last call, at the timestamps the
+    // edges actually carried -- this is what makes a late loop cost latency instead of
+    // dropped presses.
+    Edge e;
+    while (popEdge(e)) {
+        if (_seq.onEdge(e.ms, e.pressed) == ButtonSequencer::EV_PRESS_EDGE) {
+            triggerEvent(ANY_PRESS);
         }
-
-        _clickCount = 0;
-        _state = IDLE;
     }
-    
-    // Handle long press while button is held
-    if (_state == PRESSED && (now - _pressTime) > BUTTON_LONG_PRESS_TIME_MS) {
-        triggerEvent(LONG_PRESS);
-        _state = IDLE;  // Prevent multiple press events
-        _clickCount = 0;
-    }
-}
 
-bool Button::readButton() {
-    if (_isAnalog) {
-        return (analogRead(_pin) < _analogThreshold);
-    } else {
-        return (digitalRead(_pin) == _activeState);
-    }
-}
-
-void Button::handleStateChange() {
-    uint32_t now = millis();
-    
-    if (_currentState) {
-        // Button pressed
-        _pressTime = now;
-        _state = PRESSED;
-        triggerEvent(ANY_PRESS);
-    } else {
-        // Button released
-        if (_state == PRESSED) {
-            uint32_t pressDuration = now - _pressTime;
-            
-            if (pressDuration < BUTTON_LONG_PRESS_TIME_MS) {
-                // Short press detected
-                _clickCount++;
-                _releaseTime = now;
-                _state = WAITING_FOR_MULTI_CLICK;
-            } else {
-                // Long press already handled in update()
-                _state = IDLE;
-                _clickCount = 0;
-            }
+    // Resolve gestures whose window has now closed. Drain in a loop: one call can only
+    // return a single event, and a long press followed by a pending count could produce
+    // two.
+    for (;;) {
+        ButtonSequencer::Event ev = _seq.tick(now);
+        if (ev == ButtonSequencer::EV_NONE) break;
+        switch (ev) {
+            case ButtonSequencer::EV_SHORT:     triggerEvent(SHORT_PRESS); break;
+            case ButtonSequencer::EV_DOUBLE:    triggerEvent(DOUBLE_PRESS); break;
+            case ButtonSequencer::EV_TRIPLE:    triggerEvent(TRIPLE_PRESS); break;
+            case ButtonSequencer::EV_QUADRUPLE: triggerEvent(QUADRUPLE_PRESS); break;
+            case ButtonSequencer::EV_LONG:      triggerEvent(LONG_PRESS); break;
+            default: break;
         }
+    }
+
+    // SAFELANE §6: a dropped edge is lost user input. Report it once per occurrence
+    // rather than letting a miscounted press look like a press that never happened.
+    uint32_t dropped = _dropped;
+    if (dropped != _dropped_reported) {
+        MESH_DEBUG_PRINTLN("[btn] WARNING dropped %d edge(s) -- queue overflow",
+                           (int)(dropped - _dropped_reported));
+        _dropped_reported = dropped;
     }
 }
 
 void Button::triggerEvent(EventType event) {
     _lastEvent = event;
-    
+
     switch (event) {
         case ANY_PRESS:
             if (_onAnyPress) _onAnyPress();

--- a/examples/companion_radio/ui-orig/Button.cpp
+++ b/examples/companion_radio/ui-orig/Button.cpp
@@ -119,6 +119,24 @@ void Button::captureEdgeFromISR() {
 #endif
 }
 
+// Pull events out of the sequencer until it has nothing more to say at `at`. One call
+// can only return a single event, and a deferred edge followed by a resolved count
+// produces two.
+void Button::drainSequencer(uint32_t at) {
+    for (;;) {
+        ButtonSequencer::Event ev = _seq.tick(at);
+        switch (ev) {
+            case ButtonSequencer::EV_NONE:      return;
+            case ButtonSequencer::EV_PRESS_EDGE: triggerEvent(ANY_PRESS); break;
+            case ButtonSequencer::EV_SHORT:     triggerEvent(SHORT_PRESS); break;
+            case ButtonSequencer::EV_DOUBLE:    triggerEvent(DOUBLE_PRESS); break;
+            case ButtonSequencer::EV_TRIPLE:    triggerEvent(TRIPLE_PRESS); break;
+            case ButtonSequencer::EV_QUADRUPLE: triggerEvent(QUADRUPLE_PRESS); break;
+            case ButtonSequencer::EV_LONG:      triggerEvent(LONG_PRESS); break;
+        }
+    }
+}
+
 void Button::update() {
     uint32_t now = millis();
 
@@ -155,28 +173,20 @@ void Button::update() {
     // Consumer. Drain everything captured since the last call, at the timestamps the
     // edges actually carried -- this is what makes a late loop cost latency instead of
     // dropped presses.
+    //
+    // Tick to each edge's own timestamp BEFORE feeding it. An edge deferred by the
+    // chatter window happened before this one did, so it has to be applied first or the
+    // two arrive out of order.
     Edge e;
     while (popEdge(e)) {
+        drainSequencer(e.ms);
         if (_seq.onEdge(e.ms, e.pressed) == ButtonSequencer::EV_PRESS_EDGE) {
             triggerEvent(ANY_PRESS);
         }
     }
 
-    // Resolve gestures whose window has now closed. Drain in a loop: one call can only
-    // return a single event, and a long press followed by a pending count could produce
-    // two.
-    for (;;) {
-        ButtonSequencer::Event ev = _seq.tick(now);
-        if (ev == ButtonSequencer::EV_NONE) break;
-        switch (ev) {
-            case ButtonSequencer::EV_SHORT:     triggerEvent(SHORT_PRESS); break;
-            case ButtonSequencer::EV_DOUBLE:    triggerEvent(DOUBLE_PRESS); break;
-            case ButtonSequencer::EV_TRIPLE:    triggerEvent(TRIPLE_PRESS); break;
-            case ButtonSequencer::EV_QUADRUPLE: triggerEvent(QUADRUPLE_PRESS); break;
-            case ButtonSequencer::EV_LONG:      triggerEvent(LONG_PRESS); break;
-            default: break;
-        }
-    }
+    // Resolve anything whose window has now closed.
+    drainSequencer(now);
 
     // SAFELANE §6: a dropped edge is lost user input. Report it once per occurrence
     // rather than letting a miscounted press look like a press that never happened.

--- a/examples/companion_radio/ui-orig/Button.cpp
+++ b/examples/companion_radio/ui-orig/Button.cpp
@@ -85,7 +85,7 @@ static_assert((BUTTON_EDGE_QUEUE_LEN & (BUTTON_EDGE_QUEUE_LEN - 1)) == 0,
 // Producer side. Only ever advances _q_head, which the consumer never writes. Callers
 // must guarantee it is not re-entered -- the ISR owns it outright, and update()'s poll
 // path masks interrupts around its call for exactly that reason.
-void Button::pushEdge(uint32_t ms, bool pressed) {
+void Button::pushEdge(uint32_t ms, bool pressed, bool from_isr) {
     uint8_t head = _q_head;
     uint8_t next = (uint8_t)((head + 1) & (BUTTON_EDGE_QUEUE_LEN - 1));
     if (next == _q_tail) {
@@ -94,6 +94,7 @@ void Button::pushEdge(uint32_t ms, bool pressed) {
     }
     _queue[head].ms = ms;
     _queue[head].pressed = pressed;
+    _queue[head].from_isr = from_isr;
     _q_head = next;                  // publish only after the slot is fully written
     _produced_level = pressed;
 }
@@ -104,6 +105,7 @@ bool Button::popEdge(Edge& out) {
     if (tail == _q_head) return false;
     out.ms = _queue[tail].ms;
     out.pressed = _queue[tail].pressed;
+    out.from_isr = _queue[tail].from_isr;
     _q_tail = (uint8_t)((tail + 1) & (BUTTON_EDGE_QUEUE_LEN - 1));
     return true;
 }
@@ -115,7 +117,8 @@ void Button::captureEdgeFromISR() {
     // debounces on timestamps and ignores anything that is not a transition.
     bool pressed = (digitalRead(_pin) == _activeState);
     if (pressed == _produced_level) return;   // nothing new to record
-    pushEdge(millis(), pressed);
+    _raw_isr++;
+    pushEdge(millis(), pressed, true);
 #endif
 }
 
@@ -125,14 +128,26 @@ void Button::captureEdgeFromISR() {
 void Button::drainSequencer(uint32_t at) {
     for (;;) {
         ButtonSequencer::Event ev = _seq.tick(at);
+        if (ev == ButtonSequencer::EV_NONE) return;
+        if (ev == ButtonSequencer::EV_PRESS_EDGE) { triggerEvent(ANY_PRESS); continue; }
+
+        // A gesture just resolved. Report what the PRODUCERS saw during it, before the
+        // sequencer's interpretation. A triple that logs isr=6 was captured correctly
+        // and miscounted; one that logs isr=2 was never captured at all. Those are
+        // different bugs in different layers and they look identical from the outside.
+        MESH_DEBUG_PRINTLN("[btn] capture: isr=%d poll=%d dropped=%d irq=%s",
+                           (int)_raw_isr, (int)_raw_poll, (int)_dropped,
+                           (_irq_slot >= 0) ? "armed" : "OFF");
+        _raw_isr = 0;
+        _raw_poll = 0;
+
         switch (ev) {
-            case ButtonSequencer::EV_NONE:      return;
-            case ButtonSequencer::EV_PRESS_EDGE: triggerEvent(ANY_PRESS); break;
             case ButtonSequencer::EV_SHORT:     triggerEvent(SHORT_PRESS); break;
             case ButtonSequencer::EV_DOUBLE:    triggerEvent(DOUBLE_PRESS); break;
             case ButtonSequencer::EV_TRIPLE:    triggerEvent(TRIPLE_PRESS); break;
             case ButtonSequencer::EV_QUADRUPLE: triggerEvent(QUADRUPLE_PRESS); break;
             case ButtonSequencer::EV_LONG:      triggerEvent(LONG_PRESS); break;
+            default: break;
         }
     }
 }
@@ -165,7 +180,8 @@ void Button::update() {
         if (mask) noInterrupts();
         bool level = readButton();
         if (level != _produced_level) {
-            pushEdge(now, level);
+            _raw_poll++;
+            pushEdge(now, level, false);
         }
         if (mask) interrupts();
     }
@@ -180,6 +196,11 @@ void Button::update() {
     Edge e;
     while (popEdge(e)) {
         drainSequencer(e.ms);
+        // #527 diagnostics: every edge the hardware produced, at the timestamp it was
+        // captured, naming its producer. This is the ground truth the gesture lines are
+        // derived FROM -- if a press is missing here, nothing downstream can recover it.
+        MESH_DEBUG_PRINTLN("[btn] raw t=%d %s src=%s", (int)e.ms,
+                           e.pressed ? "DOWN" : "UP", e.from_isr ? "isr" : "poll");
         if (_seq.onEdge(e.ms, e.pressed) == ButtonSequencer::EV_PRESS_EDGE) {
             triggerEvent(ANY_PRESS);
         }

--- a/examples/companion_radio/ui-orig/Button.cpp
+++ b/examples/companion_radio/ui-orig/Button.cpp
@@ -85,7 +85,7 @@ static_assert((BUTTON_EDGE_QUEUE_LEN & (BUTTON_EDGE_QUEUE_LEN - 1)) == 0,
 // Producer side. Only ever advances _q_head, which the consumer never writes. Callers
 // must guarantee it is not re-entered -- the ISR owns it outright, and update()'s poll
 // path masks interrupts around its call for exactly that reason.
-void Button::pushEdge(uint32_t ms, bool pressed, bool from_isr) {
+void Button::pushEdge(uint32_t ms, bool pressed) {
     uint8_t head = _q_head;
     uint8_t next = (uint8_t)((head + 1) & (BUTTON_EDGE_QUEUE_LEN - 1));
     if (next == _q_tail) {
@@ -94,7 +94,6 @@ void Button::pushEdge(uint32_t ms, bool pressed, bool from_isr) {
     }
     _queue[head].ms = ms;
     _queue[head].pressed = pressed;
-    _queue[head].from_isr = from_isr;
     _q_head = next;                  // publish only after the slot is fully written
     _produced_level = pressed;
 }
@@ -105,7 +104,6 @@ bool Button::popEdge(Edge& out) {
     if (tail == _q_head) return false;
     out.ms = _queue[tail].ms;
     out.pressed = _queue[tail].pressed;
-    out.from_isr = _queue[tail].from_isr;
     _q_tail = (uint8_t)((tail + 1) & (BUTTON_EDGE_QUEUE_LEN - 1));
     return true;
 }
@@ -118,7 +116,7 @@ void Button::captureEdgeFromISR() {
     bool pressed = (digitalRead(_pin) == _activeState);
     if (pressed == _produced_level) return;   // nothing new to record
     _raw_isr++;
-    pushEdge(millis(), pressed, true);
+    pushEdge(millis(), pressed);
 #endif
 }
 
@@ -131,10 +129,13 @@ void Button::drainSequencer(uint32_t at) {
         if (ev == ButtonSequencer::EV_NONE) return;
         if (ev == ButtonSequencer::EV_PRESS_EDGE) { triggerEvent(ANY_PRESS); continue; }
 
-        // A gesture just resolved. Report what the PRODUCERS saw during it, before the
-        // sequencer's interpretation. A triple that logs isr=6 was captured correctly
-        // and miscounted; one that logs isr=2 was never captured at all. Those are
-        // different bugs in different layers and they look identical from the outside.
+        // A gesture just resolved. Report what the PRODUCERS saw during it, separately
+        // from what the sequencer made of it. `isr` counts pin transitions -- two per
+        // press -- so this line distinguishes the two failures that look identical from
+        // the outside: isr=6 resolving to a SINGLE would be a counting bug, whereas a
+        // user who pressed four times and sees isr=6 has a contact that never opened.
+        // Establishing that difference took several rounds of field logs; one line per
+        // gesture, only while caplog is on, is a cheap way not to repeat them.
         MESH_DEBUG_PRINTLN("[btn] capture: isr=%d poll=%d dropped=%d irq=%s",
                            (int)_raw_isr, (int)_raw_poll, (int)_dropped,
                            (_irq_slot >= 0) ? "armed" : "OFF");
@@ -181,7 +182,7 @@ void Button::update() {
         bool level = readButton();
         if (level != _produced_level) {
             _raw_poll++;
-            pushEdge(now, level, false);
+            pushEdge(now, level);
         }
         if (mask) interrupts();
     }
@@ -196,11 +197,6 @@ void Button::update() {
     Edge e;
     while (popEdge(e)) {
         drainSequencer(e.ms);
-        // #527 diagnostics: every edge the hardware produced, at the timestamp it was
-        // captured, naming its producer. This is the ground truth the gesture lines are
-        // derived FROM -- if a press is missing here, nothing downstream can recover it.
-        MESH_DEBUG_PRINTLN("[btn] raw t=%d %s src=%s", (int)e.ms,
-                           e.pressed ? "DOWN" : "UP", e.from_isr ? "isr" : "poll");
         if (_seq.onEdge(e.ms, e.pressed) == ButtonSequencer::EV_PRESS_EDGE) {
             triggerEvent(ANY_PRESS);
         }

--- a/examples/companion_radio/ui-orig/Button.cpp
+++ b/examples/companion_radio/ui-orig/Button.cpp
@@ -77,11 +77,17 @@ bool Button::readButton() const {
     return (digitalRead(_pin) == _activeState);
 }
 
-// Producer side. Safe to call from an ISR: it only advances _q_head, which no other
-// context writes.
+// Power of two so the wrap below is a mask rather than a division -- this runs in an
+// ISR on the interrupt-capture path.
+static_assert((BUTTON_EDGE_QUEUE_LEN & (BUTTON_EDGE_QUEUE_LEN - 1)) == 0,
+              "BUTTON_EDGE_QUEUE_LEN must be a power of two");
+
+// Producer side. Only ever advances _q_head, which the consumer never writes. Callers
+// must guarantee it is not re-entered -- the ISR owns it outright, and update()'s poll
+// path masks interrupts around its call for exactly that reason.
 void Button::pushEdge(uint32_t ms, bool pressed) {
     uint8_t head = _q_head;
-    uint8_t next = (uint8_t)((head + 1) % BUTTON_EDGE_QUEUE_LEN);
+    uint8_t next = (uint8_t)((head + 1) & (BUTTON_EDGE_QUEUE_LEN - 1));
     if (next == _q_tail) {
         _dropped++;                  // full -- record the loss rather than hide it
         return;
@@ -98,7 +104,7 @@ bool Button::popEdge(Edge& out) {
     if (tail == _q_head) return false;
     out.ms = _queue[tail].ms;
     out.pressed = _queue[tail].pressed;
-    _q_tail = (uint8_t)((tail + 1) % BUTTON_EDGE_QUEUE_LEN);
+    _q_tail = (uint8_t)((tail + 1) & (BUTTON_EDGE_QUEUE_LEN - 1));
     return true;
 }
 
@@ -119,13 +125,31 @@ void Button::update() {
     // Polled producer. Under BUTTON_IRQ_CAPTURE this is a backstop: the ISR has usually
     // already published the edge and _produced_level matches, so this adds nothing. It
     // still runs, so a missed or unattachable interrupt degrades to the old sampling
-    // behaviour instead of a dead button.
+    // behaviour instead of a dead button. That matters for more than completeness: if a
+    // RELEASE edge were ever lost, the sequencer would still believe the button is held
+    // and fire a long press 3 s later -- which on the T1000-E is power-off. This resyncs
+    // within one sample.
     if ((uint32_t)(now - _lastReadTime) >= BUTTON_READ_INTERVAL_MS) {
         _lastReadTime = now;
+
+        // The ISR is the OTHER producer of this queue, so the two must take turns.
+        // pushEdge() writes a multi-word slot and then republishes _produced_level; an
+        // interrupt landing in the middle of that overwrites one of the two edges --
+        // precisely the silent-input-loss bug this whole change exists to remove. Mask
+        // across the entire read-check-push, not just the push: deciding on a level
+        // sampled before the mask can queue an edge the pin has already moved past.
+        //
+        // The window is a digitalRead plus a few stores (~1 us at 64 MHz), far short of
+        // anything the SoftDevice notices, and it is skipped outright when no interrupt
+        // is attached -- which is every non-t1000-e env, where the poll is the only
+        // producer and no masking is needed.
+        const bool mask = (_irq_slot >= 0);
+        if (mask) noInterrupts();
         bool level = readButton();
         if (level != _produced_level) {
             pushEdge(now, level);
         }
+        if (mask) interrupts();
     }
 
     // Consumer. Drain everything captured since the last call, at the timestamps the

--- a/examples/companion_radio/ui-orig/Button.h
+++ b/examples/companion_radio/ui-orig/Button.h
@@ -103,5 +103,6 @@ private:
     bool readButton() const;
     void pushEdge(uint32_t ms, bool pressed);
     bool popEdge(Edge& out);
+    void drainSequencer(uint32_t at);
     void triggerEvent(EventType event);
 };

--- a/examples/companion_radio/ui-orig/Button.h
+++ b/examples/companion_radio/ui-orig/Button.h
@@ -70,10 +70,7 @@ public:
     void captureEdgeFromISR();
 
 private:
-    // from_isr rides along so the drain can say WHICH producer saw each edge. Without
-    // it, "we captured 6 edges" cannot distinguish a working interrupt from a poll that
-    // happened to be lucky.
-    struct Edge { uint32_t ms; bool pressed; bool from_isr; };
+    struct Edge { uint32_t ms; bool pressed; };
 
     uint8_t _pin;
     bool _activeState;
@@ -91,11 +88,12 @@ private:
     volatile uint32_t _dropped = 0;
     volatile bool     _produced_level = false;   // last level PUSHED, by either producer
 
-    // #527 diagnostics: how many edges each PRODUCER actually captured, counted
-    // separately from what the sequencer made of them. This is the only way to tell a
-    // capture failure (the pin moved and we never saw it) from an interpretation
-    // failure (we saw every edge and still miscounted) -- the two have identical
-    // symptoms from the outside, and guessing between them has already cost a round.
+    // #527: how many edges each PRODUCER captured, counted separately from what the
+    // sequencer made of them. Reported once per resolved gesture. `isr` is the number
+    // of times the pin actually changed -- two per press -- so a gesture that resolves
+    // to fewer clicks than the user intended is readable straight from the log as a
+    // contact that never opened, rather than a counting bug. That distinction cost
+    // several rounds to establish; keeping the number is cheap.
     volatile uint16_t _raw_isr = 0;
     volatile uint16_t _raw_poll = 0;
 
@@ -112,7 +110,7 @@ private:
     EventCallback _onAnyPress = nullptr;
 
     bool readButton() const;
-    void pushEdge(uint32_t ms, bool pressed, bool from_isr);
+    void pushEdge(uint32_t ms, bool pressed);
     bool popEdge(Edge& out);
     void drainSequencer(uint32_t at);
     void triggerEvent(EventType event);

--- a/examples/companion_radio/ui-orig/Button.h
+++ b/examples/companion_radio/ui-orig/Button.h
@@ -2,12 +2,33 @@
 
 #include <Arduino.h>
 #include <functional>
+#include "ButtonSequencer.h"
 
-// Button timing configuration
-#define BUTTON_DEBOUNCE_TIME_MS    50      // Debounce time in ms
-#define BUTTON_CLICK_TIMEOUT_MS    500     // Max time between clicks for multi-click
-#define BUTTON_LONG_PRESS_TIME_MS  3000    // Time to trigger long press (3 seconds)
-#define BUTTON_READ_INTERVAL_MS    10      // How often to read the button
+// #527: multi-press detection reworked from polled sampling to EDGE CAPTURE.
+//
+// The public API below is unchanged -- UITask registers the same callbacks and calls
+// update() from the same place. What changed is underneath: presses are now recorded
+// with the timestamp at which they physically happened, and interpreted separately (see
+// ButtonSequencer.h). The old code could only see a press if update() happened to sample
+// while the contact was closed, so a fast triple-press on a busy loop was silently
+// delivered as a single.
+//
+// BUTTON_IRQ_CAPTURE enables a pin interrupt as the edge producer. Where it is off, the
+// poll loop produces the same edges at sampling resolution -- the state machine is
+// identical either way, so behaviour degrades to "may miss a very fast tap" rather than
+// changing shape. It is currently enabled for t1000-e only; every other env keeps the
+// polled producer.
+
+// Timing constants (debounce / click timeout / long press) live in ButtonSequencer.h so
+// the state machine can be unit-tested without Arduino, and are re-exported here by
+// inclusion for existing callers.
+
+#ifndef BUTTON_READ_INTERVAL_MS
+#define BUTTON_READ_INTERVAL_MS    10      // how often the polled producer samples
+#endif
+#ifndef BUTTON_EDGE_QUEUE_LEN
+#define BUTTON_EDGE_QUEUE_LEN      16      // captured edges buffered between update() calls
+#endif
 
 class Button {
 public:
@@ -25,10 +46,10 @@ public:
 
     Button(uint8_t pin, bool activeState = LOW);
     Button(uint8_t pin, bool activeState, bool isAnalog, uint16_t analogThreshold = 20);
-    
+
     void begin();
     void update();
-    
+
     // Set callbacks for different events
     void onShortPress(EventCallback callback) { _onShortPress = callback; }
     void onDoublePress(EventCallback callback) { _onDoublePress = callback; }
@@ -36,36 +57,41 @@ public:
     void onQuadruplePress(EventCallback callback) { _onQuadruplePress = callback; }
     void onLongPress(EventCallback callback) { _onLongPress = callback; }
     void onAnyPress(EventCallback callback) { _onAnyPress = callback; }
-    
+
     // State getters
-    bool isPressed() const { return _currentState; }
+    bool isPressed() const { return _seq.isDown(); }
     EventType getLastEvent() const { return _lastEvent; }
 
+    // #527 / SAFELANE §6: input loss must be VISIBLE, never silent. Non-zero means edges
+    // arrived faster than update() drained them and were discarded.
+    uint32_t droppedEdges() const { return _dropped; }
+
+    // Called from the pin ISR. Public only so the static trampolines can reach it.
+    void captureEdgeFromISR();
+
 private:
-    enum State {
-        IDLE,
-        PRESSED,
-        RELEASED,
-        WAITING_FOR_MULTI_CLICK
-    };
+    struct Edge { uint32_t ms; bool pressed; };
 
     uint8_t _pin;
     bool _activeState;
     bool _isAnalog;
     uint16_t _analogThreshold;
-    
-    State _state = IDLE;
-    bool _currentState;
-    bool _lastState;
-    
-    uint32_t _stateChangeTime = 0;
-    uint32_t _pressTime = 0;
-    uint32_t _releaseTime = 0;
-    uint32_t _lastReadTime = 0;
-    
-    uint8_t _clickCount = 0;
+
+    ButtonSequencer _seq;
     EventType _lastEvent = NONE;
-    
+
+    // Single-producer / single-consumer queue: the ISR (or the poll sampler) writes,
+    // update() reads. Indices are volatile and only ever advanced by their own side.
+    volatile Edge     _queue[BUTTON_EDGE_QUEUE_LEN];
+    volatile uint8_t  _q_head = 0;      // producer
+    volatile uint8_t  _q_tail = 0;      // consumer
+    volatile uint32_t _dropped = 0;
+    volatile bool     _produced_level = false;   // last level PUSHED, by either producer
+
+    uint32_t _lastReadTime = 0;
+    uint32_t _dropped_reported = 0;
+    int8_t   _irq_slot = -1;
+
     // Callbacks
     EventCallback _onShortPress = nullptr;
     EventCallback _onDoublePress = nullptr;
@@ -73,8 +99,9 @@ private:
     EventCallback _onQuadruplePress = nullptr;
     EventCallback _onLongPress = nullptr;
     EventCallback _onAnyPress = nullptr;
-    
-    bool readButton();
-    void handleStateChange();
+
+    bool readButton() const;
+    void pushEdge(uint32_t ms, bool pressed);
+    bool popEdge(Edge& out);
     void triggerEvent(EventType event);
 };

--- a/examples/companion_radio/ui-orig/Button.h
+++ b/examples/companion_radio/ui-orig/Button.h
@@ -70,7 +70,10 @@ public:
     void captureEdgeFromISR();
 
 private:
-    struct Edge { uint32_t ms; bool pressed; };
+    // from_isr rides along so the drain can say WHICH producer saw each edge. Without
+    // it, "we captured 6 edges" cannot distinguish a working interrupt from a poll that
+    // happened to be lucky.
+    struct Edge { uint32_t ms; bool pressed; bool from_isr; };
 
     uint8_t _pin;
     bool _activeState;
@@ -88,6 +91,14 @@ private:
     volatile uint32_t _dropped = 0;
     volatile bool     _produced_level = false;   // last level PUSHED, by either producer
 
+    // #527 diagnostics: how many edges each PRODUCER actually captured, counted
+    // separately from what the sequencer made of them. This is the only way to tell a
+    // capture failure (the pin moved and we never saw it) from an interpretation
+    // failure (we saw every edge and still miscounted) -- the two have identical
+    // symptoms from the outside, and guessing between them has already cost a round.
+    volatile uint16_t _raw_isr = 0;
+    volatile uint16_t _raw_poll = 0;
+
     uint32_t _lastReadTime = 0;
     uint32_t _dropped_reported = 0;
     int8_t   _irq_slot = -1;
@@ -101,7 +112,7 @@ private:
     EventCallback _onAnyPress = nullptr;
 
     bool readButton() const;
-    void pushEdge(uint32_t ms, bool pressed);
+    void pushEdge(uint32_t ms, bool pressed, bool from_isr);
     bool popEdge(Edge& out);
     void drainSequencer(uint32_t at);
     void triggerEvent(EventType event);

--- a/examples/companion_radio/ui-orig/ButtonSequencer.h
+++ b/examples/companion_radio/ui-orig/ButtonSequencer.h
@@ -23,8 +23,28 @@
 // against synthetic edges -- bursts, dropped releases, bounce storms. None of the
 // previous implementation ever had a test.
 
+// DEBOUNCE, AND WHY IT IS THIS SMALL
+//
+// Debounce is genuinely needed. Switch contacts do not close cleanly: they chatter,
+// making and breaking several times over the first few milliseconds. Feed that chatter
+// in raw and the counter increments on every spurious release -- one press reports as a
+// QUADRUPLE. That failure is no better than the one this file exists to fix.
+//
+// But it only has to outlast the CHATTER, which on a tactile dome is single-digit
+// milliseconds. The 50 ms inherited from the original implementation was ~10x that, and
+// it was destroying real input: a fast double-tap has each press and each gap well
+// under 50 ms, so the first release was thrown away, the second press stopped looking
+// like a transition, and the whole gesture collapsed into one click. 10 ms is the
+// conventional figure for this kind of switch and leaves room for taps five times
+// faster than a human can produce.
+//
+// The window is also no longer allowed to DELETE anything -- see onEdge(). An edge
+// inside the window is deferred and applied when the window closes. That matters for
+// more than counting: under the old discard rule, a tap shorter than the window lost
+// its release, the machine went on believing the button was held, and fired a LONG
+// press three seconds later -- which on the T1000-E is power-off.
 #ifndef BUTTON_DEBOUNCE_TIME_MS
-#define BUTTON_DEBOUNCE_TIME_MS    50      // ignore an edge this soon after the last accepted one
+#define BUTTON_DEBOUNCE_TIME_MS    10      // outlast contact chatter, nothing more
 #endif
 #ifndef BUTTON_CLICK_TIMEOUT_MS
 #define BUTTON_CLICK_TIMEOUT_MS    500     // max gap between clicks for multi-click
@@ -48,40 +68,42 @@ public:
   void reset() {
     _down = false; _click_count = 0; _last_edge_ms = 0;
     _down_at = 0; _up_at = 0; _long_fired = false; _armed = false;
+    _pending_valid = false; _pending_level = false;
   }
 
   // Feed one captured edge. `pressed` is the logical level (true = button down).
   // Returns EV_PRESS_EDGE when a press-down is accepted, otherwise EV_NONE --
   // multi-click results come from tick(), because they are decided by TIME.
+  //
+  // CALLERS MUST tick(ms) FIRST, draining it, before each onEdge(ms, ...). That is what
+  // keeps a deferred edge in front of the edge that follows it; Button::update() does
+  // exactly this.
   Event onEdge(uint32_t ms, bool pressed) {
-    // Debounce by TIMESTAMP COMPARISON, not by "was it stable while I watched".
-    // Contact bounce produces a burst of edges within a few ms; anything arriving
-    // sooner than the debounce window after the last accepted edge is chatter.
     if (_last_edge_ms != 0 && (uint32_t)(ms - _last_edge_ms) < BUTTON_DEBOUNCE_TIME_MS) {
+      // Inside the chatter window: DEFER, never discard. Holding only the most recent
+      // level is what makes a bounce burst collapse correctly -- down/up/down/up in
+      // 6 ms leaves whatever the contact actually settled on, and that is what gets
+      // applied when the window closes.
+      _pending_valid = true;
+      _pending_level = pressed;
       return EV_NONE;
     }
-    if (pressed == _down) return EV_NONE;      // not a transition
-    _last_edge_ms = ms;
-    _down = pressed;
-
-    if (pressed) {
-      _down_at = ms;
-      _long_fired = false;
-      return EV_PRESS_EDGE;
-    }
-    // release: count it only if it was a short press. A long press already fired
-    // from tick() and consumed the gesture.
-    if (!_long_fired && (uint32_t)(ms - _down_at) < BUTTON_LONG_PRESS_TIME_MS) {
-      if (_click_count < 250) _click_count++;
-      _up_at = ms;
-      _armed = true;                            // a multi-click window is now open
-    }
-    return EV_NONE;
+    _pending_valid = false;      // superseded by a real, in-the-clear edge
+    return acceptEdge(ms, pressed);
   }
 
   // Call with the current time, as often or as rarely as convenient. Returns at most
   // one event per call; call until it returns EV_NONE if you want to drain.
   Event tick(uint32_t now) {
+    // A deferred edge comes first: it happened before anything this call could decide.
+    if (_pending_valid &&
+        (uint32_t)(now - _last_edge_ms) >= BUTTON_DEBOUNCE_TIME_MS) {
+      uint32_t at = _last_edge_ms + BUTTON_DEBOUNCE_TIME_MS;
+      bool lvl = _pending_level;
+      _pending_valid = false;
+      Event e = acceptEdge(at, lvl);
+      if (e != EV_NONE) return e;
+    }
     // Long press while still held. Fires once, and consumes the gesture so the
     // eventual release does not also count as a click.
     if (_down && !_long_fired &&
@@ -111,9 +133,32 @@ public:
   bool    isDown()        const { return _down; }
 
 private:
+  // Apply an edge that has cleared debounce. The single place _down moves.
+  Event acceptEdge(uint32_t ms, bool pressed) {
+    if (pressed == _down) return EV_NONE;      // not a transition
+    _last_edge_ms = ms;
+    _down = pressed;
+
+    if (pressed) {
+      _down_at = ms;
+      _long_fired = false;
+      return EV_PRESS_EDGE;
+    }
+    // release: count it only if it was a short press. A long press already fired
+    // from tick() and consumed the gesture.
+    if (!_long_fired && (uint32_t)(ms - _down_at) < BUTTON_LONG_PRESS_TIME_MS) {
+      if (_click_count < 250) _click_count++;
+      _up_at = ms;
+      _armed = true;                            // a multi-click window is now open
+    }
+    return EV_NONE;
+  }
+
   bool     _down        = false;
   bool     _armed       = false;   // a release happened; a multi-click window is open
   bool     _long_fired  = false;
+  bool     _pending_valid = false; // an edge is waiting out the chatter window
+  bool     _pending_level = false;
   uint8_t  _click_count = 0;
   uint32_t _last_edge_ms = 0;
   uint32_t _down_at     = 0;

--- a/examples/companion_radio/ui-orig/ButtonSequencer.h
+++ b/examples/companion_radio/ui-orig/ButtonSequencer.h
@@ -1,0 +1,121 @@
+#pragma once
+#include <stdint.h>
+#include <stddef.h>
+
+// #527: the press-counting state machine, separated from the hardware.
+//
+// WHY THIS EXISTS AS ITS OWN THING
+//
+// The old Button did edge detection by polling: update() read the pin, and a press
+// only counted if the level was observed STABLE across samples spanning >50 ms. When
+// UITask::loop() ran late -- and on a board also servicing radio, BLE, GPS and sensors
+// it does -- a press could begin and end between two reads and be discarded entirely.
+// No counter increment, no event, no log. A dropped click was indistinguishable from
+// no click, which is exactly how a triple-press silently resolved as a single.
+//
+// This class never touches a pin. It consumes (timestamp, level) EDGES that were
+// captured when they happened, and decides what they mean whenever it is asked. A loop
+// that stalls 800 ms and then feeds it four edges stamped 120 ms apart still resolves a
+// QUADRUPLE, because it reasons about when things HAPPENED rather than when it looked.
+// Lateness costs latency, never correctness.
+//
+// It is also plain C++ with no Arduino dependency, so the whole thing is unit-testable
+// against synthetic edges -- bursts, dropped releases, bounce storms. None of the
+// previous implementation ever had a test.
+
+#ifndef BUTTON_DEBOUNCE_TIME_MS
+#define BUTTON_DEBOUNCE_TIME_MS    50      // ignore an edge this soon after the last accepted one
+#endif
+#ifndef BUTTON_CLICK_TIMEOUT_MS
+#define BUTTON_CLICK_TIMEOUT_MS    500     // max gap between clicks for multi-click
+#endif
+#ifndef BUTTON_LONG_PRESS_TIME_MS
+#define BUTTON_LONG_PRESS_TIME_MS  3000    // held this long = long press
+#endif
+
+class ButtonSequencer {
+public:
+  enum Event : uint8_t {
+    EV_NONE = 0,
+    EV_PRESS_EDGE,      // a press-down was accepted (wake the display, etc.)
+    EV_SHORT,
+    EV_DOUBLE,
+    EV_TRIPLE,
+    EV_QUADRUPLE,
+    EV_LONG,
+  };
+
+  void reset() {
+    _down = false; _click_count = 0; _last_edge_ms = 0;
+    _down_at = 0; _up_at = 0; _long_fired = false; _armed = false;
+  }
+
+  // Feed one captured edge. `pressed` is the logical level (true = button down).
+  // Returns EV_PRESS_EDGE when a press-down is accepted, otherwise EV_NONE --
+  // multi-click results come from tick(), because they are decided by TIME.
+  Event onEdge(uint32_t ms, bool pressed) {
+    // Debounce by TIMESTAMP COMPARISON, not by "was it stable while I watched".
+    // Contact bounce produces a burst of edges within a few ms; anything arriving
+    // sooner than the debounce window after the last accepted edge is chatter.
+    if (_last_edge_ms != 0 && (uint32_t)(ms - _last_edge_ms) < BUTTON_DEBOUNCE_TIME_MS) {
+      return EV_NONE;
+    }
+    if (pressed == _down) return EV_NONE;      // not a transition
+    _last_edge_ms = ms;
+    _down = pressed;
+
+    if (pressed) {
+      _down_at = ms;
+      _long_fired = false;
+      return EV_PRESS_EDGE;
+    }
+    // release: count it only if it was a short press. A long press already fired
+    // from tick() and consumed the gesture.
+    if (!_long_fired && (uint32_t)(ms - _down_at) < BUTTON_LONG_PRESS_TIME_MS) {
+      if (_click_count < 250) _click_count++;
+      _up_at = ms;
+      _armed = true;                            // a multi-click window is now open
+    }
+    return EV_NONE;
+  }
+
+  // Call with the current time, as often or as rarely as convenient. Returns at most
+  // one event per call; call until it returns EV_NONE if you want to drain.
+  Event tick(uint32_t now) {
+    // Long press while still held. Fires once, and consumes the gesture so the
+    // eventual release does not also count as a click.
+    if (_down && !_long_fired &&
+        (uint32_t)(now - _down_at) >= BUTTON_LONG_PRESS_TIME_MS) {
+      _long_fired = true;
+      _click_count = 0;
+      _armed = false;
+      return EV_LONG;
+    }
+    // Multi-click window closed -> resolve the count.
+    if (_armed && !_down && (uint32_t)(now - _up_at) >= BUTTON_CLICK_TIMEOUT_MS) {
+      uint8_t n = _click_count;
+      _click_count = 0;
+      _armed = false;
+      switch (n) {
+        case 0:  return EV_NONE;
+        case 1:  return EV_SHORT;
+        case 2:  return EV_DOUBLE;
+        case 3:  return EV_TRIPLE;
+        default: return EV_QUADRUPLE;   // 4 or more
+      }
+    }
+    return EV_NONE;
+  }
+
+  uint8_t pendingClicks() const { return _click_count; }
+  bool    isDown()        const { return _down; }
+
+private:
+  bool     _down        = false;
+  bool     _armed       = false;   // a release happened; a multi-click window is open
+  bool     _long_fired  = false;
+  uint8_t  _click_count = 0;
+  uint32_t _last_edge_ms = 0;
+  uint32_t _down_at     = 0;
+  uint32_t _up_at       = 0;
+};

--- a/test/test_button/test_button.cpp
+++ b/test/test_button/test_button.cpp
@@ -5,163 +5,287 @@
 // counter increment, no event and no log. These tests exist so that failure mode is
 // impossible to reintroduce silently -- they feed edges with explicit timestamps, the
 // way a real burst arrives, rather than depending on when a loop happened to look.
+//
+// The FIELD-CAPTURED gestures at the bottom come from the owner's own presses off the
+// device (debug_logs/serial-capture-20260802-132132.txt). He taps fast -- well under
+// 50 ms between presses -- and that is the requirement, not an edge case.
 #include <gtest/gtest.h>
+#include <vector>
 #include "../../examples/companion_radio/ui-orig/ButtonSequencer.h"
 
 using E = ButtonSequencer::Event;
 
-// Helper: press down at `t`, release at `t+hold`.
-static void click(ButtonSequencer& b, uint32_t t, uint32_t hold = 60) {
-  b.onEdge(t, true);
-  b.onEdge(t + hold, false);
-}
+// Mirrors Button::update() exactly: tick to each edge's own timestamp BEFORE feeding
+// it, so a deferred edge stays ahead of the edge behind it, and drain fully afterwards.
+// Testing against anything looser would not be testing what ships.
+struct Harness {
+  ButtonSequencer b;
+  std::vector<E> all;
 
-// Drain tick() at `now` and return the single resolved event (EV_NONE if nothing).
-static E settle(ButtonSequencer& b, uint32_t now) { return b.tick(now); }
+  Harness() { b.reset(); }
+
+  void drain(uint32_t at) {
+    for (;;) {
+      E e = b.tick(at);
+      if (e == E::EV_NONE) return;
+      all.push_back(e);
+    }
+  }
+  void edge(uint32_t ms, bool pressed) {
+    drain(ms);
+    E e = b.onEdge(ms, pressed);
+    if (e != E::EV_NONE) all.push_back(e);
+  }
+  // press down at `t`, release after `hold`
+  void tap(uint32_t t, uint32_t hold) { edge(t, true); edge(t + hold, false); }
+
+  // Resolved gestures only -- press-edge notifications are display housekeeping.
+  std::vector<E> gestures() const {
+    std::vector<E> g;
+    for (E e : all) if (e != E::EV_PRESS_EDGE) g.push_back(e);
+    return g;
+  }
+  int pressEdges() const {
+    int n = 0;
+    for (E e : all) if (e == E::EV_PRESS_EDGE) n++;
+    return n;
+  }
+};
+
+static std::vector<E> one(E e) { return std::vector<E>{e}; }
 
 // ------------------------------------------------------------------ basic counts
 TEST(Seq, SingleClick) {
-  ButtonSequencer b; b.reset();
-  click(b, 1000);
-  EXPECT_EQ(settle(b, 1000 + 60 + BUTTON_CLICK_TIMEOUT_MS), E::EV_SHORT);
+  Harness h; h.tap(1000, 60); h.drain(1060 + BUTTON_CLICK_TIMEOUT_MS);
+  EXPECT_EQ(h.gestures(), one(E::EV_SHORT));
 }
 TEST(Seq, DoubleClick) {
-  ButtonSequencer b; b.reset();
-  click(b, 1000); click(b, 1200);
-  EXPECT_EQ(settle(b, 1200 + 60 + BUTTON_CLICK_TIMEOUT_MS), E::EV_DOUBLE);
+  Harness h; h.tap(1000, 60); h.tap(1200, 60); h.drain(1260 + BUTTON_CLICK_TIMEOUT_MS);
+  EXPECT_EQ(h.gestures(), one(E::EV_DOUBLE));
 }
 TEST(Seq, TripleClick) {
-  ButtonSequencer b; b.reset();
-  click(b, 1000); click(b, 1200); click(b, 1400);
-  EXPECT_EQ(settle(b, 1400 + 60 + BUTTON_CLICK_TIMEOUT_MS), E::EV_TRIPLE);
+  Harness h; h.tap(1000, 60); h.tap(1200, 60); h.tap(1400, 60);
+  h.drain(1460 + BUTTON_CLICK_TIMEOUT_MS);
+  EXPECT_EQ(h.gestures(), one(E::EV_TRIPLE));
 }
 TEST(Seq, QuadrupleClick) {
-  ButtonSequencer b; b.reset();
-  click(b, 1000); click(b, 1150); click(b, 1300); click(b, 1450);
-  EXPECT_EQ(settle(b, 1450 + 60 + BUTTON_CLICK_TIMEOUT_MS), E::EV_QUADRUPLE);
+  Harness h;
+  for (int i = 0; i < 4; i++) h.tap(1000 + i * 150, 60);
+  h.drain(1510 + BUTTON_CLICK_TIMEOUT_MS);
+  EXPECT_EQ(h.gestures(), one(E::EV_QUADRUPLE));
 }
 TEST(Seq, FiveClicksClampToQuadruple) {
-  ButtonSequencer b; b.reset();
-  for (int i = 0; i < 5; i++) click(b, 1000 + i * 150);
-  EXPECT_EQ(settle(b, 2000 + BUTTON_CLICK_TIMEOUT_MS), E::EV_QUADRUPLE);
+  Harness h;
+  for (int i = 0; i < 5; i++) h.tap(1000 + i * 150, 60);
+  h.drain(2000 + BUTTON_CLICK_TIMEOUT_MS);
+  EXPECT_EQ(h.gestures(), one(E::EV_QUADRUPLE));
 }
 
-// -------------------------------------------------- THE FIELD FAILURE: a late loop
-// Four taps in under a second, then the consumer does not tick() for 800 ms because
-// the main loop was busy. The old implementation lost three of these outright. The
-// count must survive, because the edges carry their own timestamps.
+// ------------------------------------------------- THE FIELD FAILURE #1: a late loop
+// Four taps in under a second, then the consumer does not drain for 800 ms because the
+// main loop was busy. The old implementation lost three of these outright. The count
+// must survive, because the edges carry their own timestamps.
 TEST(Seq, LateDrainStillResolvesQuadruple) {
-  ButtonSequencer b; b.reset();
-  click(b, 1000, 80); click(b, 1160, 80); click(b, 1320, 80); click(b, 1480, 80);
-  // nothing ticks for 800ms after the last release
-  EXPECT_EQ(settle(b, 1560 + 800), E::EV_QUADRUPLE);
+  Harness h;
+  for (int i = 0; i < 4; i++) h.tap(1000 + i * 160, 80);
+  h.drain(1560 + 800);            // nothing drained for 800ms after the last release
+  EXPECT_EQ(h.gestures(), one(E::EV_QUADRUPLE));
 }
 TEST(Seq, EdgesDeliveredInOneBatchAfterStall) {
-  ButtonSequencer b; b.reset();
-  // all edges captured during a stall, fed at once, timestamps preserved
-  b.onEdge(2000, true);  b.onEdge(2070, false);
-  b.onEdge(2200, true);  b.onEdge(2270, false);
-  b.onEdge(2400, true);  b.onEdge(2470, false);
-  EXPECT_EQ(settle(b, 3500), E::EV_TRIPLE);
+  Harness h;
+  h.tap(2000, 70); h.tap(2200, 70); h.tap(2400, 70);
+  h.drain(3500);
+  EXPECT_EQ(h.gestures(), one(E::EV_TRIPLE));
 }
 
-// ------------------------------------------------------------------- press edges
+// ------------------------------------------- THE FIELD FAILURE #2: fast taps (#527)
+// The owner taps bam-bam-bam, well under 50 ms between presses. The first version of
+// this file DISCARDED any edge inside the debounce window, which erased the first
+// release, made the second press stop looking like a transition, and collapsed the
+// whole gesture into one click. These are the gestures that must work.
+TEST(Seq, FastDoubleTap_30msPress_30msGap) {
+  Harness h;
+  h.tap(1000, 30);      // down 1000, up 1030
+  h.tap(1060, 30);      // down 1060, up 1090
+  h.drain(1090 + BUTTON_CLICK_TIMEOUT_MS);
+  EXPECT_EQ(h.gestures(), one(E::EV_DOUBLE));
+  EXPECT_EQ(h.pressEdges(), 2);
+}
+TEST(Seq, FastTripleTap_UnderFiftyMsGaps) {
+  Harness h;
+  h.tap(1000, 35); h.tap(1070, 35); h.tap(1140, 35);
+  h.drain(1175 + BUTTON_CLICK_TIMEOUT_MS);
+  EXPECT_EQ(h.gestures(), one(E::EV_TRIPLE));
+  EXPECT_EQ(h.pressEdges(), 3);
+}
+TEST(Seq, FastQuadTap_WholeGestureUnder500ms) {
+  Harness h;
+  for (int i = 0; i < 4; i++) h.tap(1000 + i * 110, 40);   // whole gesture ~370ms
+  h.drain(1370 + BUTTON_CLICK_TIMEOUT_MS);
+  EXPECT_EQ(h.gestures(), one(E::EV_QUADRUPLE));
+  EXPECT_EQ(h.pressEdges(), 4);
+}
+// The narrowest gesture the 10 ms window can carry: press and gap both at the floor.
+TEST(Seq, TapsAtTheDebounceFloorStillCount) {
+  Harness h;
+  h.tap(1000, BUTTON_DEBOUNCE_TIME_MS);
+  h.tap(1000 + 2 * BUTTON_DEBOUNCE_TIME_MS, BUTTON_DEBOUNCE_TIME_MS);
+  h.drain(2000);
+  EXPECT_EQ(h.gestures(), one(E::EV_DOUBLE));
+}
+
+// ------------------------------------------------------------------ press edges
 TEST(Seq, PressEdgeReportedPerPress) {
-  ButtonSequencer b; b.reset();
-  EXPECT_EQ(b.onEdge(1000, true),  E::EV_PRESS_EDGE);
-  EXPECT_EQ(b.onEdge(1060, false), E::EV_NONE);
-  EXPECT_EQ(b.onEdge(1200, true),  E::EV_PRESS_EDGE);   // second press also reports
+  Harness h;
+  h.edge(1000, true); h.edge(1060, false); h.edge(1200, true);
+  EXPECT_EQ(h.pressEdges(), 2);
 }
 
 // ------------------------------------------------------------------ debounce
-TEST(Seq, BounceBurstCountsOnce) {
-  ButtonSequencer b; b.reset();
-  b.onEdge(1000, true);
-  b.onEdge(1003, false);   // chatter, inside debounce
-  b.onEdge(1006, true);    // chatter
-  b.onEdge(1009, false);   // chatter
-  b.onEdge(1080, false);   // real release, past debounce
-  EXPECT_EQ(settle(b, 1080 + BUTTON_CLICK_TIMEOUT_MS), E::EV_SHORT);
+// Contact chatter: make/break several times in a few ms. Must be ONE click, because
+// the deferred level is overwritten each time and only what the contact settles on is
+// ever applied.
+TEST(Seq, BounceBurstOnPressCountsOnce) {
+  Harness h;
+  h.edge(1000, true);
+  h.edge(1002, false); h.edge(1004, true); h.edge(1006, false); h.edge(1008, true);
+  h.edge(1200, false);            // real release, well clear
+  h.drain(1200 + BUTTON_CLICK_TIMEOUT_MS);
+  EXPECT_EQ(h.gestures(), one(E::EV_SHORT));
+  EXPECT_EQ(h.pressEdges(), 1);
+}
+TEST(Seq, BounceBurstOnReleaseCountsOnce) {
+  Harness h;
+  h.edge(1000, true);
+  h.edge(1100, false);
+  h.edge(1102, true); h.edge(1104, false); h.edge(1106, true); h.edge(1108, false);
+  h.drain(1200 + BUTTON_CLICK_TIMEOUT_MS);
+  EXPECT_EQ(h.gestures(), one(E::EV_SHORT));
 }
 TEST(Seq, RepeatedSameLevelIsNotATransition) {
-  ButtonSequencer b; b.reset();
-  b.onEdge(1000, true);
-  EXPECT_EQ(b.onEdge(1100, true), E::EV_NONE);   // still down, not a new press
-  b.onEdge(1200, false);
-  EXPECT_EQ(settle(b, 1200 + BUTTON_CLICK_TIMEOUT_MS), E::EV_SHORT);
+  Harness h;
+  h.edge(1000, true);
+  h.edge(1100, true);             // still down, not a new press
+  h.edge(1200, false);
+  h.drain(1200 + BUTTON_CLICK_TIMEOUT_MS);
+  EXPECT_EQ(h.gestures(), one(E::EV_SHORT));
+  EXPECT_EQ(h.pressEdges(), 1);
+}
+
+// ------------------------------------------------------- deferral, not deletion
+// A tap SHORTER than the debounce window. Under the old discard rule the release was
+// thrown away, the machine went on believing the button was held, and fired a LONG
+// press 3 s later -- power-off on the T1000-E. It must resolve as a click, and there
+// must be no LONG afterwards.
+TEST(Seq, TapShorterThanDebounceStillCountsAndNeverWedges) {
+  Harness h;
+  h.edge(1000, true);
+  h.edge(1000 + BUTTON_DEBOUNCE_TIME_MS - 5, false);   // inside the window
+  h.drain(1000 + BUTTON_DEBOUNCE_TIME_MS + BUTTON_CLICK_TIMEOUT_MS);
+  EXPECT_EQ(h.gestures(), one(E::EV_SHORT));
+  EXPECT_FALSE(h.b.isDown());
+  h.drain(1000 + 5000);                                // long past the long-press mark
+  EXPECT_EQ(h.gestures(), one(E::EV_SHORT));           // still exactly one event
+}
+TEST(Seq, DeferredEdgeAppliesEvenWithNoFurtherInput) {
+  Harness h;
+  h.edge(1000, true);
+  h.edge(1003, false);
+  EXPECT_TRUE(h.b.isDown());                           // not applied yet
+  h.drain(1000 + BUTTON_DEBOUNCE_TIME_MS);
+  EXPECT_FALSE(h.b.isDown());                          // window closed, release applied
 }
 
 // ------------------------------------------------------------------- long press
 TEST(Seq, LongPressFiresWhileHeld) {
-  ButtonSequencer b; b.reset();
-  b.onEdge(1000, true);
-  EXPECT_EQ(b.tick(1000 + BUTTON_LONG_PRESS_TIME_MS), E::EV_LONG);
+  Harness h;
+  h.edge(1000, true);
+  h.drain(1000 + BUTTON_LONG_PRESS_TIME_MS);
+  EXPECT_EQ(h.gestures(), one(E::EV_LONG));
 }
 TEST(Seq, LongPressFiresOnlyOnce) {
-  ButtonSequencer b; b.reset();
-  b.onEdge(1000, true);
-  EXPECT_EQ(b.tick(1000 + BUTTON_LONG_PRESS_TIME_MS),        E::EV_LONG);
-  EXPECT_EQ(b.tick(1000 + BUTTON_LONG_PRESS_TIME_MS + 500),  E::EV_NONE);
+  Harness h;
+  h.edge(1000, true);
+  h.drain(1000 + BUTTON_LONG_PRESS_TIME_MS);
+  h.drain(1000 + BUTTON_LONG_PRESS_TIME_MS + 500);
+  EXPECT_EQ(h.gestures(), one(E::EV_LONG));
 }
-// A long press must NOT also register as a click when released -- otherwise
-// power-off would be followed by a stray SHORT.
+// A long press must NOT also register as a click when released -- otherwise power-off
+// would be followed by a stray SHORT.
 TEST(Seq, LongPressReleaseDoesNotCountAsClick) {
-  ButtonSequencer b; b.reset();
-  b.onEdge(1000, true);
-  EXPECT_EQ(b.tick(4000), E::EV_LONG);
-  b.onEdge(4200, false);
-  EXPECT_EQ(settle(b, 4200 + BUTTON_CLICK_TIMEOUT_MS), E::EV_NONE);
+  Harness h;
+  h.edge(1000, true);
+  h.drain(4000);
+  h.edge(4200, false);
+  h.drain(4200 + BUTTON_CLICK_TIMEOUT_MS);
+  EXPECT_EQ(h.gestures(), one(E::EV_LONG));
 }
-// The old code could fire a spurious LONG_PRESS after a MISSED release, which on the
-// T1000-E means power-off. Here a release is always observed, so a held-then-released
-// press below the threshold can never become a long press.
 TEST(Seq, HeldJustUnderThresholdIsAClickNotALong) {
-  ButtonSequencer b; b.reset();
-  b.onEdge(1000, true);
-  EXPECT_EQ(b.tick(1000 + BUTTON_LONG_PRESS_TIME_MS - 1), E::EV_NONE);
-  b.onEdge(1000 + BUTTON_LONG_PRESS_TIME_MS - 1, false);
-  EXPECT_EQ(settle(b, 1000 + BUTTON_LONG_PRESS_TIME_MS + BUTTON_CLICK_TIMEOUT_MS),
-            E::EV_SHORT);
+  Harness h;
+  h.edge(1000, true);
+  h.edge(1000 + BUTTON_LONG_PRESS_TIME_MS - 1, false);
+  h.drain(1000 + BUTTON_LONG_PRESS_TIME_MS + BUTTON_CLICK_TIMEOUT_MS);
+  EXPECT_EQ(h.gestures(), one(E::EV_SHORT));
 }
 
 // ------------------------------------------------------------------- windows
 TEST(Seq, GapBeyondWindowSplitsIntoTwoSingles) {
-  ButtonSequencer b; b.reset();
-  click(b, 1000);
-  EXPECT_EQ(settle(b, 1060 + BUTTON_CLICK_TIMEOUT_MS), E::EV_SHORT);
-  click(b, 2000);
-  EXPECT_EQ(settle(b, 2060 + BUTTON_CLICK_TIMEOUT_MS), E::EV_SHORT);
+  Harness h;
+  h.tap(1000, 60); h.drain(1060 + BUTTON_CLICK_TIMEOUT_MS);
+  h.tap(2000, 60); h.drain(2060 + BUTTON_CLICK_TIMEOUT_MS);
+  EXPECT_EQ(h.gestures(), (std::vector<E>{E::EV_SHORT, E::EV_SHORT}));
 }
 TEST(Seq, NoEventBeforeWindowCloses) {
-  ButtonSequencer b; b.reset();
-  click(b, 1000); click(b, 1200);
-  EXPECT_EQ(b.tick(1260 + BUTTON_CLICK_TIMEOUT_MS - 10), E::EV_NONE);  // still open
-  EXPECT_EQ(b.tick(1260 + BUTTON_CLICK_TIMEOUT_MS),      E::EV_DOUBLE);
+  Harness h;
+  h.tap(1000, 60); h.tap(1200, 60);
+  h.drain(1260 + BUTTON_CLICK_TIMEOUT_MS - 10);
+  EXPECT_TRUE(h.gestures().empty());
+  h.drain(1260 + BUTTON_CLICK_TIMEOUT_MS);
+  EXPECT_EQ(h.gestures(), one(E::EV_DOUBLE));
 }
 TEST(Seq, ResolvesOnlyOncePerGesture) {
-  ButtonSequencer b; b.reset();
-  click(b, 1000);
-  EXPECT_EQ(settle(b, 1060 + BUTTON_CLICK_TIMEOUT_MS), E::EV_SHORT);
-  EXPECT_EQ(settle(b, 1060 + BUTTON_CLICK_TIMEOUT_MS + 1000), E::EV_NONE);
+  Harness h;
+  h.tap(1000, 60);
+  h.drain(1060 + BUTTON_CLICK_TIMEOUT_MS);
+  h.drain(1060 + BUTTON_CLICK_TIMEOUT_MS + 1000);
+  EXPECT_EQ(h.gestures(), one(E::EV_SHORT));
 }
 
 // ------------------------------------------------------------------- safety
 TEST(Seq, IdleProducesNothing) {
-  ButtonSequencer b; b.reset();
-  for (uint32_t t = 0; t < 10000; t += 250) EXPECT_EQ(b.tick(t), E::EV_NONE);
+  Harness h;
+  for (uint32_t t = 0; t < 10000; t += 250) h.drain(t);
+  EXPECT_TRUE(h.all.empty());
 }
 TEST(Seq, ResetClearsPendingGesture) {
-  ButtonSequencer b; b.reset();
-  click(b, 1000); click(b, 1200);
-  b.reset();
-  EXPECT_EQ(settle(b, 5000), E::EV_NONE);
+  Harness h;
+  h.tap(1000, 60); h.tap(1200, 60);
+  h.b.reset(); h.all.clear();
+  h.drain(5000);
+  EXPECT_TRUE(h.all.empty());
 }
 TEST(Seq, MillisWraparound) {
-  ButtonSequencer b; b.reset();
+  Harness h;
   const uint32_t near_wrap = 0xFFFFFF00u;
-  b.onEdge(near_wrap, true);
-  b.onEdge(near_wrap + 80, false);          // wraps past 0xFFFFFFFF
-  EXPECT_EQ(settle(b, near_wrap + 80 + BUTTON_CLICK_TIMEOUT_MS), E::EV_SHORT);
+  h.tap(near_wrap, 80);                               // release wraps past 0xFFFFFFFF
+  h.drain(near_wrap + 80 + BUTTON_CLICK_TIMEOUT_MS);
+  EXPECT_EQ(h.gestures(), one(E::EV_SHORT));
+}
+
+// -------------------------------------------------------- field-captured gestures
+// Real press-down timestamps from the owner's device. The triples were already being
+// counted correctly and must stay that way.
+TEST(Seq, FieldCapture_TripleAt95297) {
+  Harness h;
+  h.tap(95297, 300); h.tap(95780, 300); h.tap(96224, 379);
+  h.drain(97103);
+  EXPECT_EQ(h.gestures(), one(E::EV_TRIPLE));
+}
+TEST(Seq, FieldCapture_TripleAt111033) {
+  Harness h;
+  h.tap(111033, 250); h.tap(111393, 250); h.tap(111869, 307);
+  h.drain(112676);
+  EXPECT_EQ(h.gestures(), one(E::EV_TRIPLE));
 }
 
 int main(int argc, char **argv) { ::testing::InitGoogleTest(&argc, argv); return RUN_ALL_TESTS(); }

--- a/test/test_button/test_button.cpp
+++ b/test/test_button/test_button.cpp
@@ -1,0 +1,167 @@
+// #527: press-counting state machine tests.
+//
+// The defect this replaces: a triple-press resolved as a SINGLE on real hardware,
+// because presses that were not sampled at the right instant were discarded with no
+// counter increment, no event and no log. These tests exist so that failure mode is
+// impossible to reintroduce silently -- they feed edges with explicit timestamps, the
+// way a real burst arrives, rather than depending on when a loop happened to look.
+#include <gtest/gtest.h>
+#include "../../examples/companion_radio/ui-orig/ButtonSequencer.h"
+
+using E = ButtonSequencer::Event;
+
+// Helper: press down at `t`, release at `t+hold`.
+static void click(ButtonSequencer& b, uint32_t t, uint32_t hold = 60) {
+  b.onEdge(t, true);
+  b.onEdge(t + hold, false);
+}
+
+// Drain tick() at `now` and return the single resolved event (EV_NONE if nothing).
+static E settle(ButtonSequencer& b, uint32_t now) { return b.tick(now); }
+
+// ------------------------------------------------------------------ basic counts
+TEST(Seq, SingleClick) {
+  ButtonSequencer b; b.reset();
+  click(b, 1000);
+  EXPECT_EQ(settle(b, 1000 + 60 + BUTTON_CLICK_TIMEOUT_MS), E::EV_SHORT);
+}
+TEST(Seq, DoubleClick) {
+  ButtonSequencer b; b.reset();
+  click(b, 1000); click(b, 1200);
+  EXPECT_EQ(settle(b, 1200 + 60 + BUTTON_CLICK_TIMEOUT_MS), E::EV_DOUBLE);
+}
+TEST(Seq, TripleClick) {
+  ButtonSequencer b; b.reset();
+  click(b, 1000); click(b, 1200); click(b, 1400);
+  EXPECT_EQ(settle(b, 1400 + 60 + BUTTON_CLICK_TIMEOUT_MS), E::EV_TRIPLE);
+}
+TEST(Seq, QuadrupleClick) {
+  ButtonSequencer b; b.reset();
+  click(b, 1000); click(b, 1150); click(b, 1300); click(b, 1450);
+  EXPECT_EQ(settle(b, 1450 + 60 + BUTTON_CLICK_TIMEOUT_MS), E::EV_QUADRUPLE);
+}
+TEST(Seq, FiveClicksClampToQuadruple) {
+  ButtonSequencer b; b.reset();
+  for (int i = 0; i < 5; i++) click(b, 1000 + i * 150);
+  EXPECT_EQ(settle(b, 2000 + BUTTON_CLICK_TIMEOUT_MS), E::EV_QUADRUPLE);
+}
+
+// -------------------------------------------------- THE FIELD FAILURE: a late loop
+// Four taps in under a second, then the consumer does not tick() for 800 ms because
+// the main loop was busy. The old implementation lost three of these outright. The
+// count must survive, because the edges carry their own timestamps.
+TEST(Seq, LateDrainStillResolvesQuadruple) {
+  ButtonSequencer b; b.reset();
+  click(b, 1000, 80); click(b, 1160, 80); click(b, 1320, 80); click(b, 1480, 80);
+  // nothing ticks for 800ms after the last release
+  EXPECT_EQ(settle(b, 1560 + 800), E::EV_QUADRUPLE);
+}
+TEST(Seq, EdgesDeliveredInOneBatchAfterStall) {
+  ButtonSequencer b; b.reset();
+  // all edges captured during a stall, fed at once, timestamps preserved
+  b.onEdge(2000, true);  b.onEdge(2070, false);
+  b.onEdge(2200, true);  b.onEdge(2270, false);
+  b.onEdge(2400, true);  b.onEdge(2470, false);
+  EXPECT_EQ(settle(b, 3500), E::EV_TRIPLE);
+}
+
+// ------------------------------------------------------------------- press edges
+TEST(Seq, PressEdgeReportedPerPress) {
+  ButtonSequencer b; b.reset();
+  EXPECT_EQ(b.onEdge(1000, true),  E::EV_PRESS_EDGE);
+  EXPECT_EQ(b.onEdge(1060, false), E::EV_NONE);
+  EXPECT_EQ(b.onEdge(1200, true),  E::EV_PRESS_EDGE);   // second press also reports
+}
+
+// ------------------------------------------------------------------ debounce
+TEST(Seq, BounceBurstCountsOnce) {
+  ButtonSequencer b; b.reset();
+  b.onEdge(1000, true);
+  b.onEdge(1003, false);   // chatter, inside debounce
+  b.onEdge(1006, true);    // chatter
+  b.onEdge(1009, false);   // chatter
+  b.onEdge(1080, false);   // real release, past debounce
+  EXPECT_EQ(settle(b, 1080 + BUTTON_CLICK_TIMEOUT_MS), E::EV_SHORT);
+}
+TEST(Seq, RepeatedSameLevelIsNotATransition) {
+  ButtonSequencer b; b.reset();
+  b.onEdge(1000, true);
+  EXPECT_EQ(b.onEdge(1100, true), E::EV_NONE);   // still down, not a new press
+  b.onEdge(1200, false);
+  EXPECT_EQ(settle(b, 1200 + BUTTON_CLICK_TIMEOUT_MS), E::EV_SHORT);
+}
+
+// ------------------------------------------------------------------- long press
+TEST(Seq, LongPressFiresWhileHeld) {
+  ButtonSequencer b; b.reset();
+  b.onEdge(1000, true);
+  EXPECT_EQ(b.tick(1000 + BUTTON_LONG_PRESS_TIME_MS), E::EV_LONG);
+}
+TEST(Seq, LongPressFiresOnlyOnce) {
+  ButtonSequencer b; b.reset();
+  b.onEdge(1000, true);
+  EXPECT_EQ(b.tick(1000 + BUTTON_LONG_PRESS_TIME_MS),        E::EV_LONG);
+  EXPECT_EQ(b.tick(1000 + BUTTON_LONG_PRESS_TIME_MS + 500),  E::EV_NONE);
+}
+// A long press must NOT also register as a click when released -- otherwise
+// power-off would be followed by a stray SHORT.
+TEST(Seq, LongPressReleaseDoesNotCountAsClick) {
+  ButtonSequencer b; b.reset();
+  b.onEdge(1000, true);
+  EXPECT_EQ(b.tick(4000), E::EV_LONG);
+  b.onEdge(4200, false);
+  EXPECT_EQ(settle(b, 4200 + BUTTON_CLICK_TIMEOUT_MS), E::EV_NONE);
+}
+// The old code could fire a spurious LONG_PRESS after a MISSED release, which on the
+// T1000-E means power-off. Here a release is always observed, so a held-then-released
+// press below the threshold can never become a long press.
+TEST(Seq, HeldJustUnderThresholdIsAClickNotALong) {
+  ButtonSequencer b; b.reset();
+  b.onEdge(1000, true);
+  EXPECT_EQ(b.tick(1000 + BUTTON_LONG_PRESS_TIME_MS - 1), E::EV_NONE);
+  b.onEdge(1000 + BUTTON_LONG_PRESS_TIME_MS - 1, false);
+  EXPECT_EQ(settle(b, 1000 + BUTTON_LONG_PRESS_TIME_MS + BUTTON_CLICK_TIMEOUT_MS),
+            E::EV_SHORT);
+}
+
+// ------------------------------------------------------------------- windows
+TEST(Seq, GapBeyondWindowSplitsIntoTwoSingles) {
+  ButtonSequencer b; b.reset();
+  click(b, 1000);
+  EXPECT_EQ(settle(b, 1060 + BUTTON_CLICK_TIMEOUT_MS), E::EV_SHORT);
+  click(b, 2000);
+  EXPECT_EQ(settle(b, 2060 + BUTTON_CLICK_TIMEOUT_MS), E::EV_SHORT);
+}
+TEST(Seq, NoEventBeforeWindowCloses) {
+  ButtonSequencer b; b.reset();
+  click(b, 1000); click(b, 1200);
+  EXPECT_EQ(b.tick(1260 + BUTTON_CLICK_TIMEOUT_MS - 10), E::EV_NONE);  // still open
+  EXPECT_EQ(b.tick(1260 + BUTTON_CLICK_TIMEOUT_MS),      E::EV_DOUBLE);
+}
+TEST(Seq, ResolvesOnlyOncePerGesture) {
+  ButtonSequencer b; b.reset();
+  click(b, 1000);
+  EXPECT_EQ(settle(b, 1060 + BUTTON_CLICK_TIMEOUT_MS), E::EV_SHORT);
+  EXPECT_EQ(settle(b, 1060 + BUTTON_CLICK_TIMEOUT_MS + 1000), E::EV_NONE);
+}
+
+// ------------------------------------------------------------------- safety
+TEST(Seq, IdleProducesNothing) {
+  ButtonSequencer b; b.reset();
+  for (uint32_t t = 0; t < 10000; t += 250) EXPECT_EQ(b.tick(t), E::EV_NONE);
+}
+TEST(Seq, ResetClearsPendingGesture) {
+  ButtonSequencer b; b.reset();
+  click(b, 1000); click(b, 1200);
+  b.reset();
+  EXPECT_EQ(settle(b, 5000), E::EV_NONE);
+}
+TEST(Seq, MillisWraparound) {
+  ButtonSequencer b; b.reset();
+  const uint32_t near_wrap = 0xFFFFFF00u;
+  b.onEdge(near_wrap, true);
+  b.onEdge(near_wrap + 80, false);          // wraps past 0xFFFFFFFF
+  EXPECT_EQ(settle(b, near_wrap + 80 + BUTTON_CLICK_TIMEOUT_MS), E::EV_SHORT);
+}
+
+int main(int argc, char **argv) { ::testing::InitGoogleTest(&argc, argv); return RUN_ALL_TESTS(); }

--- a/variants/t1000-e/platformio.ini
+++ b/variants/t1000-e/platformio.ini
@@ -101,6 +101,7 @@ build_flags = ${t1000-e.build_flags}
   -D DISPLAY_CLASS=NullDisplayDriver
   -D PIN_BUZZER=25
   -D PIN_BUZZER_EN=37      ; P1/5 - required for T1000-E
+  -D BUTTON_IRQ_CAPTURE    ; #527 - interrupt edge capture for multi-press detection
 build_src_filter = ${t1000-e.build_src_filter}
   +<helpers/ui/buzzer.cpp>
   +<../examples/companion_radio/*.cpp>
@@ -127,6 +128,7 @@ build_flags = ${t1000-e.build_flags}
   -D DISPLAY_CLASS=NullDisplayDriver
   -D PIN_BUZZER=25
   -D PIN_BUZZER_EN=37      ; P1/5 - required for T1000-E
+  -D BUTTON_IRQ_CAPTURE    ; #527 - interrupt edge capture for multi-press detection
   -D ADVERT_NAME='"@@MAC"'
 build_src_filter = ${t1000-e.build_src_filter}
   +<helpers/nrf52/SerialBLEInterface.cpp>


### PR DESCRIPTION
Fixes #527. Task #551.

A triple-press on the SenseCAP T1000-E resolved as a SINGLE. Owner-verified fixed on hardware.

## Root cause

`ui-orig/Button` detected presses by **polling**: `update()` read the pin every 10 ms and only accepted a level once it had been observed stable across the 50 ms debounce window. On a loop also servicing radio, BLE, GPS and sensors, a press that began and ended between two reads was discarded outright — no counter increment, no event, no log. A dropped click was indistinguishable from no click, which is why the symptom read as "the button ignores fast presses" rather than a defect.

There were really **three** defects, found in that order, each hidden behind the previous one:

1. **Sampling** — presses not observed at the right instant were lost. Fixed by capturing edges with the timestamp at which they happened and interpreting them separately.
2. **The debounce discarded transitions.** On a fast double-tap the first release landed inside the window and was deleted, so the second press was no longer a transition and was ignored — the gesture collapsed into one click. Worse, a tap shorter than the window lost its release entirely: the machine went on believing the button was held and fired a LONG press three seconds later, **which on the T1000-E is power-off.**
3. **50 ms was ~10x the actual contact chatter** and was itself eating presses. Field logs show real releases as short as **2–3 ms**.

## Design

- **`ButtonSequencer`** — the press-counting state machine, split out with no Arduino dependency so it is unit-testable. Consumes `(timestamp, level)` edges and resolves gestures from the timestamps they carry. A loop that stalls 800 ms and then delivers four edges stamped 120 ms apart still resolves a QUADRUPLE: lateness costs latency, never correctness.
- **`Button`** — the hardware half. Captures edges into a single-producer/single-consumer queue; drains it into the sequencer.
- **Debounce defers, never deletes.** An edge inside the window is applied when the window closes. Bounce still collapses correctly because only the most recent level survives, so `down/up/down/up` in 6 ms leaves whatever the contact settled on. Window is now 10 ms.
- **`BUTTON_IRQ_CAPTURE`** adds a pin interrupt as the edge producer, enabled on the two **t1000-e companion envs only**. Every other env keeps the polled producer feeding the same state machine — no behaviour change there. Other boards deferred per owner direction; the XIAO additionally has a separate `PIN_USER_BTN` defect (P0.00 is the 32.768 kHz crystal input, not a button — the silkscreened USR is an LED), recorded on #527.
- **Queue overflow is counted and logged**, never silently eating input (SAFELANE §6).

## Review

Gemini 2.5-pro found a real defect: the queue was not actually single-producer — both the ISR and the poll path called `pushEdge()`, and an interrupt landing between the slot write and the `_q_head` publish overwrote the other's edge. The poll path now masks interrupts across its whole read-check-push (skipped entirely when no interrupt is attached, i.e. every non-t1000-e env). Log: `docs/llm-consultations/2026-08-02-527-button-irq-review-gemini-gemini-2.5-pro.log`.

## Tests

**29 native cases**, all green. The three fast-tap cases (30 ms press / 30 ms gap double, sub-50 ms-gap triple, whole-gesture-under-500 ms quad) **fail at `-DBUTTON_DEBOUNCE_TIME_MS=50` and pass at 10** — they pin the defect rather than the fix. Also covers bounce bursts on both edges, a sub-debounce tap that must not wedge into power-off, late and batched drain, long-press consumption, the multi-click window, `millis()` wraparound, and two gestures replayed from the owner's own field capture.

## Hardware verification (sensecap-t1000e-1)

Owner confirmed working, with app-side confirmation of the resulting state changes. Field logs show `irq=armed`, `poll=0`, `dropped=0`, and every gesture internally consistent — `isr=2` -> SINGLE, `isr=4` -> DOUBLE, `isr=6` -> TRIPLE, `isr=8` -> QUAD across twelve gestures.

## Retained diagnostic

One line per resolved gesture, only while caplog is enabled:

    [btn] capture: isr=6 poll=0 dropped=0 irq=armed

`isr` counts pin transitions, two per press. It is what separates the two failures that look identical from outside the device: `isr=6` resolving to a SINGLE would be a counting bug, whereas a user who pressed four times and sees `isr=6` has a contact that never opened. Establishing that difference took several rounds of field logs.

## Scope

Touches only `ui-orig/Button.{h,cpp}`, `ButtonSequencer.h`, `test/test_button/`, and two `-D BUTTON_IRQ_CAPTURE` lines in `variants/t1000-e/platformio.ini`. No overlap with the `0xC5`/caps contract surface.