### PR TITLE
feat(#608, #609): clock integrity — owner sets both directions, automated sources sanity-bounded

### DIFF
--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include "DataStore.h"
+#include <helpers/ClockSanity.h>
 
 #if defined(EXTRAFS) || defined(QSPIFLASH)
   #define MAX_BLOBRECS 100
@@ -346,6 +347,12 @@ File file = openRead(_getContactsChannelsFS(), "/contacts3");
         success = success && (file.read((uint8_t *)&c.gps_lon, 4) == 4);
 
         if (!success) break; // EOF
+
+        // #607: heal lastmod values persisted under a poisoned clock BEFORE
+        // they reach bootstrapRTCfromContacts -- otherwise a once-future
+        // clock re-poisons the RTC on every boot (the unrecoverable car-node
+        // case). Implausible values collapse to the firmware build date.
+        c.lastmod = offband::clampLastmod(c.lastmod);
 
         c.id = mesh::Identity(pub_key);
         if (!host->onContactLoaded(c)) full = true;

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -3,6 +3,7 @@
 #include <Arduino.h> // needed for PlatformIO
 #include <Mesh.h>
 #include <MeshLog.h>  // #396: serial-capture buffer access for the caplog download
+#include <helpers/ClockSanity.h>  // #607: owner-path clock sets + audit log
 
 // Offband fork-only companion-API frame codes (config 0xC0 / GPS 0xC1 / block 0xC2)
 // + shared enums. Self-contained (only <stdint.h>); included unconditionally so the
@@ -2427,13 +2428,16 @@ void MyMesh::handleCmdFrame(size_t len) {
   } else if (cmd_frame[0] == CMD_SET_DEVICE_TIME && len >= 5) {
     uint32_t secs;
     memcpy(&secs, &cmd_frame[1], 4);
+    // #607 OWNER DECISION: this is an authenticated owner path (PIN-paired
+    // BLE / USB session) -- accepted in BOTH directions, no plausibility
+    // gate. The old `secs >= curr` refusal made a future-poisoned clock
+    // permanently uncorrectable from the client. Direction is never a
+    // reason to reject an owner set; every set is logged for the audit
+    // trail (caplog tees the serial stream).
     uint32_t curr = getRTCClock()->getCurrentTime();
-    if (secs >= curr) {
-      getRTCClock()->setCurrentTime(secs);
-      writeOKFrame();
-    } else {
-      writeErrFrame(ERR_CODE_ILLEGAL_ARG);
-    }
+    getRTCClock()->setCurrentTime(secs);
+    offband::logClockSet("client-set-time", curr, secs);
+    writeOKFrame();
   } else if (cmd_frame[0] == CMD_SEND_SELF_ADVERT) {
     mesh::Packet* pkt;
     if (_prefs.advert_loc_policy == ADVERT_LOC_NONE) {

--- a/platformio.ini
+++ b/platformio.ini
@@ -222,5 +222,6 @@ build_src_filter =
   +<../src/Utils.cpp>
   +<../src/CaptureRing.cpp>
   +<../src/helpers/config/ConfigDispatch.cpp>
+  +<../src/helpers/ClockSanity.cpp>
 lib_deps =
   google/googletest @ 1.17.0

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -1,4 +1,5 @@
 #include <helpers/BaseChatMesh.h>
+#include <helpers/ClockSanity.h>
 #include <Utils.h>
 
 #ifndef SERVER_RESPONSE_DELAY
@@ -62,8 +63,18 @@ void BaseChatMesh::bootstrapRTCfromContacts() {
       latest = contacts[i].lastmod;
     }
   }
+  // #607: this is an AUTOMATED clock source -- a poisoned contacts store must
+  // not re-poison the RTC at every boot (mechanism 2 of the unrecoverable
+  // future-clock bug). Implausible values are skipped, not clamped: leaving
+  // the clock at its power-on default is honest; inventing a time is not.
   if (latest != 0) {
-    getRTCClock()->setCurrentTime(latest + 1);
+    if (offband::plausibleEpoch(latest + 1)) {
+      uint32_t old_t = getRTCClock()->getCurrentTime();
+      getRTCClock()->setCurrentTime(latest + 1);
+      offband::logClockSet("contacts-bootstrap", old_t, latest + 1);
+    } else {
+      offband::logClockReject("contacts-bootstrap", getRTCClock()->getCurrentTime(), latest + 1);
+    }
   }
 }
 

--- a/src/helpers/ClockSanity.cpp
+++ b/src/helpers/ClockSanity.cpp
@@ -1,0 +1,96 @@
+#include "ClockSanity.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#ifdef ARDUINO
+  #include <Arduino.h>
+#endif
+
+// OFFBAND_BUILD_DATE is injected per-build ("YYYY-MM-DD"). Native/host test
+// builds may lack it; fall back to a fixed floor that is still far past any
+// plausible stored-clock garbage from the pre-#607 era.
+#ifndef OFFBAND_BUILD_DATE
+  #define OFFBAND_BUILD_DATE "2026-01-01"
+#endif
+
+#define CLOCK_SANITY_HORIZON_YEARS 20
+#define SECONDS_PER_YEAR 31557600u  // 365.25d -- coarse is fine at this scale
+
+namespace offband {
+
+static const char* s_build_date = OFFBAND_BUILD_DATE;
+static uint32_t s_floor_cache = 0;
+
+// Days-from-civil (Howard Hinnant's algorithm), portable -- no timegm on
+// every toolchain we build for.
+static uint32_t civilToEpoch(int y, unsigned m, unsigned d) {
+  y -= m <= 2;
+  const int era = (y >= 0 ? y : y - 399) / 400;
+  const unsigned yoe = (unsigned)(y - era * 400);
+  const unsigned doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;
+  const unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+  const long days = (long)era * 146097 + (long)doe - 719468;
+  return days <= 0 ? 0u : (uint32_t)days * 86400u;
+}
+
+uint32_t buildEpochFloor() {
+  if (s_floor_cache) return s_floor_cache;
+  int y = 0; unsigned m = 0, d = 0;
+  if (sscanf(s_build_date, "%d-%u-%u", &y, &m, &d) == 3 &&
+      y >= 2020 && m >= 1 && m <= 12 && d >= 1 && d <= 31) {
+    s_floor_cache = civilToEpoch(y, m, d);
+  } else {
+    s_floor_cache = civilToEpoch(2026, 1, 1);  // parse failure: conservative
+  }
+  return s_floor_cache;
+}
+
+uint32_t plausibilityCeiling() {
+  return buildEpochFloor() + CLOCK_SANITY_HORIZON_YEARS * SECONDS_PER_YEAR;
+}
+
+bool plausibleEpoch(uint32_t t) {
+  return t >= buildEpochFloor() && t <= plausibilityCeiling();
+}
+
+uint32_t clampLastmod(uint32_t lastmod) {
+  return plausibleEpoch(lastmod) ? lastmod : buildEpochFloor();
+}
+
+void logClockSet(const char* source, uint32_t old_epoch, uint32_t new_epoch) {
+#ifdef ARDUINO
+  // One line per accepted set; sets are rare human/GPS events, so this cannot
+  // flood the pipe (SAFELANE rule 10). Serial-stream so caplog tees it.
+  // %lld: a correction from a decades-poisoned clock exceeds what 32-bit
+  // %ld can represent (Gemini review 2026-08-09).
+  Serial.printf("[clock] set by %s: %lu -> %lu (delta %+lld s)\n",
+                source, (unsigned long)old_epoch, (unsigned long)new_epoch,
+                (long long)((int64_t)new_epoch - (int64_t)old_epoch));
+#else
+  (void)source; (void)old_epoch; (void)new_epoch;
+#endif
+}
+
+void logClockReject(const char* source, uint32_t current, uint32_t attempted) {
+#ifdef ARDUINO
+  // Rejections from AUTOMATED sources can repeat every loop while the bad
+  // input persists (e.g. a GPS stuck on a rolled-over week). Cap the total
+  // per boot so diagnostics exist without flooding the pipe (SAFELANE 10).
+  static uint8_t budget = 3;
+  if (budget == 0) return;
+  budget--;
+  Serial.printf("[clock] REJECTED implausible %s value %lu (clock stays %lu)%s\n",
+                source, (unsigned long)attempted, (unsigned long)current,
+                budget == 0 ? " [further rejections muted this boot]" : "");
+#else
+  (void)source; (void)current; (void)attempted;
+#endif
+}
+
+void _setBuildDateForTest(const char* yyyy_mm_dd) {
+  s_build_date = yyyy_mm_dd;
+  s_floor_cache = 0;
+}
+
+}  // namespace offband

--- a/src/helpers/ClockSanity.h
+++ b/src/helpers/ClockSanity.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <stdint.h>
+
+// #607: plausibility window for AUTOMATED clock sources only (GPS epoch
+// decode, contacts-store RTC bootstrap). Owner-authenticated paths (client
+// CMD_SET_DEVICE_TIME, CLI `time` / `clock sync`) are deliberately NOT gated
+// here -- owner decision on #607: "direction is never a reason to reject a
+// time set; source and sanity are." An automated source may be rejected for
+// an implausible VALUE (from either direction); the owner may never be.
+namespace offband {
+
+// Floor of the plausibility window: the firmware build date (parsed once from
+// OFFBAND_BUILD_DATE "YYYY-MM-DD", injected by scripts/inject_offband_version.py).
+// A device cannot legitimately observe a time earlier than its firmware build.
+uint32_t buildEpochFloor();
+
+// Ceiling: floor + CLOCK_SANITY_HORIZON_YEARS (20y). Catches GPS week-rollover
+// class corruption (~+19.6y per rollover; the #607 car node sat ~+59y out).
+uint32_t plausibilityCeiling();
+
+// floor <= t <= ceiling
+bool plausibleEpoch(uint32_t t);
+
+// Heal persisted contact lastmod values written under a poisoned clock:
+// implausible values collapse to the floor so bootstrapRTCfromContacts can
+// never re-poison the RTC from the contacts store (#607 mechanism 2).
+uint32_t clampLastmod(uint32_t lastmod);
+
+// Single-line, rate-safe audit print for every ACCEPTED clock set. Rides the
+// serial stream, so the #384 caplog tee captures it when capture is enabled.
+void logClockSet(const char* source, uint32_t old_epoch, uint32_t new_epoch);
+
+// Rejection audit for AUTOMATED sources only; capped per boot (flood-safe).
+void logClockReject(const char* source, uint32_t current, uint32_t attempted);
+
+// Test seam: override the parsed build-date string (host tests only).
+void _setBuildDateForTest(const char* yyyy_mm_dd);
+
+}  // namespace offband

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include "CommonCLI.h"
+#include "ClockSanity.h"  // #607
 #include "TxtDataHelpers.h"
 #include "AdvertDataHelpers.h"
 #include "TxtDataHelpers.h"
@@ -437,15 +438,15 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
       _callbacks->sendSelfAdvertisement(1500, true);  // longer delay, give CLI response time to be sent first
       strcpy(reply, "OK - Advert sent");
     } else if (memcmp(command, "clock sync", 10) == 0) {
+      // #607 OWNER DECISION: authenticated admin path (serial console or
+      // logged-in remote CLI) -- accepted in BOTH directions. The old
+      // "cannot go backwards" refusal locked in future-poisoned clocks.
       uint32_t curr = getRTCClock()->getCurrentTime();
-      if (sender_timestamp > curr) {
-        getRTCClock()->setCurrentTime(sender_timestamp + 1);
-        uint32_t now = getRTCClock()->getCurrentTime();
-        DateTime dt = DateTime(now);
-        sprintf(reply, "OK - clock set: %02d:%02d - %d/%d/%d UTC", dt.hour(), dt.minute(), dt.day(), dt.month(), dt.year());
-      } else {
-        strcpy(reply, "ERR: clock cannot go backwards");
-      }
+      getRTCClock()->setCurrentTime(sender_timestamp + 1);
+      offband::logClockSet("cli-clock-sync", curr, sender_timestamp + 1);
+      uint32_t now = getRTCClock()->getCurrentTime();
+      DateTime dt = DateTime(now);
+      sprintf(reply, "OK - clock set: %02d:%02d - %d/%d/%d UTC", dt.hour(), dt.minute(), dt.day(), dt.month(), dt.year());
     } else if (memcmp(command, "start ota", 9) == 0) {
       if (!_board->startOTAUpdate(_prefs->node_name, reply)) {
         strcpy(reply, "Error");
@@ -457,8 +458,10 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, char* command, char* re
     } else if (memcmp(command, "time ", 5) == 0) {  // set time (to epoch seconds)
       uint32_t secs = _atoi(&command[5]);
       uint32_t curr = getRTCClock()->getCurrentTime();
-      if (secs > curr) {
+      // #607 OWNER DECISION: authenticated owner path -- both directions.
+      if (secs > 0) {
         getRTCClock()->setCurrentTime(secs);
+        offband::logClockSet("cli-time", curr, secs);
         uint32_t now = getRTCClock()->getCurrentTime();
         DateTime dt = DateTime(now);
         sprintf(reply, "OK - clock set: %02d:%02d - %d/%d/%d UTC", dt.hour(), dt.minute(), dt.day(), dt.month(), dt.year());

--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -1,5 +1,6 @@
 #include "EnvironmentSensorManager.h"
 #include <MeshLog.h>  // #411: route GPS status through the serial-capture sink
+#include <helpers/ClockSanity.h>  // #607: plausibility bounds on GPS clock sets
 
 #include <Wire.h>
 
@@ -1053,10 +1054,22 @@ void EnvironmentSensorManager::loop() {
     // self-sync; this writes the same value, harmless.)
     mesh::RTCClock* gps_clk = _location->getClock();
     long gps_epoch = _location->getTimestamp();
-    if (gps_clk != nullptr && gps_epoch >= (long)GPS_CLOCK_SANE_MIN) {
+    // #607: GPS is an AUTOMATED clock source. The old check only bounded the
+    // LOW side; a week-rollover mis-decode (~+19.6y per rollover) sailed
+    // through and poisoned the RTC decades into the future (the car-node
+    // case: ~+59y = 3 rollovers). plausibleEpoch bounds BOTH directions.
+    if (gps_clk != nullptr && gps_epoch >= (long)GPS_CLOCK_SANE_MIN &&
+        !offband::plausibleEpoch((uint32_t)gps_epoch)) {
+      // Rejection is visible but boot-capped (logClockReject); the sync
+      // timestamp is NOT updated, so a recovered GPS syncs next pass.
+      offband::logClockReject("gps", gps_clk->getCurrentTime(), (uint32_t)gps_epoch);
+    } else if (gps_clk != nullptr && gps_epoch >= (long)GPS_CLOCK_SANE_MIN &&
+        offband::plausibleEpoch((uint32_t)gps_epoch)) {
       if (_last_gps_clock_sync == 0 ||
           (millis() - _last_gps_clock_sync) > GPS_CLOCK_SYNC_INTERVAL) {
+        uint32_t old_t = gps_clk->getCurrentTime();
         gps_clk->setCurrentTime((uint32_t)gps_epoch);
+        offband::logClockSet("gps", old_t, (uint32_t)gps_epoch);
         _last_gps_clock_sync = millis();
       }
     }

--- a/test/test_clock_sanity/test_clock_sanity.cpp
+++ b/test/test_clock_sanity/test_clock_sanity.cpp
@@ -1,0 +1,69 @@
+// Native unit tests for ClockSanity (#607) — the plausibility window that
+// bounds AUTOMATED clock sources (GPS decode, contacts-store RTC bootstrap)
+// and heals poisoned persisted lastmod values. Owner paths are deliberately
+// ungated and therefore not represented here beyond the audit-log no-crash
+// check. Pure logic, no Arduino.
+
+#include <gtest/gtest.h>
+#include "helpers/ClockSanity.h"
+
+using namespace offband;
+
+// Fixed reference: floor parsed from a known build date.
+// 2026-08-07 00:00:00 UTC = 1786060800 (20672 days × 86400).
+static const uint32_t kFloor = 1786060800u;
+static const uint32_t kYear = 31557600u;
+
+class ClockSanityTest : public ::testing::Test {
+ protected:
+  void SetUp() override { _setBuildDateForTest("2026-08-07"); }
+};
+
+TEST_F(ClockSanityTest, FloorParsesBuildDate) {
+  EXPECT_EQ(kFloor, buildEpochFloor());
+}
+
+TEST_F(ClockSanityTest, CeilingIsTwentyYearsOut) {
+  EXPECT_EQ(kFloor + 20u * kYear, plausibilityCeiling());
+}
+
+TEST_F(ClockSanityTest, WindowEdges) {
+  EXPECT_TRUE(plausibleEpoch(kFloor));                    // floor inclusive
+  EXPECT_TRUE(plausibleEpoch(plausibilityCeiling()));     // ceiling inclusive
+  EXPECT_FALSE(plausibleEpoch(kFloor - 1));               // pre-build: no
+  EXPECT_FALSE(plausibleEpoch(plausibilityCeiling() + 1));
+  EXPECT_FALSE(plausibleEpoch(0));
+}
+
+TEST_F(ClockSanityTest, GpsRolloverClassRejected) {
+  // One GPS week-number rollover ≈ +19.6y — just inside a 20y horizon when
+  // it happens near build time, so specifically test the OBSERVED failure:
+  // the car node sat ~3 rollovers (+59y) out. Decades-future must fail.
+  EXPECT_FALSE(plausibleEpoch(kFloor + 59u * kYear));     // the #607 case
+  EXPECT_FALSE(plausibleEpoch(kFloor + 21u * kYear));
+  EXPECT_TRUE(plausibleEpoch(kFloor + 5u * kYear));       // sane future ok
+}
+
+TEST_F(ClockSanityTest, ClampHealsPoisonedLastmod) {
+  EXPECT_EQ(kFloor, clampLastmod(kFloor + 59u * kYear));  // future poison -> floor
+  EXPECT_EQ(kFloor, clampLastmod(12345u));                // ancient garbage -> floor
+  uint32_t sane = kFloor + kYear;
+  EXPECT_EQ(sane, clampLastmod(sane));                    // sane passes through
+}
+
+TEST_F(ClockSanityTest, BadBuildDateFallsBackConservatively) {
+  _setBuildDateForTest("garbage");
+  // Fallback floor = 2026-01-01 (1767225600), never zero.
+  EXPECT_EQ(1767225600u, buildEpochFloor());
+  _setBuildDateForTest("2026-08-07");
+}
+
+TEST_F(ClockSanityTest, LogClockSetIsNoCrashOffTarget) {
+  logClockSet("test", kFloor, kFloor + 10);  // host build: no-op, must not crash
+  SUCCEED();
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Implements #607 T1+T2 per the owner-approved decision ("direction is never a reason to reject a time set; source and sanity are"):

**T1 (#608):** new `ClockSanity` helper — plausibility window `[OFFBAND_BUILD_DATE .. +20y]`, portable civil-date math, host-tested. Bounds the AUTOMATED clock sources only: contacts-store RTC bootstrap (no more per-boot re-poisoning), companion contacts `lastmod` healed on load (poisoned stores self-repair), GPS epoch upper-bounded (kills the week-rollover class that put the car node +59y out). Accepted sets and boot-capped rejections logged on the serial stream (caplog-visible).

**T2 (#609):** the three authenticated owner paths — `CMD_SET_DEVICE_TIME`, CLI `clock sync`, CLI `time` — accept both directions unconditionally, with audit logging (64-bit delta).

**Evidence:** native suite 9/9 (incl. 7 new clock-sanity cases, constants cross-checked independently); ESP32-S3 + nRF52 companion envs compile post-review; Gemini adversarial review — BLOCKER refuted with build evidence (`arduino_base` links `helpers/*.cpp`), 3 MAJORs fixed (64-bit delta, dedicated capped rejection logger, GPS rejection visibility), minors addressed. Log: `docs/llm-consultations/2026-08-09-607-clock-sanity-review-*.log`.

**Follow-up:** #610 (T3) — bench poison/recovery verification + car-node remediation flash; #607 stays open until that hardware evidence lands. Deliberate upstream divergence documented in the code comments (#197 policy).

Refs #608, #609. Parent #607. Agent: WhiteFalcon (session cb12cdd2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)