### PR TITLE
task: remote-diagnostics receiver setup script + user guide (#569)

### DIFF
--- a/docs/remote-diagnostics.md
+++ b/docs/remote-diagnostics.md
@@ -1,0 +1,206 @@
+# Remote diagnostics: caplog live forward + command surface
+
+Capture a node's in-flight log lines off-device, live, during a bounded window —
+so the lead-up to a crash survives the reboot that wipes the on-device RAM ring.
+This is the tool for a node that panics in the field where a serial cable isn't
+practical (a rooftop repeater, a solar node).
+
+- **caplog** is the on-device capture: a small RAM ring that tees the mesh log
+  (boot / error / debug / packet levels). It is wiped on every reboot, so a
+  panic destroys exactly the evidence you want.
+- **caplog forward** streams each captured line off-device as it happens, as a
+  UDP syslog datagram, to a sink you run (rsyslog on a Pi or any Linux box). The
+  lines land in a file that outlives the node's reboot.
+- **The command surface** (`offband-cmd`) lets you arm/disarm the forward and
+  read the results from your workstation over the cmdrelay HTTP API — no manual
+  SSH-and-curl on the sink host.
+
+```
+  node (repeater/observer/…)                 sink host (Pi)            you
+  ┌────────────────────────┐   UDP :514   ┌──────────────────┐
+  │ caplog ring  ──forward─┼──────────────▶│ rsyslog (imudp)  │
+  │ (boot/err/dbg/packet)  │  local0.info  │   ─► offband-    │
+  └───────────▲────────────┘  caplog-<node>│      caplog.log  │
+              │                             └──────────────────┘
+              │ admin CLI (set syslog.*, caplog forward)              ┌──────────┐
+              └───────────────── cmdrelay HTTP ─────────────────────── │offband-  │
+                                                                       │  cmd     │
+                                                                       └──────────┘
+```
+
+The forward is **telemetry-only** and only compiled into WiFi-telemetry builds
+(e.g. `*_repeater_telemetry`). A node with no sink configured never forwards.
+
+---
+
+## 1. Stand up the receiver (once, on the sink host)
+
+On the Pi (or any Debian/systemd host running `rsyslog`):
+
+```bash
+sudo scripts/offband-caplog-receiver-setup.sh
+```
+
+That installs an rsyslog drop-in (`/etc/rsyslog.d/30-offband-caplog.conf`) that
+binds a UDP listener on **:514** and routes the devices' datagrams — matched by
+their `caplog-<node>:` tag — into their own file at
+`/var/log/offband-caplog.log`, plus a weekly logrotate policy (8 kept). It's
+idempotent — safe to re-run.
+
+> The routing matches the devices' **tag** (`caplog-<node>:`, i.e. programname
+> starting with `caplog-`), so only caplog lines land in the file and the host's
+> own syslog is untouched — no facility is hijacked. `stop` keeps those matched
+> lines out of `/var/log/syslog` too.
+
+Options (`--help` prints the full man-style version):
+
+- `--port <n>` — UDP port to listen on. Range 1–65535, default 514. Must match
+  the device's `set syslog.port`.
+- `--log-path <path>` — file caplog lines are written to. Default
+  `/var/log/offband-caplog.log`; pass the same value on `--uninstall` if you
+  changed it.
+- `--retention <weeks>` — weekly-rotated logs to keep. Integer ≥ 0, default 8
+  (~two months); 0 keeps none.
+- `--uninstall` — remove the drop-in + logrotate policy and restart rsyslog;
+  leaves existing logfiles in place.
+- `--dry-run` — print every change without modifying anything; combines with
+  install or `--uninstall`.
+
+If the host already loads `imudp`, the script adds only the routing rule (it
+won't double-bind the listener) and tells you to confirm the existing UDP input
+covers your port.
+
+**Verify the sink before you touch a device:**
+
+```bash
+logger -n <this-host-ip> -P 514 -p local0.info -t caplog-test "hello"
+tail -n1 /var/log/offband-caplog.log        # -> ... caplog-test hello
+```
+
+Routing is by the **tag** — the `caplog-` prefix (programname), which is why the
+test line uses `-t caplog-test`. The `-p local0.info` just mirrors what the
+device sends; it isn't what selects the file.
+
+If nothing lands: check the host firewall allows inbound **UDP 514**
+(`ufw allow 514/udp` if you run ufw), and that `logger` targeted the right IP.
+
+> **Security.** UDP syslog is plaintext and unauthenticated — anyone on the LAN
+> can write to the port, and the source is spoofable. Keep the sink on a trusted
+> network; don't expose :514 to the internet. The file may contain packet
+> metadata but no keys or PSKs (the firmware logs only derived properties).
+
+---
+
+## 2. Arm the forward on the node
+
+The sink target is a **runtime pref** (#566) — set it once and it persists across
+reboots. Set it over the serial console or remotely via the command surface
+(§3). Over serial:
+
+```
+set syslog.host <this-host-ip>
+set syslog.port 514            # only if you changed it from the default
+caplog forward 300            # arm a 300-second window; streams to the sink
+```
+
+- `caplog forward <sec>` opens a bounded window (min 30 s, default 300),
+  enables capture, and brings WiFi up for the duration so lines stream live. It
+  auto-reverts (drops WiFi, closes the window) when the timer expires.
+- `caplog forward off` disarms immediately and stops capture.
+- `get syslog.host` reads back the configured sink (empty = forward off).
+- `caplog start [boot|error|debug|packet]` sets the capture verbosity; `packet`
+  is the most detail (every LoRa RX/TX). Higher levels = more datagrams.
+
+Choose the window to match the failure. For a node that panics under thermal or
+charging stress, arm it when the conditions are present (e.g. mid-day on a solar
+node) and keep the window long enough to catch the event — the lines already on
+the sink survive the reboot even though the node's own ring does not.
+
+---
+
+## 3. Drive it from your workstation (`offband-cmd`)
+
+`scripts/offband-cmd.py` wraps the cmdrelay admin API so you can queue commands,
+watch the queue, and pull results without logging into the sink host. Invoke it
+as `python scripts/offband-cmd.py …`, or symlink it onto your `PATH` as
+`offband-cmd` (used below). Configure it once via env (no secret lives in the
+repo):
+
+```bash
+export OFFBAND_CMDRELAY_URL=http://<cmdrelay-host>:8765
+export OFFBAND_CMDRELAY_ADMIN_TOKEN=<admin-bearer-token>
+export OFFBAND_PI_SSH=<user>@<sink-host>          # only for `caplog tail`
+export OFFBAND_CAPLOG_PATH=/var/log/offband-caplog.log
+```
+
+Then:
+
+```bash
+offband-cmd caplog <node> forward 300      # arm the forward (queues a CLI cmd)
+offband-cmd status <node>                   # liveness: last poll, queue, recent cmds
+offband-cmd queue  <node> "get syslog.host" # run any admin CLI line on the node
+offband-cmd result <node> <cmd_id> --wait 120
+offband-cmd caplog <node> off               # disarm + stop capture
+offband-cmd caplog <node> tail -n 50        # last 50 forwarded lines for this node
+```
+
+The node polls cmdrelay on its own schedule, so a queued command runs on the
+next poll — `status` shows when it last checked in. Queued CLI commands are
+rate-limited to one per second on the device; queue them one at a time.
+
+> `caplog tail` is the one operation that still SSHes into the sink host (to read
+> the file). Everything else is pure HTTP. That SSH goes away once cmdrelay is
+> adopted in-repo with a native `/caplog` endpoint (#572).
+
+---
+
+## 4. Read the logs
+
+```bash
+tail -f /var/log/offband-caplog.log                 # everything, live
+grep -F 'caplog-<node>:' /var/log/offband-caplog.log # one node
+```
+
+rsyslog stamps its own receive time and the source host on ingest; each line
+also carries the device's own `[millis]` prefix, so you can line up device time
+against wall-clock. After a reboot, the last lines before the gap are the
+lead-up to the event.
+
+### Feeding a central log store (optional)
+
+The sink is standard RFC-3164 syslog, so any log pipeline can consume it without
+a custom parser:
+
+- **Loki + Grafana** — the log analog of Prometheus. Point Promtail or Fluent
+  Bit at `/var/log/offband-caplog.log`, or add an rsyslog `omfwd` action to the
+  drop-in to relay the matched `caplog-*` lines straight to Loki. Best fit if you
+  already run Grafana.
+- **ELK / Graylog / Splunk** — ingest the file, or `omfwd` the matched lines on.
+
+This is **log** data. Prometheus is metrics-only and does not consume it — the
+metrics surface (battery %, RSSI, heap) is Offband's separate MQTT telemetry,
+which a Prometheus MQTT exporter can scrape.
+
+---
+
+## 5. Roll back
+
+```bash
+sudo scripts/offband-caplog-receiver-setup.sh --uninstall   # sink host
+# device: caplog forward off   (or)   set syslog.host        (empty = off)
+```
+
+Uninstall removes the rsyslog drop-in and logrotate policy and restarts rsyslog;
+it leaves the existing logfile in place (delete it by hand if you want it gone).
+
+---
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| `logger` test line never lands | firewall (UDP 514 inbound); right sink IP; `systemctl status rsyslog` |
+| Device armed, no lines | `get syslog.host` set? window still open (re-arm)? node has WiFi credentials + can associate? |
+| Lines in `/var/log/syslog` too | the drop-in's `stop` didn't take — confirm `30-offband-caplog.conf` is present and rsyslog was restarted |
+| Duplicate-input / bind error on restart | host already loads `imudp`; re-run the script (it detects this) or remove the older UDP input |
+| No datagrams during a panic | the forward window must be open *before* the crash — arm a window long enough to span the failure |

--- a/scripts/offband-caplog-receiver-setup.sh
+++ b/scripts/offband-caplog-receiver-setup.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# =============================================================================
+# offband-caplog-receiver-setup.sh  (#569)
+#
+# Stand up an rsyslog sink for Offband's caplog live syslog forward: a UDP
+# listener that routes the device's datagrams — matched by their tag
+# `caplog-<node>:` (programname) — into their own rotated logfile, without
+# touching the host's other syslog traffic.
+#
+# Device side (see docs/remote-diagnostics.md):
+#   set syslog.host <this-host-ip>
+#   set syslog.port <port>            (default 514)
+#   caplog forward <seconds>
+#
+# The device sends `<134>caplog-<node>: <line>` (PRI 134 = local0.info). This
+# script installs an rsyslog drop-in that binds the UDP input (only if imudp
+# isn't already loaded) and routes lines whose programname starts with
+# `caplog-` to a dedicated file, plus a logrotate policy. Only caplog lines are
+# captured — the host's other syslog is untouched. Idempotent; re-running is
+# safe. `--uninstall` reverses it.
+#
+# Target: Debian / Raspberry Pi OS (systemd + rsyslog). Run as root.
+# =============================================================================
+set -euo pipefail
+
+RSYSLOG_CONF="/etc/rsyslog.d/30-offband-caplog.conf"
+LOGROTATE_CONF="/etc/logrotate.d/offband-caplog"
+
+# Defaults (overridable by flags)
+LOG_PATH="/var/log/offband-caplog.log"
+PORT=514
+RETAIN_WEEKS=8
+ACTION="install"
+DRY_RUN=0
+
+usage() {
+  cat <<EOF
+NAME
+    $(basename "$0") — install or remove the Offband caplog rsyslog receiver
+
+SYNOPSIS
+    sudo $0 [--port <n>] [--log-path <path>] [--retention <weeks>] [--dry-run]
+    sudo $0 --uninstall [--log-path <path>] [--dry-run]
+
+DESCRIPTION
+    Install (default) or remove an rsyslog drop-in plus a logrotate policy that
+    routes Offband devices' caplog datagrams (tag caplog-<node>:, matched by
+    programname) into a dedicated logfile. Idempotent; safe to re-run.
+
+OPTIONS
+    --port <n>
+        UDP port to listen on for incoming syslog datagrams.
+        Range 1-65535. Default: $PORT (the syslog well-known port). Must match
+        the device's 'set syslog.port'.
+
+    --log-path <path>
+        Absolute path of the file caplog lines are written to.
+        Default: $LOG_PATH. On --uninstall this names the
+        logrotate target that gets removed, so pass the same value you
+        installed with if you changed it.
+
+    --retention <weeks>
+        Number of weekly-rotated logs to keep before deletion.
+        Integer >= 0. Default: $RETAIN_WEEKS (~two months); 0 keeps none.
+
+    --uninstall
+        Remove the rsyslog drop-in and the logrotate policy, then restart
+        rsyslog. The existing logfile(s) are left in place. Reverses an install.
+
+    --dry-run
+        Print every change (files that would be written/removed, the service
+        restart) without modifying anything. Combines with install or
+        --uninstall.
+
+    -h, --help
+        Print this help and exit.
+
+EXAMPLES
+    sudo $0
+        Install with defaults: UDP $PORT -> $LOG_PATH, keep ${RETAIN_WEEKS}w.
+
+    sudo $0 --port 5514 --retention 4
+        Listen on UDP 5514; keep 4 weeks of rotated logs.
+
+    sudo $0 --uninstall
+        Remove the receiver configuration.
+EOF
+}
+
+log()  { printf '  %s\n' "$*"; }
+note() { printf 'NOTE: %s\n' "$*" >&2; }
+die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --log-path)   LOG_PATH="${2:?}"; shift 2 ;;
+    --port)       PORT="${2:?}"; shift 2 ;;
+    --retention)  RETAIN_WEEKS="${2:?}"; shift 2 ;;
+    --uninstall)  ACTION="uninstall"; shift ;;
+    --dry-run)    DRY_RUN=1; shift ;;
+    -h|--help)    usage; exit 0 ;;
+    *)            die "unknown argument: $1 (see --help)" ;;
+  esac
+done
+
+case "$PORT" in
+  ''|*[!0-9]*) die "--port must be numeric (got: $PORT)" ;;
+esac
+[ "$PORT" -ge 1 ] && [ "$PORT" -le 65535 ] || die "--port out of range 1-65535 (got: $PORT)"
+case "$RETAIN_WEEKS" in
+  ''|*[!0-9]*) die "--retention must be numeric (got: $RETAIN_WEEKS)" ;;
+esac
+
+[ "$(id -u)" -eq 0 ] || die "must run as root (use sudo)"
+command -v rsyslogd >/dev/null 2>&1 || die "rsyslog not found — install it first (apt install rsyslog)"
+
+restart_rsyslog() {
+  if [ "$DRY_RUN" -eq 1 ]; then log "[dry-run] would restart rsyslog"; return; fi
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl restart rsyslog
+  else
+    service rsyslog restart
+  fi
+}
+
+write_file() {  # write_file <path> <<<content-on-stdin
+  local path="$1" content
+  content="$(cat)"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] would write $path:"
+    printf '%s\n' "$content" | sed 's/^/      | /'
+    return
+  fi
+  printf '%s\n' "$content" > "$path"
+  log "wrote $path"
+}
+
+if [ "$ACTION" = "uninstall" ]; then
+  log "Removing Offband caplog receiver..."
+  for f in "$RSYSLOG_CONF" "$LOGROTATE_CONF"; do
+    if [ -e "$f" ]; then
+      if [ "$DRY_RUN" -eq 1 ]; then log "[dry-run] would remove $f"; else rm -f "$f"; log "removed $f"; fi
+    else
+      log "not present: $f"
+    fi
+  done
+  restart_rsyslog
+  note "The logfile $LOG_PATH (and its rotated copies) were left in place — remove by hand if you want them gone."
+  log "Done. Offband caplog routing removed; rsyslog restarted."
+  exit 0
+fi
+
+# ---- install --------------------------------------------------------------
+log "Installing Offband caplog receiver (port $PORT -> $LOG_PATH, keep ${RETAIN_WEEKS}w)..."
+
+# Is imudp already loaded anywhere BUT our own drop-in? rsyslog hard-errors on a
+# duplicate module load, so if the host already listens on UDP we must NOT load
+# it (or bind an input) again — we only add the routing rule. Match BOTH the
+# modern `module(load="imudp")` and the legacy `$ModLoad imudp` syntaxes; then
+# drop our own conf from the results (re-runs just overwrite it, so it doesn't
+# count as "elsewhere").
+imudp_elsewhere=0
+if grep -rlE 'load="?imudp|ModLoad[[:space:]]+imudp' /etc/rsyslog.conf /etc/rsyslog.d/ 2>/dev/null \
+     | grep -qvF "$RSYSLOG_CONF"; then
+  imudp_elsewhere=1
+fi
+
+if [ "$imudp_elsewhere" -eq 1 ]; then
+  note "rsyslog already loads imudp elsewhere — NOT binding a new UDP input."
+  note "Verify an existing UDP input covers port $PORT (e.g. in /etc/rsyslog.conf)."
+  write_file "$RSYSLOG_CONF" <<EOF
+# Offband caplog receiver (#569) — routing only.
+# imudp is loaded elsewhere on this host; verify a UDP input covers port $PORT.
+# Match the devices' tag (caplog-<node>:) by programname so ONLY caplog lines
+# are captured; the host's other syslog traffic is untouched.
+if (\$programname startswith "caplog-") then {
+    action(type="omfile" file="$LOG_PATH")
+    stop
+}
+EOF
+else
+  write_file "$RSYSLOG_CONF" <<EOF
+# Offband caplog receiver (#569).
+# Binds a UDP syslog listener and routes the Offband devices' datagrams into a
+# dedicated file by matching their tag (caplog-<node>:) on programname — so ONLY
+# caplog lines are captured and the host's other syslog traffic is untouched.
+# \`stop\` keeps the matched caplog lines out of /var/log/syslog as well.
+module(load="imudp")
+input(type="imudp" port="$PORT")
+
+if (\$programname startswith "caplog-") then {
+    action(type="omfile" file="$LOG_PATH")
+    stop
+}
+EOF
+fi
+
+write_file "$LOGROTATE_CONF" <<EOF
+# Offband caplog logfile rotation (#569).
+$LOG_PATH {
+    weekly
+    rotate $RETAIN_WEEKS
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0640 syslog adm
+    postrotate
+        /usr/lib/rsyslog/rsyslog-rotate 2>/dev/null || true
+    endscript
+}
+EOF
+
+restart_rsyslog
+
+cat >&2 <<EOF
+
+Done. Offband caplog receiver is live.
+
+  Listening : UDP $PORT $( [ "$imudp_elsewhere" -eq 1 ] && echo "(via the host's existing imudp input — verify it covers $PORT)" )
+  Logfile   : $LOG_PATH  (rotated weekly, ${RETAIN_WEEKS} kept)
+
+Verify it end to end:
+  1. Send a test line from another host:
+       logger -n <this-host-ip> -P $PORT -p local0.info -t caplog-test "hello"
+     then on this host:
+       tail -n1 $LOG_PATH        # -> ... caplog-test hello
+  2. Point a device at it:  set syslog.host <this-host-ip>  (set syslog.port $PORT if not 514)
+     then arm:              caplog forward 300
+  3. Watch one node's lines: grep -F 'caplog-<node>:' $LOG_PATH
+
+If this host runs a firewall, allow inbound UDP $PORT (e.g. ufw allow $PORT/udp).
+Roll back any time:  sudo $0 --uninstall
+EOF


### PR DESCRIPTION
## What

Make the caplog live syslog forward **usable by others**: a receiver-side setup script for the rsyslog sink, plus an operator guide covering the whole flow (device → sink → reading logs → command surface). Part of the Remote Diagnostics epic (#565).

## `scripts/offband-caplog-receiver-setup.sh`

Idempotent installer for the rsyslog sink + logrotate policy.

- **Routes by programname** (the device's `caplog-<node>:` tag), **not facility** — only caplog lines land in the dedicated file; the host's own syslog is untouched (no `local0` hijack, nothing to tear down). This matches the tag the firmware was built to emit.
- **Detects an existing `imudp` load** — both modern `module(load="imudp")` and legacy `$ModLoad imudp` — and emits a routing-only drop-in so it never double-binds the UDP listener.
- Flags `--port` / `--log-path` / `--retention` / `--dry-run` / `--uninstall`, with a **man-style `--help`** (SYNOPSIS + per-option OPTIONS). Root + rsyslog preflight; `systemctl`→`service` fallback.

## `docs/remote-diagnostics.md`

Operator guide: receiver setup, arming the forward on the device (`set syslog.host` / `caplog forward`), the `offband-cmd` command surface, reading logs, **feeding a central store** (Loki/ELK/Graylog — with the note that Prometheus is the *separate* MQTT-telemetry metrics path, not caplog), security, rollback, troubleshooting.

## Verification

- `bash -n` clean; `--help`, arg-validation, and **both** imudp-detection branches exercised and correct.
- **Gemini 2.5-pro (3 passes):** initial review, the facility→programname routing redesign, and a final pre-commit fact-check of the ingestion note — all clean, no issues.
- Receiver-side only; no firmware/device change, no flash.

Closes #569
