### PR TITLE
refactor(#684): decouple WifiConfigProvider wifi.status from observer WifiBootstrap

### DIFF
--- a/src/helpers/config/WifiConfigProvider.cpp
+++ b/src/helpers/config/WifiConfigProvider.cpp
@@ -10,15 +10,23 @@
 
 #include "WifiConfigProvider.h"
 #include "ConfigDispatch.h"
-#include "../wifi_observer/WifiBootstrap.h"   // wifi.status reads WifiBootstrap
-                                              // (observer bring-up; see header --
-                                              // #365 supplies its own off-observer)
 #include <cstdio>
 #include <cstring>
 
 #ifdef ARDUINO
   #include <Preferences.h>
-  #include <WiFi.h>   // WiFi.localIP() for wifi.status
+  #include <WiFi.h>   // WiFi.status()/localIP() for wifi.status
+#endif
+
+// #684: wifi.status reports ONE uniform vocabulary across every WiFi-capable
+// role (owner D1/D3, 2026-08-01). On an OBSERVER build the authoritative source
+// is the WifiBootstrap STA/AP bring-up machine. A non-observer build (companion
+// #365, repeater #301) runs no such machine, so it derives the SAME words from
+// the raw WiFi driver + stored creds. The observer header is pulled ONLY on
+// observer builds -- that is exactly what lets WifiConfigProvider link with zero
+// wifi_observer/ sources off-observer (the gap #370 left; unblocks #462).
+#ifdef OFFBAND_OBSERVER
+  #include "../wifi_observer/WifiBootstrap.h"
 #endif
 
 namespace offband {
@@ -165,10 +173,10 @@ bool handleGetWifi(char* reply, size_t reply_size, const char* field) {
         return true;
     }
     if (config::strEq(field, "status")) {
-#ifdef ARDUINO
-        // Reach into the WifiBootstrap state via the singleton.
-        // Render a single human-readable line summarizing the
-        // current STA state + IP when connected.
+#if defined(ARDUINO) && defined(OFFBAND_OBSERVER)
+        // Observer: authoritative state from the WifiBootstrap STA/AP machine.
+        // Render a single human-readable line summarizing the current STA state
+        // + IP when connected.
         auto state = wifiBootstrap().state();
         const char* st = "?";
         switch (state) {
@@ -202,6 +210,42 @@ bool handleGetWifi(char* reply, size_t reply_size, const char* field) {
             }
         } else {
             snprintf(reply, reply_size, "wifi.status = %s\n", st);
+        }
+#elif defined(ARDUINO)
+        // Non-observer (companion #365 / repeater #301): no WifiBootstrap
+        // machine. Derive the SAME vocabulary from stored creds + the raw WiFi
+        // driver, so the meshcore-client#375 contract holds unchanged:
+        //   no SSID stored           -> AwaitingSetup   (not provisioned)
+        //   WL_CONNECTED             -> StaConnected ip=<addr>
+        //   NO_SSID/FAILED/LOST      -> StaFailed
+        //   otherwise (idle/dscn/scn)-> StaConnecting
+        String ssid;
+        {
+            Preferences p;
+            if (p.begin("wifi", /*readOnly=*/true)) { ssid = p.getString("ssid", ""); p.end(); }
+        }
+        if (ssid.isEmpty()) {
+            snprintf(reply, reply_size, "wifi.status = AwaitingSetup\n");
+        } else {
+            wl_status_t ws = WiFi.status();
+            if (ws == WL_CONNECTED) {
+                snprintf(reply, reply_size, "wifi.status = StaConnected ip=%s\n",
+                         WiFi.localIP().toString().c_str());
+            } else if ((WiFi.getMode() & WIFI_MODE_STA) == 0 ||
+                       ws == WL_NO_SSID_AVAIL || ws == WL_CONNECT_FAILED ||
+                       ws == WL_CONNECTION_LOST) {
+                // Not connected AND not actively attempting: either STA was never
+                // brought up (creds stored but WiFi.begin() not called -- the
+                // on-demand / burst-WiFi repeater #301 case), or a terminal
+                // failure. Report StaFailed rather than the false-positive
+                // StaConnecting (Gemini 2.5 review, #684). getMode() returns
+                // WIFI_MODE_NULL when WiFi is uninitialised -- safe.
+                snprintf(reply, reply_size, "wifi.status = StaFailed\n");
+            } else {
+                // STA is up and working toward a link (transient IDLE /
+                // DISCONNECTED / SCAN during an active attempt).
+                snprintf(reply, reply_size, "wifi.status = StaConnecting\n");
+            }
         }
 #else
         snprintf(reply, reply_size, "wifi.status = (host build)\n");

--- a/src/helpers/config/WifiConfigProvider.h
+++ b/src/helpers/config/WifiConfigProvider.h
@@ -11,14 +11,14 @@
 // read-only `wifi.status`. Persistence is the `"wifi"` NVS namespace via
 // Preferences (role-neutral) -- NOT a NodePrefs/DataStore offset.
 //
-// KNOWN COUPLING (deliberate, deferred to #365): the `wifi.status` GET reads the
-// observer's `WifiBootstrap` state machine. That is the observer's STA/AP
-// bring-up; a non-observer companion's runtime-WiFi path (#325/#365) has its own
-// bring-up, so what `wifi.status` means off-observer is a #365 design decision,
-// not a mechanical move. This provider keeps the WifiBootstrap dependency for the
-// observer; #365 wires its own status source when it lands. (Owner call
-// 2026-07-29: #370 relocates + decouples DISPLAY, leaves WiFi's WifiBootstrap
-// coupling to #365.)
+// STATUS SOURCE (#684, resolved 2026-08-01): `wifi.status` reports ONE uniform
+// vocabulary for every WiFi-capable role. On an OBSERVER build it reads the
+// authoritative `WifiBootstrap` STA/AP state machine; on a non-observer build
+// (companion #365, repeater #301) it derives the SAME words from the raw WiFi
+// driver + stored creds. The `WifiBootstrap` header is included ONLY under
+// `OFFBAND_OBSERVER`, so this provider links with zero `wifi_observer/` sources
+// off-observer -- closing the gap #370 left and unblocking #462. (Owner D1/D3:
+// uniform WiFi across all WiFi-capable roles; one status vocabulary, not two.)
 //
 // The handlers are exposed here (not file-static) because the observer's `_sys`
 // string CLI (dispatchObserverCli, still in ObserverCli.cpp) calls them too --

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -394,6 +394,12 @@ build_src_filter = ${heltec_v4_oled.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
+  ; #684/#365: the shared role-agnostic config surface, compiled on a
+  ; NON-observer WiFi companion. This is the build-proof that WifiConfigProvider
+  ; links with zero wifi_observer/ sources (the decouple #370 left to #365). The
+  ; providers self-register; the 0xC0 wire dispatch that makes them live is a
+  ; later #365 step -- here they compile+link dormant.
+  +<helpers/config/*.cpp>
   ${esp32_no_ble.build_src_filter}
 lib_deps =
   ${heltec_v4_oled.lib_deps}


### PR DESCRIPTION
Child task of **#365** (Feature #295 / Epic #300). Decouples `WifiConfigProvider.wifi.status` from the observer's `WifiBootstrap` machine so the provider links on a non-`OFFBAND_OBSERVER` build — the gap #370 left. Also unblocks **#462** non-observer enablement.

## Change (3 files)
- `WifiConfigProvider.cpp` — `wifi.status` reads `WifiBootstrap` only under `#ifdef OFFBAND_OBSERVER`. Off-observer it derives the **same** vocabulary from stored creds + `WiFi.status()`, gating `StaConnecting` on STA actually being enabled (`WiFi.getMode()`) so an idle-but-configured device (burst-WiFi repeater #301) isn't falsely reported as connecting.
- `WifiConfigProvider.h` — coupling note updated to RESOLVED.
- `variants/heltec_v4/platformio.ini` — `+<helpers/config/*.cpp>` on the non-observer `heltec_v4_companion_radio_wifi` env as the link-proof.

## Contract preserved
Observer `wifi.status` output **byte-identical** (only the guard condition moved). Non-observer emits the same words for shared states, so meshcore-client#375 holds unchanged. `wifi.pwd` write-only untouched.

## Verification
- `heltec_v4_companion_radio_wifi` (**non-observer**) — SUCCESS. Proves the provider links with zero `wifi_observer/` sources.
- `heltec_v4_companion_observer_wifi` (**observer**) — SUCCESS, no regression.
- `RAK_4631_companion_radio_usb` (**nRF52**) — SUCCESS, `config/` not leaked.
- **Gemini 2.5** (`gemini-2.5-pro`) adversarial review — 1 MAJOR (`WL_IDLE_STATUS` false-positive) **fixed** (with a more precise `getMode()` gate than the literal suggestion); rest clean. Log: `docs/llm-consultations/2026-08-13-684-wifi-status-decouple-gemini-gemini-2.5-pro.log`.

## Not in scope
Companion `0xC0` dispatch gating + cap-bit advertise — later #365 children. The providers self-register on the proof env but stay dormant (no wire dispatch) until then.

Closes #684.
Agent: BrownWaterfall (session edc95854)
