### PR TITLE
feat(#561): caplog live syslog forward + common caplog persistence (#562)

### DIFF
--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -92,6 +92,23 @@ static uint32_t g_wifi_on_accum_ms = 0;
 static uint32_t g_wifi_on_last_check_ms = 0;
 static uint16_t g_wifi_on_pct_last_24h_x100 = 0;  // 0-10000 = 0.00-100.00%
 
+// #561: caplog live syslog forward. During an operator-armed, bounded window,
+// stream captured log lines off-device as UDP syslog datagrams to a remote sink
+// (rsyslog on the Pi) so a panic's lead-up survives the reboot the RAM ring
+// cannot hold. Compiled in only when WIFI_SYSLOG_HOST is defined (repeater
+// telemetry env); a no-op otherwise. Drains via meshLogConsume() in the MAIN
+// LOOP so the hot-path sink (mesh_log_line) is untouched.
+#ifdef WIFI_SYSLOG_HOST
+  #ifndef WIFI_SYSLOG_PORT
+    #define WIFI_SYSLOG_PORT 514
+  #endif
+  #include <WiFiUdp.h>
+  #include "../../src/MeshLog.h"
+  static WiFiUDP  g_caplog_udp;
+  static uint32_t g_caplog_fwd_until_ms = 0;   // 0 = off; else forward-window deadline
+  static void wifi_telemetry_caplog_forward_service();
+#endif
+
 // D6 / issue #60: OTA active-upload extension. While an OTA upload is in
 // progress, refresh the persistent-mode deadline on each chunk so a slow
 // upload doesn't get cut off when the user's original "wifi on N" window
@@ -503,6 +520,11 @@ static void wifi_telemetry_loop() {
     }
 #endif
 
+#ifdef WIFI_SYSLOG_HOST
+    // #561: ship any newly-captured lines while a forward window is open + WiFi up.
+    wifi_telemetry_caplog_forward_service();
+#endif
+
     if ((int32_t)(millis() - g_tel_next_publish_ms) >= 0) {
         wifi_telemetry_collect_and_publish();
         g_tel_next_publish_ms = millis() + WIFI_TELEMETRY_INTERVAL_MS;
@@ -590,6 +612,21 @@ void wifi_telemetry_set_persistent(uint32_t duration_ms) {
     // collect_and_publish will skip transport.end() because persistent is set.
     g_tel_next_publish_ms = millis();
 }
+
+#ifdef WIFI_SYSLOG_HOST
+// #561: arm/disarm caplog live syslog forward for `window_sec`. Opens the
+// forward window and brings WiFi up (persistent) for the same window so lines
+// stream live; capture-enable is done by the CLI verb. window_sec == 0 disarms.
+void wifi_telemetry_caplog_forward(uint32_t window_sec) {
+    if (window_sec == 0) {
+        g_caplog_fwd_until_ms = 0;
+        wifi_telemetry_set_persistent(0);
+        return;
+    }
+    g_caplog_fwd_until_ms = millis() + window_sec * 1000UL;
+    wifi_telemetry_set_persistent(window_sec * 1000UL);
+}
+#endif
 
 int wifi_telemetry_is_persistent(void) {
     return g_tel_persistent_until_ms != 0 ? 1 : 0;
@@ -862,6 +899,50 @@ static void wifi_telemetry_http_cmd_poll() {
     }
 }
 #endif // CMD_TRANSPORT_HTTP
+
+#ifdef WIFI_SYSLOG_HOST
+// #561: drain new caplog lines and ship each as a UDP syslog datagram. Called
+// each servicing pass while the forward window is open and WiFi is up. All I/O
+// here is network — meshLogConsume() already released the sink's critical
+// section, so nothing here can stall the capture hot path.
+static void wifi_telemetry_caplog_forward_service() {
+    if (g_caplog_fwd_until_ms == 0) return;
+    if ((int32_t)(millis() - g_caplog_fwd_until_ms) >= 0) {
+        g_caplog_fwd_until_ms = 0;   // window closed; persistent-mode auto-revert (loop) drops WiFi
+        return;
+    }
+    if (WiFi.status() != WL_CONNECTED) return;
+    static uint8_t buf[512];
+    // Bounded per call: drain ONE chunk (<=512 B, a few lines) per loop pass, NOT
+    // the whole ring. A full 16 KB ring drained in one call would be a burst of
+    // hundreds of WiFiUDP sends that can block on LwIP back-pressure and stall the
+    // main loop — starving the LoRa Dispatcher and dropping packets (fatal for a
+    // repeater). The service runs every loop pass, so the ring still drains
+    // promptly, just spread across iterations. (Gemini review #561: BLOCKER.)
+    size_t n = meshLogConsume(buf, sizeof(buf));
+    if (n > 0) {
+        // One syslog datagram per whole line (PRI 134 = local0.info). rsyslog
+        // stamps its own receive time + source host on ingest; the line already
+        // carries the device's [millis] prefix.
+        size_t start = 0;
+        for (size_t i = 0; i < n; ++i) {
+            bool eol = (buf[i] == '\n');
+            if (eol || i + 1 == n) {
+                size_t end = eol ? i : i + 1;   // exclude the trailing '\n'
+                if (end > start) {
+                    g_caplog_udp.beginPacket(WIFI_SYSLOG_HOST, WIFI_SYSLOG_PORT);
+                    // Clean RFC-3164-ish TAG so rsyslog parses programname reliably:
+                    // "caplog-<node>:" -> filter `programname startswith 'caplog-'`.
+                    g_caplog_udp.printf("<134>caplog-%s: ", WIFI_TELEMETRY_NODE_ID);
+                    g_caplog_udp.write(&buf[start], end - start);
+                    g_caplog_udp.endPacket();
+                }
+                start = i + 1;
+            }
+        }
+    }
+}
+#endif // WIFI_SYSLOG_HOST
 
 // Constructs the remote command handler + callbacks, registers the
 // transport-level message callback. Called once from wifi_telemetry_setup().

--- a/src/CaptureRing.cpp
+++ b/src/CaptureRing.cpp
@@ -63,6 +63,26 @@ size_t CaptureRing::snapshot(uint8_t* out, size_t out_cap, size_t offset) const 
   return n;
 }
 
+size_t CaptureRing::consume(uint8_t* out, size_t out_cap) {
+  if (_count == 0 || out_cap == 0) return 0;
+  size_t limit = _count < out_cap ? _count : out_cap;
+  // Take through the last '\n' that fits in out_cap so we hand back only whole
+  // lines. If no '\n' fits (a line longer than out_cap, or an unterminated
+  // trailing line), take `limit` bytes anyway so the drain always progresses.
+  size_t last_nl = 0;
+  bool found = false;
+  for (size_t i = 0; i < limit; ++i) {
+    if (_buf[ring_wrap(_tail + i, _cap)] == '\n') { last_nl = i + 1; found = true; }
+  }
+  size_t take = found ? last_nl : limit;
+  for (size_t i = 0; i < take; ++i) {
+    out[i] = _buf[ring_wrap(_tail + i, _cap)];
+  }
+  _tail = ring_wrap(_tail + take, _cap);
+  _count -= take;
+  return take;
+}
+
 void CaptureRing::clear() {
   _tail = 0;
   _count = 0;

--- a/src/CaptureRing.h
+++ b/src/CaptureRing.h
@@ -36,6 +36,14 @@ public:
   // The offset lets the download path stream the buffer in chunks.
   size_t snapshot(uint8_t* out, size_t out_cap, size_t offset = 0) const;
 
+  // #561: copy oldest WHOLE lines that fit in out_cap into out (oldest-first)
+  // and REMOVE them from the ring; returns bytes copied. Unlike snapshot (a
+  // read-only peek), consume advances past what it returns, so a log forwarder
+  // can drain new lines without tracking offsets across eviction. Always makes
+  // progress — if no '\n' fits within out_cap it takes out_cap bytes — so a
+  // drain loop never stalls.
+  size_t consume(uint8_t* out, size_t out_cap);
+
   // Drop all contents.
   void clear();
 

--- a/src/MeshLog.cpp
+++ b/src/MeshLog.cpp
@@ -88,6 +88,16 @@ size_t meshLogSnapshot(uint8_t* out, size_t out_cap, size_t offset) {
   return n;
 }
 
+size_t meshLogConsume(uint8_t* out, size_t out_cap) {
+  // #561: copy + REMOVE oldest whole lines under the lock (short critical
+  // section: pure memory move, no I/O). The caller ships `out` off-device
+  // outside the lock, then calls again until this returns 0.
+  MLOG_ENTER();
+  size_t n = g_ring.consume(out, out_cap);
+  MLOG_EXIT();
+  return n;
+}
+
 void meshLogDumpSerial() {
   // Read in small chunks, each under a brief lock, writing to Serial between
   // locks so the critical section stays short (Serial writes can block).

--- a/src/MeshLog.h
+++ b/src/MeshLog.h
@@ -70,6 +70,11 @@ size_t meshLogCapacity();
 // bytes in — lets the #396 download stream the buffer in chunks. Returns bytes
 // copied (0 when offset >= bytesUsed()).
 size_t meshLogSnapshot(uint8_t* out, size_t out_cap, size_t offset = 0);
+// #561: drain oldest whole lines into out (removing them from the ring) under
+// the sink lock; returns bytes copied. Lets a main-loop log forwarder pull new
+// lines and ship them off-device (syslog/UDP) without offset-tracking across
+// eviction. Network I/O by the caller happens OUTSIDE this lock.
+size_t meshLogConsume(uint8_t* out, size_t out_cap);
 // Stream the captured buffer to Serial in chunks (local-console `caplog dump`).
 // Best-effort: stop capture first for a clean dump. Framed remote download is #396.
 void   meshLogDumpSerial();

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -100,6 +100,9 @@ extern "C" {
   void wifi_telemetry_set_persistent(uint32_t duration_ms);
   int  wifi_telemetry_is_persistent(void);
   uint32_t wifi_telemetry_persistent_remaining_ms(void);
+#ifdef WIFI_SYSLOG_HOST
+  void wifi_telemetry_caplog_forward(uint32_t window_sec);  // #561 live syslog forward
+#endif
 #ifdef CMD_TRANSPORT_HTTP
   // LoRa#216: HTTP cmd-poll controls
   void     wifi_telemetry_cmd_poll_now(void);
@@ -128,6 +131,11 @@ static bool isValidName(const char *n) {
 }
 
 void CommonCLI::loadPrefs(FILESYSTEM* fs) {
+  // #562: common caplog defaults, set before any file load. An old prefs file
+  // predating these fields short-reads to EOF in loadPrefsInt and leaves these
+  // intact; a fresh node with no prefs file keeps them too.
+  _prefs->caplog_enabled = 0;
+  _prefs->caplog_level = MLOG_DEBUG;
   if (fs->exists("/com_prefs")) {
     loadPrefsInt(fs, "/com_prefs");   // new filename
   } else if (fs->exists("/node_prefs")) {
@@ -194,7 +202,9 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     file.read((uint8_t *)&_prefs->flood_max_advert, sizeof(_prefs->flood_max_advert));            // 293
     file.read((uint8_t *)&_prefs->ui_led_enabled, sizeof(_prefs->ui_led_enabled));                // 294
     file.read((uint8_t *)&_prefs->ui_display_mode, sizeof(_prefs->ui_display_mode));              // 295
-    // next: 296
+    file.read((uint8_t *)&_prefs->caplog_enabled, sizeof(_prefs->caplog_enabled));                // 296  (#562)
+    file.read((uint8_t *)&_prefs->caplog_level, sizeof(_prefs->caplog_level));                    // 297  (#562)
+    // next: 298
     // NOTE: radio_fem_rxgain stays at offset 291 (its pre-1.16 offset) so existing Offband prefs
     // files survive the 1.16.0 base-update; the new upstream flood fields append after it. For old
     // SPIFFS files predating a field, file.read returns 0 bytes and the field keeps its in-memory
@@ -231,6 +241,14 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     _prefs->radio_fem_rxgain = constrain(_prefs->radio_fem_rxgain, 0, 1); // boolean
     _prefs->ui_led_enabled = constrain(_prefs->ui_led_enabled, 0, 1); // boolean (#542)
     _prefs->ui_display_mode = constrain(_prefs->ui_display_mode, 0, 2); // #542 A2 tristate
+    _prefs->caplog_enabled = constrain(_prefs->caplog_enabled, 0, 1);       // #562 boolean
+    _prefs->caplog_level = constrain(_prefs->caplog_level, 0, MLOG_PACKET); // #562 level bound
+
+    // #562: apply persisted caplog state at boot (common across roles). Capture
+    // is independent of the serial mirror, so this is safe on a USB-serial
+    // companion too.
+    meshLogSetLevel(_prefs->caplog_level);
+    meshLogSetEnabled(_prefs->caplog_enabled != 0);
 
     file.close();
   }
@@ -297,7 +315,9 @@ void CommonCLI::savePrefs(FILESYSTEM* fs) {
     file.write((uint8_t *)&_prefs->flood_max_advert, sizeof(_prefs->flood_max_advert));           // 293
     file.write((uint8_t *)&_prefs->ui_led_enabled, sizeof(_prefs->ui_led_enabled));               // 294
     file.write((uint8_t *)&_prefs->ui_display_mode, sizeof(_prefs->ui_display_mode));             // 295
-    // next: 296
+    file.write((uint8_t *)&_prefs->caplog_enabled, sizeof(_prefs->caplog_enabled));              // 296  (#562)
+    file.write((uint8_t *)&_prefs->caplog_level, sizeof(_prefs->caplog_level));                  // 297  (#562)
+    // next: 298
 
     file.close();
   }
@@ -834,10 +854,38 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
       } else {
         meshLogSetLevel(lvl);
         meshLogSetEnabled(true);
+        _prefs->caplog_level = lvl;        // #562: persist so capture survives reboot
+        _prefs->caplog_enabled = 1;
+        savePrefs();
         snprintf(reply, 160, "caplog on (level %s)", meshLogLevelName(lvl));
       }
+    } else if (memcmp(command, "caplog forward", 14) == 0 && (command[14] == 0 || command[14] == ' ')) {
+      // #561: live syslog forward -- stream captured lines off-device during a
+      // bounded window (survives a reboot the RAM ring cannot). Telemetry-only.
+#if defined(ENABLE_WIFI_TELEMETRY) && defined(WIFI_SYSLOG_HOST)
+      const char* arg = (command[14] == ' ') ? &command[15] : "";
+      if (memcmp(arg, "off", 3) == 0) {
+        wifi_telemetry_caplog_forward(0);
+        meshLogSetEnabled(false);
+        _prefs->caplog_enabled = 0;
+        savePrefs();
+        strcpy(reply, "caplog forward off");
+      } else {
+        uint32_t sec = (*arg) ? (uint32_t)_atoi(arg) : 300;   // bare -> 5 min default
+        if (sec < 30) sec = 30;                                // floor: focused test
+        meshLogSetEnabled(true);
+        _prefs->caplog_enabled = 1;
+        savePrefs();
+        wifi_telemetry_caplog_forward(sec);
+        snprintf(reply, 160, "caplog forward on %us (streaming to syslog)", (unsigned)sec);
+      }
+#else
+      strcpy(reply, "caplog forward: not available on this build");
+#endif
     } else if (memcmp(command, "caplog stop", 11) == 0 && (command[11] == 0 || command[11] == ' ')) {
       meshLogSetEnabled(false);
+      _prefs->caplog_enabled = 0;          // #562: persist off across reboot
+      savePrefs();
       strcpy(reply, "caplog off");
     } else if (memcmp(command, "caplog erase", 12) == 0 && (command[12] == 0 || command[12] == ' ')) {
       meshLogClear();

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -72,6 +72,13 @@ struct NodePrefs { // persisted to file
   // #542 A2: OLED mode. 0 = auto (on, blanks after timeout — default/today), 1 = always on
   // (no blank), 2 = always off (dark). Only meaningful on builds with a DISPLAY_CLASS.
   uint8_t ui_display_mode;
+  // #562: caplog (MeshLog capture) persistence -- common across all CommonCLI
+  // roles (repeater / observer / room-server / sensor). Append-only at the END
+  // of the prefs layout. Defaulted in CommonCLI::loadPrefs() (not in-class, to
+  // keep NodePrefs an aggregate) so a role that never loads a prefs file, and an
+  // old file predating these fields, both get the common default (OFF, DEBUG).
+  uint8_t caplog_enabled; // 0 = off (default), 1 = on
+  uint8_t caplog_level;   // MLOG_* level; capture lines with level <= this
 };
 
 // #542 A2: values for NodePrefs::ui_display_mode.

--- a/test/test_capture_ring/test_capture_ring.cpp
+++ b/test/test_capture_ring/test_capture_ring.cpp
@@ -130,6 +130,67 @@ TEST(CaptureRing, SnapshotOffsetClampsToRemaining) {
   EXPECT_EQ(0, memcmp(out, "lo\n", 3));
 }
 
+// #561: consume() — the forwarder drain. Copies oldest whole lines that fit in
+// out_cap AND removes them, so a drain loop pulls new lines without tracking
+// offsets across eviction.
+TEST(CaptureRing, ConsumeReturnsAndRemovesWholeLines) {
+  uint8_t buf[64];
+  CaptureRing r(buf, sizeof(buf));
+  appendStr(r, "one\ntwo\nthree\n");        // 14 bytes
+  uint8_t out[64];
+  size_t n = r.consume(out, sizeof(out));
+  EXPECT_EQ(14u, n);
+  EXPECT_EQ(0, memcmp(out, "one\ntwo\nthree\n", 14));
+  EXPECT_EQ(0u, r.bytesUsed());              // consumed content is gone
+}
+
+TEST(CaptureRing, ConsumeTakesWholeLinesFittingInCap) {
+  uint8_t buf[64];
+  CaptureRing r(buf, sizeof(buf));
+  appendStr(r, "aaaa\nbbbb\ncccc\n");        // 15 bytes, three 5-byte lines
+  uint8_t out[12];
+  size_t n = r.consume(out, sizeof(out));    // cap 12 -> whole lines up to last '\n' <=12
+  EXPECT_EQ(10u, n);
+  EXPECT_EQ(0, memcmp(out, "aaaa\nbbbb\n", 10));
+  EXPECT_EQ(5u, r.bytesUsed());              // "cccc\n" remains
+  size_t n2 = r.consume(out, sizeof(out));
+  EXPECT_EQ(5u, n2);
+  EXPECT_EQ(0, memcmp(out, "cccc\n", 5));
+  EXPECT_EQ(0u, r.bytesUsed());
+}
+
+TEST(CaptureRing, ConsumeEmptyReturnsZero) {
+  uint8_t buf[16];
+  CaptureRing r(buf, sizeof(buf));
+  uint8_t out[16];
+  EXPECT_EQ(0u, r.consume(out, sizeof(out)));
+}
+
+TEST(CaptureRing, ConsumeThenAppendContinues) {
+  uint8_t buf[64];
+  CaptureRing r(buf, sizeof(buf));
+  uint8_t out[64];
+  appendStr(r, "first\n");
+  EXPECT_EQ(6u, r.consume(out, sizeof(out)));
+  appendStr(r, "second\n");
+  size_t n = r.consume(out, sizeof(out));
+  EXPECT_EQ(7u, n);
+  EXPECT_EQ(0, memcmp(out, "second\n", 7));
+}
+
+// A trailing unterminated line (e.g. a line truncated at MLOG_LINE_MAX) must
+// not stall the drain — consume takes it rather than waiting forever.
+TEST(CaptureRing, ConsumeNoNewlineForcesProgress) {
+  uint8_t buf[16];
+  CaptureRing r(buf, sizeof(buf));
+  appendStr(r, "abc");                       // no newline
+  uint8_t out[16];
+  size_t n = r.consume(out, sizeof(out));
+  EXPECT_EQ(3u, n);
+  EXPECT_EQ(0, memcmp(out, "abc", 3));
+  EXPECT_EQ(0u, r.bytesUsed());
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -145,6 +145,10 @@ build_flags =
   -D WIFI_TELEMETRY_MQTT_PORT=${mqtt_secrets.port}
   -D WIFI_TELEMETRY_MQTT_USER='"${mqtt_secrets.user}"'
   -D WIFI_TELEMETRY_MQTT_PASS='"${mqtt_secrets.password}"'
+  ; #561: caplog live syslog forward target -- same Pi as MQTT/cmdrelay (rsyslog
+  ; on UDP 514). Host from secrets, never a hardcoded LAN IP. Defining this
+  ; compiles the forwarder IN; leaving it undefined compiles it out (no-op).
+  -D WIFI_SYSLOG_HOST='"${mqtt_secrets.host}"'
   ; Per issue #86: shared secret for remote-OTA-trigger via MQTT command
   ; topic. Must be defined; user sets [ota_secrets] trigger_secret in
   ; platformio.local.ini. Build will fail if the section is missing.


### PR DESCRIPTION
## What

Live **caplog syslog forward** — the durable diagnostics-capture path. Captured log lines stream off-device (UDP syslog → rsyslog on the Pi) during an operator-armed **bounded window**, so a panic's lead-up survives the reboot the RAM ring cannot hold. This replaces the abandoned ring-pull design (a reboot wipes the RAM ring, so pull-on-demand can never capture pre-crash data).

Folds in **caplog persistence made common** across repeater/observer/room-server/sensor (#562; was companion-only).

## Design

- **`CaptureRing::consume()`** — line-aware drain (copy + remove oldest whole lines), eviction-safe, always makes progress (never stalls). TDD; 5 new native tests.
- **`meshLogConsume()`** — locked wrapper. The forwarder drains in the **main loop**, so the capture hot path (`mesh_log_line`, incl. LoRa RX/TX) is untouched.
- **`caplog_forward_service()`** — one UDP syslog datagram per line while the window is open + WiFi up. **Bounded per-loop drain** (Gemini BLOCKER fix): a full 16 KB ring can't burst hundreds of `WiFiUDP` sends and stall the LoRa `Dispatcher`.
- **`caplog forward [sec] / off`** CLI verb — arms the window + persistent-WiFi (reuses `wifi_telemetry_set_persistent`), disarms + stops capture on `off`. `WIFI_SYSLOG_HOST` build flag from `${mqtt_secrets.host}` (no hardcoded LAN IP).
- **Persistence (#562):** caplog `enabled`/`level` moved into the shared `CommonCLI` `NodePrefs` (append-only offsets 296/297) + boot-apply — common across all CommonCLI roles.

## Verification

- **Native tests:** `test_capture_ring` green — 5 new `consume` tests (TDD RED→GREEN), 11 existing still pass.
- **Builds:** native + `Generic_E22_sx1262_repeater` (feature-out) + `RAK_3401_repeater` (nRF52, #562) + `heltec_v4_repeater_telemetry` (feature-in). `ci-green` runs the full matrix.
- **Gemini 2.5-pro review:** one BLOCKER (unbounded main-loop drain → Dispatcher starvation) — **fixed** (bounded per-loop drain). No other findings.
- **Hardware — end-to-end on ST-P:** `caplog forward 300` → packet + debug lines landed in the Pi's `/var/log/offband-caplog.log` via rsyslog, receive-stamped + source-tagged `caplog-stp-lab`. Forwarder shipped the boot-to-now backlog + live traffic without stalling.

## Receiver setup (already applied on the Pi)

`/etc/rsyslog.d/30-offband-caplog.conf`:
```
local0.*    /var/log/offband-caplog.log
& stop
```
+ logrotate (weekly, keep 8, compress). Routing is by facility (`local0`) — parse-independent. rsyslog `imudp` on :514 already enabled.

## Notes

- The ring is RAM/non-retained, so this is the durable path; CrashLog (separate slice) remains the tool for the crash *snapshot* itself.
- #561 was re-scoped from ring-pull to this forward during the build (grounded: the RAM ring can't survive a reboot; owner-directed).

Closes #561
Closes #562
