### PR TITLE
feat(#611): 0xC6 on-air packet-hash query for CoreScope correlation

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -209,6 +209,42 @@ namespace offband { MqttBrokerPool& wifiObserverPool(); }
 #define AUTO_ADD_ROOM_SERVER      (1 << 3)  // 0x08 - auto-add Room Server (ADV_TYPE_ROOM)
 #define AUTO_ADD_SENSOR           (1 << 4)  // 0x10 - auto-add Sensor (ADV_TYPE_SENSOR)
 
+// #611: record the on-air hash of an outgoing channel message. A repeat of the same
+// (timestamp, channel) key OVERWRITES in place rather than adding a second entry, so
+// a lookup can never return a stale hash for a key the client is asking about now.
+// The client is responsible for not reusing a key across two DIFFERENT message texts
+// (see the 0xC6 contract in OffbandConfigProtocol.h) -- same text under the same key
+// is deterministic (AES-128 ECB, no IV) and therefore yields the same hash anyway.
+void MyMesh::recordSentPktHash(uint32_t msg_timestamp, uint8_t channel_idx, const uint8_t* hash) {
+  for (uint8_t s = 0; s < offband::OFFBAND_PKTHASH_RING_SLOTS; s++) {
+    if (_pkthash_ring[s].used &&
+        _pkthash_ring[s].msg_timestamp == msg_timestamp &&
+        _pkthash_ring[s].channel_idx == channel_idx) {
+      memcpy(_pkthash_ring[s].hash, hash, MAX_HASH_SIZE);
+      return;
+    }
+  }
+  SentPktHash& e = _pkthash_ring[_pkthash_next];
+  e.msg_timestamp = msg_timestamp;
+  e.channel_idx   = channel_idx;
+  memcpy(e.hash, hash, MAX_HASH_SIZE);
+  e.used = true;
+  _pkthash_next = (uint8_t)((_pkthash_next + 1) % offband::OFFBAND_PKTHASH_RING_SLOTS);
+}
+
+// #611: returns the retained hash for a key, or nullptr if it was never sent this
+// session or has been evicted (caller replies OFFBAND_PKTHASH_ERR_UNKNOWN_KEY).
+const uint8_t* MyMesh::lookupSentPktHash(uint32_t msg_timestamp, uint8_t channel_idx) const {
+  for (uint8_t s = 0; s < offband::OFFBAND_PKTHASH_RING_SLOTS; s++) {
+    if (_pkthash_ring[s].used &&
+        _pkthash_ring[s].msg_timestamp == msg_timestamp &&
+        _pkthash_ring[s].channel_idx == channel_idx) {
+      return _pkthash_ring[s].hash;
+    }
+  }
+  return nullptr;
+}
+
 void MyMesh::writeOKFrame() {
   uint8_t buf[1];
   buf[0] = RESP_CODE_OK;
@@ -1212,6 +1248,16 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
       _serial(NULL), telemetry(MAX_PACKET_PAYLOAD - 4), _store(&store), _ui(ui) {
   _iter_started = false;
   _cli_rescue = false;
+  // #611: clear the packet-hash ring here rather than relying on the_mesh having
+  // static storage duration (which zero-initializes it today). That guarantee is
+  // non-local -- it silently disappears if this object is ever heap-allocated -- and
+  // a garbage `used` flag would make lookupSentPktHash() return a bogus hash, which
+  // the client would then correlate against CoreScope. Matches this constructor's
+  // body-init convention.
+  for (uint8_t s = 0; s < offband::OFFBAND_PKTHASH_RING_SLOTS; s++) {
+    _pkthash_ring[s].used = false;
+  }
+  _pkthash_next = 0;
 #ifdef OFFBAND_OBSERVER
   // Strycher/LoRa#325: init the USB-serial observer-CLI accumulator here
   // (matching this constructor's body-init convention) so _obs_cli_len is
@@ -1824,6 +1870,51 @@ void MyMesh::handleCmdFrame(size_t len) {
   // documented in OffbandConfigProtocol.h and is the single source of truth shared
   // with the client. Gated on PIN_BUZZER because the capability bit is; a board that
   // never advertises OFFBAND_CAP2_NOTIFY_SCOPE must not answer 0xC5 either.
+  // #611: on-air packet-hash query. Canonical contract in OffbandConfigProtocol.h.
+  // Read-only lookup against the send-path ring -- no hardware gate (every companion
+  // build has a channel-send path), so OFFBAND_CAP2_PKT_HASH is advertised
+  // unconditionally and this needs no #ifdef.
+  if (cmd_frame[0] == offband::CMD_OFFBAND_PKT_HASH && len >= 2) {
+    if (cmd_frame[1] == offband::OFFBAND_PKTHASH_GET) {
+      // [0xC6][0x01][ts:4][chan:1] -- exactly 7 bytes. Strict equality, not >=:
+      // the contract documents a fixed length, so a longer frame is a client bug and
+      // silently ignoring trailing bytes would hide it (Gemini review, #611).
+      if (len != 7) {
+        out_frame[0] = offband::RESP_CODE_OFFBAND_PKT_HASH;
+        out_frame[1] = offband::OFFBAND_PKTHASH_ERR;
+        out_frame[2] = offband::OFFBAND_PKTHASH_ERR_MALFORMED;
+        _serial->writeFrame(out_frame, 3);
+        return;
+      }
+      uint32_t ts;
+      memcpy(&ts, &cmd_frame[2], 4);
+      uint8_t chan = cmd_frame[6];
+      const uint8_t* h = lookupSentPktHash(ts, chan);
+      if (h == nullptr) {
+        out_frame[0] = offband::RESP_CODE_OFFBAND_PKT_HASH;
+        out_frame[1] = offband::OFFBAND_PKTHASH_ERR;
+        out_frame[2] = offband::OFFBAND_PKTHASH_ERR_UNKNOWN_KEY;
+        _serial->writeFrame(out_frame, 3);
+        return;
+      }
+      // Echo the key so the client can match reply->request without relying on
+      // ordering (the 0xC5 SET-echo precedent).
+      int o = 0;
+      out_frame[o++] = offband::RESP_CODE_OFFBAND_PKT_HASH;
+      out_frame[o++] = offband::OFFBAND_PKTHASH_GET;
+      memcpy(&out_frame[o], &ts, 4); o += 4;
+      out_frame[o++] = chan;
+      memcpy(&out_frame[o], h, MAX_HASH_SIZE); o += MAX_HASH_SIZE;
+      _serial->writeFrame(out_frame, o);
+      return;
+    }
+    out_frame[0] = offband::RESP_CODE_OFFBAND_PKT_HASH;
+    out_frame[1] = offband::OFFBAND_PKTHASH_ERR;
+    out_frame[2] = offband::OFFBAND_PKTHASH_ERR_MALFORMED;  // unknown sub-code
+    _serial->writeFrame(out_frame, 3);
+    return;
+  }
+
   if (cmd_frame[0] == offband::CMD_OFFBAND_DEVICE_UI && len >= 2) {
     uint8_t sub = cmd_frame[1];
     // #509: gate PER SUB-COMMAND, not for the whole command.
@@ -2165,6 +2256,10 @@ void MyMesh::handleCmdFrame(size_t len) {
 #else
     if (board.canControlLed()) offband_caps2 |= offband::OFFBAND_CAP2_INDICATORS;
 #endif
+    // #611: on-air packet-hash query (0xC6). No hardware dependency -- it only needs
+    // the channel-send path, which every companion build has -- so unlike the bits
+    // above this is advertised unconditionally.
+    offband_caps2 |= offband::OFFBAND_CAP2_PKT_HASH;
     out_frame[i++] = offband_caps2;          // v18+
     // #542 B1: current indicator state, so the client renders the toggles on connect
     // with no extra GET round-trip (the FEM-LNA precedent). Appended UNCONDITIONALLY.
@@ -2330,7 +2425,12 @@ void MyMesh::handleCmdFrame(size_t len) {
     } else {
       ChannelDetails channel;
       bool success = getChannel(channel_idx, channel);
-      if (success && sendGroupMessage(msg_timestamp, channel.channel, _prefs.node_name, text, len - i)) {
+      // #611: capture the on-air packet hash so a capable client can correlate this
+      // send with an observer sighting via the 0xC6 query. The reply below stays a
+      // bare writeOKFrame() -- unchanged for stock/alternate clients.
+      uint8_t sent_hash[MAX_HASH_SIZE];
+      if (success && sendGroupMessage(msg_timestamp, channel.channel, _prefs.node_name, text, len - i, sent_hash)) {
+        recordSentPktHash(msg_timestamp, channel_idx, sent_hash);
         writeOKFrame();
       } else {
         writeErrFrame(ERR_CODE_NOT_FOUND); // bad channel_idx

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -19,7 +19,7 @@
 // bumps the code even without a frame-layout change -- 17 was "+ caplog cap bit
 // (0x20)", 16 was "FEM LNA cap 0x04 / 0xC3". This change sets caps2 bit 0x01 and adds
 // the 0xC5 command, so it follows the same rule.
-#define FIRMWARE_VER_CODE 21   // #542: + caps2 bit 0x04 INDICATORS + 0xC5 led/display sub-codes + led/display state in device-info. Prior 20 (#509): caps2 0x02 BUTTON_MATRIX. Prior 19 (#510): caps2 0x01 NOTIFY_SCOPE + 0xC5. Prior 18 (#508): second caps byte at offset 84
+#define FIRMWARE_VER_CODE 22   // #611: + caps2 bit 0x08 PKT_HASH + 0xC6 packet-hash query. Prior 21 (#542): caps2 0x04 INDICATORS + 0xC5 led/display sub-codes + led/display state in device-info. Prior 20 (#509): caps2 0x02 BUTTON_MATRIX. Prior 19 (#510): caps2 0x01 NOTIFY_SCOPE + 0xC5. Prior 18 (#508): second caps byte at offset 84
 
 #ifndef FIRMWARE_BUILD_DATE
 #define FIRMWARE_BUILD_DATE "6 Jun 2026"
@@ -84,6 +84,10 @@
 
 #include <helpers/BaseChatMesh.h>
 #include <helpers/TransportKeyStore.h>
+// #611: the packet-hash ring is sized from the canonical wire contract
+// (OFFBAND_PKTHASH_RING_SLOTS) rather than a duplicated literal. Safe to include
+// here -- this header pulls only <stdint.h> and defines no types of its own.
+#include "OffbandConfigProtocol.h"
 
 /* -------------------------------------------------------------------------------------- */
 
@@ -97,6 +101,18 @@ struct AdvertPath {
   char    name[32];
   uint32_t recv_timestamp;
   uint8_t path[MAX_PATH_SIZE];
+};
+
+// #611: one retained on-air packet hash for an outgoing channel message, so the
+// client can correlate its own send with an observer's sighting (0xC6 query).
+// Keyed by (msg_timestamp, channel_idx) -- both already arrive in
+// CMD_SEND_CHANNEL_TXT_MSG, so no change to that (stock-client) frame.
+// 13 bytes per entry; OFFBAND_PKTHASH_RING_SLOTS of them = 104 bytes.
+struct SentPktHash {
+  uint32_t msg_timestamp;
+  uint8_t  channel_idx;
+  uint8_t  hash[MAX_HASH_SIZE];
+  bool     used;               // false = empty slot (a hash of all-zero is legal)
 };
 
 class MyMesh : public BaseChatMesh, public DataStoreHost {
@@ -242,6 +258,15 @@ public:
   bool hasPendingWork() const;
 
 private:
+  // #611: retained hashes of recent outgoing channel messages, for the 0xC6 query.
+  // FIFO by _pkthash_next; a duplicate (timestamp, channel) overwrites in place so a
+  // repeat key never yields a stale hash. Not persisted -- correlation is only useful
+  // for the current session, and CoreScope sightings are queried promptly.
+  SentPktHash _pkthash_ring[offband::OFFBAND_PKTHASH_RING_SLOTS];
+  uint8_t     _pkthash_next = 0;
+  void recordSentPktHash(uint32_t msg_timestamp, uint8_t channel_idx, const uint8_t* hash);
+  const uint8_t* lookupSentPktHash(uint32_t msg_timestamp, uint8_t channel_idx) const;
+
   void writeOKFrame();
   void writeErrFrame(uint8_t err_code);
   void writeDisabledFrame();

--- a/examples/companion_radio/OffbandConfigProtocol.h
+++ b/examples/companion_radio/OffbandConfigProtocol.h
@@ -52,13 +52,14 @@ namespace offband {
 // 0xC-RANGE ALLOCATION MAP (frame byte[0]) -- keep this current when adding a
 // code. NOTE: some codes are #defined in MyMesh.cpp (GPS, CAPLOG), not here, so
 // grep the WHOLE 0xC range before claiming one (a partial grep missed FEM_LNA
-// and collided CAPLOG onto 0xC3 -- #408). Next free: 0xC6.
+// and collided CAPLOG onto 0xC3 -- #408). Next free: 0xC7.
 //   0xC0 CMD_OFFBAND_CONFIG    (this file)
 //   0xC1 CMD_OFFBAND_GPS       (MyMesh.cpp)
 //   0xC2 CMD_OFFBAND_BLOCK     (this file)
 //   0xC3 CMD_OFFBAND_FEM_LNA   (this file)
 //   0xC4 CMD_OFFBAND_CAPLOG    (MyMesh.cpp, #396)
 //   0xC5 CMD_OFFBAND_DEVICE_UI (this file, #509/#510)
+//   0xC6 CMD_OFFBAND_PKT_HASH  (this file, #611)
 
 // === 0xC5 DEVICE-UI COMMAND -- CANONICAL WIRE CONTRACT (#509/#510) ============
 // Owner-directed 2026-08-01: FIRMWARE OWNS THIS CONTRACT. The client codes to what
@@ -107,6 +108,60 @@ constexpr uint8_t OFFBAND_UI_DISPLAY_GET = 0x05;  // -> [0xC5][0x05][mode]
 constexpr uint8_t OFFBAND_UI_DISPLAY_SET = 0x06;  // [0xC5][0x06][mode] -> echo
 constexpr uint8_t OFFBAND_UI_LED_GET     = 0x07;  // -> [0xC5][0x07][on]
 constexpr uint8_t OFFBAND_UI_LED_SET     = 0x08;  // [0xC5][0x08][on]   -> echo
+
+// === 0xC6 PACKET-HASH QUERY -- CANONICAL WIRE CONTRACT (#611) =================
+// FIRMWARE OWNS THIS CONTRACT (same discipline as 0xC5). Agreed with the client
+// (QuietSnow) 2026-08-10; owner-approved. The client codes to what is written here.
+//
+// PURPOSE: let the client correlate its OWN outgoing channel message with an
+// observer's sighting of the same on-air packet (CoreScope observer_count). The
+// client cannot reproduce this hash itself -- for outgoing channel messages it
+// stamps a plaintext content hash, and the on-air hash is over the ENCRYPTED
+// payload, needing byte-exact parity on the "<sender>: " prefix, the timestamp and
+// the channel encryption.
+//
+//   REQUEST                          REPLY
+//   [0xC6][0x01][ts:4][chan:1]       [0xC6][0x01][ts:4][chan:1][hash:8]   hash GET
+//   (any, on failure)                [0xC6][0x7F][reason]                 error
+//
+// ts     : uint32 LE -- the msg_timestamp the client sent in CMD_SEND_CHANNEL_TXT_MSG
+// chan   : uint8    -- the channel_idx from that same command
+// hash   : MAX_HASH_SIZE (8) bytes -- Packet::calculatePacketHash of the sent packet
+// reason : 1 unknown key (never sent this session, or evicted from the ring)
+//          2 malformed frame (bad length)
+//
+// The reply ECHOES the key so the client can match reply->request without relying on
+// ordering (same precedent as the 0xC5 SET echoes). Request 7 B, reply 15 B -- far
+// under the ATT MTU-3 floor, so never chunked.
+//
+// WHY A CLIENT-ISSUED QUERY, NOT AN EXTENDED OK: capability bits advertise
+// firmware->client, so the firmware cannot know whether the CONNECTED client is
+// hash-capable. Gating an extended reply on a cap bit is therefore impossible --
+// firmware would have to mutate the channel-send OK for everyone or no one. A
+// client-initiated query inverts it: only a capable client ever emits 0xC6, so
+// writeOKFrame() on the channel-send path is untouched. Zero stock-client surface.
+//
+// KEY UNIQUENESS IS THE CLIENT'S RESPONSIBILITY. (ts, chan) is not inherently
+// unique -- msg_timestamp is Unix SECONDS. Utils::encrypt is AES-128 ECB with no IV,
+// so it is deterministic: two sends with the SAME text/ts/chan produce an identical
+// hash (harmless -- either ring entry is correct). Only DIFFERENT text under the same
+// (ts, chan) is ambiguous, and it would silently return the wrong hash. The client
+// supplies msg_timestamp, so it must never reuse a (ts, chan) pair for two different
+// message texts (bump ts by 1 s on collision). A firmware-side correlation tag was
+// rejected: it would mean changing CMD_SEND_CHANNEL_TXT_MSG, i.e. the stock-client
+// surface this design exists to avoid touching.
+//
+// Gated on OFFBAND_CAP2_PKT_HASH (caps byte 2, bit 3) + FIRMWARE_VER_CODE >= 22.
+// ==============================================================================
+constexpr uint8_t CMD_OFFBAND_PKT_HASH       = 0xC6;
+constexpr uint8_t RESP_CODE_OFFBAND_PKT_HASH = 0xC6;
+constexpr uint8_t OFFBAND_PKTHASH_GET        = 0x01;  // [0xC6][0x01][ts:4][chan:1]
+constexpr uint8_t OFFBAND_PKTHASH_ERR        = 0x7F;  // [0xC6][0x7F][reason]
+constexpr uint8_t OFFBAND_PKTHASH_ERR_UNKNOWN_KEY = 1;
+constexpr uint8_t OFFBAND_PKTHASH_ERR_MALFORMED   = 2;
+// Outstanding sends retained for correlation. 8 entries x 13 B = 104 B. FIFO;
+// duplicate-key insert overwrites (most-recent-wins).
+constexpr uint8_t OFFBAND_PKTHASH_RING_SLOTS = 8;
 constexpr uint8_t OFFBAND_UI_ERR        = 0x7F;
 // error reason bytes
 constexpr uint8_t OFFBAND_UI_ERR_UNSUPPORTED_ACTION = 1;
@@ -220,7 +275,8 @@ enum MqttAuthType  : uint8_t { MQTT_AUTH_NONE = 0, MQTT_AUTH_BASIC = 1, MQTT_AUT
 //    0   0x01   OFFBAND_CAP2_NOTIFY_SCOPE     this change  #510
 //    1   0x02   OFFBAND_CAP2_BUTTON_MATRIX    this change  #509
 //    2   0x04   OFFBAND_CAP2_INDICATORS      this change  #542
-//    3-7 0x08.. -- free --
+//    3   0x08   OFFBAND_CAP2_PKT_HASH         this change  #611
+//    4-7 0x10.. -- free --
 // ===============================================================================
 // bit 0 (0x01): device notification scope ALL/SELF/NONE is supported and settable.
 // Set only where the device can actually make a sound -- gated on PIN_BUZZER, exactly
@@ -236,6 +292,11 @@ constexpr uint8_t OFFBAND_CAP2_BUTTON_MATRIX = 0x02;
 // canControlLed() || DISPLAY_CLASS, independent of NOTIFY_SCOPE -- a buzzer-less display
 // board (e.g. Heltec V4) advertises THIS but not scope. #542 B1.
 constexpr uint8_t OFFBAND_CAP2_INDICATORS = 0x04;
+// bit 3 (0x08): the device can report the on-air packet hash of an outgoing channel
+// message, queried via 0xC6 (#611). Unconditional on Offband companion builds -- it
+// needs no hardware, only the send path. A client that does not see this bit (or sees
+// FIRMWARE_VER_CODE < 22) must never emit 0xC6.
+constexpr uint8_t OFFBAND_CAP2_PKT_HASH = 0x08;
 constexpr uint8_t OFFBAND_CAP_WIFI_OBSERVER = 0x01;  // bit 0: config backend (wifi_observer) compiled in
 constexpr uint8_t OFFBAND_CAP_BLOCK         = 0x02;  // bit 1: user-block list (BlockStore) compiled in (#241)
 constexpr uint8_t OFFBAND_CAP_FEM_LNA       = 0x04;  // bit 2: FEM LNA runtime control available (#298)

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -483,7 +483,8 @@ int  BaseChatMesh::sendCommandData(const ContactInfo& recipient, uint32_t timest
   return rc;
 }
 
-bool BaseChatMesh::sendGroupMessage(uint32_t timestamp, mesh::GroupChannel& channel, const char* sender_name, const char* text, int text_len) {
+bool BaseChatMesh::sendGroupMessage(uint32_t timestamp, mesh::GroupChannel& channel, const char* sender_name, const char* text, int text_len,
+                                    uint8_t* out_pkt_hash) {
   uint8_t temp[5+MAX_TEXT_LEN+32];
   memcpy(temp, &timestamp, 4);   // mostly an extra blob to help make packet_hash unique
   temp[4] = 0;  // TXT_TYPE_PLAIN
@@ -498,6 +499,14 @@ bool BaseChatMesh::sendGroupMessage(uint32_t timestamp, mesh::GroupChannel& chan
 
   auto pkt = createGroupDatagram(PAYLOAD_TYPE_GRP_TXT, channel, temp, 5 + prefix_len + text_len);
   if (pkt) {
+    // #611: capture the hash HERE -- before sendFloodScoped(). Once the packet is
+    // queued for transmission the pool may recycle it, so reading it afterwards is
+    // a use-after-recycle. The hash is over the packet's own bytes (payload type +
+    // encrypted payload), so it is final the moment createGroupDatagram returns and
+    // does not depend on when the packet actually goes on air.
+    if (out_pkt_hash != nullptr) {
+      pkt->calculatePacketHash(out_pkt_hash);
+    }
     sendFloodScoped(channel, pkt);
     return true;
   }

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -151,7 +151,15 @@ public:
   mesh::Packet* createSelfAdvert(const char* name, double lat, double lon);
   int  sendMessage(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char* text, uint32_t& expected_ack, uint32_t& est_timeout);
   int  sendCommandData(const ContactInfo& recipient, uint32_t timestamp, uint8_t attempt, const char* text, uint32_t& est_timeout);
-  bool sendGroupMessage(uint32_t timestamp, mesh::GroupChannel& channel, const char* sender_name, const char* text, int text_len);
+  // #611: out_pkt_hash (optional) receives the transmitted packet's
+  // Packet::calculatePacketHash -- MAX_HASH_SIZE bytes -- so a caller can
+  // correlate its own outgoing channel message with an observer's sighting of
+  // the same on-air packet (CoreScope). Defaults to nullptr, so every existing
+  // caller is unaffected. Needed because the packet does not escape this
+  // function: it is handed to sendFloodScoped and only a bool comes back, so
+  // the hash cannot be obtained at the call site.
+  bool sendGroupMessage(uint32_t timestamp, mesh::GroupChannel& channel, const char* sender_name, const char* text, int text_len,
+                        uint8_t* out_pkt_hash = nullptr);
   bool sendGroupData(mesh::GroupChannel& channel, uint8_t* path, uint8_t path_len, uint16_t data_type, const uint8_t* data, int data_len);
   int  sendLogin(const ContactInfo& recipient, const char* password, uint32_t& est_timeout);
   int  sendAnonReq(const ContactInfo& recipient, const uint8_t* data, uint8_t len, uint32_t& tag, uint32_t& est_timeout);


### PR DESCRIPTION
## Summary
Implements #611. A capable client can query the **on-air packet hash** of its own outgoing channel message via a new `0xC6` command, so it can ask CoreScope how many nodes repeated that packet.

The client cannot compute this itself: for outgoing channel messages it stamps a *plaintext* content hash, while the on-air hash is over the **encrypted** payload and needs byte-exact parity on the `"<sender>: "` prefix, the timestamp, and the channel encryption.

## Wire contract
```
REQUEST                       REPLY
[0xC6][0x01][ts:4][chan:1]    [0xC6][0x01][ts:4][chan:1][hash:8]
(failure)                     [0xC6][0x7F][reason]   1=unknown key, 2=malformed
```
Canonical spec lives in `OffbandConfigProtocol.h` (firmware owns this contract, same discipline as `0xC5`). Key = `(msg_timestamp, channel_idx)`, both already present in `CMD_SEND_CHANNEL_TXT_MSG`. Reply echoes the key so the client can match reply→request without relying on ordering. Request is **exactly 7 bytes** — a longer frame returns `reason 2` rather than being silently accepted.

## Why a client-issued query, not an extended channel-send reply
Capability bits advertise **firmware → client**. The firmware cannot know whether the *connected* client is hash-capable, so gating an extended OK on a cap bit is impossible — it would have to mutate the reply for everyone or no one. A client-initiated query inverts it: only a capable client ever emits `0xC6`, so **`writeOKFrame()` on the channel-send path is untouched**. Zero stock-client surface.

## Verification
- **Round-trip CONFIRMED on hardware by the owner** — debug log shows the `0xC6` query and reply working end-to-end against a flashed device. Firmware communication is not the open issue.
- Flashed and exercised on `wismesh1w-companion` (RAK3401 WisMesh 1W Booster, `RAK_3401_companion_radio_ble`), config-preserving nRF52 DFU.
- Builds SUCCESS: `Heltec_v3_companion_radio_ble` (ESP32) + `RAK_4631_companion_radio_ble` + `RAK_3401_companion_radio_ble` (nRF52). Second/third arch deliberately, because this touches shared MeshCore-base code (`BaseChatMesh`) — the #350/#463 lesson.
- Gemini 2.5-pro: **APPROVED**. It specifically confirmed the load-bearing claim: the hash captured before `sendFloodScoped` equals what an off-air observer computes, because `calculatePacketHash` covers `payloadType + payload` only and later hops mutate *header* path bytes. Its MINOR (`len < 7` → `len != 7`) applied.

## Implementation notes
- `BaseChatMesh::sendGroupMessage` gains `out_pkt_hash = nullptr` (additive; existing callers unaffected) because the packet never escapes that function — it goes to `sendFloodScoped` and only a `bool` returns. The hash is taken **immediately after `createGroupDatagram`, before `sendFloodScoped`**: once queued, the pool may recycle the packet.
- 8-slot FIFO ring (104 B). A duplicate key **overwrites in place**, so a repeated key can never return a stale hash.
- Ring is cleared in the constructor. Static-storage zero-init makes that unnecessary today, but the guarantee is non-local and a garbage `used` flag would hand the client a bogus hash to correlate.
- Key uniqueness across *different* message texts is the client's job (documented in the contract) and is confirmed accepted by the client agent: monotonic per-channel timestamps, bump to `last_ts + 1` on reuse. AES-128 ECB with no IV is deterministic, so same-text collisions yield the same hash and are harmless — only different text under one key is ambiguous.

## Allocations (recorded in the same commit per #514)
- `0xC6 CMD_OFFBAND_PKT_HASH` — registry "next free" advanced to `0xC7`
- `OFFBAND_CAP2_PKT_HASH = 0x08` — caps byte 2, bit 3
- `FIRMWARE_VER_CODE 21 → 22`

Swept clean before claiming, across **every** remote branch and both repos' open issues. The cap bit is advertised **unconditionally** — unlike its neighbours it has no hardware dependency, only the send path.

## Cross-repo
Contract negotiated and settled with the client agent (QuietSnow) before implementation; client counterparts are OffbandMesh/meshcore-client#550 / #551 under epic #524. The client half is gated on this landing.

Refs #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Agent: VioletBarn — recorded retroactively 2026-08-12 on owner attribution (session id not known to the recording agent, FoggyCanyon/2d2b37f1).
