### PR TITLE
task(#696): add wifi clear + surface STA disconnect reason

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -31,7 +31,7 @@ jobs:
           echo "PIO_SECRETS_FILE=$RUNNER_TEMP/ci-secrets.ini" >> "$GITHUB_ENV"
 
       - name: Run Unit Tests
-        run: pio test -e native -e native_kiss_modem -vv
+        run: pio test -e native -e native_kiss_modem -e native_wifi_clear -vv
 
       - name: Upload Test Results
         # Upload test results even if the test step failed.

--- a/platformio.ini
+++ b/platformio.ini
@@ -224,7 +224,11 @@ build_flags = -std=c++17
   -I src
   -I test/mocks
 test_build_src = yes
-test_ignore = test_kiss_modem
+; test_wifi_clear needs WifiConfigProvider.cpp linked, whose static
+; ProviderRegistrar would register a provider into the process-global table
+; and break test_config_overlap's "fresh process => zero providers"
+; precondition. Same isolation reason as test_kiss_modem: own env below.
+test_ignore = test_kiss_modem, test_wifi_clear
 build_src_filter =
   -<*>
   +<../src/Utils.cpp>
@@ -239,6 +243,28 @@ build_src_filter =
   ; fails to link. (#628)
   +<../src/MeshLog.cpp>
   +<../src/helpers/ConfigSerializer.cpp>
+lib_deps =
+  google/googletest @ 1.17.0
+
+; #696: wifi clear + STA disconnect-reason. Isolated from [env:native]
+; because WifiConfigProvider.cpp self-registers a config provider at static
+; init (see test_ignore above).
+[env:native_wifi_clear]
+platform = native
+test_framework = googletest
+build_flags = -std=c++17
+  -I test/mocks
+  -I src
+  ; WifiObserverConfig.h hard-#errors without one of these (#536); this code
+  ; is observer scope, so OFFBAND_OBSERVER is the honest one to declare.
+  -D OFFBAND_OBSERVER
+test_build_src = yes
+test_filter = test_wifi_clear
+build_src_filter =
+  -<*>
+  +<../src/helpers/config/ConfigDispatch.cpp>
+  +<../src/helpers/config/WifiConfigProvider.cpp>
+  +<../src/helpers/wifi_observer/WifiBootstrap.cpp>
 lib_deps =
   google/googletest @ 1.17.0
 

--- a/src/helpers/config/WifiConfigProvider.cpp
+++ b/src/helpers/config/WifiConfigProvider.cpp
@@ -69,6 +69,70 @@ bool handleSetWifiField(char* reply, size_t reply_size,
     return true;
 }
 
+bool handleClearWifi(char* reply, size_t reply_size, const char* what) {
+    // #689/#696: the only way to un-set WiFi creds. `set wifi.pwd ""` is
+    // deliberately rejected (empty SSID collides with the no-creds
+    // detection in WifiBootstrap::begin), which left a stored PSK
+    // permanently stuck -- and a stored PSK raises the STA scan-auth
+    // threshold to WPA2, so the node can never join an OPEN network
+    // again (#692). Before this, the only escape was a full NVS wipe,
+    // which also destroys the device identity.
+    //
+    // Default (no argument) clears the password only: that is the
+    // recoverable case, and dropping the SSID too would silently send
+    // the node back to "awaiting setup" when the user asked for less.
+    bool clear_ssid = false;
+    if (what == nullptr || what[0] == '\0' || config::strEq(what, "pwd")) {
+        clear_ssid = false;
+    } else if (config::strEq(what, "all")) {
+        clear_ssid = true;
+    } else {
+        snprintf(reply, reply_size,
+                 "ERROR: usage: wifi clear [pwd|all]\n");
+        return true;
+    }
+#ifdef ARDUINO
+    Preferences p;
+    if (!p.begin("wifi", /*readOnly=*/false)) {
+        snprintf(reply, reply_size,
+                 "ERROR: cannot open NVS namespace 'wifi'\n");
+        return true;
+    }
+    // remove(), NOT putString("") -- per #98, writing an empty string does
+    // not reliably clear an ESP32 NVS key, which would leave the very
+    // stale-PSK state this command exists to escape.
+    //
+    // The return value MUST be checked: this command exists to rescue a
+    // device stranded by a stale PSK, so reporting success on a failed
+    // erase would send the user away believing they are fixed when the
+    // node is still unable to join an open AP.
+    //
+    // But remove() also returns false when the key was simply ABSENT
+    // (nvs_erase_key -> ESP_ERR_NVS_NOT_FOUND), which is the common case:
+    // a device that never had a PSK, or a second `wifi clear`. Treating
+    // that as failure would report a scary NVS error for a no-op. isKey()
+    // separates the two: only a key that exists and refuses to erase is
+    // a real failure.
+    const bool pwd_erase_failed  = p.isKey("pwd")  && !p.remove("pwd");
+    const bool ssid_erase_failed = clear_ssid && p.isKey("ssid") && !p.remove("ssid");
+    p.end();
+    if (pwd_erase_failed || ssid_erase_failed) {
+        snprintf(reply, reply_size,
+                 "ERROR: could not clear wifi.%s (NVS erase failed)\n",
+                 pwd_erase_failed ? "pwd" : "ssid");
+        return true;
+    }
+#endif
+    if (clear_ssid) {
+        snprintf(reply, reply_size,
+                 "wifi cleared (ssid + pwd). Reboot to apply.\n");
+    } else {
+        snprintf(reply, reply_size,
+                 "wifi.pwd cleared. Reboot to join an open network.\n");
+    }
+    return true;
+}
+
 bool handleGetWifi(char* reply, size_t reply_size, const char* field) {
     if (field == nullptr) {
         snprintf(reply, reply_size,
@@ -118,6 +182,24 @@ bool handleGetWifi(char* reply, size_t reply_size, const char* field) {
         if (state == WifiBootstrapState::StaConnected) {
             snprintf(reply, reply_size, "wifi.status = %s ip=%s\n",
                      st, WiFi.localIP().toString().c_str());
+        } else if (state == WifiBootstrapState::StaConnecting) {
+            // #696: the field cannot read the serial log -- a remote
+            // reporter only ever sees this line. A bare "StaConnecting"
+            // is indistinguishable between "SSID never matched" and
+            // "PSK rejected", which is what stalled #692. Carry the
+            // retry count and the last disconnect reason here.
+            const uint8_t reason = wifiBootstrap().lastDisconnectReason();
+            const char* rname = WifiBootstrap::disconnectReasonName(reason);
+            if (reason == 0) {
+                snprintf(reply, reply_size,
+                         "wifi.status = %s retry=%u (no disconnect event yet)\n",
+                         st, (unsigned)wifiBootstrap().staRetryCount());
+            } else {
+                snprintf(reply, reply_size,
+                         "wifi.status = %s retry=%u last_reason=%u(%s)\n",
+                         st, (unsigned)wifiBootstrap().staRetryCount(),
+                         (unsigned)reason, rname ? rname : "UNKNOWN");
+            }
         } else {
             snprintf(reply, reply_size, "wifi.status = %s\n", st);
         }
@@ -163,6 +245,12 @@ bool wifiConfigSet(const char* key, const char* value, char* reply, size_t reply
         if (!config::parseBool(value, on)) { snprintf(reply, reply_size, "ERROR: wifi.enabled expects 0|1\n"); return true; }
         return handleSetWifiEnabled(reply, reply_size, on);
     }
+    // #689/#696: wire-path parity for the clear. MUST be tested before the
+    // generic "wifi." prefix below for the same reason wifi.enabled is --
+    // otherwise this falls through to handleSetWifiField and writes an NVS
+    // key literally named "clear" instead of removing the password.
+    if (config::strEq(key, "wifi.clear"))
+        return handleClearWifi(reply, reply_size, value);
     if (strncmp(key, "wifi.", 5) == 0)            // wifi.ssid / wifi.pwd
         return handleSetWifiField(reply, reply_size, key + 5, value);
 

--- a/src/helpers/config/WifiConfigProvider.h
+++ b/src/helpers/config/WifiConfigProvider.h
@@ -43,4 +43,11 @@ bool handleGetWifi(char* reply, size_t reply_size, const char* field);
 // wifi.enabled policy flag (NVS "wifi"/"enabled", default true; reboot-to-apply).
 bool handleSetWifiEnabled(char* reply, size_t reply_size, bool enabled);
 
+// #689/#696: credential clear. `what` is nullptr/""/"pwd" (clear the PSK only,
+// the default) or "all" (also clear the SSID). Uses Preferences::remove(), NOT
+// putString(""), which does not reliably clear an ESP32 NVS key (#98). This is
+// the only escape from a stored PSK, which otherwise raises the STA scan-auth
+// threshold and permanently blocks OPEN-network association (#692).
+bool handleClearWifi(char* reply, size_t reply_size, const char* what);
+
 }  // namespace offband

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -611,8 +611,16 @@ bool dispatchObserverCli(const char* cmd, char* reply, size_t reply_size,
         }
         if (eq(rest, "enable"))  return handleSetWifiEnabled(reply, reply_size, true);
         if (eq(rest, "disable")) return handleSetWifiEnabled(reply, reply_size, false);
+        // #689/#696: "wifi clear" / "wifi clear pwd" / "wifi clear all".
+        // skipPrefix returns the remainder after the subcommand (empty
+        // string when bare), which handleClearWifi treats as "pwd".
+        const char* clr_rest = skipPrefix(rest, "clear");
+        if (clr_rest != nullptr) {
+            return handleClearWifi(reply, reply_size, clr_rest);
+        }
         snprintf(reply, reply_size,
-                 "ERROR: unknown wifi subcommand (status | enable | disable)\n");
+                 "ERROR: unknown wifi subcommand "
+                 "(status | enable | disable | clear)\n");
         return true;
     }
 #endif  // OFFBAND_OBSERVER (display/wifi verbs -- #538 Option A)

--- a/src/helpers/wifi_observer/WifiBootstrap.cpp
+++ b/src/helpers/wifi_observer/WifiBootstrap.cpp
@@ -50,9 +50,42 @@ void WifiBootstrap::deriveApSsid(const uint8_t* mac_bytes, char* out,
 }
 
 // -------------------------------------------------------------------------
+// #696: STA disconnect-reason table. Pure + host-testable; deliberately
+// NOT a full mirror of WIFI_REASON_* -- only the codes that actually
+// discriminate a field failure, so the string table stays small on a
+// flash-constrained observer. Unknown codes return nullptr and the
+// caller prints the raw number (never a wrong label).
+// -------------------------------------------------------------------------
+const char* WifiBootstrap::disconnectReasonName(uint8_t reason) {
+    switch (reason) {
+        case 2:   return "AUTH_EXPIRE";
+        case 4:   return "ASSOC_EXPIRE";
+        case 15:  return "4WAY_HANDSHAKE_TIMEOUT";  // PSK rejected by AP
+        case 200: return "BEACON_TIMEOUT";
+        case 201: return "NO_AP_FOUND";             // SSID never matched a
+                                                    // scan result meeting the
+                                                    // auth threshold
+        case 202: return "AUTH_FAIL";
+        case 203: return "ASSOC_FAIL";
+        case 204: return "HANDSHAKE_TIMEOUT";
+        case 205: return "CONNECTION_FAIL";
+        default:  return nullptr;
+    }
+}
+
+// -------------------------------------------------------------------------
 // Lifecycle (Arduino target only; host build skips).
 // -------------------------------------------------------------------------
 #ifdef ARDUINO
+
+// Written from the WiFi event task, read from the main loop and from the
+// `wifi status` handler. Single byte, so the read is atomic on xtensa --
+// no tearing, and a stale-by-one-event read is harmless for a diagnostic.
+static volatile uint8_t s_last_disc_reason = 0;
+
+uint8_t WifiBootstrap::lastDisconnectReason() const {
+    return s_last_disc_reason;
+}
 
 void WifiBootstrap::begin() {
     // ----------------------------------------------------------------------
@@ -118,6 +151,18 @@ void WifiBootstrap::begin() {
             p2.end();
         }
         // PSK redacted from logs per CLAUDE.md security note.
+        //
+        // #696: capture the disconnect reason before the first association
+        // attempt, so nothing is missed. Registered here rather than at
+        // construction because WiFi.onEvent needs the event loop, which
+        // WiFi.mode() below brings up. The handler only records -- it must
+        // not touch the state machine, since it runs on the WiFi task.
+        WiFi.onEvent(
+            [](arduino_event_id_t, arduino_event_info_t info) {
+                s_last_disc_reason =
+                    (uint8_t)info.wifi_sta_disconnected.reason;
+            },
+            ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
         WiFi.mode(WIFI_STA);
         // Meshtastic V4 coex fix: yield 2.4 GHz radio between DTIM beacons
         // so BT controller can schedule advertising/connection slots.
@@ -149,8 +194,20 @@ void WifiBootstrap::loop() {
 #endif
             } else if (millis() - last_attempt_ms_ > 10000) {
                 sta_retry_count_++;
-                Serial.printf("[WifiBootstrap] STA retry #%u\n",
-                              sta_retry_count_);
+                // #696: carry the last disconnect reason on the retry line.
+                // Without it this loop printed a bare counter forever and a
+                // never-associating node was indistinguishable from a
+                // rejected-PSK one (#692).
+                const uint8_t reason = s_last_disc_reason;
+                const char* rname = disconnectReasonName(reason);
+                if (reason == 0) {
+                    Serial.printf("[WifiBootstrap] STA retry #%u\n",
+                                  sta_retry_count_);
+                } else {
+                    Serial.printf("[WifiBootstrap] STA retry #%u last_reason=%u(%s)\n",
+                                  sta_retry_count_, (unsigned)reason,
+                                  rname ? rname : "UNKNOWN");
+                }
                 WiFi.reconnect();
                 last_attempt_ms_ = millis();
             }
@@ -217,6 +274,9 @@ WifiBootstrap& wifiBootstrap() {
 void WifiBootstrap::begin() {}
 void WifiBootstrap::loop() {}
 bool WifiBootstrap::isStaConnected() const { return false; }
+// #696: no WiFi stack on the host build, so no disconnect event can
+// ever have fired -- the same sentinel the Arduino path uses at boot.
+uint8_t WifiBootstrap::lastDisconnectReason() const { return 0; }
 WifiBootstrap& wifiBootstrap() {
     static WifiBootstrap inst;
     return inst;

--- a/src/helpers/wifi_observer/WifiBootstrap.h
+++ b/src/helpers/wifi_observer/WifiBootstrap.h
@@ -39,6 +39,23 @@ public:
 
     WifiBootstrapState state() const { return state_; }
 
+    // #696: STA association diagnostics. Before this, a failed
+    // association surfaced only as StaConnecting forever, with no
+    // reason anywhere -- the field had no way to tell "SSID never
+    // matched" from "PSK rejected" (#692). The ESP32 already
+    // produces a reason code on every disconnect; these expose it.
+    //
+    // 0 means "no disconnect event seen yet" -- WIFI_REASON_* has no
+    // zero member, so it is unambiguous as a sentinel.
+    uint8_t  lastDisconnectReason() const;
+    uint32_t staRetryCount() const { return sta_retry_count_; }
+
+    // Short name for a WIFI_REASON_* code, e.g. 201 -> "NO_AP_FOUND".
+    // Returns nullptr for codes not in the table, so callers can fall
+    // back to printing the bare number rather than a misleading label.
+    // Pure + static: host-testable without WiFi (see test_wifi_reason).
+    static const char* disconnectReasonName(uint8_t reason);
+
 private:
     WifiBootstrapState state_ = WifiBootstrapState::Boot;
     uint32_t sta_retry_count_ = 0;

--- a/test/test_wifi_clear/test_wifi_clear.cpp
+++ b/test/test_wifi_clear/test_wifi_clear.cpp
@@ -1,0 +1,116 @@
+// Native regression tests for #696 (under #689): the `wifi clear` command and
+// the STA disconnect-reason surfacing that #692 needed.
+//
+// What is and isn't covered on host: the NVS writes in handleClearWifi sit
+// behind #ifdef ARDUINO, so these tests pin the ARGUMENT CONTRACT and the
+// REPLY STRINGS -- which is where the field-visible behaviour lives. The
+// Preferences::remove() call itself is hardware-verified on the bench (#692),
+// not here; claiming otherwise would be a test that proves less than it looks.
+
+#include <gtest/gtest.h>
+#include <cstring>
+#include "helpers/config/WifiConfigProvider.h"
+#include "helpers/config/ConfigDispatch.h"
+#include "helpers/wifi_observer/WifiBootstrap.h"
+
+using offband::handleClearWifi;
+using offband::WifiBootstrap;
+
+// ---------------------------------------------------------------------------
+// wifi clear -- argument contract
+// ---------------------------------------------------------------------------
+
+TEST(WifiClear, BareAndPwdClearThePasswordOnly) {
+  char reply[160];
+
+  // Bare `wifi clear` arrives as the empty remainder from skipPrefix.
+  ASSERT_TRUE(handleClearWifi(reply, sizeof(reply), ""));
+  EXPECT_NE(nullptr, strstr(reply, "wifi.pwd cleared"));
+  // Must NOT claim the SSID went with it -- the user asked for less.
+  EXPECT_EQ(nullptr, strstr(reply, "ssid"));
+
+  // Explicit "pwd" is the same path.
+  ASSERT_TRUE(handleClearWifi(reply, sizeof(reply), "pwd"));
+  EXPECT_NE(nullptr, strstr(reply, "wifi.pwd cleared"));
+  EXPECT_EQ(nullptr, strstr(reply, "ssid"));
+
+  // nullptr is reachable via the config wire path (configSet with no value)
+  // and must behave as the safe default rather than crashing.
+  ASSERT_TRUE(handleClearWifi(reply, sizeof(reply), nullptr));
+  EXPECT_NE(nullptr, strstr(reply, "wifi.pwd cleared"));
+}
+
+TEST(WifiClear, AllClearsBoth) {
+  char reply[160];
+  ASSERT_TRUE(handleClearWifi(reply, sizeof(reply), "all"));
+  EXPECT_NE(nullptr, strstr(reply, "ssid"));
+  EXPECT_NE(nullptr, strstr(reply, "pwd"));
+}
+
+TEST(WifiClear, UnknownArgumentIsRejectedNotSilentlyTreatedAsPwd) {
+  // The regression that matters: a typo must NOT quietly perform a partial
+  // clear. `wifi clear everything` has to error, not drop the password.
+  char reply[160];
+  ASSERT_TRUE(handleClearWifi(reply, sizeof(reply), "everything"));
+  EXPECT_EQ(0, strncmp(reply, "ERROR:", 6)) << "reply was: " << reply;
+  EXPECT_NE(nullptr, strstr(reply, "wifi clear [pwd|all]"));
+}
+
+// ---------------------------------------------------------------------------
+// Disconnect-reason naming -- the instrument #692 lacked
+// ---------------------------------------------------------------------------
+
+TEST(WifiReason, MapsTheCodesThatDiscriminateAFieldFailure) {
+  // 201 vs 15 is the whole point: "never matched an AP" vs "AP rejected the
+  // key". These two send the investigation in opposite directions.
+  EXPECT_STREQ("NO_AP_FOUND", WifiBootstrap::disconnectReasonName(201));
+  EXPECT_STREQ("4WAY_HANDSHAKE_TIMEOUT",
+               WifiBootstrap::disconnectReasonName(15));
+  EXPECT_STREQ("CONNECTION_FAIL", WifiBootstrap::disconnectReasonName(205));
+  EXPECT_STREQ("AUTH_EXPIRE", WifiBootstrap::disconnectReasonName(2));
+  EXPECT_STREQ("BEACON_TIMEOUT", WifiBootstrap::disconnectReasonName(200));
+}
+
+TEST(WifiReason, UnknownCodesReturnNullSoCallersPrintTheNumber) {
+  // Deliberate: an unmapped code must not borrow a neighbouring label. The
+  // callers fall back to printing the raw number, which stays truthful.
+  EXPECT_EQ(nullptr, WifiBootstrap::disconnectReasonName(99));
+  EXPECT_EQ(nullptr, WifiBootstrap::disconnectReasonName(255));
+}
+
+TEST(WifiReason, ZeroIsTheNoEventYetSentinel) {
+  // WIFI_REASON_* has no zero member, so 0 unambiguously means "no disconnect
+  // event has fired". Callers special-case it rather than printing "0(UNKNOWN)".
+  EXPECT_EQ(nullptr, WifiBootstrap::disconnectReasonName(0));
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch routing -- the ordering regression the provider comment warns about
+// ---------------------------------------------------------------------------
+
+TEST(WifiClearDispatch, WifiDotClearRoutesToClearNotTheFieldSetter) {
+  // WifiConfigProvider self-registers at static init, so the real dispatch
+  // table is live here. `wifi.clear` MUST be matched before the generic
+  // `wifi.` prefix: if that ordering is ever reversed, this key falls through
+  // to handleSetWifiField and writes an NVS key literally named "clear"
+  // instead of erasing the credentials -- a silent failure of the one command
+  // that exists to rescue a stranded device (#692).
+  char reply[160];
+
+  ASSERT_TRUE(offband::config::dispatchSet("wifi.clear", "all",
+                                           reply, sizeof(reply)));
+  EXPECT_NE(nullptr, strstr(reply, "cleared"))
+      << "wifi.clear was not routed to handleClearWifi; reply: " << reply;
+  // The field-setter's ACK shape must NOT appear -- that is the regression.
+  EXPECT_EQ(nullptr, strstr(reply, "chars entered"));
+
+  // And the bad-argument contract survives the wire path too.
+  ASSERT_TRUE(offband::config::dispatchSet("wifi.clear", "everything",
+                                           reply, sizeof(reply)));
+  EXPECT_EQ(0, strncmp(reply, "ERROR:", 6)) << "reply was: " << reply;
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Closes #696. Under #689. Diagnosis context: #692.

## Why

A community observer (Heltec V3, `offband-v1.3.0`) deploying on an open, passwordless public network sits at `wifi.status = StaConnecting` forever (#692). Two firmware gaps made that undiagnosable from the field:

1. **No reason is surfaced anywhere.** `StaFailed` is unreachable in practice (`WifiBootstrap.cpp:151`), so a node that never associates and a node whose PSK was rejected look identical — both are `StaConnecting`, forever, with nothing logged.
2. **A stored PSK cannot be cleared.** `set wifi.pwd ""` is deliberately rejected, so the only escape was a full NVS wipe that also destroys the device identity.

Gap 2 is not cosmetic. `[verified: framework source]` In arduino-esp32 2.0.17 (`framework-arduinoespressif32 3.20017`, pinned via `platformio/espressif32@6.11.0`), `wifi_sta_config()` (`libraries/WiFi/src/WiFiSTA.cpp:87-108`) sets `sta.threshold.authmode = WIFI_AUTH_OPEN` and raises it to `_minSecurity` — `WIFI_AUTH_WPA2_PSK` (`WiFiSTA.cpp:118`) — **only when `password[0] != 0`**. Nothing in this repo calls `WiFi.setMinSecurity()`. So any non-empty stored PSK filters an open AP out of the scan match entirely: the device never attempts association and reports nothing. That is exactly #692's signature.

## What changed

**`wifi clear [pwd|all]`** — clears stored credentials.
- `Preferences::remove()`, **not** `putString("")`, which does not reliably clear an ESP32 NVS key (#98).
- The `remove()` result is checked. `isKey()` distinguishes an **absent** key — a harmless no-op, and the common case on a device that never had a PSK — from an erase that genuinely failed. Reporting success on a failed erase would send an operator away believing a stranded node was rescued.
- Bare `wifi clear` clears the password only; `all` is an explicit opt-in for the SSID too, so a user asking for less is never silently returned to "awaiting setup".
- Reachable from the `_sys` channel CLI and from the config wire path via the `wifi.clear` key, matched **before** the generic `wifi.` prefix so it cannot fall through to the field setter and write an NVS key literally named `clear`.

**STA disconnect-reason surfacing** — `WiFi.onEvent` handler for `ARDUINO_EVENT_WIFI_STA_DISCONNECTED` records the reason; it appears on the retry log line and in the `wifi status` reply. The status reply is the load-bearing half: a remote reporter cannot read a serial log, so `wifi status` is the only instrument they have. Unmapped codes print the bare number rather than a guessed label.

```
before:  wifi.status = StaConnecting
after:   wifi.status = StaConnecting retry=12 last_reason=201(NO_AP_FOUND)
```

That single line separates every open hypothesis on #692 in one reboot: 201 `NO_AP_FOUND` (SSID mismatch / 5 GHz-only / OWE-only / stale-PSK threshold) vs 15 `4WAY_HANDSHAKE_TIMEOUT` (matched, key rejected) vs 205 `CONNECTION_FAIL` (AP-side refusal).

**Not changed:** `WiFi.begin()`, the 10-second retry loop, the state machine, and the deliberate empty-value rejection in `set wifi.pwd`. The association decision path is untouched, so this build reproduces the reporter's behaviour rather than masking it.

## Verification

- **Native tests: 7/7.** New `test/test_wifi_clear/`, run by a dedicated `native_wifi_clear` env — isolated because `WifiConfigProvider.cpp` self-registers a config provider at static init, which would break `test_config_overlap`'s fresh-process precondition. Wired into `run-unit-tests.yml`; without that the test would exist but never run in CI.
- **Existing suites unaffected** — `pio test -e native -e native_kiss_modem` green.
- **Builds: 4/4 SUCCESS** — `Heltec_v3_companion_observer_wifi`, `heltec_v4_companion_observer_wifi`, `heltec_v4_tft_companion_observer_wifi`, `Xiao_S3_WIO_companion_observer_wifi`. That is every env compiling this code, and all four are in the CI matrix.
- **Not hardware-verified yet.** #689 and #692 stay open for the bench matrix on `hv3-bench` against an open AP. The `Preferences::remove()` call itself sits behind `#ifdef ARDUINO`, so the host tests pin the argument contract and reply strings, not the erase.

## Gemini review

Run per the standing gate (`scripts/llm-consult.py --backend gemini --model gemini-2.5-pro`), three passes — the first two responses ended before finishing their category list, so the remainder was re-run rather than counted as passed. Verdict: safe to open as a PR.

| Finding | Severity | Disposition |
|---|---|---|
| `Preferences::remove()` return value ignored | BLOCKER | **Fixed.** Its suggested patch was **not** adopted as written: `remove()` also returns `false` when the key is simply absent (`nvs_erase_key` → `ESP_ERR_NVS_NOT_FOUND`), so that patch would report "NVS write failed" on any device that never had a PSK. Implemented with `isKey()` instead; Gemini confirmed the reasoning on the following pass. |
| `WIFI_REASON_CONNECTION_FAIL` (205) "not defined in IDF 4.4" | MINOR | **Refuted with evidence.** It is at line 121 of the exact SDK header this build compiles against (`framework-arduinoespressif32/tools/sdk/esp32s3/include/esp_wifi/include/esp_wifi_types.h`), alongside 204 and 4. No change. |
| `putString`/`putBool` results unchecked in the pre-existing setters | MINOR | **Deferred to #697.** Fixing it changes user-facing copy on `set wifi.ssid`/`set wifi.pwd` and is unrelated to the #692 bug this PR exists to serve. Filed rather than silently dropped. |
| Missing test for `wifi.clear` dispatch routing | suggestion | **Implemented** — `WifiClearDispatch.WifiDotClearRoutesToClearNotTheFieldSetter` pins the ordering against a future regression. |

## Reviewer notes

- Concurrency: the reason byte is written from the WiFi event task and read from the main loop / `wifi status`. Single byte, `volatile`, atomic on xtensa; a stale-by-one-event read is harmless for a diagnostic.
- Worst-case `wifi status` line is ~86 bytes, inside the 140-byte `_sys` frame limit — no truncation.
- User-facing strings in this PR were reviewed and approved by the owner before commit.

Agent: JadeFox (session c170fdab)
