### PR TITLE
bug(#602): remove SafeBoot VBAT_ENABLE override that prevents Wio Tracker L1 Pro from booting

### DIFF
--- a/variants/wio-tracker-l1/platformio.ini
+++ b/variants/wio-tracker-l1/platformio.ini
@@ -18,8 +18,21 @@ build_flags = ${nrf52_base.build_flags}
   -D GPS_BAUD_RATE=9600
   ; --- SafeBoot pre-init power guard (Meshtastic PR #10391) ---
   ; PIN_VBAT_READ=16 + ADC_M=2.0 + AREF=3.6 (default) + VBAT_ENABLE=30
-  -D SAFEBOOT_VBAT_ENABLE_PIN=VBAT_ENABLE
-  -D SAFEBOOT_VBAT_ENABLE_ACTIVE=LOW
+  ;
+  ; #602: do NOT gate the battery divider from SafeBoot on this board.
+  ; variant.cpp:70-72 drives VBAT_ENABLE HIGH to ENABLE the divider, and
+  ; WioTrackerL1Board::getBattMilliVolts() relies on that state (it never
+  ; touches the pin). The previous SAFEBOOT_VBAT_ENABLE_ACTIVE=LOW was copied
+  ; from xiao_nrf52, whose variant.h documents the opposite convention
+  ; ("Output LOW to enable"). Driving LOW here DISABLED the divider for the
+  ; duration of SafeBoot's sample, so it read a dead divider, fell below
+  ; SLEEP_MV and deep-slept before USB/display init -- at ANY state of charge
+  ; (measured 4232 mV via the client while the device refused to boot).
+  ;
+  ; Do NOT "fix" this by setting ACTIVE=HIGH: SafeBoot releases the pin to
+  ; !ACTIVE after sampling, which would leave the divider DISABLED and break
+  ; getBattMilliVolts() for the rest of runtime. Leaving the override
+  ; undefined makes the gate block a documented no-op (SafeBoot.cpp:352-355).
   -D DEFAULT_SAFE_BOOT_WAKE_MV=3700
   -D DEFAULT_SAFE_BOOT_SLEEP_MV=3400
   -D DEFAULT_SAFE_BOOT_RECHECK_SECS=120


### PR DESCRIPTION
Closes #620. Fixes the boot failure reported in #602 (parent stays open pending merge).

## Problem

The shipped `offband-v1.3.0` build of `WioTrackerL1_companion_radio_ble` **does not boot** on Seeed Wio Tracker L1 Pro hardware — no USB enumeration in any device class, OLED dark. The bootloader stays reachable by double-tap reset, so the board looks bricked but is not.

## Cause

`variants/wio-tracker-l1/variant.cpp:70-72` drives `VBAT_ENABLE` (pin 30) **HIGH** to *enable* the battery divider, and `WioTrackerL1Board::getBattMilliVolts()` relies on that state — it never touches the pin.

The variant told SafeBoot the pin was **active-LOW**, a value copied from `xiao_nrf52`, whose `variant.h` documents the opposite convention (*"Output LOW to enable reading of the BAT voltage"*). So SafeBoot **disabled** the divider, sampled a dead one, read below `DEFAULT_SAFE_BOOT_SLEEP_MV=3400`, and deep-slept before USB and display init — **at any state of charge**.

## The change

```diff
-  -D SAFEBOOT_VBAT_ENABLE_PIN=VBAT_ENABLE
-  -D SAFEBOOT_VBAT_ENABLE_ACTIVE=LOW
```

Two flags removed; everything else added is an explanatory comment. With `SAFEBOOT_VBAT_ENABLE_PIN` undefined the gate block is a documented no-op, so SafeBoot samples with the divider already enabled by variant init. **Thresholds deliberately untouched.**

**Not fixed by inverting to `ACTIVE=HIGH`** — SafeBoot releases the pin to `!ACTIVE` after sampling, which would leave the divider disabled and break `getBattMilliVolts()` at runtime.

## Verification — hardware, not just CI

| Build | SafeBoot | VBAT gate | Result on device |
|---|---|---|---|
| `offband-v1.3.0` release | enabled | `ACTIVE=LOW` | **dead** — no USB, dark OLED |
| spike `-D SAFE_BOOT_DISABLED` | compiled out | n/a | boots |
| **this fix** | **enabled** | **removed** | **boots, OLED on** |

The middle row isolated SafeBoot as the blocker (flag effectiveness verified by binary string inspection, not assumed). The third proves the *gate polarity* was the defect, not the thresholds — SafeBoot is fully active in the working build.

Owner-confirmed on hardware: boots, screen on, client reports `1.3.0-1.16.0`. Battery measured **4232 mV** while the stock image refused to boot, which is what ruled out a genuine low-voltage condition.

Built clean on current `firmware-base` after rebasing off the 1.3.0 tag used for the isolated A/B.

## Gemini adversarial review

Run per the required gate: `gemini-2.5-pro`, audit log `docs/llm-consultations/2026-08-10-gemini-602-review-gemini-gemini-2.5-pro.log`.

**Findings addressed:**

- *"Is deleting the override correct, or does it leave a latent problem?"* — Reviewer independently verified init ordering (`initVariant()` before `setup()`) and that nRF52 wake-from-SYSTEM_OFF is a full reset, so no path reaches SafeBoot with the divider unenabled. **Confirmed correct, no change needed.**
- *"Do the two ADC math paths disagree?"* — Reviewer confirmed both reduce to `raw × 1.7578`. **No discrepancy.**

**Findings deliberately not addressed in this PR, with justification:**

- *"The `!ACTIVE` release is a bug in `SafeBoot.cpp` itself, actively misconfiguring at least four other boards"* — **Agreed, and filed as #619 (P1).** Not fixed here because it changes shared boot behaviour on `xiao_nrf52` and three `ikoka_*` variants, none of which I can test, and it rests on a `variant.cpp` comment rather than a schematic. Folding it in would put unverifiable multi-board changes behind a hardware-verified single-board fix.
- *"A comment is inadequate to stop the next board copying `xiao_nrf52`'s defines"* — **Agreed.** That is exactly what #619 closes; the comment here only protects this variant in the interim.
- *"Leaving thresholds untouched"* — Reviewer judged `3400`/`3700` reasonable and the hysteresis latch **desirable** for solar field nodes, contradicting the framing in #604. That counter-argument is recorded in full on #604 and the issue should be rescoped; it does not affect this PR, which changes no thresholds.

## Scope

This variant only. Audited every variant setting `SAFEBOOT_VBAT_ENABLE_ACTIVE` — `xiao_nrf52`, `sensecap_solar`, and the three `ikoka_*` boards all match their own `variant.cpp`. **`wio-tracker-l1` was the only mismatch.**

Related: #602 (parent), #619 (shared-component defect), #604 (fleet thresholds), #601 (pio-flash nRF52 bootloader-package gap).

Agent: WindyForest (session 1055b272)