### PR TITLE
fix(#554): repeater broker CLI routing — reach dispatchObserverCli from the real command terminals

### DIFF
--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -6,13 +6,18 @@
 #include <RTClib.h>
 #include "MeshLog.h"   // serial-capture sink control (#395 caplog verbs)
 
-// Plan 2 v2 Task 11: ObserverCli dispatcher hooked into handleCommand's
-// fall-through. Compiles in only when OFFBAND_OBSERVER is defined
-// (observer envs); other envs have zero impact.
-// #538: dispatchObserverCli (the broker-config CLI) is reused on the repeater
-// under OFFBAND_MQTT_POOL. ObserverCli.h declares BOTH dispatchObserverCli and
-// wifiObserverPool(); the observer pipeline header (WifiObserver.h) stays
-// observer-only. The observer keeps both includes (byte-identical).
+// Plan 2 v2 Task 11 / #538 / #554: ObserverCli dispatcher (the broker-config
+// CLI). Reached as a fall-through from the real command terminals -- bare
+// "mqtt ..." verbs in handleCommand, "set mqtt.*" in handleSetCmd, and
+// "get mqtt.*" in handleGetCmd (search "#554"). Compiles in for OFFBAND_OBSERVER
+// (observer) and OFFBAND_MQTT_POOL (repeater multi-broker pool); other envs have
+// zero impact.
+//   #554 note: the Plan 2 v2 wiring lived inside handleRegionCmd, which is only
+//   entered for "region"-prefixed input -- so mqtt verbs never reached it and the
+//   broker CLI was unreachable over serial AND over the client RemoteCommand path
+//   on the repeater. Moving it to the actual terminals fixed that.
+// ObserverCli.h declares BOTH dispatchObserverCli and wifiObserverPool(); the
+// observer pipeline header (WifiObserver.h) stays observer-only.
 #if defined(OFFBAND_OBSERVER) || defined(OFFBAND_MQTT_POOL)
   #include "wifi_observer/ObserverCli.h"
 #endif
@@ -799,6 +804,26 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
       _callbacks->formatRadioStatsReply(reply);
     } else if (sender_timestamp == 0 && memcmp(command, "stats-core", 10) == 0 && (command[10] == 0 || command[10] == ' ')) {
       _callbacks->formatStatsReply(reply);
+#if defined(OFFBAND_OBSERVER) || defined(OFFBAND_MQTT_POOL)
+    // #554: broker-config CLI fall-through for BARE "mqtt ..." verbs
+    // (status/enable/disable/view/clear). "get mqtt.*" / "set mqtt.*" are caught
+    // earlier by the "get "/"set " intercepts (-> handleGetCmd / handleSetCmd),
+    // which carry their own dispatchObserverCli fall-through.
+    //
+    // Previously the only dispatchObserverCli call site was stranded in
+    // handleRegionCmd (reachable only via a "region"-prefixed command), so the
+    // broker CLI was unreachable on the repeater (#554) -- both the serial admin
+    // console and the client-over-RemoteCommand path route through here.
+    //
+    // reply is the CLI's fixed 160-byte reply contract (e.g. serial reply[160]);
+    // handleCommand carries no reply_size, so 160 is the only size safe on every
+    // caller. dispatchObserverCli is fully snprintf-bounded to reply_size, so this
+    // never overruns; long "mqtt status" dumps truncate at 160 -- "mqtt view <N>"
+    // gives full per-broker detail within the frame.
+    } else if (offband::dispatchObserverCli(command, reply, /*reply_size=*/160,
+                                             offband::wifiObserverPool())) {
+      // handled by the broker-config CLI
+#endif
     } else {
       strcpy(reply, "Unknown command");
     }
@@ -1091,6 +1116,14 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
       _prefs->adc_multiplier = 0.0f;
       strcpy(reply, "Error: unsupported by this board");
     };
+#if defined(OFFBAND_OBSERVER) || defined(OFFBAND_MQTT_POOL)
+  // #554: "set mqtt.*" (mqtt.broker.<N>.*, mqtt.iata, mqtt.status_interval) ->
+  // broker CLI. dispatchObserverCli strips the "set " head itself. 160 = the
+  // fixed CLI reply contract (see handleCommand note); set-echo replies are short.
+  } else if (offband::dispatchObserverCli(command, reply, /*reply_size=*/160,
+                                          offband::wifiObserverPool())) {
+    // handled by the broker-config CLI
+#endif
   } else {
     strcpy(reply, "unknown config: ");
     StrHelper::strncpy(&reply[16], config, 160-17);
@@ -1279,6 +1312,14 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
     sprintf(reply, "> %u mV", _board->getBootVoltage());
 #else
     strcpy(reply, "ERROR: Power management not supported");
+#endif
+#if defined(OFFBAND_OBSERVER) || defined(OFFBAND_MQTT_POOL)
+  // #554: "get mqtt.broker.<N>.<key>" -> broker CLI (symmetric read of the
+  // "set mqtt.broker.*" surface). dispatchObserverCli strips the "get " head.
+  // 160 = the fixed CLI reply contract (see handleCommand note).
+  } else if (offband::dispatchObserverCli(command, reply, /*reply_size=*/160,
+                                          offband::wifiObserverPool())) {
+    // handled by the broker-config CLI
 #endif
   } else {
     sprintf(reply, "??: %s", config);
@@ -1472,14 +1513,10 @@ void CommonCLI::handleRegionCmd(char* command, char* reply) {
     if (len == 0) {
       strcpy(reply, "-none-");
     }
-#if defined(OFFBAND_OBSERVER) || defined(OFFBAND_MQTT_POOL)
-  } else if (offband::dispatchObserverCli(command, reply, /*reply_size=*/1024,
-                                            offband::wifiObserverPool())) {
-    // handled by the broker-config CLI (mqtt status / enable / disable /
-    // set mqtt.iata / set mqtt.status_interval / set mqtt.broker.<N>.*).
-    // #538: also active on the repeater under OFFBAND_MQTT_POOL, operating on
-    // the repeater's pool via its wifiObserverPool() accessor.
-#endif
+  // #554: the dispatchObserverCli fall-through that used to sit HERE was dead --
+  // handleRegionCmd is only entered for "region"-prefixed commands, so mqtt verbs
+  // never reached it. Moved to the real terminals of handleCommand / handleSetCmd
+  // / handleGetCmd (search "#554"). Left this note so it is not re-added here.
 #if defined(OFFBAND_CONFIG_CLI)
   } else if (offband::config::dispatchCliLine(command, reply, /*reply_size=*/1024)) {
     // #462: shared config-CLI bridge -- generic `set <key> <value>` / `get <key>`

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -549,16 +549,22 @@ void MqttBrokerPool::workerLoop() {
             static uint32_t s_rot_log_ms = 0;
             if (now - s_rot_log_ms >= 10000U) {
                 s_rot_log_ms = now;
-                char L[220]; int o = 0; uint8_t en = 0;
+                // #554: tls_cfg = configured TLS/WSS brokers the rotation
+                // scheduler tracks (rotation-eligible). This is NOT the enabled
+                // count -- it ignores cfg.enabled entirely. Do NOT confuse the
+                // "tls=" field with `mqtt status`'s "enabled=" (enabledCount()):
+                // a slot can be configured-TLS here yet disabled there. The field
+                // was previously mislabeled "en=", which read as "enabled".
+                char L[220]; int o = 0; uint8_t tls_cfg = 0;
                 for (uint8_t s = 0; s < OFFBAND_MAX_BROKERS; ++s) {
                     const MqttBroker& b = brokers_[s];
-                    if (b.isConfigured() && isTlsTransport(b.config())) en++;
+                    if (b.isConfigured() && isTlsTransport(b.config())) tls_cfg++;
                 }
                 uint32_t dwleft = (now - last_rotate_ms_ < MQTT_ROTATE_DWELL_MS)
                                   ? (MQTT_ROTATE_DWELL_MS - (now - last_rotate_ms_)) / 1000U : 0U;
                 o += snprintf(L + o, (size_t)(sizeof(L) - o),
-                              "[rot] heap=%u en=%u live=%u/%u dwleft=%us |",
-                              (unsigned)ESP.getFreeHeap(), (unsigned)en, (unsigned)tls_live,
+                              "[rot] heap=%u tls=%u live=%u/%u dwleft=%us |",
+                              (unsigned)ESP.getFreeHeap(), (unsigned)tls_cfg, (unsigned)tls_live,
                               (unsigned)OFFBAND_MAX_LIVE_TLS, (unsigned)dwleft);
                 static const char* AB[] = {"DN","CO","UP","BK","HC","HH"};
                 for (uint8_t s = 0; s < OFFBAND_MAX_BROKERS && o < (int)sizeof(L) - 24; ++s) {


### PR DESCRIPTION
## What

The repeater's broker-config CLI (`mqtt status/enable/disable/view`, `set`/`get mqtt.broker.N.*`, `set mqtt.iata`, `set mqtt.status_interval`) was **completely unreachable**. `dispatchObserverCli()` had a single call site stranded inside `handleRegionCmd()`, which `handleCommand()` only enters for `"region"`-prefixed input — so mqtt verbs fell to `Unknown command` / `unknown config` / `??:`. **Both** #538 config surfaces route through `handleCommand`:
- the serial admin console, and
- the client-over-RemoteCommand path (`runCli` → `the_mesh.handleCommand`).

…so neither worked. This predates #538 (the original Plan 2 v2 splice was already in the dead location); #538 only widened its guard and inherited the dead path.

The observer was unaffected — it reaches the dispatch via `CliPassthrough` (channel/companion admin) and the typed `CMD_OFFBAND_CONFIG` path, never via raw `handleCommand`.

## Fix

- Move the `dispatchObserverCli` fall-through to the three **real** terminals: `handleCommand` (bare `mqtt …`), `handleSetCmd` (`set mqtt.*`), `handleGetCmd` (`get mqtt.*`), guarded `#if defined(OFFBAND_OBSERVER) || defined(OFFBAND_MQTT_POOL)`.
- Delete the dead `handleRegionCmd` splice (comment left so it isn't re-added).
- `reply_size = 160` — the fixed CLI reply contract. `handleCommand` has no `reply_size` and its smallest caller buffer is the 160-byte serial stack buffer, so 160 is the only universally-safe size. **The old splice's `1024` would have overrun that stack buffer had it ever been reachable.** `dispatchObserverCli` is fully `snprintf`-bounded, so 160 never overruns; long `mqtt status` dumps truncate — `mqtt view <N>` gives full per-broker detail.
- Rename the misleading `[rot]` debug counter `en=` → `tls=`: it counts **configured TLS/WSS brokers** (rotation-eligible), *not* enabled brokers. During HW verify it read as "enabled" and looked like a CLI-vs-engine divergence — it wasn't (both read the same singleton pool; state was coherent).

## Test / verification

Host `handleCommand` routing test isn't cleanly feasible (7 collaborators + Arduino/RTClib to stub for a 1500-line TU) — **HW verify is the test-of-record**, on ST-P (`heltec_v4_repeater_telemetry_stp`):

| Command | Result | Proves |
|---|---|---|
| `mqtt status` | responds (`configured=5 enabled=0 up=0` + per-slot) | `handleCommand` routing |
| `get mqtt.broker.0.url` | `mqtt://mqtt1.okimesh.org:1883` | `handleGetCmd` routing |
| `set mqtt.broker.0.host x` | `ERROR: unknown broker field 'host'` (dispatch's error, wrote nothing) | `handleSetCmd` routing |

Broker config untouched; repeat left off.

**Builds (local):** `heltec_v4_repeater_telemetry` + `_stp` + `heltec_v4_companion_observer_wifi` (observer regression) + `heltec_v4_repeater` (bare zero-impact) — all SUCCESS. Full `ci-green` matrix is the merge gate.

**Gemini 2.5-pro reviewed** both changes (routing + rename) — no blockers.

Closes #554.
