### PR TITLE
feat(#542): Epic B1 — companion LED/display control via the 0xC5 app contract

### DIFF
--- a/docs/superpowers/plans/2026-08-03-indicator-companion-contract.md
+++ b/docs/superpowers/plans/2026-08-03-indicator-companion-contract.md
@@ -19,20 +19,42 @@
 - The matrix sub-codes (0x03/0x04) and their internal logic stay FuchsiaCreek's — this plan only
   lifts the outer buzzer gate into the scope arm and adds the led/display arms.
 
-## Execution blockers (do not start coding until both clear)
+## ⚠ CORRECTED by FuchsiaCreek coordination (msgs 375/376, 2026-08-03)
 
-1. **FuchsiaCreek confirms** the `0xC5` dispatch block isn't mid-edit by their button work (msg 374).
-2. **A1 (#546) + A2 (#548) merged.** This branch is stacked on A2; the companion prefs re-apply A1's
-   reverted companion patch and add display. Rebase onto `firmware-base` once A1+A2 land.
+Their #509/#510 work is **committed but unpushed**, so a branch scan couldn't see it. Two of this
+plan's original assumptions were wrong:
 
-## Merge-ordered shared enums (announced msg 365; re-verify before claiming)
+1. **The `0xC5` gate is ALREADY per-sub-code** on `feat/509-button-dispatch @ 5becb6aa` — the blanket
+   `#ifndef PIN_BUZZER` reject is gone (scope→`PIN_BUZZER`, matrix→`PIN_USER_BTN`). **Task 5 is no
+   longer a restructure** — it is purely additive: two predicates (`is_display_sub`/`is_led_sub`),
+   two gate arms (led runtime `board.canControlLed()` modeled on `CMD_OFFBAND_FEM_LNA` @ MyMesh.cpp:1977,
+   display compile-time `DISPLAY_CLASS`), add both bools to the `(void)` line (:1851, or `-Werror`
+   breaks on the full matrix), handlers before the unknown-sub tail (:1969).
+2. **caps2 `0x02` is TAKEN** (`OFFBAND_CAP2_BUTTON_MATRIX`, #509). **Use `0x04`.**
+
+## Execution — split by dependency
+
+- **Companion-internal half (Tasks 2, 3, 4) — DO NOW, conflict-free.** `NodePrefs`/`DataStore` prefs
+  (append after the already-**merged** `button_actions`) + `ui-new` tristate + boot-apply. Zero
+  overlap with FuchsiaCreek (they're in `ui-orig/Button*` for #527).
+- **Contract/dispatch half (Tasks 1, 5, 6) — GATED on #509/#510 landing.** Stack on their branch (not
+  `firmware-base`) so the dispatch is already per-sub-code and the registry (0x01/0x02) is settled.
+  **Owner decides** whether to land #509/#510 ahead of the #527 button work (FuchsiaCreek deferred it
+  to Ben). Also still stacked behind A1 (#546) + A2 (#548).
+
+## Merge-ordered shared enums (CORRECTED per msgs 375/376)
 
 | Allocation | Value |
 |---|---|
-| `OFFBAND_UI_DISPLAY_GET` / `SET` | `0xC5` sub `0x05` / `0x06` |
-| `OFFBAND_UI_LED_GET` / `SET` | `0xC5` sub `0x07` / `0x08` |
-| `OFFBAND_CAP2_INDICATORS` | caps byte 2 bit 1 (`0x02`) |
-| `FIRMWARE_VER_CODE` | 19 → **20** (led+display values appended to device-info) |
+| `OFFBAND_UI_DISPLAY_GET` / `SET` | `0xC5` sub `0x05` / `0x06` (free — confirmed) |
+| `OFFBAND_UI_LED_GET` / `SET` | `0xC5` sub `0x07` / `0x08` (free — confirmed) |
+| `OFFBAND_CAP2_INDICATORS` | caps byte 2 bit **2 (`0x04`)** — 0x02 taken by BUTTON_MATRIX |
+| error reason byte | **6** (`UNSUPPORTED_INDICATOR`) — 1-5 taken |
+| `FIRMWARE_VER_CODE` | **read the merged value at rebase** (20 on FuchsiaCreek's branch; do NOT hardcode 21) |
+
+**Conventions to keep in the SET arms (FuchsiaCreek):** compare-before-`savePrefs()` (a client
+`onChange` control emits a SET burst; unconditional save = flash burn), and echo the STORED value back
+(client renders what the device holds).
 
 ## Ground truth (verified)
 

--- a/docs/superpowers/plans/2026-08-03-indicator-companion-contract.md
+++ b/docs/superpowers/plans/2026-08-03-indicator-companion-contract.md
@@ -1,0 +1,349 @@
+# Indicator Companion Contract (Epic B1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the **companion** user led + display control (the light-show-off feature) through the app, by extending the `0xC5` device-UI contract — because the companion has no CLI. Firmware side only; the client UI is a separate repo (owner).
+
+**Architecture:** Companion led/display persisted in its own `NodePrefs`/`DataStore` blob; display applied through `ui-new`'s existing `setAlwaysOn` mechanism (generalized to a tristate, which also serves the observer's #141 `display always on`); exposed over the wire as new `0xC5` sub-codes and a new caps-byte-2 bit, with the `0xC5` gate generalized from "whole-command buzzer gate" to per-sub-code capability gating. Mirrors the `0xC3` FEM-LNA precedent.
+
+**Tech Stack:** C++11/Arduino-ESP32, PlatformIO, companion-API binary frames, LittleFS prefs blob.
+
+**Feature:** #542 · **Citadel:** create a B1 task before coding.
+
+## Ownership & coordination (owner-directed 2026-08-03)
+
+- **BrownHawk owns the `0xC5` gate structure** for this. **FuchsiaCreek (#509/#510) adapts** their
+  notify-scope + button-matrix work to the generalized gate; they are currently on button-press
+  detection. Coordination sent (Agent Mail msg 374). **Do not restructure the `0xC5` dispatch until
+  FuchsiaCreek confirms no in-flight conflict on that block.**
+- The matrix sub-codes (0x03/0x04) and their internal logic stay FuchsiaCreek's — this plan only
+  lifts the outer buzzer gate into the scope arm and adds the led/display arms.
+
+## Execution blockers (do not start coding until both clear)
+
+1. **FuchsiaCreek confirms** the `0xC5` dispatch block isn't mid-edit by their button work (msg 374).
+2. **A1 (#546) + A2 (#548) merged.** This branch is stacked on A2; the companion prefs re-apply A1's
+   reverted companion patch and add display. Rebase onto `firmware-base` once A1+A2 land.
+
+## Merge-ordered shared enums (announced msg 365; re-verify before claiming)
+
+| Allocation | Value |
+|---|---|
+| `OFFBAND_UI_DISPLAY_GET` / `SET` | `0xC5` sub `0x05` / `0x06` |
+| `OFFBAND_UI_LED_GET` / `SET` | `0xC5` sub `0x07` / `0x08` |
+| `OFFBAND_CAP2_INDICATORS` | caps byte 2 bit 1 (`0x02`) |
+| `FIRMWARE_VER_CODE` | 19 → **20** (led+display values appended to device-info) |
+
+## Ground truth (verified)
+
+- Companion uses **`ui-new`** UITask on all envs `[verified: platformio.ini +<ui-new/*.cpp>]`.
+- `ui-new` already has `setAlwaysOn(bool)` + `_always_on` (#141 observer applier) —
+  `[verified: ui-new/UITask.cpp:721, UITask.h:41]`. Generalizing it to a tristate serves BOTH the
+  companion display setting and the observer's existing `display always on` (reconcile folds in here).
+- `0xC5` handler at `MyMesh.cpp:1819`; hard `#ifndef PIN_BUZZER` early-return rejects the whole
+  command; Heltec V4 has no `PIN_BUZZER`. `[verified]`
+- caps byte 2 assembled at `MyMesh.cpp:2026-2033`; device-info appends at the tail, VER-gated.
+- `0xC3` FEM-LNA (`MyMesh.cpp:1942`) is the SET/GET + device-info-value template.
+- Companion `NodePrefs`/`DataStore`: led was offset 145 (A1's reverted patch); display → **146**.
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `examples/companion_radio/OffbandConfigProtocol.h` | Declare `OFFBAND_UI_DISPLAY_GET/SET`, `OFFBAND_UI_LED_GET/SET`, `OFFBAND_CAP2_INDICATORS`; document the per-sub-code gate; bump VER_CODE note |
+| `examples/companion_radio/NodePrefs.h` | Add `ui_led_enabled` (re-apply) + `ui_display_mode` |
+| `examples/companion_radio/DataStore.cpp` | Persist both at offsets 145 / 146 (append-only, matched read/write) |
+| `examples/companion_radio/MyMesh.cpp` | Defaults before loadPrefs; boot-apply led (board) + display (ui_task); generalize `0xC5` gate + add led/display sub-codes; caps2 `INDICATORS`; device-info values + VER_CODE 20 |
+| `examples/companion_radio/ui-new/UITask.h` | Add `setDisplayMode(uint8_t)`; keep `setAlwaysOn` as a thin wrapper |
+| `examples/companion_radio/ui-new/UITask.cpp` | Generalize the always-on mechanism to a tristate (auto/always-on/always-off) |
+| `examples/companion_radio/MyMesh.h` | `FIRMWARE_VER_CODE` 19 → 20 |
+
+Observer reconcile: the `#141` `display always on` applier (registered in main.cpp) calls the same
+`setDisplayMode` — no separate B2 needed; note it in the PR.
+
+---
+
+### Task 1: Contract declarations (OffbandConfigProtocol.h)
+
+**Files:** Modify `examples/companion_radio/OffbandConfigProtocol.h`
+
+- [ ] **Step 1: Verify no new sub-code / caps bit landed since msg 365**
+
+Run: `grep -nE "OFFBAND_UI_[A-Z_]+ *=|OFFBAND_CAP2_[A-Z_]+ *=" examples/companion_radio/OffbandConfigProtocol.h`
+Expected: sub-codes 0x01-0x04 + 0x7F, caps2 0x01 only. If 0x05-0x08 or caps2 0x02 are taken, STOP and re-coordinate.
+
+- [ ] **Step 2: Add the declarations**
+
+In the `0xC5` sub-code block, after `OFFBAND_UI_MATRIX_SET = 0x04`:
+
+```cpp
+// #542 B1: indicator sub-codes (led + OLED). Gated on OFFBAND_CAP2_INDICATORS, NOT on
+// the buzzer -- a display/LED setting needs no buzzer. mode: 0 auto, 1 always-on, 2 always-off.
+constexpr uint8_t OFFBAND_UI_DISPLAY_GET = 0x05;  // -> [0xC5][0x05][mode]
+constexpr uint8_t OFFBAND_UI_DISPLAY_SET = 0x06;  // [0xC5][0x06][mode] -> echo
+constexpr uint8_t OFFBAND_UI_LED_GET     = 0x07;  // -> [0xC5][0x07][on]
+constexpr uint8_t OFFBAND_UI_LED_SET     = 0x08;  // [0xC5][0x08][on] -> echo
+```
+
+Near the caps byte 2 block, after `OFFBAND_CAP2_NOTIFY_SCOPE`:
+
+```cpp
+// #542 B1: led/display runtime control present (canControlLed() || DISPLAY_CLASS).
+// Independent of NOTIFY_SCOPE: a buzzer-less display board advertises THIS but not scope.
+constexpr uint8_t OFFBAND_CAP2_INDICATORS = 0x02;
+```
+
+Update the `0xC5` header comment: the command is NO LONGER whole-gated on the buzzer; each sub-code
+is gated on its own capability (scope→PIN_BUZZER, matrix→its capability, led→canControlLed,
+display→DISPLAY_CLASS).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/companion_radio/OffbandConfigProtocol.h
+git commit -m "feat(#542): 0xC5 led/display sub-codes + INDICATORS caps bit; per-sub-code gate contract"
+```
+
+---
+
+### Task 2: Companion prefs — led (re-apply) + display
+
+**Files:** `examples/companion_radio/NodePrefs.h`, `examples/companion_radio/DataStore.cpp`
+
+- [ ] **Step 1: Re-apply A1's reverted companion led field, then add display**
+
+In `NodePrefs.h`, after `button_actions[4]`:
+
+```cpp
+  // #542: indicator prefs. LED enable (1=normal,0=off); display mode (0 auto,1 always-on,2 off).
+  // Serialized LAST in DataStore (offsets 145/146), append-only.
+  uint8_t ui_led_enabled;
+  uint8_t ui_display_mode;
+```
+
+(Base source: `docs/superpowers/epic-b-groundwork/542-companion-led-persist.patch` for the led half.)
+
+- [ ] **Step 2: Persist both (DataStore read + write, matched order)**
+
+After the `button_actions` read (offset 141):
+
+```cpp
+    file.read((uint8_t *)&_prefs.ui_led_enabled, sizeof(_prefs.ui_led_enabled));          // 145
+    file.read((uint8_t *)&_prefs.ui_display_mode, sizeof(_prefs.ui_display_mode));         // 146
+```
+
+After the `button_actions` write:
+
+```cpp
+    file.write((uint8_t *)&_prefs.ui_led_enabled, sizeof(_prefs.ui_led_enabled));          // 145
+    file.write((uint8_t *)&_prefs.ui_display_mode, sizeof(_prefs.ui_display_mode));         // 146
+```
+
+- [ ] **Step 3: Build + commit**
+
+Run: `pio run -e heltec_v4_companion_radio_ble 2>&1 | tail -6` → SUCCESS
+
+```bash
+git add examples/companion_radio/NodePrefs.h examples/companion_radio/DataStore.cpp
+git commit -m "feat(#542): persist companion ui_led_enabled + ui_display_mode (DataStore 145/146)"
+```
+
+---
+
+### Task 3: Generalize ui-new to a display tristate
+
+**Files:** `examples/companion_radio/ui-new/UITask.h`, `examples/companion_radio/ui-new/UITask.cpp`
+
+- [ ] **Step 1: Read the full ui-new blank/always-on logic first**
+
+Run: `sed -n '270,300p;680,740p' examples/companion_radio/ui-new/UITask.cpp`
+Identify where `_always_on` gates the auto-off blank in `loop()`, so the tristate extends the SAME
+gate rather than a parallel one.
+
+- [ ] **Step 2: Add `setDisplayMode` + an always-off member**
+
+In `UITask.h`, near `_always_on`:
+
+```cpp
+  uint8_t _disp_mode = 0;   // #542: 0 auto, 1 always-on, 2 always-off
+```
+
+Declare `void setDisplayMode(uint8_t mode);` and keep `void setAlwaysOn(bool on);`.
+
+- [ ] **Step 3: Implement the tristate**
+
+Replace/extend `setAlwaysOn` so it delegates, and add `setDisplayMode`:
+
+```cpp
+void UITask::setDisplayMode(uint8_t mode) {
+  _disp_mode = mode;
+  _always_on = (mode == 1);            // reuse existing blank-gate for always-on
+  if (_display == NULL) return;
+  if (mode == 2) {                     // always-off: dark now
+    if (_display->isOn()) _display->turnOff();
+  } else {                             // auto / always-on: light + fresh timeout
+    if (!_display->isOn()) _display->turnOn();
+    _auto_off = millis() + AUTO_OFF_MILLIS;
+  }
+}
+
+void UITask::setAlwaysOn(bool on) { setDisplayMode(on ? 1 : 0); }  // #141 observer applier reconciles here
+```
+
+In `loop()`, where the auto-off blank runs, add an always-off guard so mode 2 stays dark and does not
+relight on activity/newMsg (find each `_display->turnOn()` / `_auto_off = ...` activity path and gate
+it on `_disp_mode != 2`). **Enumerate every relight path in ui-new (newMsg, button, connection) — the
+grep in Step 1 lists them — and gate each.**
+
+- [ ] **Step 4: Build + commit**
+
+Run: `pio run -e heltec_v4_companion_radio_ble 2>&1 | tail -6` → SUCCESS
+
+```bash
+git add examples/companion_radio/ui-new/UITask.h examples/companion_radio/ui-new/UITask.cpp
+git commit -m "feat(#542): ui-new display tristate (generalizes #141 always-on; reconcile)"
+```
+
+---
+
+### Task 4: Defaults + boot-apply (companion)
+
+**Files:** `examples/companion_radio/MyMesh.cpp`
+
+- [ ] **Step 1: Defaults before loadPrefs**
+
+Next to the existing `_prefs.radio_fem_rxgain = 1;` init:
+
+```cpp
+  _prefs.ui_led_enabled = 1;                   // #542 default on
+  _prefs.ui_display_mode = 0;                   // #542 default auto
+```
+
+- [ ] **Step 2: Boot-apply**
+
+Where FEM LNA is applied at boot (`if (board.canControlLoRaFemLna()) ...`):
+
+```cpp
+  if (board.canControlLed()) board.setLedEnabled(_prefs.ui_led_enabled != 0);
+#ifdef DISPLAY_CLASS
+  ui_task.setDisplayMode(_prefs.ui_display_mode);
+#endif
+```
+
+- [ ] **Step 3: Build + commit** (`heltec_v4_companion_radio_ble` → SUCCESS)
+
+```bash
+git commit -am "feat(#542): companion boot-apply led + display mode from prefs"
+```
+
+---
+
+### Task 5: Generalize the 0xC5 gate + add led/display sub-codes  ⚠ COORDINATION-GATED (FuchsiaCreek)
+
+**Files:** `examples/companion_radio/MyMesh.cpp` (~1819)
+
+**Do not start until FuchsiaCreek (msg 374) confirms no in-flight edit to this block.**
+
+- [ ] **Step 1: Lift the buzzer gate into the scope arm**
+
+Remove the top-level `#ifndef PIN_BUZZER { return NO_BUZZER; }` early-return. Move that check INSIDE
+the scope sub-codes (`OFFBAND_UI_SCOPE_GET`/`SET`): if `!PIN_BUZZER`, those two arms return the same
+`OFFBAND_UI_ERR_NO_BUZZER`. Matrix arms (0x03/0x04) unchanged. **Preserve exact scope/matrix behavior.**
+
+- [ ] **Step 2: Add the led/display arms** (pattern from `0xC3`, echo the sub-code):
+
+```cpp
+    if (sub == offband::OFFBAND_UI_DISPLAY_GET) {
+      out_frame[0]=RESP_CODE_OFFBAND_DEVICE_UI; out_frame[1]=sub; out_frame[2]=_prefs.ui_display_mode;
+      _serial->writeFrame(out_frame,3); return;
+    }
+    if (sub == offband::OFFBAND_UI_DISPLAY_SET && len>=3) {
+#ifdef DISPLAY_CLASS
+      uint8_t want=cmd_frame[2];
+      if (want>2){ /* OFFBAND_UI_ERR + OFFBAND_UI_ERR_MALFORMED */ ... return; }
+      _prefs.ui_display_mode=want; savePrefs(); ui_task.setDisplayMode(want);
+      out_frame[0]=RESP_CODE_OFFBAND_DEVICE_UI; out_frame[1]=sub; out_frame[2]=want;
+      _serial->writeFrame(out_frame,3);
+#else
+      /* OFFBAND_UI_ERR + a "no display" reason */
+#endif
+      return;
+    }
+    // OFFBAND_UI_LED_GET / _SET: same shape, value 0/1, gated on board.canControlLed().
+```
+
+Add a reason byte for "unsupported indicator" to the error enum if none fits.
+
+- [ ] **Step 3: Build + commit** (`heltec_v4_companion_radio_ble`, `heltec_v4_tft_companion_radio_ble` → SUCCESS)
+
+```bash
+git commit -am "feat(#542): 0xC5 per-sub-code gate + led/display SET/GET (companion)"
+```
+
+---
+
+### Task 6: caps byte 2 INDICATORS + device-info values + VER_CODE
+
+**Files:** `examples/companion_radio/MyMesh.cpp` (caps ~2026, device-info tail), `MyMesh.h`
+
+- [ ] **Step 1: Advertise INDICATORS**
+
+At the caps2 assembly (after the `#ifdef PIN_BUZZER ... NOTIFY_SCOPE` block):
+
+```cpp
+#ifdef DISPLAY_CLASS
+    offband_caps2 |= offband::OFFBAND_CAP2_INDICATORS;
+#else
+    if (board.canControlLed()) offband_caps2 |= offband::OFFBAND_CAP2_INDICATORS;
+#endif
+```
+
+- [ ] **Step 2: Append current values to device-info** (so the client renders on connect, no GET
+round-trip — the FEM-LNA precedent). Append AFTER `offband_caps2`, unconditionally, VER-gated:
+
+```cpp
+    out_frame[i++] = _prefs.ui_led_enabled;    // v20+
+    out_frame[i++] = _prefs.ui_display_mode;   // v20+
+```
+
+- [ ] **Step 3: Bump VER_CODE** in `MyMesh.h`: `19` → `20`, with a comment noting +led/display values.
+
+- [ ] **Step 4: Build + commit**
+
+```bash
+git commit -am "feat(#542): advertise INDICATORS cap + led/display in device-info; VER_CODE 20"
+```
+
+---
+
+### Task 7: Full matrix + Gemini + hardware
+
+- [ ] **Step 1: Build matrix** — `heltec_v4_companion_radio_ble`, `_usb`, `heltec_v4_tft_companion_radio_ble`,
+  a buzzer board (`t1000-e`-class if present) to prove scope still gates on buzzer, and `RAK_4631_companion_radio_ble`. All SUCCESS.
+- [ ] **Step 2: Gemini 2.5-pro review** — scrutinize: the gate generalization preserves scope/matrix
+  behavior exactly; offsets 145/146 read==write; the ui-new tristate gates EVERY relight path for
+  always-off; device-info append + VER bump; INDICATORS advertised correctly on buzzer-less display boards.
+- [ ] **Step 3: Hardware (Tier-2 flash, explicit per-flash owner GO)** — on a Heltec V4 companion via the
+  **client app** (or a raw `0xC5` frame): set display always-off → OLED dark, persists; led off; verify
+  the buzzer-less V4 now ACCEPTS these (no NO_BUZZER). Owner-driven since it needs the app.
+- [ ] **Step 4: PR** (human merge approval). Body: the gate generalization + FuchsiaCreek coordination,
+  the observer-reconcile fold-in, Gemini findings, hardware evidence. Note client UI is a separate repo.
+
+## Deferred / out of scope
+
+- **Client UI** (`OffbandMesh/meshcore-client`) — owner's repo, consumes this contract.
+- No native test (harness can't compile MyMesh/companion API; owner-approved on-device test — as A1/A2).
+
+## Self-Review
+
+**Spec coverage (design §8 contract, §9 observer reconcile):** 0xC5 sub-codes → T1/T5; caps bit → T1/T6;
+device-info → T6; companion pref+apply → T2/T3/T4; per-sub-code gate → T5; observer reconcile → folded
+into T3 (ui-new setAlwaysOn delegates to setDisplayMode). ✓
+**Placeholders:** T3 Step 3 and T5 Step 2 require enumerating ui-new relight paths / matching the exact
+error-frame shape from the existing scope arm — both are "read-the-existing-pattern-then-mirror" steps
+with concrete greps, not vague handwaves. All new code shown.
+**Type consistency:** `ui_led_enabled`/`ui_display_mode` (uint8_t), `setDisplayMode(uint8_t)`,
+`OFFBAND_UI_{DISPLAY,LED}_{GET,SET}` 0x05-0x08, `OFFBAND_CAP2_INDICATORS` 0x02, VER 20 — consistent
+across contract, prefs, handler, caps, device-info.
+**Load-bearing risk:** T5 must preserve scope/matrix behavior byte-for-byte (FuchsiaCreek's contract) —
+the gate move is the one place a regression could hit their feature; Gemini T7-2 checks it explicitly.

--- a/examples/companion_radio/AbstractUITask.h
+++ b/examples/companion_radio/AbstractUITask.h
@@ -53,5 +53,9 @@ public:
   // Non-pure with a no-op default: implementations without a buzzer inherit the
   // default and are unaffected.
   virtual void applyBuzzerMute(bool quiet) { (void)quiet; }
+  // #542 B1: OLED mode (0 auto, 1 always-on, 2 always-off). No-op default: UIs
+  // without a controllable display inherit it and are unaffected. Applied live from
+  // the 0xC5 display SET sub-code and at boot.
+  virtual void setDisplayMode(uint8_t mode) { (void)mode; }
   virtual void loop() = 0;
 };

--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -261,6 +261,10 @@ void DataStore::loadPrefsInt(const char *filename, NodePrefs& _prefs, double& no
     // #509: button-action matrix, APPEND-ONLY after notify_scope (offsets 141..144).
     // Short-reads to EOF on pre-#509 files, leaving the caller-set defaults.
     file.read((uint8_t *)_prefs.button_actions, sizeof(_prefs.button_actions));           // 141
+    // #542 B1: indicator prefs, APPEND-ONLY after button_actions. Short-read to EOF on
+    // older files leaves the caller-set defaults (led on / display auto).
+    file.read((uint8_t *)&_prefs.ui_led_enabled, sizeof(_prefs.ui_led_enabled));          // 145
+    file.read((uint8_t *)&_prefs.ui_display_mode, sizeof(_prefs.ui_display_mode));         // 146
 
     file.close();
   }
@@ -312,6 +316,8 @@ void DataStore::savePrefs(const NodePrefs& _prefs, double node_lat, double node_
     file.write((uint8_t *)&_prefs.notify_scope, sizeof(_prefs.notify_scope));             // 140
     // #509: button-action matrix, APPEND-ONLY -- mirror of the read order. (141..144)
     file.write((uint8_t *)_prefs.button_actions, sizeof(_prefs.button_actions));           // 141
+    file.write((uint8_t *)&_prefs.ui_led_enabled, sizeof(_prefs.ui_led_enabled));          // 145 (#542 B1)
+    file.write((uint8_t *)&_prefs.ui_display_mode, sizeof(_prefs.ui_display_mode));         // 146 (#542 B1)
 
     file.close();
   }

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1258,6 +1258,8 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
   // (before loadPrefs) so a prefs file written before the field existed short-reads to
   // EOF and leaves this default in place. No-op on boards without a controllable FEM.
   _prefs.radio_fem_rxgain = 1;
+  _prefs.ui_led_enabled = 1;    // #542 B1 default: LED on (set before loadPrefs)
+  _prefs.ui_display_mode = 0;   // #542 B1 default: display auto
 
   // #510: notification scope. Default ALL = today's behaviour. Set BEFORE loadPrefs for
   // the same reason as caplog below: a prefs file written before this field existed
@@ -1404,6 +1406,11 @@ void MyMesh::begin(bool has_display) {
   // which needs a matching client change; until that ships the pref stays at its default.
   if (board.canControlLoRaFemLna()) {
     board.setLoRaFemLnaEnabled(_prefs.radio_fem_rxgain != 0);
+  }
+  // #542 B1: apply persisted LED enable. No-op on boards without a controllable LED.
+  // (Display mode is applied by ui_task.begin(), which reads the pref directly.)
+  if (board.canControlLed()) {
+    board.setLedEnabled(_prefs.ui_led_enabled != 0);
   }
 }
 
@@ -1833,6 +1840,11 @@ void MyMesh::handleCmdFrame(size_t len) {
                                 sub == offband::OFFBAND_UI_SCOPE_SET);
     const bool is_matrix_sub = (sub == offband::OFFBAND_UI_MATRIX_GET ||
                                 sub == offband::OFFBAND_UI_MATRIX_SET);
+    // #542 B1: indicator sub-codes, gated on their own capability (not the buzzer).
+    const bool is_display_sub = (sub == offband::OFFBAND_UI_DISPLAY_GET ||
+                                 sub == offband::OFFBAND_UI_DISPLAY_SET);
+    const bool is_led_sub     = (sub == offband::OFFBAND_UI_LED_GET ||
+                                 sub == offband::OFFBAND_UI_LED_SET);
 #ifndef PIN_BUZZER
     if (is_scope_sub) {
       out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
@@ -1851,7 +1863,26 @@ void MyMesh::handleCmdFrame(size_t len) {
       return;
     }
 #endif
-    (void)is_scope_sub; (void)is_matrix_sub;
+    // #542 B1: display needs a display (compile-time DISPLAY_CLASS); led needs a
+    // controllable LED (runtime, like FEM LNA). Same NO_BUZZER-style typed error so
+    // the client shows WHY, not a bare illegal-arg.
+#ifndef DISPLAY_CLASS
+    if (is_display_sub) {
+      out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+      out_frame[1] = offband::OFFBAND_UI_ERR;
+      out_frame[2] = offband::OFFBAND_UI_ERR_UNSUPPORTED_INDICATOR;
+      _serial->writeFrame(out_frame, 3);
+      return;
+    }
+#endif
+    if (is_led_sub && !board.canControlLed()) {
+      out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+      out_frame[1] = offband::OFFBAND_UI_ERR;
+      out_frame[2] = offband::OFFBAND_UI_ERR_UNSUPPORTED_INDICATOR;
+      _serial->writeFrame(out_frame, 3);
+      return;
+    }
+    (void)is_scope_sub; (void)is_matrix_sub; (void)is_display_sub; (void)is_led_sub;
 {
     if (sub == offband::OFFBAND_UI_SCOPE_GET) {
       out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
@@ -1969,6 +2000,57 @@ void MyMesh::handleCmdFrame(size_t len) {
       _serial->writeFrame(out_frame, 4);
       return;
     }
+    // #542 B1: OLED mode (0 auto, 1 always-on, 2 always-off). Gated above on DISPLAY_CLASS.
+    if (sub == offband::OFFBAND_UI_DISPLAY_GET) {
+      out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+      out_frame[1] = sub;
+      out_frame[2] = _prefs.ui_display_mode;
+      _serial->writeFrame(out_frame, 3);
+      return;
+    }
+    if (sub == offband::OFFBAND_UI_DISPLAY_SET && len >= 3) {
+      uint8_t want = cmd_frame[2];
+      if (want > 2) {
+        out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+        out_frame[1] = offband::OFFBAND_UI_ERR;
+        out_frame[2] = offband::OFFBAND_UI_ERR_MALFORMED;
+        _serial->writeFrame(out_frame, 3);
+        return;
+      }
+      // Persist only on a real change -- a client control bound to onChange can emit a
+      // SET burst; an unconditional savePrefs() would put that burst on flash.
+      if (_prefs.ui_display_mode != want) {
+        _prefs.ui_display_mode = want;
+        savePrefs();
+      }
+      if (_ui) _ui->setDisplayMode(want);   // apply live
+      out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+      out_frame[1] = sub;
+      out_frame[2] = _prefs.ui_display_mode;   // echo stored value
+      _serial->writeFrame(out_frame, 3);
+      return;
+    }
+    // #542 B1: status/traffic LED. Gated above on board.canControlLed().
+    if (sub == offband::OFFBAND_UI_LED_GET) {
+      out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+      out_frame[1] = sub;
+      out_frame[2] = _prefs.ui_led_enabled ? 1 : 0;
+      _serial->writeFrame(out_frame, 3);
+      return;
+    }
+    if (sub == offband::OFFBAND_UI_LED_SET && len >= 3) {
+      uint8_t want = cmd_frame[2] ? 1 : 0;
+      if (_prefs.ui_led_enabled != want) {
+        _prefs.ui_led_enabled = want;
+        savePrefs();
+      }
+      board.setLedEnabled(want != 0);   // apply live
+      out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
+      out_frame[1] = sub;
+      out_frame[2] = _prefs.ui_led_enabled ? 1 : 0;
+      _serial->writeFrame(out_frame, 3);
+      return;
+    }
     // Unknown sub-code -> typed error, never a silent fall-through.
     out_frame[0] = offband::RESP_CODE_OFFBAND_DEVICE_UI;
     out_frame[1] = offband::OFFBAND_UI_ERR;
@@ -2074,7 +2156,19 @@ void MyMesh::handleCmdFrame(size_t len) {
     // board may have either without the other.
     offband_caps2 |= offband::OFFBAND_CAP2_BUTTON_MATRIX;
 #endif
+    // #542 B1: led/display indicator control. DISPLAY_CLASS boards always advertise it
+    // (they have an OLED); non-display boards advertise it only if the LED is controllable.
+    // Independent of NOTIFY_SCOPE so a buzzer-less display board still gets the control.
+#ifdef DISPLAY_CLASS
+    offband_caps2 |= offband::OFFBAND_CAP2_INDICATORS;
+#else
+    if (board.canControlLed()) offband_caps2 |= offband::OFFBAND_CAP2_INDICATORS;
+#endif
     out_frame[i++] = offband_caps2;          // v18+
+    // #542 B1: current indicator state, so the client renders the toggles on connect
+    // with no extra GET round-trip (the FEM-LNA precedent). Appended UNCONDITIONALLY.
+    out_frame[i++] = _prefs.ui_led_enabled;   // v21+
+    out_frame[i++] = _prefs.ui_display_mode;  // v21+
     _serial->writeFrame(out_frame, i);
   } else if (cmd_frame[0] == CMD_APP_START &&
              len >= 8) { // sent when app establishes connection, respond with node ID

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -19,7 +19,7 @@
 // bumps the code even without a frame-layout change -- 17 was "+ caplog cap bit
 // (0x20)", 16 was "FEM LNA cap 0x04 / 0xC3". This change sets caps2 bit 0x01 and adds
 // the 0xC5 command, so it follows the same rule.
-#define FIRMWARE_VER_CODE 20   // #509: + caps2 bit 0x02 BUTTON_MATRIX (gated on PIN_USER_BTN). Prior 19 (#510): caps2 bit 0x01 NOTIFY_SCOPE + 0xC5. Prior 18 (#508): second caps byte at offset 84
+#define FIRMWARE_VER_CODE 21   // #542: + caps2 bit 0x04 INDICATORS + 0xC5 led/display sub-codes + led/display state in device-info. Prior 20 (#509): caps2 0x02 BUTTON_MATRIX. Prior 19 (#510): caps2 0x01 NOTIFY_SCOPE + 0xC5. Prior 18 (#508): second caps byte at offset 84
 
 #ifndef FIRMWARE_BUILD_DATE
 #define FIRMWARE_BUILD_DATE "6 Jun 2026"

--- a/examples/companion_radio/NodePrefs.h
+++ b/examples/companion_radio/NodePrefs.h
@@ -68,6 +68,11 @@ struct NodePrefs {  // persisted to file
   // escape hatch and must never be user-remappable, or a bad assignment can leave a
   // board unrecoverable.
   uint8_t button_actions[4];
+  // #542 B1: indicator prefs — LED enable (1=normal, 0=off) and OLED mode
+  // (0 auto, 1 always-on, 2 always-off). Serialized LAST in DataStore (offsets
+  // 145/146), append-only — same flat-stream reason as the fields above.
+  uint8_t ui_led_enabled;
+  uint8_t ui_display_mode;
 };
 
 // #509: button-sequence indices. Order is the press count, so the array index IS the

--- a/examples/companion_radio/OffbandConfigProtocol.h
+++ b/examples/companion_radio/OffbandConfigProtocol.h
@@ -101,6 +101,12 @@ constexpr uint8_t OFFBAND_UI_SCOPE_GET  = 0x01;
 constexpr uint8_t OFFBAND_UI_SCOPE_SET  = 0x02;
 constexpr uint8_t OFFBAND_UI_MATRIX_GET = 0x03;
 constexpr uint8_t OFFBAND_UI_MATRIX_SET = 0x04;
+// #542 B1: indicator sub-codes. Gated on OFFBAND_CAP2_INDICATORS (NOT the buzzer) --
+// a display/LED setting needs no buzzer. display mode: 0 auto, 1 always-on, 2 always-off.
+constexpr uint8_t OFFBAND_UI_DISPLAY_GET = 0x05;  // -> [0xC5][0x05][mode]
+constexpr uint8_t OFFBAND_UI_DISPLAY_SET = 0x06;  // [0xC5][0x06][mode] -> echo
+constexpr uint8_t OFFBAND_UI_LED_GET     = 0x07;  // -> [0xC5][0x07][on]
+constexpr uint8_t OFFBAND_UI_LED_SET     = 0x08;  // [0xC5][0x08][on]   -> echo
 constexpr uint8_t OFFBAND_UI_ERR        = 0x7F;
 // error reason bytes
 constexpr uint8_t OFFBAND_UI_ERR_UNSUPPORTED_ACTION = 1;
@@ -108,6 +114,7 @@ constexpr uint8_t OFFBAND_UI_ERR_UNKNOWN_SEQUENCE   = 2;
 constexpr uint8_t OFFBAND_UI_ERR_NO_BUZZER          = 3;
 constexpr uint8_t OFFBAND_UI_ERR_NO_GPS             = 4;
 constexpr uint8_t OFFBAND_UI_ERR_MALFORMED          = 5;
+constexpr uint8_t OFFBAND_UI_ERR_UNSUPPORTED_INDICATOR = 6;  // #542 B1: no controllable LED/display
 constexpr uint8_t CMD_OFFBAND_CONFIG       = 0xC0;  // request:  cmd_frame[0]
 constexpr uint8_t RESP_CODE_OFFBAND_CONFIG = 0xC0;  // response: out_frame[0]
 
@@ -212,7 +219,8 @@ enum MqttAuthType  : uint8_t { MQTT_AUTH_NONE = 0, MQTT_AUTH_BASIC = 1, MQTT_AUT
 //   ---  -----  ----------------------------  ----------  --------------------------
 //    0   0x01   OFFBAND_CAP2_NOTIFY_SCOPE     this change  #510
 //    1   0x02   OFFBAND_CAP2_BUTTON_MATRIX    this change  #509
-//    2-7 0x04.. -- free --
+//    2   0x04   OFFBAND_CAP2_INDICATORS      this change  #542
+//    3-7 0x08.. -- free --
 // ===============================================================================
 // bit 0 (0x01): device notification scope ALL/SELF/NONE is supported and settable.
 // Set only where the device can actually make a sound -- gated on PIN_BUZZER, exactly
@@ -224,6 +232,10 @@ constexpr uint8_t OFFBAND_CAP2_NOTIFY_SCOPE = 0x01;
 // speaker. A board with a button and no buzzer can still map "send advert" to double
 // press, so gating this on the buzzer would refuse a feature the hardware can do.
 constexpr uint8_t OFFBAND_CAP2_BUTTON_MATRIX = 0x02;
+// bit 2 (0x04): led/display indicator control is supported and settable. Gated on
+// canControlLed() || DISPLAY_CLASS, independent of NOTIFY_SCOPE -- a buzzer-less display
+// board (e.g. Heltec V4) advertises THIS but not scope. #542 B1.
+constexpr uint8_t OFFBAND_CAP2_INDICATORS = 0x04;
 constexpr uint8_t OFFBAND_CAP_WIFI_OBSERVER = 0x01;  // bit 0: config backend (wifi_observer) compiled in
 constexpr uint8_t OFFBAND_CAP_BLOCK         = 0x02;  // bit 1: user-block list (BlockStore) compiled in (#241)
 constexpr uint8_t OFFBAND_CAP_FEM_LNA       = 0x04;  // bit 2: FEM LNA runtime control available (#298)

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -693,8 +693,15 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
 
   _node_prefs = node_prefs;
 
+  // #542 B1: seed the display mode from prefs and set the boot state accordingly.
+  _disp_mode = (_node_prefs != NULL) ? _node_prefs->ui_display_mode : 0;
+  _always_on = (_disp_mode == 1);
   if (_display != NULL) {
-    _display->turnOn();
+    if (_disp_mode == 2) {
+      _display->turnOff();   // always-off: boot dark
+    } else {
+      _display->turnOn();
+    }
   }
 
 #ifdef PIN_BUZZER
@@ -718,13 +725,23 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
 
 // #141: display always-on toggle. Persisted in NVS (offband_ui); applied here
 // live by the observer CLI (and at boot) via the applier registered in main.cpp.
+// #542 B1: reconciled onto the tristate — always-on is mode 1, normal is mode 0 (auto).
 void UITask::setAlwaysOn(bool on) {
-  _always_on = on;
+  setDisplayMode(on ? 1 : 0);
+}
+
+// #542 B1: OLED mode. 0 auto (on, blanks after timeout), 1 always-on, 2 always-off (dark).
+// Applied live; the loop's blank decision honours _disp_mode. Reused by the observer
+// #141 applier (via setAlwaysOn above) and the 0xC5 display SET sub-code.
+void UITask::setDisplayMode(uint8_t mode) {
+  _disp_mode = mode;
+  _always_on = (mode == 1);
   if (_display == NULL) return;
-  if (on) {
-    if (!_display->isOn()) _display->turnOn();   // light it now; the loop's auto-off is gated on _always_on
+  if (mode == 2) {
+    if (_display->isOn()) _display->turnOff();     // always-off: dark now, stays dark
   } else {
-    _auto_off = millis() + AUTO_OFF_MILLIS;      // resume the normal timeout from now (no abrupt blank)
+    if (!_display->isOn()) _display->turnOn();      // auto / always-on: light it now
+    _auto_off = millis() + AUTO_OFF_MILLIS;         // fresh timeout (no abrupt blank)
   }
 }
 
@@ -788,7 +805,7 @@ void UITask::newMsg(uint8_t path_len, const char* from_name, const char* text, i
   setCurrScreen(msg_preview);
 
   if (_display != NULL) {
-    if (!_display->isOn() && !hasConnection()) {
+    if (!_display->isOn() && !hasConnection() && _disp_mode != 2) {  // #542 B1: not in always-off
 #ifdef OFFBAND_OBSERVER
       offband::crashLogf("[ui] newMsg: display off + no conn -> turnOn");
 #endif
@@ -1001,7 +1018,9 @@ void UITask::loop() {
       _auto_off = millis() + AUTO_OFF_MILLIS;
     }
 #endif
-    if (!_always_on && millis() > _auto_off) {   // #141: always-on skips the auto-blank (+ KEEP_DISPLAY_ON_USB above)
+    // #542 B1: mode 2 (always-off) enforces dark every loop — self-corrects any relight.
+    // #141: always-on (mode 1) skips the auto-blank; auto (mode 0) blanks on timeout.
+    if (_disp_mode == 2 || (!_always_on && millis() > _auto_off)) {
       _display->turnOff();
     }
 #endif
@@ -1037,7 +1056,7 @@ void UITask::loop() {
 
 char UITask::checkDisplayOn(char c) {
   if (_display != NULL) {
-    if (!_display->isOn()) {
+    if (!_display->isOn() && _disp_mode != 2) {   // #542 B1: button does not wake a deliberately-off screen
       _display->turnOn();   // turn display on and consume event
       c = 0;
     }

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -727,6 +727,10 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
 // live by the observer CLI (and at boot) via the applier registered in main.cpp.
 // #542 B1: reconciled onto the tristate — always-on is mode 1, normal is mode 0 (auto).
 void UITask::setAlwaysOn(bool on) {
+  // #542 B1: the legacy bool cannot express always-off (mode 2). If the user set
+  // always-off explicitly (via the 0xC5 command), a legacy setAlwaysOn(false) must
+  // NOT silently downgrade it to auto -- the newer, more specific control wins.
+  if (_disp_mode == 2) return;
   setDisplayMode(on ? 1 : 0);
 }
 
@@ -741,7 +745,7 @@ void UITask::setDisplayMode(uint8_t mode) {
     if (_display->isOn()) _display->turnOff();     // always-off: dark now, stays dark
   } else {
     if (!_display->isOn()) _display->turnOn();      // auto / always-on: light it now
-    _auto_off = millis() + AUTO_OFF_MILLIS;         // fresh timeout (no abrupt blank)
+    if (mode == 0) _auto_off = millis() + AUTO_OFF_MILLIS;  // fresh timeout only for auto (always-on never blanks)
   }
 }
 

--- a/examples/companion_radio/ui-new/UITask.h
+++ b/examples/companion_radio/ui-new/UITask.h
@@ -39,6 +39,7 @@ class UITask : public AbstractUITask {
   unsigned long ui_started_at, next_batt_chck;
   int next_backlight_btn_check = 0;
   bool _always_on = false;   // #141: when true, never auto-blank the display
+  uint8_t _disp_mode = 0;    // #542 B1: 0 auto, 1 always-on, 2 always-off (dark)
   int  _rotation = 0;            // #148: desired display rotation in degrees (0/180)
   bool _rotation_dirty = true;   // #148: rotation needs (re)applying on the next render
   bool _was_on = false;          // #148: display on/off edge, to re-apply rotation after a wake
@@ -95,7 +96,10 @@ public:
   void toggleGPS();
 
   // #141: display always-on toggle (set via `display always on/off` over the _sys CLI).
+  // #542 B1: reconciled onto the tristate — setAlwaysOn(on) == setDisplayMode(on ? 1 : 0).
   void setAlwaysOn(bool on);
+  // #542 B1: OLED mode. 0 auto (on, blanks after timeout), 1 always-on, 2 always-off (dark).
+  void setDisplayMode(uint8_t mode);
 
   // #148: request a display rotation (deg 0/180); applied at the next render cycle.
   void requestRotation(uint8_t deg);

--- a/examples/companion_radio/ui-new/UITask.h
+++ b/examples/companion_radio/ui-new/UITask.h
@@ -99,7 +99,7 @@ public:
   // #542 B1: reconciled onto the tristate — setAlwaysOn(on) == setDisplayMode(on ? 1 : 0).
   void setAlwaysOn(bool on);
   // #542 B1: OLED mode. 0 auto (on, blanks after timeout), 1 always-on, 2 always-off (dark).
-  void setDisplayMode(uint8_t mode);
+  void setDisplayMode(uint8_t mode) override;
 
   // #148: request a display rotation (deg 0/180); applied at the next render cycle.
   void requestRotation(uint8_t deg);


### PR DESCRIPTION
The companion half of #542. The companion has no CLI, so LED + OLED control reaches it through the **0xC5 device-UI contract** — the "wire it up so the client can be added later" piece. Citadel `Crosswire-2ak`. Agent: BrownHawk (session 8a9de97d). Independent branch off `firmware-base` (A1/A2 + FuchsiaCreek #552 already merged).

## What it adds
- **Companion prefs** — `ui_led_enabled` + `ui_display_mode` (DataStore 145/146, append-only).
- **`ui-new` display tristate** — auto / always-on / always-off, with the observer **#141 `setAlwaysOn` reconciled onto it** (folds the observer display path into one).
- **`0xC5` sub-codes** `0x05-0x08` (display + led GET/SET), added to FuchsiaCreek's per-sub-code gate — **display gated on `DISPLAY_CLASS`, led on `board.canControlLed()`**, neither on the buzzer (a V4 companion has no buzzer). Modeled on the scope/FEM-LNA handlers: persist-only-on-change + echo stored value.
- **caps2 bit `0x04` `INDICATORS`**, advertised on `DISPLAY_CLASS || canControlLed`, independent of NOTIFY_SCOPE. led+display state in device-info. `FIRMWARE_VER_CODE 20 → 21`.

## Coordination
Owner assigned me the `0xC5` gate structure; FuchsiaCreek (#509/#510/#552) supplied the exact merged dispatch state (Agent Mail 375/376). Enum allocation (`0x05-0x08`, caps `0x04`, err byte 6, VER read-at-rebase) confirmed against the merged base — **not** inferred. Their scope/matrix logic is untouched; I only added arms.

## Verification
- **Builds green:** heltec_v4 companion BLE/USB, TFT companion, RAK_4631 (nRF52), **t1000e** (buzzer+button, no display — proves the per-sub-code gate + the `-Werror` `(void)`-line), observer.
- **Gemini 2.5-pro:** load-bearing parts (prefs offsets, gate, handlers) confirmed correct. Applied 2 findings (setAlwaysOn no longer clobbers explicit always-off; timer-reset only for auto). Rejected the device-info cap-gating finding with rationale (the established contract is unconditional-fixed-layout-per-VER, matching the FEM-LNA byte — gating mine would make the frame inconsistent). Log in `docs/llm-consultations/`.
- **On-device end-to-end is via the client app** (renders the toggles) — that's the separate `meshcore-client` repo (owner). The firmware exposes the contract byte-exactly; a raw-`0xC5` bench test or the client UI verifies it end-to-end.

## Test plan (reviewer / client)
- [ ] `0xC5` `0x06` display SET (mode 0/1/2) on a V4 companion → OLED auto/lit/dark; persists reboot; NO `NO_BUZZER` (the bug this fixes)
- [ ] `0xC5` `0x08` led SET → TX LED on/off
- [ ] device-info advertises `INDICATORS` on a V4 companion; led/display state present (v21)
- [ ] a board without display+LED does not advertise `INDICATORS`; sub-codes return `UNSUPPORTED_INDICATOR`

Requires human review + merge approval. Client UI tracked separately in `OffbandMesh/meshcore-client`.