### PR TITLE
fix: cap caplog RAM ring at 8 KB on Heltec V2 (v1.4.0 release blocker)

### DIFF
--- a/discord/1.4.0.md
+++ b/discord/1.4.0.md
@@ -1,0 +1,13 @@
+📻 **Offband firmware v1.4.0** is out — the first release on the MeshCore 1.17.0 base. The app's device screen shows `1.4.0-1.17.0` once a device is upgraded.
+
+🧳 **Your settings survive the upgrade.** 1.17.0 changed how device preferences are stored; this release migrates existing config automatically on first boot, verified across 7 device combinations. If a device comes up with factory defaults after upgrading, that's the migration refusing a record it couldn't safely read — post the model and previous version here so we can look.
+
+🕰️ **Future-stuck clocks are recoverable.** A normal clock sync from the app now brings a poisoned clock back, no wipe needed. GPS and mesh time sources are bounded so they can't poison a clock in the first place.
+
+🌐 **Eastme.sh is now CoreComms.net** (WiFi observer builds) — thanks to EldoonNemar for the heads-up and the original PR. Existing devices keep their stored broker config; `mqtt clear 3` and a reboot picks up the new seed (same for slot 4, Eastmesh.au, whose old TLS pin no longer validates).
+
+🛰️ **CoreScope observer counts — the firmware half** (Experimental). This is the firmware that client 1.5.0-beta.1's Experimental CoreScope badge has been waiting for: with both installed, it shows how many OKIMesh CoreScope observers heard each packet. Phone-side lookup against the existing MQTT observer feeds — nothing new on-air, no internet→mesh path, and tied specifically to OKIMesh's CoreScope, not a generic backend.
+
+🛠️ **Also fixed:** identical credential redaction on both log-download paths, a stale SafeBoot battery gate on the Wio Tracker L1, and a smaller log-capture buffer on Heltec V2 boards to fit the new base in RAM.
+
+Release + images: https://github.com/OffbandMesh/meshcore-firmware/releases/tag/offband-v1.4.0 📡

--- a/variants/heltec_v2/platformio.ini
+++ b/variants/heltec_v2/platformio.ini
@@ -5,6 +5,10 @@ build_flags =
   ${esp32_base.build_flags}
   -I variants/heltec_v2
   -D HELTEC_LORA_V2
+  ; #685: original-ESP32 DRAM is the tightest in the fleet -- the BLE companion
+  ; env overflowed dram0_0_seg by 616 B on the 1.17.0 base. Use the nRF52-sized
+  ; caplog ring (8 KB vs the 16 KB ESP32 default) to buy ~8 KB of headroom.
+  -D OFFBAND_CAPLOG_RING_BYTES=8192
   -D RADIO_CLASS=CustomSX1276
   -D WRAPPER_CLASS=CustomSX1276Wrapper
   -D P_LORA_DIO_0=26


### PR DESCRIPTION
Fix for #683 (owner picked Option A). One flag in the shared `[Heltec_lora32_v2]` section: `OFFBAND_CAPLOG_RING_BYTES=8192` (the existing nRF52/STM32 default). The 1.17.0 base grew static RAM ~310 B and tipped the original-ESP32 BLE companion over its DRAM ceiling by 616 B in the release pipeline; the 8 KB ring frees ~8 KB of headroom. Trade-off (owner-approved): shorter log-capture window on V2 only.

Verified: `Heltec_v2_companion_radio_ble` links locally (was 664 B over). Gemini 2.5 Pro LGTM (clarified after a contradictory verdict header — both consults logged in docs/llm-consultations/). After merge: re-point tags `offband-v1.4.0{,-rc1}` to the merge commit on the owner's GO (no release objects exist on the current tags).

If the approved `discord/1.4.0.md` copy lands in time it rides this branch; otherwise it follows separately.

Agent: WhiteFalcon (session cb12cdd2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)