### PR TITLE
task: runtime-configurable caplog syslog target (#566)

### DIFF
--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -95,13 +95,12 @@ static uint16_t g_wifi_on_pct_last_24h_x100 = 0;  // 0-10000 = 0.00-100.00%
 // #561: caplog live syslog forward. During an operator-armed, bounded window,
 // stream captured log lines off-device as UDP syslog datagrams to a remote sink
 // (rsyslog on the Pi) so a panic's lead-up survives the reboot the RAM ring
-// cannot hold. Compiled in only when WIFI_SYSLOG_HOST is defined (repeater
-// telemetry env); a no-op otherwise. Drains via meshLogConsume() in the MAIN
-// LOOP so the hot-path sink (mesh_log_line) is untouched.
-#ifdef WIFI_SYSLOG_HOST
-  #ifndef WIFI_SYSLOG_PORT
-    #define WIFI_SYSLOG_PORT 514
-  #endif
+// cannot hold. #566: compiled in for all telemetry builds; the sink host/port
+// are a RUNTIME pref (syslog.host / syslog.port), seeded from WIFI_SYSLOG_HOST/
+// PORT build flags if present, so any node targets any sink without a rebuild
+// (empty host = forward off). Drains via meshLogConsume() in the MAIN LOOP so
+// the hot-path sink (mesh_log_line) is untouched.
+#ifdef ENABLE_WIFI_TELEMETRY
   #include <WiFiUdp.h>
   #include "../../src/MeshLog.h"
   static WiFiUDP  g_caplog_udp;
@@ -520,7 +519,7 @@ static void wifi_telemetry_loop() {
     }
 #endif
 
-#ifdef WIFI_SYSLOG_HOST
+#ifdef ENABLE_WIFI_TELEMETRY
     // #561: ship any newly-captured lines while a forward window is open + WiFi up.
     wifi_telemetry_caplog_forward_service();
 #endif
@@ -613,7 +612,7 @@ void wifi_telemetry_set_persistent(uint32_t duration_ms) {
     g_tel_next_publish_ms = millis();
 }
 
-#ifdef WIFI_SYSLOG_HOST
+#ifdef ENABLE_WIFI_TELEMETRY
 // #561: arm/disarm caplog live syslog forward for `window_sec`. Opens the
 // forward window and brings WiFi up (persistent) for the same window so lines
 // stream live; capture-enable is done by the CLI verb. window_sec == 0 disarms.
@@ -900,7 +899,7 @@ static void wifi_telemetry_http_cmd_poll() {
 }
 #endif // CMD_TRANSPORT_HTTP
 
-#ifdef WIFI_SYSLOG_HOST
+#ifdef ENABLE_WIFI_TELEMETRY
 // #561: drain new caplog lines and ship each as a UDP syslog datagram. Called
 // each servicing pass while the forward window is open and WiFi is up. All I/O
 // here is network — meshLogConsume() already released the sink's critical
@@ -912,6 +911,10 @@ static void wifi_telemetry_caplog_forward_service() {
         return;
     }
     if (WiFi.status() != WL_CONNECTED) return;
+    // #566: runtime sink from prefs. Empty host = no sink configured -> nothing
+    // to forward (the build-flag WIFI_SYSLOG_HOST only seeds the default).
+    NodePrefs* prefs = the_mesh.getNodePrefs();
+    if (prefs->syslog_host[0] == '\0') return;
     static uint8_t buf[512];
     // Bounded per call: drain ONE chunk (<=512 B, a few lines) per loop pass, NOT
     // the whole ring. A full 16 KB ring drained in one call would be a burst of
@@ -930,7 +933,7 @@ static void wifi_telemetry_caplog_forward_service() {
             if (eol || i + 1 == n) {
                 size_t end = eol ? i : i + 1;   // exclude the trailing '\n'
                 if (end > start) {
-                    g_caplog_udp.beginPacket(WIFI_SYSLOG_HOST, WIFI_SYSLOG_PORT);
+                    g_caplog_udp.beginPacket(prefs->syslog_host, prefs->syslog_port);
                     // Clean RFC-3164-ish TAG so rsyslog parses programname reliably:
                     // "caplog-<node>:" -> filter `programname startswith 'caplog-'`.
                     g_caplog_udp.printf("<134>caplog-%s: ", WIFI_TELEMETRY_NODE_ID);
@@ -942,7 +945,7 @@ static void wifi_telemetry_caplog_forward_service() {
         }
     }
 }
-#endif // WIFI_SYSLOG_HOST
+#endif // ENABLE_WIFI_TELEMETRY (#561 caplog forward)
 
 // Constructs the remote command handler + callbacks, registers the
 // transport-level message callback. Called once from wifi_telemetry_setup().

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -100,9 +100,7 @@ extern "C" {
   void wifi_telemetry_set_persistent(uint32_t duration_ms);
   int  wifi_telemetry_is_persistent(void);
   uint32_t wifi_telemetry_persistent_remaining_ms(void);
-#ifdef WIFI_SYSLOG_HOST
-  void wifi_telemetry_caplog_forward(uint32_t window_sec);  // #561 live syslog forward
-#endif
+  void wifi_telemetry_caplog_forward(uint32_t window_sec);  // #561 live syslog forward (#566: runtime target)
 #ifdef CMD_TRANSPORT_HTTP
   // LoRa#216: HTTP cmd-poll controls
   void     wifi_telemetry_cmd_poll_now(void);
@@ -136,6 +134,19 @@ void CommonCLI::loadPrefs(FILESYSTEM* fs) {
   // intact; a fresh node with no prefs file keeps them too.
   _prefs->caplog_enabled = 0;
   _prefs->caplog_level = MLOG_DEBUG;
+  // #566: seed the syslog forward sink from build flags (if any); a node with no
+  // flag starts with no sink (forward off until `set syslog.host`).
+#ifdef WIFI_SYSLOG_HOST
+  strncpy(_prefs->syslog_host, WIFI_SYSLOG_HOST, sizeof(_prefs->syslog_host) - 1);
+  _prefs->syslog_host[sizeof(_prefs->syslog_host) - 1] = '\0';
+#else
+  _prefs->syslog_host[0] = '\0';
+#endif
+#ifdef WIFI_SYSLOG_PORT
+  _prefs->syslog_port = WIFI_SYSLOG_PORT;
+#else
+  _prefs->syslog_port = 514;
+#endif
   if (fs->exists("/com_prefs")) {
     loadPrefsInt(fs, "/com_prefs");   // new filename
   } else if (fs->exists("/node_prefs")) {
@@ -204,7 +215,9 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     file.read((uint8_t *)&_prefs->ui_display_mode, sizeof(_prefs->ui_display_mode));              // 295
     file.read((uint8_t *)&_prefs->caplog_enabled, sizeof(_prefs->caplog_enabled));                // 296  (#562)
     file.read((uint8_t *)&_prefs->caplog_level, sizeof(_prefs->caplog_level));                    // 297  (#562)
-    // next: 298
+    file.read((uint8_t *)_prefs->syslog_host, sizeof(_prefs->syslog_host));                       // 298  (#566)
+    file.read((uint8_t *)&_prefs->syslog_port, sizeof(_prefs->syslog_port));                      // 362  (#566)
+    // next: 364
     // NOTE: radio_fem_rxgain stays at offset 291 (its pre-1.16 offset) so existing Offband prefs
     // files survive the 1.16.0 base-update; the new upstream flood fields append after it. For old
     // SPIFFS files predating a field, file.read returns 0 bytes and the field keeps its in-memory
@@ -243,6 +256,8 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     _prefs->ui_display_mode = constrain(_prefs->ui_display_mode, 0, 2); // #542 A2 tristate
     _prefs->caplog_enabled = constrain(_prefs->caplog_enabled, 0, 1);       // #562 boolean
     _prefs->caplog_level = constrain(_prefs->caplog_level, 0, MLOG_PACKET); // #562 level bound
+    _prefs->syslog_host[sizeof(_prefs->syslog_host) - 1] = '\0';            // #566 NUL-terminate
+    if (_prefs->syslog_port == 0) _prefs->syslog_port = 514;                // #566 sane default
 
     // #562: apply persisted caplog state at boot (common across roles). Capture
     // is independent of the serial mirror, so this is safe on a USB-serial
@@ -317,7 +332,9 @@ void CommonCLI::savePrefs(FILESYSTEM* fs) {
     file.write((uint8_t *)&_prefs->ui_display_mode, sizeof(_prefs->ui_display_mode));             // 295
     file.write((uint8_t *)&_prefs->caplog_enabled, sizeof(_prefs->caplog_enabled));              // 296  (#562)
     file.write((uint8_t *)&_prefs->caplog_level, sizeof(_prefs->caplog_level));                  // 297  (#562)
-    // next: 298
+    file.write((uint8_t *)_prefs->syslog_host, sizeof(_prefs->syslog_host));                     // 298  (#566)
+    file.write((uint8_t *)&_prefs->syslog_port, sizeof(_prefs->syslog_port));                    // 362  (#566)
+    // next: 364
 
     file.close();
   }
@@ -862,7 +879,9 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
     } else if (memcmp(command, "caplog forward", 14) == 0 && (command[14] == 0 || command[14] == ' ')) {
       // #561: live syslog forward -- stream captured lines off-device during a
       // bounded window (survives a reboot the RAM ring cannot). Telemetry-only.
-#if defined(ENABLE_WIFI_TELEMETRY) && defined(WIFI_SYSLOG_HOST)
+      // #566: gated on ENABLE_WIFI_TELEMETRY only -- the sink host/port is a
+      // runtime pref (set syslog.host/port), no longer a build-time flag.
+#if defined(ENABLE_WIFI_TELEMETRY)
       const char* arg = (command[14] == ' ') ? &command[15] : "";
       if (memcmp(arg, "off", 3) == 0) {
         wifi_telemetry_caplog_forward(0);
@@ -1088,6 +1107,21 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
     } else {
       strcpy(reply, "Error, max 64");
     }
+  } else if (memcmp(config, "syslog.host ", 12) == 0) {
+    // #566: runtime caplog syslog-forward sink host (empty = forward off).
+    strncpy(_prefs->syslog_host, &config[12], sizeof(_prefs->syslog_host) - 1);
+    _prefs->syslog_host[sizeof(_prefs->syslog_host) - 1] = '\0';
+    savePrefs();
+    strcpy(reply, "OK");
+  } else if (memcmp(config, "syslog.port ", 12) == 0) {
+    int p = atoi(&config[12]);
+    if (p > 0 && p <= 65535) {
+      _prefs->syslog_port = (uint16_t)p;
+      savePrefs();
+      strcpy(reply, "OK");
+    } else {
+      strcpy(reply, "Error, port 1-65535");
+    }
   } else if (memcmp(config, "flood.max ", 10) == 0) {
     uint8_t m = atoi(&config[10]);
     if (m <= 64) {
@@ -1310,6 +1344,10 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
     sprintf(reply, "> %d", (uint32_t)_prefs->flood_max);
   } else if (isKey(config, "direct.txdelay")) {
     sprintf(reply, "> %s", StrHelper::ftoa(_prefs->direct_tx_delay_factor));
+  } else if (isKey(config, "syslog.host")) {
+    sprintf(reply, "> %s", _prefs->syslog_host);       // #566 (empty = forward off)
+  } else if (isKey(config, "syslog.port")) {
+    sprintf(reply, "> %d", (uint32_t)_prefs->syslog_port); // #566
   } else if (isKey(config, "owner.info")) {
     auto start = reply;
     *reply++ = '>';

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -79,6 +79,11 @@ struct NodePrefs { // persisted to file
   // old file predating these fields, both get the common default (OFF, DEBUG).
   uint8_t caplog_enabled; // 0 = off (default), 1 = on
   uint8_t caplog_level;   // MLOG_* level; capture lines with level <= this
+  // #566: runtime caplog syslog-forward target (empty host = no sink / forward
+  // off). Seeded from the WIFI_SYSLOG_HOST/PORT build flags; settable at runtime
+  // via `set syslog.host` / `set syslog.port`. Append-only at the end.
+  char     syslog_host[64];
+  uint16_t syslog_port;
 };
 
 // #542 A2: values for NodePrefs::ui_display_mode.


### PR DESCRIPTION
## What

Make the caplog live-syslog-forward sink **host/port a runtime pref** instead of a build-time macro, so any telemetry node can target any rsyslog sink without a rebuild and be reconfigured over the mesh/serial admin CLI.

Part of the Remote Diagnostics epic (#565): the step that lets an operator point a node's caplog forward at a sink from the command surface (offband-cmd / CLI), no image rebuild.

## Changes (3 files, +64/−18)

- **`NodePrefs`** gains `char syslog_host[64]` + `uint16_t syslog_port`, append-only at the end of the persisted layout (offsets 298 / 362; next: 364).
- **`loadPrefs()`** seeds them from `WIFI_SYSLOG_HOST`/`WIFI_SYSLOG_PORT` build flags if present, else empty host / port 514.
- **`loadPrefsInt()`** reads them back (a 0-byte read on pre-298 prefs files keeps the seeded default — clean upgrade) and sanitises (NUL-terminate host, `port==0 → 514`).
- **`savePrefs()`** persists them.
- **New CLI:** `set syslog.host <h>` / `set syslog.port <n>` (+ `get` for both). Empty host clears the sink (forward off). Port validated 1–65535.
- **Forwarder + `caplog forward` verb** un-gated from `#ifdef WIFI_SYSLOG_HOST` → `#ifdef ENABLE_WIFI_TELEMETRY`; the service reads `prefs->syslog_host/port` at send time and no-ops when the host is empty. Bounded per-loop drain unchanged (no new stall risk on the LoRa dispatcher).

Common across repeater/observer/room/sensor (shared `CommonCLI` `NodePrefs`).

## Verification

- **Builds green:** `heltec_v4_repeater_telemetry` (ENABLE_WIFI_TELEMETRY runtime path), `Heltec_v3_repeater` (generic ESP32, `#else` path), `RAK_4631_repeater` (nRF52, struct-growth).
- **Gemini 2.5-pro review:** no issues — confirmed offset layout, old-file back-compat, sanitisation, CLI bounds, and the bounded-drain forwarder all correct. "Approved for merge."
- **No new unit test:** the change is prefs-plumbing + CLI parsing inside `CommonCLI`, which isn't in the host-test harness (Mesh/board/identity deps) — same bucket as #562 (caplog persistence). Real end-to-end verification is the #568 patio hardware run (set a runtime target, confirm lines land at the sink).

Closes #566
