### PR TITLE
chore(#592): OKIMesh broker slots 0-1 → wss/anon over TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
 ## [Unreleased]
 
+### Changed
+- **OKIMesh broker slots 0-1 moved to wss/TLS** — the two seeded OKIMesh brokers now use
+  `wss://mqtt{1,2}.okimesh.org:9002/mqtt` over TLS (`letsencrypt` CA) instead of plaintext
+  `mqtt://…:1883`. Auth stays anonymous (TLS secures the transport; no MQTT credential).
+  Both remain disabled by default (#262). Note: as wss/TLS, these slots now wait for a
+  valid wall clock — `mqtt status` shows `held(no-clock)` until NTP/GPS, then connects.
+  Fresh-NVS only; existing devices keep their stored config. (#592)
+
 ## [1.3.0] - 2026-08-06
 
 The **field-diagnostics** release. Adds an end-to-end crash/observability stack —

--- a/docs/observer-cli-commands.md
+++ b/docs/observer-cli-commands.md
@@ -134,12 +134,12 @@ mqtt status
   eastme.sh; some brokers expect a `v1_<pubkey>` prefix. If a wss slot won't
   authenticate, try the other form. (Defaulting this per broker is #95.)
 
-### Seeded broker slots (#317)
+### Seeded broker slots (#317, #592)
 
 | Slot | Broker | url | ca_cert | jwt_audience |
 |---|---|---|---|---|
-| 0 | OKIMesh mqtt1 | `mqtt://mqtt1.okimesh.org:1883` | — (tcp / anon) | — |
-| 1 | OKIMesh mqtt2 | `mqtt://mqtt2.okimesh.org:1883` | — (tcp / anon) | — |
+| 0 | OKIMesh mqtt1 | `wss://mqtt1.okimesh.org:9002/mqtt` | `letsencrypt` | — (anon) |
+| 1 | OKIMesh mqtt2 | `wss://mqtt2.okimesh.org:9002/mqtt` | `letsencrypt` | — (anon) |
 | 2 | MeshMapper | `wss://mqtt.meshmapper.net:443/mqtt` | `isrg-x2` | `mqtt.meshmapper.net` |
 | 3 | eastme.sh | `wss://mqtt.eastme.sh:443/mqtt` | `letsencrypt` | `mqtt.eastme.sh` |
 | 4 | Eastmesh.au | `wss://mqtt2.eastmesh.au:443/mqtt` | `letsencrypt` | `mqtt2.eastmesh.au` |
@@ -165,10 +165,12 @@ mqtt status
   mis-configured right after a `set` (#67). Do your `set`s, then
   `mqtt enable <N>` (which reloads), or reboot. If a field looks wrong, re-apply
   it while the slot is enabled.
-- **wss/TLS brokers need a valid wall clock** (cert validity + JWT `exp`). Until
-  the clock syncs (NTP, or a GPS fix), such a slot reads `state=held(no-clock)`
-  in `mqtt status` — that's *deferred, not failing*; it connects on its own once
-  the clock is sane. tcp brokers (CoreScope) never wait on the clock.
+- **wss/TLS brokers need a valid wall clock** (cert validity, and JWT `exp` where
+  used). Until the clock syncs (NTP, or a GPS fix), such a slot reads
+  `state=held(no-clock)` in `mqtt status` — that's *deferred, not failing*; it
+  connects on its own once the clock is sane. This now includes the OKIMesh
+  slots (0, 1), which moved to wss in #592; a plain-`mqtt://` tcp broker (e.g. a
+  hand-added LAN Mosquitto) never waits on the clock.
 
 ## First-time bring-up (minimal)
 

--- a/scripts/test_observer_nvs_round_trip.py
+++ b/scripts/test_observer_nvs_round_trip.py
@@ -150,9 +150,9 @@ int main() {
     // populateDefaultBrokers — Plan 2 v2 Task 3 Step 5
     // -----------------------------------------------------------------------
     // Slot 2 was just written above with a custom URL ("mqtt.example.org").
-    // Slots 0 + 1 + 3 are still virgin. populateDefaultBrokers should (#317):
-    //   - fill slot 0 with OKIMesh mqtt1 (tcp/anon, disabled since #262)
-    //   - fill slot 1 with OKIMesh mqtt2 (tcp/anon, disabled)
+    // Slots 0 + 1 + 3 are still virgin. populateDefaultBrokers should (#592):
+    //   - fill slot 0 with OKIMesh mqtt1 (wss/anon, letsencrypt CA, disabled)
+    //   - fill slot 1 with OKIMesh mqtt2 (wss/anon, letsencrypt CA, disabled)
     //   - fill slot 3 with Eastme.sh (wss/jwt, disabled, letsencrypt CA)
     //   - LEAVE slot 2 alone (already has user-set URL -- would otherwise be
     //     MeshMapper under the #317 layout)
@@ -165,13 +165,14 @@ int main() {
     if (!readBrokerConfig(2, slot2)) { puts("FAIL read slot 2"); return 1; }
     if (!readBrokerConfig(3, slot3)) { puts("FAIL read slot 3"); return 1; }
 
-    // Slot 0 = OKIMesh mqtt1: plaintext + anonymous. Ships DISABLED (#262 --
-    // a fresh flash must not auto-publish anywhere).
-    if (strcmp(slot0.url, "mqtt://mqtt1.okimesh.org:1883") != 0) {  // #170: was mqtt.w8oof.net
+    // Slot 0 = OKIMesh mqtt1 (#592): wss + anonymous over TLS ("letsencrypt" CA).
+    // Auth stays None -- TLS secures the transport, no MQTT credential. Ships
+    // DISABLED (#262 -- a fresh flash must not auto-publish anywhere).
+    if (strcmp(slot0.url, "wss://mqtt1.okimesh.org:9002/mqtt") != 0) {  // #592: was mqtt://:1883
         printf("FAIL slot 0 url after populate: '%s'\n", slot0.url);
         return 1;
     }
-    if (slot0.transport != BrokerTransport::Tcp) {
+    if (slot0.transport != BrokerTransport::Wss) {
         printf("FAIL slot 0 transport: %d\n", (int)slot0.transport);
         return 1;
     }
@@ -179,23 +180,39 @@ int main() {
         printf("FAIL slot 0 auth_type: %d\n", (int)slot0.auth_type);
         return 1;
     }
+    if (strcmp(slot0.ca_cert_name, "letsencrypt") != 0) {
+        printf("FAIL slot 0 ca_cert_name: '%s'\n", slot0.ca_cert_name);
+        return 1;
+    }
+    if (slot0.jwt_audience[0] != '\0') {
+        printf("FAIL slot 0 jwt_audience should be empty (anon): '%s'\n", slot0.jwt_audience);
+        return 1;
+    }
     if (slot0.enabled) {
         printf("FAIL slot 0 (OKIMesh mqtt1) should default to DISABLED (#262)\n");
         return 1;
     }
 
-    // Slot 1 = OKIMesh mqtt2 (#317): same plaintext/anon config as mqtt1,
-    // also disabled. Replaced LetsMesh-US, which is no longer seeded.
-    if (strcmp(slot1.url, "mqtt://mqtt2.okimesh.org:1883") != 0) {
+    // Slot 1 = OKIMesh mqtt2 (#592): same wss/anon/letsencrypt config as mqtt1,
+    // also disabled. (#317 put mqtt2 here, replacing LetsMesh-US.)
+    if (strcmp(slot1.url, "wss://mqtt2.okimesh.org:9002/mqtt") != 0) {
         printf("FAIL slot 1 url after populate: '%s'\n", slot1.url);
         return 1;
     }
-    if (slot1.transport != BrokerTransport::Tcp) {
+    if (slot1.transport != BrokerTransport::Wss) {
         printf("FAIL slot 1 transport: %d\n", (int)slot1.transport);
         return 1;
     }
     if (slot1.auth_type != BrokerAuthType::None) {
         printf("FAIL slot 1 auth_type: %d\n", (int)slot1.auth_type);
+        return 1;
+    }
+    if (strcmp(slot1.ca_cert_name, "letsencrypt") != 0) {
+        printf("FAIL slot 1 ca_cert_name: '%s'\n", slot1.ca_cert_name);
+        return 1;
+    }
+    if (slot1.jwt_audience[0] != '\0') {
+        printf("FAIL slot 1 jwt_audience should be empty (anon): '%s'\n", slot1.jwt_audience);
         return 1;
     }
     if (slot1.enabled) {

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -327,26 +327,32 @@ bool clearBrokerConfig(uint8_t slot) {
 // changing this layout does NOT re-shuffle slots on a device already seeded
 // under an older layout; it takes effect only on a fresh NVS.)
 //
-//   slot 0  OKIMesh mqtt1      mqtt://mqtt1.okimesh.org:1883    tcp / anon   disabled  (#262)
-//   slot 1  OKIMesh mqtt2      mqtt://mqtt2.okimesh.org:1883    tcp / anon   disabled  (#317)
+//   slot 0  OKIMesh mqtt1      wss://mqtt1.okimesh.org:9002/mqtt  wss / anon   disabled  (#592)
+//   slot 1  OKIMesh mqtt2      wss://mqtt2.okimesh.org:9002/mqtt  wss / anon   disabled  (#592)
 //   slot 2  MeshMapper         wss://mqtt.meshmapper.net        wss / jwt    disabled
 //   slot 3  Eastme.sh          wss://mqtt.eastme.sh             wss / jwt    disabled
 //   slot 4  Eastmesh.au        wss://mqtt2.eastmesh.au          wss / jwt    disabled
 //   slots 5-9  (MQTT Custom)   left empty for the operator to fill
 //
-// #317 reseat: the OKI Mesh's own two brokers now hold slots 0-1 (mqtt1 was
-// formerly labelled "CoreScope Dayton"; mqtt2 is new and shares mqtt1's
-// plaintext/anon/1883 config). LetsMesh-US and LetsMesh-EU were DROPPED from
-// the seed to make room -- they remain fully supported for operators who add
-// them by hand ("gts-r4" still resolves in lookupCaCertPem(), and the bare-host
-// audience note below still applies). MeshMapper and Eastme.sh swapped to 2/3;
-// Eastmesh.au moved 5 -> 4.
+// #317 reseat: the OKI Mesh's own two brokers hold slots 0-1 (mqtt1 was
+// formerly labelled "CoreScope Dayton"; mqtt2 is new). LetsMesh-US and
+// LetsMesh-EU were DROPPED from the seed to make room -- they remain fully
+// supported for operators who add them by hand ("gts-r4" still resolves in
+// lookupCaCertPem(), and the bare-host audience note below still applies).
+// MeshMapper and Eastme.sh swapped to 2/3; Eastmesh.au moved 5 -> 4.
+//
+// #592: slots 0-1 moved from plaintext mqtt://:1883 to wss://:9002/mqtt over
+// TLS with a "letsencrypt" CA. Auth stays anonymous (BrokerAuthType::None) --
+// TLS secures the transport; there is no MQTT-layer credential, so no JWT
+// audience/owner and no username. Unlike the plaintext form, a wss slot cannot
+// complete its TLS handshake until the wall clock is sane (NTP/GPS), so it
+// reads state=held(no-clock) in `mqtt status` until then -- deferred, not
+// failing (#69).
 //
 // As of #262 NO slot is enabled by default -- a fresh flash must not
-// auto-publish to any upstream broker. Slot 0 (plaintext + anon, no TLS cert /
-// no JWT; validated live on HV3 -- #42/#48) was formerly the sole
-// default-enabled slot, which made out-of-region fresh flashes feed
-// OKIMesh CoreScope tagged as Dayton/HAO.
+// auto-publish to any upstream broker. Slot 0 was formerly the sole
+// default-enabled slot (validated live on HV3 -- #42/#48), which made
+// out-of-region fresh flashes feed OKIMesh CoreScope tagged as Dayton/HAO.
 // The wss brokers stay disabled until the operator opts in; their ca_cert
 // names ("letsencrypt", "isrg-x2" -- plus "gts-r4" for a hand-added LetsMesh)
 // all resolve in MqttBroker.cpp's lookupCaCertPem(), and while disabled they
@@ -387,8 +393,8 @@ struct DefaultBrokerSpec {
 // Slots 0-4. Slots 5-9 (MQTT Custom) are intentionally absent so they stay empty.
 // jwt_audience is the BARE host (#95); ca_cert names resolve in MqttBroker.cpp.
 constexpr DefaultBrokerSpec kDefaultBrokerSpecs[] = {
-    {false, "mqtt://mqtt1.okimesh.org:1883",          BrokerTransport::Tcp, 1883, BrokerAuthType::None, "",                        ""},
-    {false, "mqtt://mqtt2.okimesh.org:1883",          BrokerTransport::Tcp, 1883, BrokerAuthType::None, "",                        ""},
+    {false, "wss://mqtt1.okimesh.org:9002/mqtt",      BrokerTransport::Wss, 9002, BrokerAuthType::None, "",                        "letsencrypt"},
+    {false, "wss://mqtt2.okimesh.org:9002/mqtt",      BrokerTransport::Wss, 9002, BrokerAuthType::None, "",                        "letsencrypt"},
     {false, "wss://mqtt.meshmapper.net:443/mqtt",     BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt.meshmapper.net",     "isrg-x2"},
     {false, "wss://mqtt.eastme.sh:443/mqtt",          BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt.eastme.sh",          "letsencrypt"},
     {false, "wss://mqtt2.eastmesh.au:443/mqtt",       BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt2.eastmesh.au",       "letsencrypt"},


### PR DESCRIPTION
Closes #592
Sub-issue #593 (code-landing task) closed on push.

Agent: GreenCave (session 8fe5f971)

## What this does

Moves the two seeded OKIMesh brokers (slots 0, 1) from plaintext tcp to **wss over TLS, anonymous**.

| Slot | Before (#317) | After |
|---|---|---|
| 0 | `mqtt://mqtt1.okimesh.org:1883` — tcp / none | `wss://mqtt1.okimesh.org:9002/mqtt` — wss / none / letsencrypt |
| 1 | `mqtt://mqtt2.okimesh.org:1883` — tcp / none | `wss://mqtt2.okimesh.org:9002/mqtt` — wss / none / letsencrypt |

- Transport `wss`, port `9002`, auth `none` (TLS secures the transport; no MQTT credential), ca_cert `letsencrypt`, no jwt_audience.
- **Both stay disabled by default** (#262 unchanged).

## Verified against the live brokers (not assumed)

Connected exactly as the firmware will — anonymous MQTT-over-wss to each URL:

| Check | Result |
|---|---|
| wss `:9002` reachable | ✅ both hosts |
| TLS cert | ✅ Let's Encrypt (mqtt1 `CN=mqtt1.okimesh.org`; mqtt2 wildcard `*.okimesh.org`) |
| anonymous CONNECT | ✅ CONNACK **rc=0** on both, no credentials |
| path `/mqtt` | ✅ connects (and `/` also connects — mosquitto ws listener is path-agnostic, so `/mqtt` isn't fragile) |

**Caveat:** the probe validated the certs against the system trust store (confirming they're Let's Encrypt-issued). It did not exercise the firmware's *bundled* `letsencrypt` PEM — that must be the current ISRG Root X1 chain for on-device validation. Almost certainly fine (eastme.sh already ships on `letsencrypt`); only an actual device flash confirms it.

## Also verified in firmware-base

`wss + auth=none + cert` is a coherent, connect-valid config: `populateBaseConfig()` applies the CA cert for any wss/tls transport and auth is applied independently — no path assumes wss requires JWT. `letsencrypt` resolves in `lookupCaCertPem()`.

## Behavior change

As wss/TLS, slots 0-1 now gate on a valid wall clock — `mqtt status` reads `held(no-clock)` until NTP/GPS, then connects (plaintext connected instantly). Doc + comment updated to say so. Fresh-NVS only; existing devices keep stored config.

## Verification

- `python scripts/test_observer_nvs_round_trip.py` → `OK: NVS round-trip + clamp tests pass.` (exit 0)
- Gemini adversarial review: **OK to merge**, no significant flaws; confirmed the wss+none+cert combo and that nothing special-cases slot 0 by transport. Its one nitpick (symmetric slot-1 `jwt_audience` assertion) was applied.

## Files

- `src/helpers/wifi_observer/ConfigSchema.cpp` — seed table + comment block
- `scripts/test_observer_nvs_round_trip.py` — slot 0/1 assertions (Tcp→Wss, +ca_cert, +audience)
- `docs/observer-cli-commands.md` — seeded-slots table + wss-clock gotcha
- `CHANGELOG.md` — `[Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)