### PR TITLE
bug(#711): fix the BLE frame-size ceiling, pin it with a regression test, run native tests in CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+## What this changes
+Brief description, and which role(s)/variant(s) it affects
+(companion / observer / repeater / room / bridge / tooling / docs).
+
+Closes #
+
+## Tests
+
+**If this fixes a bug: does the test embed the broken behaviour, or have you watched it fail?**
+
+A regression test is not verified until it has failed for the right reason. Either:
+- keep the pre-fix behaviour in the test as a reference and assert it differs (permanent, runs on every CI run), or
+- revert the fix, watch the test fail, restore it, and say so here.
+
+Beware the circular assertion: if a test derives its expected value from the thing under test,
+a bug that corrupts that value also corrupts the expectation, and the test passes while the
+product is broken. (#711 -- a regression of #450 that shipped because nothing asserted the
+invariant, and whose first draft test passed against the broken code.)
+
+- [ ] Tests added/updated, and shown to fail without the fix
+- [ ] No test: state why here (only the owner waives a test)
+
+## Verification
+- [ ] Builds affected envs (name them; include any DRAM-tight env not in the CI matrix, e.g. `Heltec_v2_companion_radio_ble`)
+- [ ] `pio test` green for every native env
+- [ ] Hardware-verified, or explicitly stated as NOT hardware-verified
+
+## Review
+- [ ] Gemini-reviewed (`scripts/llm-consult.py --backend gemini`); findings fixed or justified below
+
+Note: an LLM review is a second opinion, not a gate that can be trusted alone. The #454 review
+certified as "correct" the exact two things that later broke.
+
+## Notes
+Anything a reviewer needs: risks, follow-ups filed, what is deliberately out of scope.
+
+Agent: <AMName> (session <uuid8>)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,15 @@ jobs:
       - name: Every ESP32 env compiling SerialBLEInterface.cpp declares NimBLE
         run: python scripts/check_esp32_ble_deps.py
 
-  # #712: the [env:native] googletest suites existed but NOTHING ran them in CI, so every
-  # invariant they encode was unenforced on PRs. That is how #711 (a regression of #450)
-  # reached the field: the frame-size ceiling had no mechanical guard, only a comment.
-  # Runs the whole native suite, not just the frame-size one -- 14 suites / 153 cases were
-  # already green locally when this job was added, so it gates on real, passing coverage.
+  # #712: the googletest suites existed but NOTHING ran them in CI, so every invariant they
+  # encode was unenforced on PRs. That is how #711 (a regression of #450) reached the field:
+  # the frame-size ceiling had no mechanical guard, only a comment.
+  #
+  # Envs are DISCOVERED, not listed. There are two native test envs today ([env:native] and
+  # [env:native_kiss_modem], the latter excluded from the former via test_ignore), and a
+  # hardcoded `pio test -e native` silently skipped the second one -- the same "looks
+  # covered, isn't" failure this job exists to end. Any future env with `platform = native`
+  # is picked up automatically.
   native-tests:
     runs-on: ubuntu-latest
     steps:
@@ -60,8 +64,37 @@ jobs:
       - name: Install PlatformIO
         run: pip install --upgrade platformio
 
+      - name: Discover native test environments
+        id: envs
+        run: |
+          set -euo pipefail
+          envs=$(python - <<'PY'
+          import configparser
+          cfg = configparser.ConfigParser(strict=False)
+          cfg.read('platformio.ini')
+          names = [s.split(':', 1)[1] for s in cfg.sections()
+                   if s.startswith('env:')
+                   and cfg.get(s, 'platform', fallback='').strip() == 'native']
+          print(' '.join(sorted(names)))
+          PY
+          )
+          echo "Discovered native test envs: ${envs:-<none>}"
+          # Fail loudly rather than passing green having run nothing. A test job that
+          # silently executes zero tests is worse than no job at all: it reports success.
+          if [ -z "$envs" ]; then
+            echo "::error::No native test environments found in platformio.ini" >&2
+            exit 1
+          fi
+          echo "envs=$envs" >> "$GITHUB_OUTPUT"
+
       - name: Run native unit tests
-        run: pio test -e native
+        run: |
+          set -euo pipefail
+          for e in ${{ steps.envs.outputs.envs }}; do
+            echo "::group::pio test -e $e"
+            pio test -e "$e"
+            echo "::endgroup::"
+          done
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,26 @@ jobs:
       - name: Every ESP32 env compiling SerialBLEInterface.cpp declares NimBLE
         run: python scripts/check_esp32_ble_deps.py
 
+  # #712: the [env:native] googletest suites existed but NOTHING ran them in CI, so every
+  # invariant they encode was unenforced on PRs. That is how #711 (a regression of #450)
+  # reached the field: the frame-size ceiling had no mechanical guard, only a comment.
+  # Runs the whole native suite, not just the frame-size one -- 14 suites / 153 cases were
+  # already green locally when this job was added, so it gates on real, passing coverage.
+  native-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install PlatformIO
+        run: pip install --upgrade platformio
+
+      - name: Run native unit tests
+        run: pio test -e native
+
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -165,12 +185,14 @@ jobs:
   # required check blocks the PR with no explanation instead of a red X.
   ci-green:
     runs-on: ubuntu-latest
-    needs: [config-lint, build]
+    needs: [config-lint, native-tests, build]
     if: always()
     steps:
       - name: All required CI jobs green
         run: |
           echo "config-lint: ${{ needs.config-lint.result }}"
+          echo "native-tests: ${{ needs.native-tests.result }}"
           echo "build (all matrix legs): ${{ needs.build.result }}"
           test "${{ needs.config-lint.result }}" = "success"
+          test "${{ needs.native-tests.result }}" = "success"
           test "${{ needs.build.result }}" = "success"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,15 @@ jobs:
       - name: Install PlatformIO
         run: pip install --upgrade platformio
 
+      # Required even though nothing here is flashed: PlatformIO parses the WHOLE
+      # platformio.ini (including the ${node_secrets...} interpolations used by the
+      # device envs) before it can resolve [env:native], so without this every native
+      # suite ERRORs with "No section: 'node_secrets'". Mirrors config-lint and build.
+      - name: Generate dummy secrets stub (test-only; never flashed)
+        run: |
+          printf '[node_secrets]\nadmin_password = ci-dummy\n[wifi_secrets]\nssid = ci-dummy\npassword = ci-dummy\n[mqtt_secrets]\nhost = mqtt.example.com\nport = 1883\nuser = ci-dummy\npassword = ci-dummy\n[ota_secrets]\ntrigger_secret = ci-dummy\n[cmdrelay]\nurl = http://cmdrelay.example.com/cmd\n' > "$RUNNER_TEMP/ci-secrets.ini"
+          echo "PIO_SECRETS_FILE=$RUNNER_TEMP/ci-secrets.ini" >> "$GITHUB_ENV"
+
       - name: Discover native test environments
         id: envs
         run: |

--- a/src/helpers/BleFrameSizing.h
+++ b/src/helpers/BleFrameSizing.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+// #711: pure ATT frame-sizing arithmetic, deliberately free of Arduino/NimBLE/Bluefruit
+// dependencies so it is unit-testable natively (test/test_frame_size).
+//
+// WHY THIS EXISTS AS A SEPARATE, TESTABLE UNIT
+// -------------------------------------------
+// #450 fixed "a full MAX_FRAME_SIZE frame is clipped to MTU-3 over BLE" with a hardcoded
+// constant. #454 generalised it to a computed cap and reintroduced the bug the same day,
+// because the computation trusted the PEER's MTU as if it were the connection's. Nothing
+// in the tree asserted the ceiling, so the regression shipped and was only caught in the
+// field two weeks later. These functions are the logic that broke; keeping them pure is
+// what lets a test pin the invariant instead of a comment asking future authors to be
+// careful.
+
+namespace ble_frame {
+
+/// BLE spec minimum ATT MTU. Every link supports at least this.
+static const uint16_t MIN_ATT_MTU = 23;
+
+/// Bytes an ATT notification spends on its own header, unavailable to the payload.
+static const uint16_t ATT_NOTIFY_HEADER = 3;
+
+/// The connection's EFFECTIVE ATT MTU.
+///
+/// ATT negotiation settles on the MINIMUM of the two sides, so a peer advertising a
+/// large MTU (Android commonly reports 517) does not raise what the link can actually
+/// carry when our own side is configured lower. Treating the peer's number as the
+/// connection's is precisely the #711 regression.
+///
+/// `reported` -- what the stack tells us about the peer / the connection.
+/// `local`    -- the MTU we configured for ourselves (e.g. NimBLEDevice::setMTU()).
+///
+/// A `reported` value below the BLE minimum is not a usable measurement (no exchange
+/// yet, or an error), so we fall back to the conservative floor rather than to `local`:
+/// an unknown MTU must never license a larger frame.
+inline uint16_t effectiveMtu(uint16_t reported, uint16_t local) {
+  if (reported < MIN_ATT_MTU) return MIN_ATT_MTU;
+  if (local >= MIN_ATT_MTU && local < reported) return local;
+  return reported;
+}
+
+/// Largest on-wire FRAME deliverable in ONE notification on a link of `effective_mtu`,
+/// bounded by `max_frame` (the sender's frame buffer size).
+///
+/// The `max_frame` bound is a BUFFER limit, not a link limit. It must never be able to
+/// raise the result above what the link carries, which is what the previous
+/// `min(mtu - 3, MAX_FRAME_SIZE)` form did once the cached MTU was too large.
+inline size_t deliverableFrame(uint16_t effective_mtu, size_t max_frame) {
+  size_t payload = effective_mtu > ATT_NOTIFY_HEADER
+                     ? (size_t)(effective_mtu - ATT_NOTIFY_HEADER)
+                     : 0;
+  return payload < max_frame ? payload : max_frame;
+}
+
+}  // namespace ble_frame

--- a/src/helpers/esp32/SerialBLEInterface.cpp
+++ b/src/helpers/esp32/SerialBLEInterface.cpp
@@ -92,12 +92,25 @@ void SerialBLEInterface::begin(const char* prefix, char* name, uint32_t pin_code
 // callback that receives a NimBLEConnInfo&. conn_id is reachable via
 // connInfo.getConnHandle(); peer MTU via pServer->getPeerMTU(handle).
 
+// #711: the connection's ATT MTU is min(local, peer) -- ATT negotiation settles on the
+// smaller of the two sides. begin() pins our local side with NimBLEDevice::setMTU(MAX_FRAME_SIZE),
+// so a peer advertising more (Android commonly 517) does NOT raise what this link can carry.
+// Storing the peer value unclamped made maxFrameSize() saturate at MAX_FRAME_SIZE and emit
+// 176-byte frames onto a 173-byte pipe, silently losing 3 bytes per full frame (#450 regression).
+void SerialBLEInterface::setEffectiveMtu(uint16_t reported) {
+  uint16_t local = NimBLEDevice::getMTU();      // what begin() configured for our side
+  _att_mtu = ble_frame::effectiveMtu(reported, local);
+  BLE_DEBUG_PRINTLN("setEffectiveMtu(): reported=%d local=%d -> effective=%d (deliverable frame=%d)",
+                    (int)reported, (int)local, (int)_att_mtu,
+                    (int)ble_frame::deliverableFrame(_att_mtu, MAX_FRAME_SIZE));
+}
+
 void SerialBLEInterface::onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo) {
   uint16_t conn_id = connInfo.getConnHandle();
   uint16_t mtu = pServer->getPeerMTU(conn_id);
   BLE_DEBUG_PRINTLN("onConnect(), conn_id=%d, mtu=%d", conn_id, mtu);
   last_conn_id = conn_id;
-  if (mtu >= 23) _att_mtu = mtu;   // #453: initial MTU; onMTUChange updates if it grows
+  setEffectiveMtu(mtu);            // #711: clamp to our own configured MTU, never the peer's alone
 }
 
 void SerialBLEInterface::onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason) {
@@ -111,7 +124,7 @@ void SerialBLEInterface::onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& con
 
 void SerialBLEInterface::onMTUChange(uint16_t MTU, NimBLEConnInfo& connInfo) {
   BLE_DEBUG_PRINTLN("onMTUChange(), mtu=%d", MTU);
-  if (MTU >= 23) _att_mtu = MTU;   // #453: track negotiated MTU for maxFrameSize()
+  setEffectiveMtu(MTU);            // #711: same clamp -- a renegotiation cannot exceed our local MTU
 }
 
 // -------- NimBLEServerCallbacks: security/pairing events

--- a/src/helpers/esp32/SerialBLEInterface.h
+++ b/src/helpers/esp32/SerialBLEInterface.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../BaseSerialInterface.h"
+#include "../BleFrameSizing.h"   // #711: testable ATT frame-sizing arithmetic
 #include <NimBLEDevice.h>
 
 // NimBLE merges security callbacks INTO NimBLEServerCallbacks (Bluedroid had
@@ -16,7 +17,7 @@ class SerialBLEInterface : public BaseSerialInterface, NimBLEServerCallbacks, Ni
   bool oldDeviceConnected;
   bool _isEnabled;
   uint16_t last_conn_id;
-  uint16_t _att_mtu;          // #453: negotiated ATT MTU (default 23 = BLE minimum)
+  uint16_t _att_mtu;          // #711: EFFECTIVE ATT MTU = min(peer, our own configured MTU)
   uint32_t _pin_code;
   unsigned long _last_write;
   unsigned long adv_restart_time;
@@ -59,6 +60,11 @@ protected:
   void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason) override;
   void onMTUChange(uint16_t MTU, NimBLEConnInfo& connInfo) override;
 
+  // #711: record the EFFECTIVE connection MTU, i.e. min(reported, our own configured
+  // local MTU). A peer-reported value alone is not the connection's MTU: ATT settles
+  // on the minimum of the two sides. Called from onConnect and onMTUChange.
+  void setEffectiveMtu(uint16_t reported);
+
   // NimBLEServerCallbacks: security/pairing events (merged from BLESecurityCallbacks)
   uint32_t onPassKeyDisplay() override;
   void onConfirmPassKey(NimBLEConnInfo& connInfo, uint32_t pin) override;
@@ -100,11 +106,18 @@ public:
   size_t writeFrame(const uint8_t src[], size_t len) override;
   size_t checkRecvFrame(uint8_t dest[]) override;
 
-  // #453: BLE deliverable frame = negotiated ATT MTU - 3 (ATT notify header),
-  // never above MAX_FRAME_SIZE. Tracked from onConnect/onMTUChange.
+  // #453/#711: BLE deliverable frame = EFFECTIVE ATT MTU - 3 (ATT notify header),
+  // never above MAX_FRAME_SIZE (the frame buffer bound).
+  //
+  // #711: `_att_mtu` MUST already be the effective (both-sides) MTU. The connection
+  // MTU is min(local, peer), and begin() pins our local side to MAX_FRAME_SIZE via
+  // NimBLEDevice::setMTU(), so on this transport the deliverable is at most
+  // MAX_FRAME_SIZE - 3 and the MAX_FRAME_SIZE ceiling below is unreachable in
+  // practice. Caching the PEER's MTU here (which can be far larger, e.g. Android's
+  // 517) made this saturate at MAX_FRAME_SIZE and clipped 3 bytes off every full
+  // frame -- the #450 bug, reintroduced. See setEffectiveMtu().
   size_t maxFrameSize() const override {
-    uint16_t m = _att_mtu > 3 ? (uint16_t)(_att_mtu - 3) : 0;
-    return m < MAX_FRAME_SIZE ? (size_t)m : (size_t)MAX_FRAME_SIZE;
+    return ble_frame::deliverableFrame(_att_mtu, MAX_FRAME_SIZE);
   }
 };
 

--- a/src/helpers/nrf52/SerialBLEInterface.cpp
+++ b/src/helpers/nrf52/SerialBLEInterface.cpp
@@ -277,12 +277,25 @@ size_t SerialBLEInterface::maxFrameSize() const {
   // #453: a single BLE notification carries the negotiated ATT MTU - 3 (ATT header).
   // Cap to that, never above MAX_FRAME_SIZE. Fall back to the BLE minimum (23-3=20)
   // when not connected so a pre-negotiation frame is never clipped.
-  uint16_t mtu = 23;
+  //
+  // #711: this deliberately shares ble_frame::deliverableFrame() with the ESP32 path
+  // rather than keeping a second hand-written copy of the same arithmetic -- the
+  // divergent copy is what let the ESP32 side regress unnoticed. The shared function is
+  // unit-tested in test/test_frame_size.
+  //
+  // NOTE the asymmetry, which is intentional: ESP32 must clamp with
+  // ble_frame::effectiveMtu() because NimBLE reports the PEER's MTU and begin() pins our
+  // local side via NimBLEDevice::setMTU(). Here, Bluefruit's conn->getMtu() is the
+  // CONNECTION's negotiated MTU (already min(local, peer)), and this port sets no explicit
+  // local MTU, so there is no second value to clamp against. Do NOT invent one: passing a
+  // guessed local MTU into effectiveMtu() would silently shrink frames on healthy links.
+  // If conn->getMtu() is ever found to report a peer-preferred value instead, THAT is the
+  // bug to fix, and it should be fixed by clamping against a real configured local MTU.
+  uint16_t mtu = ble_frame::MIN_ATT_MTU;
   BLEConnection* conn = (_conn_handle != BLE_CONN_HANDLE_INVALID)
                           ? Bluefruit.Connection(_conn_handle) : nullptr;
   if (conn != nullptr && conn->connected()) mtu = conn->getMtu();
-  uint16_t payload = mtu > 3 ? (uint16_t)(mtu - 3) : 0;
-  return payload < MAX_FRAME_SIZE ? (size_t)payload : (size_t)MAX_FRAME_SIZE;
+  return ble_frame::deliverableFrame(mtu, MAX_FRAME_SIZE);
 }
 
 size_t SerialBLEInterface::writeFrame(const uint8_t src[], size_t len) {

--- a/src/helpers/nrf52/SerialBLEInterface.h
+++ b/src/helpers/nrf52/SerialBLEInterface.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../BaseSerialInterface.h"
+#include "../BleFrameSizing.h"   // #711: shared, unit-tested ATT frame-sizing arithmetic
 #include <bluefruit.h>
 
 #ifndef BLE_TX_POWER

--- a/test/test_frame_size/test_ble_frame_sizing.cpp
+++ b/test/test_frame_size/test_ble_frame_sizing.cpp
@@ -1,0 +1,177 @@
+// #712: regression test for the BLE frame-size ceiling (#711, itself a regression of #450).
+//
+// THE INVARIANT UNDER TEST
+//   No frame handed to writeFrame() may exceed what one ATT notification delivers,
+//   i.e. effective_MTU - 3, for EVERY value of the reported MTU -- including values
+//   larger than MAX_FRAME_SIZE + 3.
+//
+// That last clause is the entire regression. #454 replaced #450's hardcoded cap with a
+// computed one that saturated at MAX_FRAME_SIZE, so any peer-reported MTU >= 179 produced
+// a 176-byte frame on a link carrying 173 and silently lost 3 bytes per full frame. A test
+// exercising only the low-MTU case (the T1000-E 169 link #454 was written for) passes on
+// the broken code and catches nothing, which is why the field found this and CI did not.
+
+#include <gtest/gtest.h>
+
+#include "helpers/BleFrameSizing.h"
+
+using namespace ble_frame;
+
+namespace {
+
+// Mirrors src/helpers/BaseSerialInterface.h. Kept as a local constant so this suite has no
+// Arduino dependency; asserted against the real value in FrameBufferConstantUnchanged.
+constexpr size_t kMaxFrame = 176;
+
+// What begin() pins our own side to: NimBLEDevice::setMTU(MAX_FRAME_SIZE).
+constexpr uint16_t kLocalMtu = 176;
+
+// Reported MTUs worth covering. 179 and 517 are the values that fail pre-fix; 517 is what
+// Android reports in the field when the client's requestMtu() is rejected.
+const uint16_t kReportedMtus[] = {0, 1, 3, 4, 22, 23, 24, 100, 169, 172, 176, 178, 179, 185, 247, 512, 517, 65535};
+
+// The pre-#711 implementation, verbatim, so the test can prove it is actually broken.
+// If this ever stops failing the assertions below, the test has lost its teeth.
+size_t legacyMaxFrameSize(uint16_t cached_mtu) {
+  uint16_t m = cached_mtu > 3 ? (uint16_t)(cached_mtu - 3) : 0;
+  return m < kMaxFrame ? (size_t)m : (size_t)kMaxFrame;
+}
+
+}  // namespace
+
+// --- the specific field failure -------------------------------------------------------
+
+// madmax_2069, 2026-08-15: peer reported a large MTU, our side was pinned at 176, the link
+// delivered 173. Three downloads each lost exactly 3 bytes x 49 full chunks = 147 bytes.
+TEST(BleFrameSizing, RegressionSeventyOneOne_PeerMtuMustNotRaiseTheLinkCeiling) {
+  const uint16_t effective = effectiveMtu(/*reported=*/517, /*local=*/kLocalMtu);
+  EXPECT_EQ(effective, 176) << "connection MTU is min(local, peer), not the peer's alone";
+
+  const size_t deliverable = deliverableFrame(effective, kMaxFrame);
+  EXPECT_EQ(deliverable, 173u) << "a 176-MTU link carries MTU-3 = 173 on-wire bytes";
+  EXPECT_LT(deliverable, kMaxFrame)
+      << "on this transport the MAX_FRAME_SIZE ceiling is unreachable: begin() pins our "
+         "local MTU to MAX_FRAME_SIZE, so the deliverable is always at most MAX_FRAME_SIZE-3";
+
+  // The payload a 2-byte-header chunk builder (caplog CHUNK) may emit.
+  const size_t payload = deliverable > 2 ? deliverable - 2 : 0;
+  EXPECT_EQ(payload, 171u);
+  EXPECT_EQ(2 + payload, 173u) << "the emitted frame must fit one notification exactly";
+}
+
+// Proves the above is a real behaviour change: the old code returns the full frame here.
+TEST(BleFrameSizing, RegressionSeventyOneOne_LegacyImplementationIsDemonstrablyBroken) {
+  EXPECT_EQ(legacyMaxFrameSize(517), kMaxFrame)
+      << "pre-#711 cached the peer MTU and saturated at MAX_FRAME_SIZE";
+  EXPECT_EQ(legacyMaxFrameSize(517) - deliverableFrame(effectiveMtu(517, kLocalMtu), kMaxFrame), 3u)
+      << "exactly the 3 bytes per full frame the field lost";
+}
+
+// The tester's arithmetic, end to end: an 8608-byte buffer chunked at the correct cap must
+// deliver 8608 bytes. At the broken cap the sum comes up 147 short, which is what the
+// client reported as "8461 of 8608 bytes in 50 chunks".
+TEST(BleFrameSizing, RegressionSeventyOneOne_DeliveredTotalEqualsAnnouncedTotal) {
+  constexpr size_t kTotal = 8608;
+  constexpr size_t kHeader = 2;
+
+  const size_t good_cap = deliverableFrame(effectiveMtu(517, kLocalMtu), kMaxFrame) - kHeader;
+  size_t delivered = 0, chunks = 0;
+  for (size_t off = 0; off < kTotal; off += good_cap, ++chunks) {
+    const size_t n = (kTotal - off) < good_cap ? (kTotal - off) : good_cap;
+    ASSERT_LE(kHeader + n, 173u) << "chunk " << chunks << " would be clipped on the wire";
+    delivered += n;
+  }
+  EXPECT_EQ(delivered, kTotal);
+
+  // Same walk at the pre-fix cap, counting what the wire would actually carry.
+  const size_t bad_cap = legacyMaxFrameSize(517) - kHeader;   // 174
+  size_t received = 0, full_chunks = 0;
+  for (size_t off = 0; off < kTotal; off += bad_cap) {
+    const size_t n = (kTotal - off) < bad_cap ? (kTotal - off) : bad_cap;
+    const size_t on_wire = (kHeader + n) > 173 ? 173 : (kHeader + n);   // ATT clips the tail
+    if (n == bad_cap) ++full_chunks;
+    received += on_wire - kHeader;
+  }
+  EXPECT_EQ(kTotal - received, 147u) << "the exact field shortfall";
+  EXPECT_EQ(3 * full_chunks, 147u) << "3 bytes per FULL chunk; the short final chunk survives";
+}
+
+// --- the general invariant ------------------------------------------------------------
+
+TEST(BleFrameSizing, EmittedFrameNeverExceedsWhatTheLinkDelivers) {
+  for (uint16_t reported : kReportedMtus) {
+    const uint16_t effective = effectiveMtu(reported, kLocalMtu);
+    const size_t deliverable = deliverableFrame(effective, kMaxFrame);
+
+    // The link's true ceiling, derived from the INPUTS rather than from `effective`.
+    // Deriving it from `effective` would make this assertion circular: a bug that
+    // inflates the effective MTU also inflates the ceiling it is checked against, and
+    // the test passes while the wire clips. That is exactly how this escaped before --
+    // verified by reverting the fix and watching only the explicit regression cases fail.
+    const uint16_t true_mtu = reported < MIN_ATT_MTU
+                                ? MIN_ATT_MTU
+                                : (kLocalMtu < reported ? kLocalMtu : reported);
+    const size_t link_ceiling = true_mtu > 3 ? (size_t)(true_mtu - 3) : 0;
+
+    EXPECT_EQ(effective, true_mtu)
+        << "reported=" << reported << ": effective MTU must be min(local, peer)";
+
+    EXPECT_LE(deliverable, link_ceiling)
+        << "reported=" << reported << " effective=" << effective
+        << ": frame would be clipped on the wire";
+    EXPECT_LE(deliverable, kMaxFrame)
+        << "reported=" << reported << ": frame would overrun the send buffer";
+
+    // And for a builder with a header, header + payload must still fit.
+    for (size_t header : {size_t(0), size_t(1), size_t(2), size_t(3), size_t(4), size_t(6)}) {
+      const size_t payload = deliverable > header ? deliverable - header : 0;
+      EXPECT_LE(header + payload, link_ceiling)
+          << "reported=" << reported << " header=" << header;
+    }
+  }
+}
+
+TEST(BleFrameSizing, EffectiveMtuIsTheMinimumOfBothSides) {
+  EXPECT_EQ(effectiveMtu(517, 176), 176);   // peer larger  -> our side wins
+  EXPECT_EQ(effectiveMtu(100, 176), 100);   // peer smaller -> peer wins
+  EXPECT_EQ(effectiveMtu(176, 176), 176);   // equal
+  EXPECT_EQ(effectiveMtu(169, 512), 169);   // T1000-E class link, generous local
+}
+
+// An unknown or nonsensical report must be conservative. It must NEVER fall through to the
+// local MTU, which would license a frame the link may not carry. This is the same lesson
+// the client already encodes ("an unknown MTU must fall back to that floor").
+TEST(BleFrameSizing, UnusableReportFallsBackToTheFloorNotToLocal) {
+  for (uint16_t bad : {uint16_t(0), uint16_t(1), uint16_t(3), uint16_t(22)}) {
+    EXPECT_EQ(effectiveMtu(bad, kLocalMtu), MIN_ATT_MTU)
+        << "reported=" << bad << " must not inherit the local MTU";
+    EXPECT_EQ(deliverableFrame(effectiveMtu(bad, kLocalMtu), kMaxFrame), 20u);
+  }
+}
+
+// Gemini flagged this during #454 and it must stay guarded: a tiny MTU must yield 0, never
+// a wrapped-huge size_t that would send a builder off the end of its buffer.
+TEST(BleFrameSizing, TinyMtuCannotUnderflow) {
+  for (uint16_t tiny : {uint16_t(0), uint16_t(1), uint16_t(2), uint16_t(3)}) {
+    EXPECT_EQ(deliverableFrame(tiny, kMaxFrame), 0u) << "mtu=" << tiny;
+  }
+  EXPECT_EQ(deliverableFrame(4, kMaxFrame), 1u);
+}
+
+TEST(BleFrameSizing, SerialAndTcpAreUnaffected) {
+  // Non-BLE transports have no ATT header; they keep the full frame.
+  EXPECT_EQ(deliverableFrame(kMaxFrame + ATT_NOTIFY_HEADER, kMaxFrame), kMaxFrame);
+  EXPECT_EQ(deliverableFrame(65535, kMaxFrame), kMaxFrame);
+}
+
+// Guards the local mirror of MAX_FRAME_SIZE: if the real constant moves, this suite's
+// numbers must be revisited rather than silently drifting out of sync.
+TEST(BleFrameSizing, FrameBufferConstantUnchanged) {
+  EXPECT_EQ(kMaxFrame, 176u)
+      << "MAX_FRAME_SIZE changed; revisit the expected values in this suite";
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## What this changes

Restores the BLE frame-size invariant reported broken in #711, pins it with a test that is proven to fail without the fix, and switches on the native test suites in CI. Affects every BLE companion role (ESP32 and nRF52) plus repo-wide CI.

Closes #712
Addresses #711 — **that issue stays OPEN**: this is bench-verified but has no hardware repro yet.

### The bug

ATT settles the connection MTU at `min(local, peer)`. `begin()` pins our local side with `NimBLEDevice::setMTU(MAX_FRAME_SIZE)`, but `onConnect` cached `getPeerMTU()` unclamped, so a peer advertising more (Android commonly 517) made `maxFrameSize()` saturate at `MAX_FRAME_SIZE` and emit 176-byte frames onto a 173-byte pipe. The stack clips the tail silently: every FULL frame lost exactly 3 bytes, the short final frame survived.

Because our own side is pinned at exactly `MAX_FRAME_SIZE`, the deliverable on this transport is **always at most `MAX_FRAME_SIZE - 3`** — the old `min(mtu-3, MAX_FRAME_SIZE)` ceiling was unreachable by construction.

Field evidence: `8461 of 8608 bytes in 50 chunks`, byte-identical on three consecutive attempts. `49 full chunks x 3 = 147`.

**This is a regression of #450**, reintroduced by #454, which traded an unconditionally-safe constant for a computed cap that is only safe when the cached MTU is truthful — and shipped with no test asserting the ceiling.

## Tests

**Does the test embed the broken behaviour, or has it been watched failing? Both.**

- `RegressionSeventyOneOne_LegacyImplementationIsDemonstrablyBroken` carries the pre-fix formula verbatim and asserts the delta is exactly 3 bytes, so the guarantee runs on every CI run rather than living in a reviewer's memory.
- Also verified by hand: reverting the fix fails **5 of 9** cases; restoring it passes 9/9.

One trap worth flagging for reviewers: the first draft of `EmittedFrameNeverExceedsWhatTheLinkDelivers` **passed against the broken code**, because it derived its expected ceiling from `effectiveMtu()`'s own output — a bug that inflates the MTU also inflates the expectation. It now derives the ceiling from the raw inputs. That is only caught by actually running the test against the broken code.

- [x] Tests added/updated, and shown to fail without the fix
- [ ] No test: state why here (only the owner waives a test)

## Verification

- [x] Builds: `heltec_v4_companion_radio_ble`, `Heltec_v2_companion_radio_ble` (DRAM-tight, **not** in the CI matrix — per #683/#686), `RAK_4631_companion_radio_ble`. `check_esp32_ble_deps.py` OK across 51 envs.
- [x] `pio test` green for every native env: `native` 153/153, `native_kiss_modem` 8/8.
- [ ] **NOT hardware-verified.** No bench repro against a link that actually clips. #711 stays open until someone confirms a clean caplog download on a link where the client's `requestMtu` fails.

## Review

- [x] Gemini-reviewed (`gemini-2.5-pro`). Its one substantive finding — the nRF52 copy of the arithmetic was a divergence risk — is **adopted**: nRF52 now delegates to the same shared function.

Its suggestion to hardcode an nRF52 local MTU is **deliberately declined**, with the reasoning recorded in-code so it is not "fixed" later: that port configures no local MTU, so a guessed value would silently shrink frames on healthy links. `conn->getMtu()` is already the negotiated value there.

Note for reviewers: an LLM review is a second opinion, not a gate. The #454 review certified as "correct" the exact two things that later broke.

## Notes

**This PR changes a required check.** `ci-green` now needs `native-tests`. Consequences:

- The native suites (161 cases across 2 envs) **have never run in CI** — every invariant they encode was unenforced. They are green as of this branch, so this gates on real, passing coverage.
- Envs are **discovered**, not listed: a hardcoded `pio test -e native` silently skipped `[env:native_kiss_modem]`. Discovery finding zero envs is a hard error, because a test job that runs nothing and reports green is worse than no job.
- **Open PRs #688 / #678 / #650 will pick this up on their next rebase** (`strict: true`). Their current runs are unaffected — `pull_request` uses the workflow from the PR head. Owners broadcast separately.

Follow-ups filed, deliberately out of scope here:
- **#714** — mechanical guards (test-required check, advisory first per owner ruling; testable-surface ratchet). Only ~8 of 86 translation units compile natively, so most firmware logic is untestable without extraction.
- Other chunked builders named in #453's audit (config stream, observer VIEW/BROKERS, block list, GPS) size against `maxFramePayload()` too, but announce no total — so they clip **silently**. Not touched here.

Agent: TopazElk (session cb83eacb)
