### PR TITLE
task: retarget Eastme.sh broker seeds to CoreComms.net (re-implement PR #282 with credit) + fix eastmesh.au CA anchor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ scripts/llm-consult.py
 .claude/hooks/checkpoint_write.py
 .claude/hooks/block-skip-bypass.py
 .claude/hooks/dw-approve-bypass.py
+
+# native test-harness build leftovers (scripts/test_observer_nvs_round_trip.py et al.)
+harness.obj
+harness.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
   recency view catches up; re-adding the contact on the peer resolves it immediately.
 
 ### Changed
+- **Eastme.sh broker seed renamed to CoreComms.net** (#677) — the seeded slot-3 broker
+  follows the service's rebrand: `wss://mqtt.corecomms.net:443/mqtt`, JWT audience
+  `mqtt.corecomms.net`, CA anchor `gts-r4` (endpoint + full TLS chain verified live
+  2026-08-13). Slot 4 (Eastmesh.au) also repinned `letsencrypt` → `gts-r4`: its live
+  chain moved to GTS Root R4, so the old anchor no longer validates at all. Fresh-NVS
+  only (#262 semantics); existing devices keep their stored config — operators with an
+  old seeded slot can `mqtt clear <N>` + reboot to reseed. Re-implements external
+  PR #282; thanks to **EldoonNemar** for the original contribution and the rebrand
+  heads-up.
+
 - **OKIMesh broker slots 0-1 moved to wss/TLS** — the two seeded OKIMesh brokers now use
   `wss://mqtt{1,2}.okimesh.org:9002/mqtt` over TLS (`letsencrypt` CA) instead of plaintext
   `mqtt://…:1883`. Auth stays anonymous (TLS secures the transport; no MQTT credential).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A [MeshCore](https://github.com/meshcore-dev/MeshCore) fork for **cross-role fir
 
 | Role | Status | What Offband adds |
 |------|--------|---------------------|
-| **Companion / Observer** | Active | WiFi + MQTT publishing of LoRa-mesh observations to public brokers (CoreScope, eastme.sh, LetsMesh), NimBLE BLE stack, multi-broker pool with TLS + JWT auth, a GPS&nbsp;>&nbsp;NTP phone-free wall clock for unattended JWT auth, position in the MQTT `/status`, and full **in-app configuration over BLE** — WiFi, the MQTT broker pool, and display, via the companion-API config command — alongside the `_sys`-channel CLI |
+| **Companion / Observer** | Active | WiFi + MQTT publishing of LoRa-mesh observations to public brokers (CoreScope, CoreComms.net, LetsMesh), NimBLE BLE stack, multi-broker pool with TLS + JWT auth, a GPS&nbsp;>&nbsp;NTP phone-free wall clock for unattended JWT auth, position in the MQTT `/status`, and full **in-app configuration over BLE** — WiFi, the MQTT broker pool, and display, via the companion-API config command — alongside the `_sys`-channel CLI |
 | **Repeater** | Active | MQTT telemetry bridging (to Mosquitto and other brokers), burst-WiFi telemetry, heap and power tuning |
 | **Room server** | Not yet | -- |
 | **Bridge** | Not yet | -- |

--- a/docs/observer-cli-commands.md
+++ b/docs/observer-cli-commands.md
@@ -110,7 +110,7 @@ stored **config**.
 
 ## Broker auth — wss/jwt (the real recipe)
 
-The public MeshCore brokers (LetsMesh, eastme.sh) use `wss` + JWT. The credential
+The public MeshCore brokers (LetsMesh, CoreComms.net) use `wss` + JWT. The credential
 is your node's **own Ed25519 public key** — the firmware mints the token; there's
 no separate registration. Configure a wss/jwt slot like this:
 
@@ -131,7 +131,7 @@ mqtt status
   (the password — you do **not** set it) and normalizes `jwt_owner` case
   internally, so the input case doesn't matter.
 - **The exact `username` form is broker-dependent.** A **bare pubkey** works on
-  eastme.sh; some brokers expect a `v1_<pubkey>` prefix. If a wss slot won't
+  CoreComms.net; some brokers expect a `v1_<pubkey>` prefix. If a wss slot won't
   authenticate, try the other form. (Defaulting this per broker is #95.)
 
 ### Seeded broker slots (#317, #592)
@@ -141,8 +141,8 @@ mqtt status
 | 0 | OKIMesh mqtt1 | `wss://mqtt1.okimesh.org:9002/mqtt` | `letsencrypt` | — (anon) |
 | 1 | OKIMesh mqtt2 | `wss://mqtt2.okimesh.org:9002/mqtt` | `letsencrypt` | — (anon) |
 | 2 | MeshMapper | `wss://mqtt.meshmapper.net:443/mqtt` | `isrg-x2` | `mqtt.meshmapper.net` |
-| 3 | eastme.sh | `wss://mqtt.eastme.sh:443/mqtt` | `letsencrypt` | `mqtt.eastme.sh` |
-| 4 | Eastmesh.au | `wss://mqtt2.eastmesh.au:443/mqtt` | `letsencrypt` | `mqtt2.eastmesh.au` |
+| 3 | CoreComms.net | `wss://mqtt.corecomms.net:443/mqtt` | `gts-r4` | `mqtt.corecomms.net` |
+| 4 | Eastmesh.au | `wss://mqtt2.eastmesh.au:443/mqtt` | `gts-r4` | `mqtt2.eastmesh.au` |
 | 5–9 | *(empty)* | — | — | — |
 
 **Every seeded slot ships disabled** (#262) — `mqtt enable <N>` to opt in.

--- a/scripts/test_observer_nvs_round_trip.py
+++ b/scripts/test_observer_nvs_round_trip.py
@@ -153,17 +153,18 @@ int main() {
     // Slots 0 + 1 + 3 are still virgin. populateDefaultBrokers should (#592):
     //   - fill slot 0 with OKIMesh mqtt1 (wss/anon, letsencrypt CA, disabled)
     //   - fill slot 1 with OKIMesh mqtt2 (wss/anon, letsencrypt CA, disabled)
-    //   - fill slot 3 with Eastme.sh (wss/jwt, disabled, letsencrypt CA)
+    //   - fill slot 3 with CoreComms.net (wss/jwt, disabled, gts-r4 CA -- #677)
     //   - LEAVE slot 2 alone (already has user-set URL -- would otherwise be
     //     MeshMapper under the #317 layout)
 
     populateDefaultBrokers();
 
-    BrokerConfig slot0, slot1, slot2, slot3;
+    BrokerConfig slot0, slot1, slot2, slot3, slot4;
     if (!readBrokerConfig(0, slot0)) { puts("FAIL read slot 0"); return 1; }
     if (!readBrokerConfig(1, slot1)) { puts("FAIL read slot 1"); return 1; }
     if (!readBrokerConfig(2, slot2)) { puts("FAIL read slot 2"); return 1; }
     if (!readBrokerConfig(3, slot3)) { puts("FAIL read slot 3"); return 1; }
+    if (!readBrokerConfig(4, slot4)) { puts("FAIL read slot 4"); return 1; }
 
     // Slot 0 = OKIMesh mqtt1 (#592): wss + anonymous over TLS ("letsencrypt" CA).
     // Auth stays None -- TLS secures the transport, no MQTT credential. Ships
@@ -220,18 +221,19 @@ int main() {
         return 1;
     }
 
-    // Slot 3 = Eastme.sh (#317, moved from slot 2): wss/jwt, letsencrypt CA,
-    // BARE audience (#95 -- the scheme-qualified "https://" form is rejected
-    // by strict validators like LetsMesh).
-    if (strcmp(slot3.url, "wss://mqtt.eastme.sh:443/mqtt") != 0) {
+    // Slot 3 = CoreComms.net (#317 moved it from slot 2; #677 renamed it from
+    // Eastme.sh and repinned to gts-r4): wss/jwt, BARE audience (#95 -- the
+    // scheme-qualified "https://" form is rejected by strict validators like
+    // LetsMesh).
+    if (strcmp(slot3.url, "wss://mqtt.corecomms.net:443/mqtt") != 0) {
         printf("FAIL slot 3 url after populate: '%s'\n", slot3.url);
         return 1;
     }
-    if (strcmp(slot3.jwt_audience, "mqtt.eastme.sh") != 0) {
+    if (strcmp(slot3.jwt_audience, "mqtt.corecomms.net") != 0) {
         printf("FAIL slot 3 jwt_audience (want bare host): '%s'\n", slot3.jwt_audience);
         return 1;
     }
-    if (strcmp(slot3.ca_cert_name, "letsencrypt") != 0) {
+    if (strcmp(slot3.ca_cert_name, "gts-r4") != 0) {
         printf("FAIL slot 3 ca_cert_name: '%s'\n", slot3.ca_cert_name);
         return 1;
     }
@@ -248,6 +250,25 @@ int main() {
     if (slot3.jwt_owner[0] != '\0' || slot3.jwt_email[0] != '\0' || slot3.username[0] != '\0') {
         printf("FAIL slot 3 identity claims should be empty: own='%s' eml='%s' usr='%s'\n",
                slot3.jwt_owner, slot3.jwt_email, slot3.username);
+        return 1;
+    }
+
+    // Slot 4 = Eastmesh.au: #677 repinned its CA anchor letsencrypt -> gts-r4
+    // (the live chain moved to GTS Root R4; the old pin no longer validates).
+    if (strcmp(slot4.url, "wss://mqtt2.eastmesh.au:443/mqtt") != 0) {
+        printf("FAIL slot 4 url after populate: '%s'\n", slot4.url);
+        return 1;
+    }
+    if (strcmp(slot4.ca_cert_name, "gts-r4") != 0) {
+        printf("FAIL slot 4 ca_cert_name (#677 anchor fix): '%s'\n", slot4.ca_cert_name);
+        return 1;
+    }
+    if (strcmp(slot4.jwt_audience, "mqtt2.eastmesh.au") != 0) {
+        printf("FAIL slot 4 jwt_audience (want bare host): '%s'\n", slot4.jwt_audience);
+        return 1;
+    }
+    if (slot4.enabled) {
+        printf("FAIL slot 4 (wss/jwt) should default to disabled\n");
         return 1;
     }
 

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -330,7 +330,7 @@ bool clearBrokerConfig(uint8_t slot) {
 //   slot 0  OKIMesh mqtt1      wss://mqtt1.okimesh.org:9002/mqtt  wss / anon   disabled  (#592)
 //   slot 1  OKIMesh mqtt2      wss://mqtt2.okimesh.org:9002/mqtt  wss / anon   disabled  (#592)
 //   slot 2  MeshMapper         wss://mqtt.meshmapper.net        wss / jwt    disabled
-//   slot 3  Eastme.sh          wss://mqtt.eastme.sh             wss / jwt    disabled
+//   slot 3  CoreComms.net      wss://mqtt.corecomms.net         wss / jwt    disabled  (#677)
 //   slot 4  Eastmesh.au        wss://mqtt2.eastmesh.au          wss / jwt    disabled
 //   slots 5-9  (MQTT Custom)   left empty for the operator to fill
 //
@@ -374,8 +374,8 @@ bool clearBrokerConfig(uint8_t slot) {
 //
 // Audiences are the BARE host (e.g. "mqtt-us-v1.letsmesh.net"), NOT the
 // scheme-qualified "https://..." form: LetsMesh validates the "aud" claim
-// strictly and rejects the scheme form; Eastme.sh is lenient (#95, verified
-// live 2026-06-11).
+// strictly and rejects the scheme form; CoreComms.net is lenient (#95, verified
+// live 2026-06-11 as Eastme.sh -- the service rebranded, #677 / PR #282).
 //
 // Invoke once at WifiObserver::begin() before MqttBrokerPool::begin().
 
@@ -396,8 +396,12 @@ constexpr DefaultBrokerSpec kDefaultBrokerSpecs[] = {
     {false, "wss://mqtt1.okimesh.org:9002/mqtt",      BrokerTransport::Wss, 9002, BrokerAuthType::None, "",                        "letsencrypt"},
     {false, "wss://mqtt2.okimesh.org:9002/mqtt",      BrokerTransport::Wss, 9002, BrokerAuthType::None, "",                        "letsencrypt"},
     {false, "wss://mqtt.meshmapper.net:443/mqtt",     BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt.meshmapper.net",     "isrg-x2"},
-    {false, "wss://mqtt.eastme.sh:443/mqtt",          BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt.eastme.sh",          "letsencrypt"},
-    {false, "wss://mqtt2.eastmesh.au:443/mqtt",       BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt2.eastmesh.au",       "letsencrypt"},
+    // #677: Eastme.sh rebranded to CoreComms.net (re-implements external PR
+    // #282 with credit). Both rows' chains verified live 2026-08-13: they now
+    // terminate at GTS Root R4, not ISRG X1 -- the old "letsencrypt" pin on
+    // eastmesh.au no longer validates at all.
+    {false, "wss://mqtt.corecomms.net:443/mqtt",      BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt.corecomms.net",      "gts-r4"},
+    {false, "wss://mqtt2.eastmesh.au:443/mqtt",       BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt2.eastmesh.au",       "gts-r4"},
 };
 constexpr uint8_t kNumDefaultBrokers =
     sizeof(kDefaultBrokerSpecs) / sizeof(kDefaultBrokerSpecs[0]);

--- a/src/helpers/wifi_observer/ConfigSchema.h
+++ b/src/helpers/wifi_observer/ConfigSchema.h
@@ -109,7 +109,7 @@ struct BrokerConfig {
     char             topic_prefix[32] = {0};  // defaults to kDefaultTopicPrefix at read
     char             iata_override[8] = {0};
     // ----- Plan 2 v2 additions (used only when auth_type=Jwt / transport=Tls|Wss)
-    char             jwt_audience[96] = {0};   // e.g. "https://mqtt2.eastmesh.au"
+    char             jwt_audience[96] = {0};   // BARE host (#95), e.g. "mqtt.corecomms.net"
     uint32_t         jwt_refresh_sec = 3600;   // re-mint token every N seconds
     char             ca_cert_name[24] = {0};   // ref into MqttCaCerts.h; "" = system store / no verify
     // ----- #63 additions: per-broker JWT identity claims
@@ -125,11 +125,11 @@ bool clearBrokerConfig(uint8_t slot);
 
 // Phase 2 (#48; layout revised in #95): seed the public-broker registry into
 // empty slots only (cfg.url[0] == '\0'); never overwrites user-set values;
-// idempotent. As of #262 ALL seeded slots ship DISABLED (slot 0 = CoreScope
-// tcp/anon; slots 1-5 wss/jwt: LetsMesh-US, Eastme.sh, MeshMapper, LetsMesh-EU,
-// Eastmesh.au) -- a fresh flash must not auto-publish to any upstream broker;
-// the operator opts in per slot (+ JWT identity claims for the wss brokers).
-// Slots 6-9 are left empty for operator-custom brokers.
+// idempotent. As of #262 ALL seeded slots ship DISABLED (#317/#592/#677
+// layout: slots 0-1 OKIMesh wss/anon; slots 2-4 wss/jwt: MeshMapper,
+// CoreComms.net, Eastmesh.au) -- a fresh flash must not auto-publish to any
+// upstream broker; the operator opts in per slot (+ JWT identity claims for
+// the jwt brokers). Slots 5-9 are left empty for operator-custom brokers.
 void populateDefaultBrokers();
 
 // #182: one-time boot migration of an upgraded observer to the per-key / no-blank

--- a/src/helpers/wifi_observer/MqttAuth.cpp
+++ b/src/helpers/wifi_observer/MqttAuth.cpp
@@ -89,7 +89,7 @@ bool MqttAuthJwt::apply(esp_mqtt_client_config_t& cfg, uint32_t now_ms) {
     // #95: default the JWT "owner" claim to THIS device's own pubkey (UPPERCASE
     // hex -- the same form as the token's publicKey claim) when no jwt_owner was
     // configured. owner==device-pubkey is the verified-working convention across
-    // every target broker (eastme.sh / LetsMesh), so this makes wss zero-touch:
+    // every target broker (CoreComms.net / LetsMesh), so this makes wss zero-touch:
     // no per-slot jwt_owner entry needed. An explicit jwt_owner still overrides.
     // Built once (pubkey is constant); owner_[65] holds exactly 64 hex + NUL.
     if (owner_[0] == '\0') {
@@ -118,7 +118,8 @@ bool MqttAuthJwt::apply(esp_mqtt_client_config_t& cfg, uint32_t now_ms) {
     // #68: build the MQTT CONNECT username once -- "v1_" + UPPERCASE hex of the
     // device pubkey. The broker strips "v1_" and verifies the token's publicKey
     // claim against it; a null username is rejected (CONNACK rc=5) even with a
-    // valid token -- proven live against mqtt.eastme.sh. Same convention for
+    // valid token -- proven live against mqtt.eastme.sh (the service has since
+    // rebranded to mqtt.corecomms.net -- #677). Same convention for
     // LetsMesh. The pubkey is constant, so build it only on first apply().
     if (username_[0] == '\0' && identity_ != nullptr) {
         char hex[2 * PUB_KEY_SIZE + 1];

--- a/src/helpers/wifi_observer/MqttAuth.h
+++ b/src/helpers/wifi_observer/MqttAuth.h
@@ -61,7 +61,7 @@ private:
 
 // ---------------------------------------------------------------------------
 // MqttAuthJwt -- JWT token, auto-refreshed every refresh_sec_.
-// Used by vendored brokers (EastMesh, LetsMesh-EU, LetsMesh-US).
+// Used by vendored brokers (CoreComms.net -- nee EastMesh, LetsMesh-EU, LetsMesh-US).
 // Token is minted via the Plan-1-vendored JwtHelper::createAuthToken.
 // ---------------------------------------------------------------------------
 class MqttAuthJwt : public MqttAuth {
@@ -87,7 +87,7 @@ private:
     uint32_t refresh_sec_  = 3600;
     uint32_t last_mint_ms_ = 0;
     char     token_[768]   = {0};
-    // #68: MQTT CONNECT username = "v1_" + UPPERCASE hex(pubkey). eastme.sh /
+    // #68: MQTT CONNECT username = "v1_" + UPPERCASE hex(pubkey). CoreComms.net /
     // LetsMesh gate auth on this; a null username is rejected (CONNACK rc=5)
     // even with a valid token (proven live). Built once on first apply().
     char     username_[72] = {0};

--- a/src/helpers/wifi_observer/MqttBroker.cpp
+++ b/src/helpers/wifi_observer/MqttBroker.cpp
@@ -65,14 +65,15 @@ static bool tlsHeapBudgetOk() {
 // CA cert lookup table.
 // ---------------------------------------------------------------------------
 // MqttCaCerts.h embeds the ISRG Root X1 cert under the name
-// kEastmeshIsrgRootX1Pem. EastMesh + LetsMesh both use Let's Encrypt
-// (ISRG Root X1) so one cert covers all three vendored brokers.
+// kEastmeshIsrgRootX1Pem (the symbol keeps its EastMesh-era name).
 //
 // Naming convention exposed to operators: "letsencrypt", "eastmesh"
-// (alias), or "isrg-x1" (alias) all map to ISRG Root X1 (Let's Encrypt RSA;
-// covers EastMesh). "isrg-x2" = Let's Encrypt ECDSA root; "gts-r4" = Google
-// Trust Services Root R4 (covers LetsMesh). New brokers add a name here +
-// a PEM in MqttCaCerts.h. #48 Item 2.
+// (legacy alias), or "isrg-x1" (alias) all map to ISRG Root X1 (Let's
+// Encrypt RSA). "isrg-x2" = Let's Encrypt ECDSA root (MeshMapper);
+// "gts-r4" = Google Trust Services Root R4, which as of #677 covers the
+// vendored wss/jwt brokers -- CoreComms.net (nee EastMesh), Eastmesh.au,
+// and LetsMesh all chain to GTS Root R4 (verified live 2026-08-13). New
+// brokers add a name here + a PEM in MqttCaCerts.h. #48 Item 2.
 const char* lookupCaCertPem(const char* name) {
     if (name == nullptr || name[0] == '\0') return nullptr;
 #ifdef ARDUINO

--- a/src/helpers/wifi_observer/MqttBrokerPool.h
+++ b/src/helpers/wifi_observer/MqttBrokerPool.h
@@ -43,7 +43,7 @@ public:
     MqttBrokerPool& operator=(const MqttBrokerPool&) = delete;
 
     // Initialize the pool. Calls populateDefaultBrokers() (idempotent;
-    // seeds slots 0-2 with EastMesh/LetsMesh defaults if empty), then
+    // seeds slots 0-4 with the public-broker defaults if empty), then
     // reads each slot's config and brings up brokers where enabled.
     //
     // device_id / node_name / version strings are stored for later
@@ -92,7 +92,7 @@ public:
     // PARSED mesh::Packet + rssi/snr/score/duration. Pool builds the
     // parsed-field JSON ONCE via buildPacketJson (route, payload_type,
     // dedupe hash, path, ...) then fans out per-broker via publishPacket.
-    // This is the CoreScope/EastMesh-ingested topic. Fed by MyMesh::logRx
+    // This is the CoreScope/CoreComms.net-ingested topic. Fed by MyMesh::logRx
     // (the post-parse hook) -- unlike publishRawFromBytes which is fed by
     // the pre-parse logRxRaw hook and can only emit /raw.
     uint8_t publishParsedPacket(const mesh::Packet& packet, int rssi,

--- a/src/helpers/wifi_observer/MqttCaCerts.h
+++ b/src/helpers/wifi_observer/MqttCaCerts.h
@@ -2,7 +2,9 @@
 
 namespace mqtt_ca_certs {
 
-// EastMesh currently presents a Let's Encrypt E7-issued certificate.
+// Kept for the "letsencrypt"/"eastmesh"/"isrg-x1" aliases. The EastMesh-era
+// brokers presented Let's Encrypt leaves; since the CoreComms.net rebrand
+// they chain to GTS Root R4 instead (#677).
 static const char kEastmeshIsrgRootX1Pem[] =
 R"PEM(-----BEGIN CERTIFICATE-----
 MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
@@ -130,7 +132,8 @@ p/SgguMh1YQdc4acLa/KNJvxn7kjNuK8YAOdgLOaVsjh4rsUecrNIdSUtUlD
 )PEM";
 
 // ISRG Root X2 (Let's Encrypt ECDSA root) -- future-proofs LE/ECDSA brokers
-// (current EastMesh brokers chain to ISRG X1). #48 Item 2.
+// (the EastMesh-era brokers chained to ISRG X1; the rebranded CoreComms.net
+// brokers now chain to GTS Root R4 -- #677). #48 Item 2.
 static const char kIsrgRootX2Pem[] =
 R"PEM(-----BEGIN CERTIFICATE-----
 MIICGzCCAaGgAwIBAgIQQdKd0XLq7qeAwSxs6S+HUjAKBggqhkjOPQQDAzBPMQsw

--- a/src/helpers/wifi_observer/ObserverCli.h
+++ b/src/helpers/wifi_observer/ObserverCli.h
@@ -35,7 +35,7 @@ namespace offband {
 //   set mqtt.broker.<N>.jwt_email <s>            -- #63 JWT "email" claim; "" clears
 //   set mqtt.broker.<N>.iata_override <code>
 //   set mqtt.broker.<N>.topic_prefix <s>
-//   set mqtt.broker.<N>.ca_cert <name>           -- letsencrypt, eastmesh, ""
+//   set mqtt.broker.<N>.ca_cert <name>           -- letsencrypt, gts-r4, isrg-x2, ""
 //   display always on | display normal           -- #141: keep the screen lit / restore the 15 s blank
 //                                                    ("display always off" is accepted as an alias for "display normal")
 //   display rotate <0|180> | display flip         -- #148: rotate the display 0/180 ("flip" toggles)

--- a/src/helpers/wifi_observer/WifiObserverConfig.h
+++ b/src/helpers/wifi_observer/WifiObserverConfig.h
@@ -35,9 +35,9 @@
 // ---------------------------------------------------------------------------
 // Hard ceiling on configurable broker slots. Plan 2 introduced the
 // configurable NVS-backed list; #95 raised the ceiling from 6 to 10 so the
-// pre-seeded public brokers (CoreScope + LetsMesh US/EU + Eastme.sh +
-// MeshMapper + Eastmesh.au = 6 slots, slots 0-5) leave four free slots (6-9)
-// for operator-custom brokers.
+// pre-seeded public brokers (under the #317/#677 layout: OKIMesh x2 +
+// MeshMapper + CoreComms.net + Eastmesh.au = 5 slots, slots 0-4) leave five
+// free slots (5-9) for operator-custom brokers.
 //
 // Static cost: MqttBrokerPool holds brokers_[OFFBAND_MAX_BROKERS], and
 // BrokerConfig is ~1.2 KB/slot (jwt_token[512] dominates), so 10 slots is


### PR DESCRIPTION
Closes nothing directly (#677 closed per push discipline; this PR is the landing vehicle).

**What:** The EastMe.sh public MQTT service rebranded to CoreComms.net. Re-implements external PR #282 (unmergeable after #95/#390/#593 churn) with credit, plus one defect found during verification.

- Slot-3 seed → `wss://mqtt.corecomms.net:443/mqtt`, bare-host JWT audience (#95), CA anchor `gts-r4`
- Slot-4 (Eastmesh.au) CA repin `letsencrypt` → `gts-r4` — its live chain moved to GTS Root R4, so the old ISRG X1 pin no longer validates at all (broken seed today)
- Docs (`observer-cli-commands.md` broker table), CLI help, README, stale layout comments; EastMesh provenance/history refs deliberately retained
- Seeds stay skip-if-present (#262): fresh/cleared NVS only; existing devices keep stored config (`mqtt clear <N>` + reboot to reseed)

**Verification (live, 2026-08-13):** mqtt.corecomms.net — DNS OK, MQTT WebSocket upgrade accepted (HTTP 101, `Sec-Websocket-Protocol: mqtt`), TLS chain `corecomms.net <- WE1 <- GTS Root R4` (PEM already embedded as `kGtsRootR4Pem`). mqtt2.eastmesh.au — same GTS R4 chain. Details in #677.

**Tests:** `scripts/test_observer_nvs_round_trip.py` updated in lockstep + new slot-4 anchor assertions — PASSES (fails against the old seed table). Build: `Heltec_v3_companion_observer_wifi` SUCCESS. Gemini 2.5 Pro review: LGTM (`docs/llm-consultations/2026-08-13-677-corecomms-rename-gemini-gemini-2.5-pro.log`).

**Credit:** Co-Authored-By: Eldoon Nemar — original contribution and rebrand heads-up in PR #282. #282 will be closed with thanks once this lands.

**Not verified:** JWT auth acceptance on corecomms.net (needs a device keypair; seed ships disabled). Optional bench check before release.

Agent: WhiteFalcon (session cb12cdd2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
