### PR TITLE
bug(#597,#598): repeater OTA robustness — pin WiFi awake during persistent windows + STA-OTA stale-server teardown

### DIFF
--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -1226,7 +1226,19 @@ void loop() {
 #ifdef HAS_EXTERNAL_WATCHDOG
   external_watchdog.loop();
 #endif
-  if (the_mesh.getNodePrefs()->powersaving_enabled && !the_mesh.hasPendingWork()) {
+  // #597: skip the idle light-sleep while a persistent-WiFi window is armed
+  // (OTA, `wifi on N`, or a caplog-forward stream). OTA already sets
+  // Board::inhibit_sleep so board.sleep() no-ops during a firmware upload, but
+  // the caplog-forward path does not — without this, a forward window still
+  // light-sleeps between LoRa events and throttles the live syslog stream.
+  // wifi_telemetry_is_persistent() tracks g_tel_persistent_until_ms, which every
+  // persistent-WiFi op (OTA, wifi-on, forward) sets — the common signal.
+  bool wifi_window_armed = false;
+#ifdef ENABLE_WIFI_TELEMETRY
+  wifi_window_armed = (wifi_telemetry_is_persistent() != 0);
+#endif
+  if (the_mesh.getNodePrefs()->powersaving_enabled && !the_mesh.hasPendingWork()
+      && !wifi_window_armed) {
 #if defined(NRF52_PLATFORM)
     board.sleep(0); // nrf ignores seconds param, sleeps whenever possible
 #else

--- a/src/helpers/ESP32Board.cpp
+++ b/src/helpers/ESP32Board.cpp
@@ -70,11 +70,15 @@ bool ESP32Board::startOTAUpdateOverSTA(const char* id, const char* password, cha
     return false;
   }
 
-  // If an OTA server is already running, refuse — caller should stopOTAUpdate first.
+  // #598: a prior OTA server may still be up — most often a stale AP-mode server
+  // from an earlier attempt, or a previous STA session that was never stopped.
+  // Rather than refusing (which forced an out-of-band `ota end` before a retry
+  // could work), tear the old server down and continue. stopOTAUpdate() ends and
+  // frees the server, clears g_ota_url, drops any AP interface, and clears
+  // inhibit_sleep — which we re-arm just below. STA WiFi was already confirmed up
+  // by the WL_CONNECTED check above and is left untouched.
   if (g_ota_server != nullptr) {
-    snprintf(reply, 80, "ERR: OTA already running at %s",
-             g_ota_url[0] ? g_ota_url : "(unknown)");
-    return false;
+    stopOTAUpdate();
   }
 
   inhibit_sleep = true;   // prevent sleep during OTA


### PR DESCRIPTION
## Summary
Two coupled repeater fixes surfaced during the patio deploy (#568), filed under #295.

Closes #597
Closes #598

### #597 — repeater skips idle light-sleep during a persistent-WiFi window
`examples/simple_repeater/main.cpp` — the powersaving guard now also skips `board.sleep(30)` while `wifi_telemetry_is_persistent()` is true (any persistent-WiFi window: OTA, `wifi on N`, caplog-forward).

**Correction to the original framing** (see #597 / #568 correction comments): OTA was *already* covered by `Board::inhibit_sleep` (`ESP32Board.h`; set by both OTA paths, and `board.sleep()` no-ops while it's set) — powersaving did **not** stall the OTA. The verified gap was the **caplog live-forward** (#561) path, which brings WiFi up persistent but never set `inhibit_sleep`, so the idle sleep throttled the live UDP syslog stream. This closes that gap and is harmlessly redundant for OTA. Gated under `#ifdef ENABLE_WIFI_TELEMETRY` (no-op on plain/nRF52 repeaters).

### #598 — STA OTA tears down a stale server instead of refusing
`src/helpers/ESP32Board.cpp` — `startOTAUpdateOverSTA()` refused whenever `g_ota_server != nullptr` (including a stale AP-mode server from a prior attempt), forcing an out-of-band `ota end` before any STA retry could work. It now calls `stopOTAUpdate()` to tear the old server down and continue. STA WiFi is already confirmed `WL_CONNECTED` and left untouched.

**Accepted trade-off** (raised by the Gemini review): teardown-and-continue means a LoRa-issued STA OTA can interrupt another client's in-progress AP OTA. Acceptable for a single-operator repeater; prioritizes retry-ability.

## Verification
- **Builds** on the 1.17.0 base (`2d63f56b`): `heltec_v4_repeater_telemetry`, `Heltec_v3_repeater`, `RAK_4631_repeater` — all SUCCESS (telemetry ESP32 / plain ESP32 / nRF52). Full `ci-green` matrix is the merge gate.
- **Gemini 2.5-pro review**: both changes sound, no blockers — `docs/llm-consultations/2026-08-13-597-598-ota-robustness-gemini-gemini-2.5-pro.log`.
- **Hardware verification: DEFERRED** — needs a bench repeater or a charged patio (not a stormy-night task). Flagging for the owner's test/merge decision; auto-merge intentionally not enabled.

Part of #295. PR-gate task #676 (Unfocused pattern — pre-push close-gate).
