### PR TITLE
epic(#177): observer TLS broker rotation — fairness, always-on primary, drop visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,53 @@ Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
 ## [Unreleased]
 
+### Fixed
+- **Observer multi-broker rotation actually rotates** (#708): with more than two TLS
+  brokers enabled, promotion was a first-eligible-by-slot-index scan whose only
+  fairness mechanism only works at exactly two candidates. Every broker above the two
+  lowest slots was starved permanently — measured on a Heltec V3 as 36/35/**0**
+  promotions over 80 minutes, with the third broker never publishing once. Promotion is
+  now oldest-served-first, verified on hardware as an even three-way cycle. The
+  selection logic moved into a dependency-free header with unit tests, because the
+  defect is invisible at two brokers and two brokers is what it was validated at.
+- **Broker slot 0 is an always-on primary again** (#707): a tcp broker holds no mbedTLS
+  context and is therefore exempt from TLS rotation — that exemption is the only thing
+  that ever made slot 0 always-on. Moving slots 0–1 to `wss` in 1.4.0 silently demoted
+  slot 0 into the rotating pool, where it was torn down and rebuilt every ~2 minutes
+  (178 evictions in one 6.9 h soak). The seed puts slot 0 back on
+  `mqtt://mqtt1.okimesh.org:1883`, with the trade recorded at the seed row so it is not
+  "upgraded" again by accident. Existing devices need the matching config profile —
+  firmware seeds only apply to fresh NVS.
+- **JWT brokers could not be configured from a config profile** (#709): the config wire
+  key was `jwt_audience` while the schema, `SCHEMA.md`, and every published profile used
+  `jwt_aud`, so setting the audience by its documented name failed with "unknown broker
+  field". Every JWT broker slot was unconfigurable. Both spellings are now accepted, on
+  the setter and the getter, keyed off the schema constant so they cannot drift apart
+  again.
+- **Publish-ring overrun is counted instead of discarded silently** (#710): when a
+  rotated-out broker fell behind, the ring clamped its cursor, counted nothing, logged
+  nothing, and the only indicator reset itself as soon as the broker caught up — a fleet
+  could discard most of its feed with every diagnostic reading clean. There is now a
+  monotonic per-broker drop counter, reported in `mqtt status` as `ring_dropped` and on a
+  60-second `[ring]` line so a passive serial capture measures it. A newly-attached
+  broker resyncs to the ring head instead of replaying stale backlog.
+
+### Changed
+- **"Held, low heap" no longer reports normal rotation as a memory error** (#715): one
+  broker state covered three different conditions and was named after the rarest. With
+  multiple TLS brokers the common case is "waiting its turn", which displayed as a
+  memory fault — on a 3-broker pool, 2 of 3 permanently showed a problem that did not
+  exist. Serial and CLI now distinguish `waiting-turn` from `held(low-heap)`. **The app
+  still shows the old wording**: the wire value is deliberately unchanged until the
+  client can accept the new one.
+- **Observer builds trimmed and the publish ring deepened** (#701/#710): observer envs
+  drop to 5 contacts, 4 user channels and 6 broker slots, freeing 14,660 B of static
+  RAM; 8,192 B of that funds a 32-slot publish ring (was 16), sized from measured
+  fleet traffic rather than estimated. **On these builds the BLE-companion half is
+  capped at 5 contacts and 4 channels** — devices holding more truncate on load
+  (favourites and most-recent survive). Non-observer builds are byte-for-byte unchanged.
+
+
 ## [1.4.0] - 2026-08-13
 
 ### Added

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1704,7 +1704,9 @@ void MyMesh::offbandStreamDrain() {
       // #175: also surface the ring send-backlog + lap flag for this slot.
       int32_t _lag = (int32_t)offband::wifiObserverPool().brokerLag((uint8_t)s);
       bool _lapped = offband::wifiObserverPool().brokerLapped((uint8_t)s);
-      offband::configRenderBrokerSlot((uint8_t)s, _ob_buf, sizeof(_ob_buf), &_rt, _owner_hex, _lag, _lapped);
+      // #710: monotonic overrun-loss counter (ring_lapped self-erases on drain).
+      uint32_t _dropped = offband::wifiObserverPool().brokerDropped((uint8_t)s);
+      offband::configRenderBrokerSlot((uint8_t)s, _ob_buf, sizeof(_ob_buf), &_rt, _owner_hex, _lag, _lapped, _dropped);
       _ob_off = 0;
     }
     // Emit ONE "key=value" line as a BROKER_KV frame for the current slot.

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -38,7 +38,20 @@ public:
   #define MAX_CONTACTS  32
 #endif
 
-#define MAX_ANON_CONTACTS  8
+// #701: overridable so heap-constrained roles can shrink the anon-contact pool.
+// DEFAULT IS UNCHANGED AT 8 -- every env that does not pass -D MAX_ANON_CONTACTS
+// compiles byte-identically to before. Only the observer envs override it, where
+// the node is a raw packet tap (ObserverPipeline::onRawReceived -> publish raw
+// bytes) and never resolves a sender, so the OBSERVER pipeline needs none of it.
+// Note the observer envs are also BLE companions, so shrinking this does cap
+// what the companion half can hold -- a deliberate trade, not free.
+// Each slot costs sizeof(ContactInfo) = 184 B in .bss on the global mesh object.
+// Lowering this reduces how many simultaneous UNKNOWN senders a node can track
+// before recycling (BaseChatMesh.cpp:86-101) -- the one behavioural effect, and
+// the reason this is a per-env opt-in rather than a new global default.
+#ifndef MAX_ANON_CONTACTS
+  #define MAX_ANON_CONTACTS  8
+#endif
 
 #ifndef MAX_CONNECTIONS
   #define MAX_CONNECTIONS  16

--- a/src/helpers/wifi_observer/BrokerRotationSelect.h
+++ b/src/helpers/wifi_observer/BrokerRotationSelect.h
@@ -34,6 +34,19 @@ struct TlsCandidate {
 
 // Choose which candidate gets the next TLS budget slot.
 // Returns kNoSlot when the budget is full or nothing is promotable.
+//
+// CALLER CONTRACT -- READ THIS BEFORE WIRING IT UP.
+// This function decides WHO WINS. It does not, and cannot, drive the losers.
+// Every candidate that is not promoted must still be driven so it self-defers
+// into HeldBudget, because the rotation scheduler only runs when at least one
+// broker reads as "waiting". Skip that and the losers stay Down, nothing ever
+// reads as waiting, rotation never fires, and the first broker to take the
+// budget keeps it forever -- worse than the starvation this replaced.
+//
+// That exact mistake shipped once and was caught only on hardware (slot 3 held
+// the budget 8.2 h while three enabled brokers sat Down). The unit tests take
+// `eligible` as an INPUT, so they verify the choice and are structurally blind
+// to the state transition that produces a candidate.
 inline uint8_t selectTlsPromotion(const TlsCandidate* c, uint8_t n,
                                   uint8_t tls_live, uint8_t max_live) {
     if (c == nullptr || tls_live >= max_live) return kNoSlot;

--- a/src/helpers/wifi_observer/BrokerRotationSelect.h
+++ b/src/helpers/wifi_observer/BrokerRotationSelect.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <cstdint>
+
+// TLS broker promotion decision, extracted from MqttBrokerPool::workerLoop()
+// so it can be unit-tested (#708).
+//
+// Deliberately dependency-free (no Arduino/ESP headers) so it builds in
+// [env:native] -- same pattern as MqttRingLog.h. The pool owns the state; this
+// header owns only the CHOICE of which queued TLS broker gets the next free
+// budget slot. Non-TLS brokers never enter here: they hold no mbedTLS context,
+// are exempt from the budget, and the pool promotes them unconditionally.
+//
+// WHY THIS EXISTS: the decision lived inline in a 40-line loop that could only
+// run on hardware. The starvation defect it contained (#708) is invisible at two
+// brokers and was validated at two, so nothing caught it. Anything that decides
+// fairness belongs somewhere a test can reach.
+
+namespace offband {
+
+static constexpr uint8_t kNoSlot = 0xFF;
+
+struct TlsCandidate {
+    // Configured TLS/wss broker in a re-drivable state (Down/Backoff/Held*),
+    // not mid-reconcile. Slots that are live, unconfigured, or non-TLS are not
+    // candidates and should be passed with eligible=false.
+    bool     eligible          = false;
+    // Rotation cooldown still active -- the slot was just evicted and must not
+    // immediately reclaim the budget it gave up (#175).
+    bool     cooling           = false;
+    // Service epoch when this broker was last promoted. 0 = never served.
+    uint32_t last_served_epoch = 0;
+};
+
+// Choose which candidate gets the next TLS budget slot.
+// Returns kNoSlot when the budget is full or nothing is promotable.
+inline uint8_t selectTlsPromotion(const TlsCandidate* c, uint8_t n,
+                                  uint8_t tls_live, uint8_t max_live) {
+    if (c == nullptr || tls_live >= max_live) return kNoSlot;
+
+    // ---------------------------------------------------------------------
+    // OLDEST-SERVED-FIRST (#708).
+    //
+    // Replaces first-eligible-by-slot-index. Under index order the ONLY fairness
+    // mechanism was the per-victim cooldown from #175, which uniquely determines
+    // a winner at exactly TWO candidates and does nothing at three or more: only
+    // one slot is ever cooling, so the lowest-indexed other candidate always won
+    // and everything above it starved permanently. Measured on hv3-bench with
+    // three enabled TLS brokers: 36 / 35 / 0 promotions over 481 samples.
+    //
+    // Ordering by service epoch fixes it structurally rather than by adding
+    // another special case: a broker that has waited longest is promoted next,
+    // regardless of index. Never-served slots carry epoch 0 and therefore win
+    // immediately, which is precisely the starvation condition.
+    //
+    // Ties break to the lower index so the choice stays deterministic (matters
+    // for the tests and for reproducible field behaviour).
+    //
+    // Epoch is a counter, not a timestamp: no millis() wraparound to reason
+    // about. At one promotion per 60 s dwell it overflows uint32 in ~8000 years.
+    // ---------------------------------------------------------------------
+    uint8_t best = kNoSlot;
+    for (uint8_t s = 0; s < n; ++s) {
+        if (!c[s].eligible || c[s].cooling) continue;
+        if (best == kNoSlot ||
+            c[s].last_served_epoch < c[best].last_served_epoch) {
+            best = s;
+        }
+    }
+    return best;
+}
+
+}  // namespace offband

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -327,12 +327,12 @@ bool clearBrokerConfig(uint8_t slot) {
 // changing this layout does NOT re-shuffle slots on a device already seeded
 // under an older layout; it takes effect only on a fresh NVS.)
 //
-//   slot 0  OKIMesh mqtt1      wss://mqtt1.okimesh.org:9002/mqtt  wss / anon   disabled  (#592)
+//   slot 0  OKIMesh mqtt1      mqtt://mqtt1.okimesh.org:1883      tcp / anon   disabled  (#707)
 //   slot 1  OKIMesh mqtt2      wss://mqtt2.okimesh.org:9002/mqtt  wss / anon   disabled  (#592)
 //   slot 2  MeshMapper         wss://mqtt.meshmapper.net        wss / jwt    disabled
 //   slot 3  CoreComms.net      wss://mqtt.corecomms.net         wss / jwt    disabled  (#677)
 //   slot 4  Eastmesh.au        wss://mqtt2.eastmesh.au          wss / jwt    disabled
-//   slots 5-9  (MQTT Custom)   left empty for the operator to fill
+//   slot 5     (MQTT Custom)   left empty for the operator to fill
 //
 // #317 reseat: the OKI Mesh's own two brokers hold slots 0-1 (mqtt1 was
 // formerly labelled "CoreScope Dayton"; mqtt2 is new). LetsMesh-US and
@@ -341,7 +341,8 @@ bool clearBrokerConfig(uint8_t slot) {
 // lookupCaCertPem(), and the bare-host audience note below still applies).
 // MeshMapper and Eastme.sh swapped to 2/3; Eastmesh.au moved 5 -> 4.
 //
-// #592: slots 0-1 moved from plaintext mqtt://:1883 to wss://:9002/mqtt over
+// #592 moved slots 0-1 from plaintext to wss; #707 moved SLOT 0 BACK to
+// plaintext (see the block on the slot-0 row). Slot 1 remains wss://:9002/mqtt over
 // TLS with a "letsencrypt" CA. Auth stays anonymous (BrokerAuthType::None) --
 // TLS secures the transport; there is no MQTT-layer credential, so no JWT
 // audience/owner and no username. Unlike the plaintext form, a wss slot cannot
@@ -390,10 +391,21 @@ struct DefaultBrokerSpec {
     const char*      ca_cert_name;   // "" when no TLS cert (tcp)
 };
 
-// Slots 0-4. Slots 5-9 (MQTT Custom) are intentionally absent so they stay empty.
+// Slots 0-4. Slot 5 (MQTT Custom) is intentionally absent so it stays empty.
 // jwt_audience is the BARE host (#95); ca_cert names resolve in MqttBroker.cpp.
 constexpr DefaultBrokerSpec kDefaultBrokerSpecs[] = {
-    {false, "wss://mqtt1.okimesh.org:9002/mqtt",      BrokerTransport::Wss, 9002, BrokerAuthType::None, "",                        "letsencrypt"},
+    // SLOT 0 IS PLAINTEXT BY DESIGN -- DO NOT "UPGRADE" IT TO wss/TLS.
+    // A tcp broker holds no mbedTLS context, so the rotation scheduler exempts
+    // it entirely: rotateTlsIfDue() never selects it as a victim and its
+    // budget_ok is unconditionally true. That exemption is the ONLY thing
+    // making slot 0 an always-on primary. #592 moved this row to wss and
+    // silently demoted it into the rotating TLS pool, where it was evicted
+    // every dwell (measured on HV3: 178 evictions in a 6.9h soak) -- the
+    // always-on property was lost without a single scheduler line changing.
+    // The trade is explicit: this feed is unencrypted in exchange for being
+    // the one broker that never rotates out. Slots 1-5 carry TLS and share
+    // the OFFBAND_MAX_LIVE_TLS budget by rotation.
+    {false, "mqtt://mqtt1.okimesh.org:1883",          BrokerTransport::Tcp, 1883, BrokerAuthType::None, "",                        ""},
     {false, "wss://mqtt2.okimesh.org:9002/mqtt",      BrokerTransport::Wss, 9002, BrokerAuthType::None, "",                        "letsencrypt"},
     {false, "wss://mqtt.meshmapper.net:443/mqtt",     BrokerTransport::Wss, 443,  BrokerAuthType::Jwt,  "mqtt.meshmapper.net",     "isrg-x2"},
     // #677: Eastme.sh rebranded to CoreComms.net (re-implements external PR

--- a/src/helpers/wifi_observer/MqttBroker.cpp
+++ b/src/helpers/wifi_observer/MqttBroker.cpp
@@ -214,7 +214,7 @@ bool MqttBroker::begin(uint8_t slot, const BrokerConfig& cfg,
         (cfg.transport == BrokerTransport::Tls ||
          cfg.transport == BrokerTransport::Wss)) {
         rt_ = BrokerRuntimeState{};
-        rt_.state = BrokerState::HeldNoHeap;
+        rt_.state = BrokerState::HeldBudget;   // #715: budget, not heap
         return true;
     }
     auth_ = makeAuth(cfg, identity);
@@ -310,7 +310,12 @@ bool MqttBroker::tryConnect(uint32_t now_ms, bool tls_budget_ok) {
     if ((cfg_.transport == BrokerTransport::Tls ||
          cfg_.transport == BrokerTransport::Wss) &&
         (!tls_budget_ok || !tlsHeapBudgetOk())) {
-        rt_.state = BrokerState::HeldNoHeap;
+        // #715: report WHICH condition deferred us. Budget-full is normal rotation
+        // (this broker is queued); below-floor heap is real resource pressure.
+        // Budget is checked first: when both are true the operator-actionable fact
+        // is the heap floor, so heap wins only when the budget was actually free.
+        rt_.state = tls_budget_ok ? BrokerState::HeldNoHeap    // budget free -> heap
+                                  : BrokerState::HeldBudget;   // waiting its turn
         return false;
     }
 

--- a/src/helpers/wifi_observer/MqttBroker.h
+++ b/src/helpers/wifi_observer/MqttBroker.h
@@ -28,11 +28,20 @@ enum class BrokerState : uint8_t {
     HeldNoClock = 4,  // #87: wss/TLS deferred pending a sane wall clock (NTP/GPS).
                       // NOT a failure -- no retry burned; released automatically on
                       // the next drive tick once wallClockSane() becomes true.
-    HeldNoHeap  = 5,  // #171: wss/TLS bring-up deferred -- the pool's TLS budget is
-                      // full (>= OFFBAND_MAX_LIVE_TLS live) or free heap is below
-                      // the floor. NOT a failure -- no retry burned; released on a
-                      // later drive tick once a TLS slot frees or heap recovers
-                      // (mirrors HeldNoClock).
+    HeldNoHeap  = 5,  // #171: wss/TLS bring-up deferred because FREE HEAP is below
+                      // OFFBAND_TLS_HEAP_FLOOR_BYTES. Real resource pressure --
+                      // rare. NOT a failure: no retry burned; released on a later
+                      // drive tick once heap recovers (mirrors HeldNoClock).
+    HeldBudget  = 6,  // #715: wss/TLS bring-up deferred because the pool already
+                      // holds OFFBAND_MAX_LIVE_TLS live TLS contexts -- this broker
+                      // is simply WAITING ITS TURN in normal rotation. Heap is fine.
+                      //
+                      // Split out of HeldNoHeap, which covered both and was named
+                      // after the rarer one. With any multi-broker setup this is the
+                      // overwhelmingly common case, and reporting it as a memory
+                      // problem caused repeated real-world misdiagnosis -- including
+                      // the field report that sent us heap-trimming for a scheduling
+                      // defect. Do NOT re-merge these.
 };
 
 enum class BrokerErrorClass : uint8_t {

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -668,6 +668,27 @@ void MqttBrokerPool::workerLoop() {
                 last_served_epoch_[pick] = ++service_epoch_;
             }
         }
+
+        // #708: every candidate that did NOT win must STILL be driven with
+        // budget_ok=false so it self-defers into HeldBudget.
+        //
+        // This is not cosmetic. rotateTlsIfDue() only runs when some broker reads
+        // as "waiting" (HeldBudget/HeldNoHeap), and a broker reaches that state
+        // ONLY through tryConnect's deferral path. Leaving non-winners untouched
+        // leaves them Down, nothing ever reads as waiting, rotation never fires,
+        // and the first broker to take the budget holds it forever.
+        //
+        // Caught on hardware, not in tests: slot 3 held the budget for 8.2 h while
+        // slots 1/2/4 sat Down with all five brokers enabled. The unit tests take
+        // `eligible` as an INPUT and only exercise the choice -- they cannot see
+        // that the caller also owns the state transition which makes a broker
+        // eligible in the first place. Extracting the decision without the
+        // transition is what broke it.
+        for (uint8_t s = 0; s < OFFBAND_MAX_BROKERS; ++s) {
+            if (!cand[s].eligible) continue;   // winners already cleared above
+            uint32_t biased = now + static_cast<uint32_t>(s) * 1000U;
+            (void)brokers_[s].tryConnect(biased, /*budget_ok=*/false);
+        }
     }
     worker_task_ = nullptr;
     vTaskDelete(nullptr);

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -141,6 +141,11 @@ void MqttBrokerPool::loop(uint32_t now_ms) {
     // pass) also flushes a rotated-back-in broker even when no new packet arrives
     // to trigger publishPacket. The worker task does NOT touch the ring.
     for (uint8_t s = 0; s < OFFBAND_MAX_BROKERS; ++s) {
+        // #710: a freshly-attached broker starts at the ring head instead of
+        // replaying an arbitrarily old backlog. Done HERE on loopTask, not in
+        // reconcileSlot() where the client is created, because that runs on the
+        // worker and the worker must never touch ring_.
+        if (pending_resync_[s].exchange(false)) ring_.resync(s);
         if (brokers_[s].runtime().state == BrokerState::Up) (void)drainBroker(s);
     }
 }
@@ -395,6 +400,11 @@ void MqttBrokerPool::reconcileSlot(uint8_t slot) {
     const bool may_alloc =
         (tlsClientsAllocated() - (brokers_[slot].hasClient() ? 1u : 0u))
             < OFFBAND_MAX_LIVE_TLS;
+    // #710: the slot is about to (re)attach a client. Ask loopTask to move this
+    // reader to the ring head so it does not replay stale backlog and does not
+    // book boot-time loss as rotation loss. Flag only -- the worker must not
+    // touch ring_.
+    pending_resync_[slot] = true;
     if (!brokers_[slot].begin(slot, cfg, *identity_, may_alloc) && cfg.enabled) {
         crashLogf("[pool] reconcileSlot %u begin FAILED state=%d err_class=%d",
                   (unsigned)slot,
@@ -594,7 +604,24 @@ void MqttBrokerPool::workerLoop() {
         // promotions over 481 samples; slot 3 never ran. Selection now lives in
         // selectTlsPromotion() (BrokerRotationSelect.h) so it is unit-testable --
         // the defect was invisible at N=2, which is the arity it was validated at.
-        TlsCandidate cand[OFFBAND_MAX_BROKERS];
+        // = {} is redundant -- TlsCandidate carries default member initializers,
+        // so plain declaration already zeroes every element. Kept explicit so a
+        // future edit that drops the NSDMIs cannot silently introduce garbage.
+        // #708 (Gemini review): stamp service on the transition INTO Up -- the
+        // definitive 'this broker actually got its turn' signal. Stamping at
+        // Connecting counted a bring-up that may fail 1-8 s later in the async
+        // handshake, letting a flaky broker consume turns while publishing
+        // nothing. A broker that never reaches Up keeps its old epoch and is
+        // retried; its own Backoff schedule prevents it monopolising selection.
+        for (uint8_t s = 0; s < OFFBAND_MAX_BROKERS; ++s) {
+            const BrokerState now_st = brokers_[s].runtime().state;
+            if (now_st == BrokerState::Up && last_known_state_[s] != BrokerState::Up) {
+                last_served_epoch_[s] = ++service_epoch_;
+            }
+            last_known_state_[s] = now_st;
+        }
+
+        TlsCandidate cand[OFFBAND_MAX_BROKERS] = {};
         for (uint8_t s = 0; s < OFFBAND_MAX_BROKERS; ++s) {
             if (reconciling_[s]) continue;
             MqttBroker& b = brokers_[s];
@@ -661,11 +688,16 @@ void MqttBrokerPool::workerLoop() {
             if (!b.hasClient()) reconcileSlot(pick);
             uint32_t biased = now + static_cast<uint32_t>(pick) * 1000U;
             (void)b.tryConnect(biased, /*budget_ok=*/true);
+            // Budget is consumed the moment a bring-up STARTS -- the mbedTLS
+            // context is allocated at Connecting, not at Up.
+            //
+            // The service epoch is NOT stamped here (#708, Gemini review):
+            // esp_mqtt_client_start() is async and the handshake takes 1-8 s
+            // (measured). A broker that reaches Connecting and then fails TLS
+            // would have consumed its turn without publishing anything. Service
+            // is stamped on the actual transition to Up, at the top of the pass.
             if (b.runtime().state == BrokerState::Connecting) {
                 tls_live++;
-                // Stamp service only on an actual bring-up, so a broker that fails
-                // to start does not lose its place in the queue.
-                last_served_epoch_[pick] = ++service_epoch_;
             }
         }
 

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -142,6 +142,37 @@ void MqttBrokerPool::loop(uint32_t now_ms) {
     for (uint8_t s = 0; s < OFFBAND_MAX_BROKERS; ++s) {
         if (brokers_[s].runtime().state == BrokerState::Up) (void)drainBroker(s);
     }
+#if defined(ARDUINO)
+    // #710: publish-ring overrun report (one line / 60s -- rule-10 safe).
+    //
+    // Emitted HERE on loopTask and deliberately NOT beside the [rot] line in
+    // workerLoop(): "The worker task does NOT touch the ring" (above) is the
+    // invariant that lets the ring run lock-free, and reading dropped_ from the
+    // worker would break exactly what the #175 concurrency review established.
+    //
+    // Covers EVERY configured slot, not just TLS ones -- [rot] filters to
+    // isTlsTransport() because it is the rotation diagnostic, which makes it
+    // structurally blind to the plaintext always-on primary (#707). That broker is
+    // the one that must never drop, so it is the one this line most needs to show.
+    //
+    // Unconditional: prints zeros when healthy. An edge-triggered line would make
+    // silence ambiguous ("no drops" vs "reporting broken"), which is the same class
+    // of silent failure this counter exists to remove.
+    {
+        static uint32_t s_ring_log_ms = 0;
+        if (now_ms - s_ring_log_ms >= 60000U) {
+            s_ring_log_ms = now_ms;
+            char L[160];
+            int o = snprintf(L, sizeof(L), "[ring] head=%u drops", (unsigned)ring_.head());
+            for (uint8_t s = 0; s < OFFBAND_MAX_BROKERS && o < (int)sizeof(L) - 16; ++s) {
+                if (!brokers_[s].isConfigured()) continue;
+                o += snprintf(L + o, (size_t)(sizeof(L) - o), " s%u=%u",
+                              (unsigned)s, (unsigned)ring_.droppedCount(s));
+            }
+            Serial.println(L);
+        }
+    }
+#endif
 }
 
 // ---------------------------------------------------------------------------

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -452,7 +452,9 @@ void MqttBrokerPool::rotateTlsIfDue(uint32_t now_ms) {
         const MqttBroker& b = brokers_[s];
         if (!b.isConfigured() || !isTlsTransport(b.config())) continue;
         tls_enabled++;
-        if (b.runtime().state == BrokerState::HeldNoHeap) waiting = true;
+        // #715: HeldBudget and HeldNoHeap are both 'deferred, wants the budget'.
+        if (b.runtime().state == BrokerState::HeldNoHeap ||
+            b.runtime().state == BrokerState::HeldBudget) waiting = true;
     }
     // Nothing to share (budget covers all enabled TLS -- PSRAM/large-heap case),
     // or nobody is actually waiting for the budget: no rotation.
@@ -566,13 +568,13 @@ void MqttBrokerPool::workerLoop() {
                               "[rot] heap=%u tls=%u live=%u/%u dwleft=%us |",
                               (unsigned)ESP.getFreeHeap(), (unsigned)tls_cfg, (unsigned)tls_live,
                               (unsigned)OFFBAND_MAX_LIVE_TLS, (unsigned)dwleft);
-                static const char* AB[] = {"DN","CO","UP","BK","HC","HH"};
+                static const char* AB[] = {"DN","CO","UP","BK","HC","HH","HB"};  // #715: HB=held(budget)
                 for (uint8_t s = 0; s < OFFBAND_MAX_BROKERS && o < (int)sizeof(L) - 24; ++s) {
                     const MqttBroker& b = brokers_[s];
                     if (!b.isConfigured() || !isTlsTransport(b.config())) continue;
                     uint8_t stv = (uint8_t)b.runtime().state;
                     o += snprintf(L + o, (size_t)(sizeof(L) - o), " s%u:%s", (unsigned)s,
-                                  stv < 6 ? AB[stv] : "?");
+                                  stv < 7 ? AB[stv] : "?");
                     if (b.runtime().state == BrokerState::Up)
                         o += snprintf(L + o, (size_t)(sizeof(L) - o), "/%us",
                                       (unsigned)((now - b.runtime().went_up_ms) / 1000U));
@@ -594,7 +596,8 @@ void MqttBrokerPool::workerLoop() {
             // Re-drive idle/held slots. HeldNoClock releases when the clock is
             // sane (#87); HeldNoHeap releases when a TLS slot frees (#171).
             if (st == BrokerState::Down || st == BrokerState::Backoff ||
-                st == BrokerState::HeldNoClock || st == BrokerState::HeldNoHeap) {
+                st == BrokerState::HeldNoClock || st == BrokerState::HeldNoHeap ||
+                st == BrokerState::HeldBudget) {   // #715
                 // #175: skip a slot still in its rotation cooldown, so the parked
                 // broker claims the freed budget instead of the just-evicted victim
                 // reclaiming it. Wrap-safe; 0 means "not cooling".

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -3,6 +3,7 @@
 // Plan 2 v2 Task 8.
 
 #include "MqttBrokerPool.h"
+#include "BrokerRotationSelect.h"   // #708: fair TLS promotion
 #include "MqttPayload.h"
 #include <helpers/diagnostics/CrashLog.h>   // #181: crashLogf() -- worker has no user ACK channel
 #include <cstring>
@@ -585,6 +586,15 @@ void MqttBrokerPool::workerLoop() {
             }
         }
 #endif
+        // #708: build the TLS candidate set while driving per-broker lifecycle.
+        // Promotion order used to be "first eligible by slot index", whose only
+        // fairness mechanism was #175's per-victim cooldown -- which uniquely
+        // determines a winner at exactly TWO candidates and does nothing at three
+        // or more. Measured on hv3-bench with three enabled TLS brokers: 36/35/0
+        // promotions over 481 samples; slot 3 never ran. Selection now lives in
+        // selectTlsPromotion() (BrokerRotationSelect.h) so it is unit-testable --
+        // the defect was invisible at N=2, which is the arity it was validated at.
+        TlsCandidate cand[OFFBAND_MAX_BROKERS];
         for (uint8_t s = 0; s < OFFBAND_MAX_BROKERS; ++s) {
             if (reconciling_[s]) continue;
             MqttBroker& b = brokers_[s];
@@ -602,10 +612,17 @@ void MqttBrokerPool::workerLoop() {
                     (int32_t)(rotated_out_until_ms_[s] - now) > 0) {
                     continue;
                 }
+                // #708: TLS slots compete for the budget and are decided below by
+                // waiting time. Non-TLS hold no mbedTLS context, never contend, and
+                // are driven immediately exactly as before.
+                if (isTlsTransport(b.config())) {
+                    cand[s].eligible          = true;
+                    cand[s].cooling           = false;   // cooldown handled above
+                    cand[s].last_served_epoch = last_served_epoch_[s];
+                    continue;
+                }
                 uint32_t biased = now + static_cast<uint32_t>(s) * 1000U;
-                // TLS budget: non-TLS always OK; TLS only if a live slot is free.
-                bool budget_ok = !isTlsTransport(b.config()) ||
-                                 (tls_live < OFFBAND_MAX_LIVE_TLS);
+                const bool budget_ok = true;   // non-TLS: never budget-limited
                 // #175 fix: rotation demotes a TLS broker via shutdown(), which
                 // DESTROYS its esp_mqtt client (client_ = nullptr) to free the
                 // ~60KB context without leaking (#327). tryConnect can only START
@@ -619,15 +636,36 @@ void MqttBrokerPool::workerLoop() {
                 // connect goes to Backoff and KEEPS its client, so this is not a
                 // reconnect storm. We are on the worker task -- the only caller
                 // allowed to run reconcileSlot's blocking begin().
-                if (isTlsTransport(b.config()) && budget_ok && !b.hasClient()) {
-                    reconcileSlot(s);
-                }
                 (void)b.tryConnect(biased, budget_ok);
-                // Consume a budget slot if this TLS broker just began bringing up.
-                if (isTlsTransport(b.config()) &&
-                    b.runtime().state == BrokerState::Connecting) {
-                    tls_live++;
-                }
+            }
+        }
+
+        // #708: award the free TLS budget to whoever has waited longest, one slot
+        // at a time until the budget is full. Loops rather than promoting once so
+        // it stays correct if OFFBAND_MAX_LIVE_TLS is ever raised above 1.
+        for (;;) {
+            uint8_t pick = selectTlsPromotion(cand, OFFBAND_MAX_BROKERS,
+                                              tls_live, OFFBAND_MAX_LIVE_TLS);
+            if (pick == kNoSlot) break;
+            cand[pick].eligible = false;          // decided this pass either way
+            MqttBroker& b = brokers_[pick];
+            // #175 fix: rotation demotes a TLS broker via releaseClient(), which
+            // DESTROYS its esp_mqtt client to free the ~60KB context without
+            // leaking (#327). tryConnect can only START an existing client -- it
+            // cannot recreate one -- so a rotated-out broker would sit Down forever
+            // and the freed budget would never refill (verified on HV3). Recreate
+            // the client first via reconcileSlot (-> begin). Only fires for a
+            // genuinely client-less broker: a failed connect goes to Backoff and
+            // KEEPS its client, so this is not a reconnect storm. We are on the
+            // worker task -- the only caller allowed to run the blocking begin().
+            if (!b.hasClient()) reconcileSlot(pick);
+            uint32_t biased = now + static_cast<uint32_t>(pick) * 1000U;
+            (void)b.tryConnect(biased, /*budget_ok=*/true);
+            if (b.runtime().state == BrokerState::Connecting) {
+                tls_live++;
+                // Stamp service only on an actual bring-up, so a broker that fails
+                // to start does not lose its place in the queue.
+                last_served_epoch_[pick] = ++service_epoch_;
             }
         }
     }

--- a/src/helpers/wifi_observer/MqttBrokerPool.h
+++ b/src/helpers/wifi_observer/MqttBrokerPool.h
@@ -161,6 +161,21 @@ private:
     // timestamp -- no millis() wraparound to reason about.
     uint32_t service_epoch_ = 0;
     uint32_t last_served_epoch_[OFFBAND_MAX_BROKERS] = {0};
+    // #708 (Gemini review): service is stamped on the transition INTO Up, not on
+    // Connecting. esp_mqtt_client_start() is async and the handshake runs 1-8 s
+    // (measured), so a broker that reaches Connecting and then fails TLS would
+    // have burned its turn without publishing. Worker-task-owned.
+    BrokerState last_known_state_[OFFBAND_MAX_BROKERS] = {};
+    // #710 (Gemini review): a broker attaching after traffic has started inherits
+    // the whole ring backlog -- it replays stale packets and its drop counter is
+    // polluted with boot-time loss. It must resync to the head.
+    //
+    // The worker sets this flag; loopTask performs the ring_.resync(). Gemini
+    // proposed calling resync() directly in reconcileSlot(), but reconcileSlot
+    // runs on the WORKER task and 'the worker task does NOT touch the ring' is
+    // the invariant that keeps the ring lock-free (1f9da010). This hand-off keeps
+    // every ring access on loopTask.
+    std::atomic<bool> pending_resync_[OFFBAND_MAX_BROKERS] = {};
     void rotateTlsIfDue(uint32_t now_ms);
 
     // Per-slot guard: true while the lifecycle worker is creating/destroying

--- a/src/helpers/wifi_observer/MqttBrokerPool.h
+++ b/src/helpers/wifi_observer/MqttBrokerPool.h
@@ -116,6 +116,10 @@ public:
     // value means that broker is misbehaving -- see the issue's overflow note.
     uint32_t brokerLag(uint8_t slot) const { return ring_.lag(slot); }
     bool     brokerLapped(uint8_t slot) const { return ring_.lapped(slot); }
+    // #710: monotonic count of messages destroyed by writer overrun before this
+    // broker consumed them. Unlike brokerLapped(), does not reset when the broker
+    // catches up -- the boolean erases its own evidence on drain.
+    uint32_t brokerDropped(uint8_t slot) const { return ring_.droppedCount(slot); }
     // #173: the device's own pubkey as UPPERCASE hex (the connect-time default for a
     // broker's jwt_owner when none is set, #95) -- so the OCFG_BROKERS dump can show
     // the resolved owner as a placeholder. Writes "" if identity unset / host build.

--- a/src/helpers/wifi_observer/MqttBrokerPool.h
+++ b/src/helpers/wifi_observer/MqttBrokerPool.h
@@ -155,6 +155,12 @@ private:
     // freed budget instead of the victim immediately reclaiming it. 0 = not
     // cooling. Compared wrap-safe via (int32_t)(deadline - now).
     uint32_t rotated_out_until_ms_[OFFBAND_MAX_BROKERS] = {0};
+    // #708: fair promotion state. service_epoch_ increments on each TLS
+    // bring-up; last_served_epoch_[s] records when slot s last got the budget
+    // (0 = never served, so a fresh slot outranks everyone). A counter, not a
+    // timestamp -- no millis() wraparound to reason about.
+    uint32_t service_epoch_ = 0;
+    uint32_t last_served_epoch_[OFFBAND_MAX_BROKERS] = {0};
     void rotateTlsIfDue(uint32_t now_ms);
 
     // Per-slot guard: true while the lifecycle worker is creating/destroying

--- a/src/helpers/wifi_observer/MqttRingLog.h
+++ b/src/helpers/wifi_observer/MqttRingLog.h
@@ -27,7 +27,7 @@ public:
     MqttRingLog() {
         memset(len_, 0, sizeof(len_));
         memset(seq_, 0, sizeof(seq_));
-        for (int i = 0; i < MQTT_RING_MAX_READERS; i++) cursor_[i] = 0;
+        for (int i = 0; i < MQTT_RING_MAX_READERS; i++) { cursor_[i] = 0; dropped_[i] = 0; }
     }
 
     // Append a payload. Returns its sequence number (1-based), or 0 if rejected
@@ -60,7 +60,21 @@ public:
         return (head_ > c) ? (head_ - c) : 0;
     }
 
+    // #710: monotonic count of messages destroyed before this reader consumed
+    // them. Unlike lapped(), this must NOT reset when the reader catches up --
+    // lapped() is derived from the current cursor position, so it erases its own
+    // evidence the moment a rotated-out broker drains, which is why silent
+    // publish-ring loss was undetectable in the field.
+    //
+    // Counted in commit() ONLY -- the single site that mutates cursor_. lag() and
+    // peek() clamp a local copy and are const, so counting there would re-tally
+    // the same loss on every poll.
+    uint32_t droppedCount(uint8_t reader) const {
+        return (reader < MQTT_RING_MAX_READERS) ? dropped_[reader] : 0;
+    }
+
     // True when the writer overran this reader's cursor (data was lost).
+    // NOTE: transient -- see droppedCount() for the durable measure.
     bool lapped(uint8_t reader) const {
         if (reader >= MQTT_RING_MAX_READERS) return false;
         return head_ > MQTT_RING_SLOTS && cursor_[reader] < tailMinus1();
@@ -89,12 +103,23 @@ public:
     void commit(uint8_t reader) {
         if (reader >= MQTT_RING_MAX_READERS) return;
         uint32_t c = cursor_[reader];
-        if (c < tailMinus1()) c = tailMinus1();
+        const uint32_t t = tailMinus1();
+        // #710: the clamp below IS the data-loss event -- the writer overran this
+        // reader and (t - c) messages were destroyed unread. Count before
+        // clamping; monotonic, so it survives the reader catching up (lapped()
+        // does not, which is why field loss was invisible).
+        if (c < t) { dropped_[reader] += (t - c); c = t; }
         if (c < head_) cursor_[reader] = c + 1;
     }
 
     // Abandon the backlog and jump to the head (used when a reader is hopelessly
     // lapped, or a broker is (re)attached and should not replay stale traffic).
+    //
+    // #710: deliberately does NOT count toward droppedCount(). resync() serves two
+    // purposes -- discarding a hopeless backlog (real loss) and attaching a broker
+    // that must not replay stale traffic (not loss) -- and the caller knows which.
+    // Counting both would make the metric ambiguous, so droppedCount() means
+    // strictly "destroyed by writer overrun", never "deliberately skipped".
     void resync(uint8_t reader) {
         if (reader >= MQTT_RING_MAX_READERS) return;
         cursor_[reader] = head_;
@@ -111,5 +136,6 @@ private:
     uint16_t len_[MQTT_RING_SLOTS];
     uint32_t seq_[MQTT_RING_SLOTS];
     uint32_t cursor_[MQTT_RING_MAX_READERS];
+    uint32_t dropped_[MQTT_RING_MAX_READERS];   // #710: monotonic overrun loss
     uint32_t head_ = 0;
 };

--- a/src/helpers/wifi_observer/MqttRingLog.h
+++ b/src/helpers/wifi_observer/MqttRingLog.h
@@ -12,8 +12,28 @@
 // Deliberately dependency-free (no Arduino/ESP headers) so it builds in
 // [env:native] and is unit-testable in isolation -- same pattern as BlockStore.h.
 
+// #710: 16 -> 32 slots (+8,192 B, funded by the #701 trim which freed 14,660 B).
+//
+// SIZED FROM MEASURED FLEET DATA, not a guess. A rotated-out broker must survive
+// (N-1) x MQTT_ROTATE_DWELL_MS without its cursor being overrun; it drops when
+//     packets_in >  MQTT_RING_SLOTS       i.e.   lambda > SLOTS / T_out
+//
+// CoreScope, 68 active observers (map.okimesh.org /api/observers, packetsLastHour):
+//     mean 0.93/min   p50 0.20   p90 2.77   max 6.57
+// Excluding the top 5 (non-Offband and suspected multi-reporting outliers) the
+// busiest legitimate observer is 3.08/min. The 24 h network histogram puts
+// minute-level peaks at ~2.3x the mean, so budget ~7.1/min burst for that node:
+//     4 rotating brokers (180 s out): 7.1 x 3 = ~21 slots
+//     5 rotating brokers (240 s out): 7.1 x 4 = ~28 slots
+// 32 covers the busiest observed node through a p99 burst at up to 5 rotating
+// TLS brokers. 16 was adequate only up to 3 brokers on SUSTAINED rates and had
+// no burst margin.
+//
+// This is still one extrapolation deep (hourly average x network burst ratio).
+// droppedCount() now measures it directly -- re-size from real drop counts on a
+// busy observer rather than from this arithmetic.
 #ifndef MQTT_RING_SLOTS
-  #define MQTT_RING_SLOTS 16
+  #define MQTT_RING_SLOTS 32
 #endif
 #ifndef MQTT_RING_MSG_MAX
   #define MQTT_RING_MSG_MAX 512

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -103,7 +103,11 @@ static const char* stateStr(BrokerState s) {
         case BrokerState::Up:          return "up";
         case BrokerState::Backoff:     return "backoff";
         case BrokerState::HeldNoClock: return "held(no-clock)";
-        case BrokerState::HeldNoHeap:  return "held(no-heap)";
+        // #715: distinct human strings. "waiting-turn" is deliberately plain --
+        // it is the NORMAL state of a rotating pool, not an error, and the old
+        // "held(no-heap)" wording sent operators hunting for a memory problem.
+        case BrokerState::HeldNoHeap:  return "held(low-heap)";
+        case BrokerState::HeldBudget:  return "waiting-turn";
         default:                       return "?";
     }
 }
@@ -118,7 +122,15 @@ static const char* brokerStateWire(BrokerState s) {
         case BrokerState::Up:          return "up";
         case BrokerState::Backoff:     return "backoff";
         case BrokerState::HeldNoClock: return "held_no_clock";
+        // #715: WIRE VALUE DELIBERATELY UNCHANGED FOR BOTH.
+        // brokerStateWire() values are pinned to the client contract (#172 /
+        // OffbandConfigProtocol.h), so emitting a new "held_budget" token would be
+        // a breaking change for clients that switch on this string. The internal
+        // split lands first; the wire token is a separate, coordinated change.
+        // Until then both report held_no_heap and the client cannot distinguish --
+        // that is the remaining half of #715, not an oversight.
         case BrokerState::HeldNoHeap:  return "held_no_heap";
+        case BrokerState::HeldBudget:  return "held_no_heap";
         default:                       return "down";
     }
 }

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -872,7 +872,8 @@ size_t configRenderBrokerSlot(uint8_t slot, char* out, size_t out_size,
                               const BrokerRuntimeState* rt,
                               const char* owner_default_hex,
                               int32_t ring_lag,
-                              bool ring_lapped) {
+                              bool ring_lapped,
+                              uint32_t ring_dropped) {
     if (out == nullptr || out_size == 0) return 0;
     out[0] = '\0';
     BrokerConfig cfg;
@@ -915,6 +916,11 @@ size_t configRenderBrokerSlot(uint8_t slot, char* out, size_t out_size,
     if (ring_lag >= 0) {
         BKV("ring_lag=%ld\n",    (long)ring_lag);
         BKV("ring_lapped=%s\n",  ring_lapped ? "yes" : "no");
+        // #710: ring_lapped is derived from the CURRENT cursor, so it reads "no"
+        // again as soon as a rotated-out broker drains -- it erases its own
+        // evidence. ring_dropped is monotonic and is the field to trust when
+        // asking "has this broker ever lost published packets".
+        BKV("ring_dropped=%lu\n", (unsigned long)ring_dropped);
     }
     // #173: resolved-default placeholders (additive). Emitted ONLY when the raw
     // field is blank, carrying the value the firmware actually uses at connect, so

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -290,7 +290,13 @@ static bool handleSetBrokerField(char* reply, size_t reply_size,
         strncpy(cfg.password, value, sizeof(cfg.password) - 1);
         cfg.password[sizeof(cfg.password) - 1] = '\0';
         sensitive = true;
-    } else if (eq(key, "jwt_audience")) {
+    // #709: the wire/CLI key is "jwt_audience", but the schema constant
+    // kKeyBrokerJwtAudience (ConfigSchema.h) -- and therefore SCHEMA.md and
+    // every published config profile -- says "jwt_aud". Accept BOTH so a
+    // profile written against the documented name applies instead of failing
+    // with "unknown broker field". Every JWT broker was unconfigurable via
+    // config profiles until this alias existed.
+    } else if (eq(key, "jwt_audience") || eq(key, kKeyBrokerJwtAudience)) {
         strncpy(cfg.jwt_audience, value, sizeof(cfg.jwt_audience) - 1);
         cfg.jwt_audience[sizeof(cfg.jwt_audience) - 1] = '\0';
     } else if (eq(key, "jwt_refresh")) {
@@ -451,7 +457,10 @@ static bool handleGetBrokerField(char* reply, size_t reply_size,
     else if (eq(key, "topic_prefix"))  snprintf(reply, reply_size, "mqtt.broker.%d.topic_prefix = %s\n", slot, cfg.topic_prefix);
     else if (eq(key, "iata_override")) snprintf(reply, reply_size, "mqtt.broker.%d.iata_override = %s\n", slot, cfg.iata_override);
     else if (eq(key, "ca_cert"))       snprintf(reply, reply_size, "mqtt.broker.%d.ca_cert = %s\n", slot, cfg.ca_cert_name);
-    else if (eq(key, "jwt_audience"))  snprintf(reply, reply_size, "mqtt.broker.%d.jwt_audience = %s\n", slot, cfg.jwt_audience);
+    // #709: accept either spelling and echo back the key the caller sent, so a
+    // diffing client matches its own key instead of seeing a phantom change.
+    else if (eq(key, "jwt_audience") || eq(key, kKeyBrokerJwtAudience))
+        snprintf(reply, reply_size, "mqtt.broker.%d.%s = %s\n", slot, key, cfg.jwt_audience);
     else if (eq(key, "jwt_refresh"))   snprintf(reply, reply_size, "mqtt.broker.%d.jwt_refresh = %u\n", slot, (unsigned)cfg.jwt_refresh_sec);
     else if (eq(key, "jwt_owner"))     snprintf(reply, reply_size, "mqtt.broker.%d.jwt_owner = %s\n", slot, cfg.jwt_owner);
     else if (eq(key, "jwt_email"))     snprintf(reply, reply_size, "mqtt.broker.%d.jwt_email = %s\n", slot, cfg.jwt_email);

--- a/src/helpers/wifi_observer/ObserverCli.h
+++ b/src/helpers/wifi_observer/ObserverCli.h
@@ -88,7 +88,12 @@ size_t configRenderBrokerSlot(uint8_t slot, char* out, size_t out_size,
                               const BrokerRuntimeState* rt = nullptr,
                               const char* owner_default_hex = nullptr,
                               int32_t ring_lag = -1,
-                              bool ring_lapped = false);
+                              bool ring_lapped = false,
+                              // #710: monotonic count of messages destroyed by
+                              // writer overrun. ring_lapped is transient and reads
+                              // false again once the broker drains, so it cannot
+                              // evidence past loss; this can.
+                              uint32_t ring_dropped = 0);
 
 // #370: the display appliers (setDisplayAlwaysOnApplier / setDisplayRotationApplier
 // / setDisplayRotationSupportedQuery) and the display.* NVS accessors moved to

--- a/test/test_broker_rotation/test_broker_rotation.cpp
+++ b/test/test_broker_rotation/test_broker_rotation.cpp
@@ -1,0 +1,145 @@
+#include <gtest/gtest.h>
+#include <vector>
+#include "helpers/wifi_observer/BrokerRotationSelect.h"
+
+using offband::TlsCandidate;
+using offband::selectTlsPromotion;
+using offband::kNoSlot;
+
+// ---------------------------------------------------------------------------
+// Rotation harness -- reproduces the pool's dwell cycle without hardware.
+//
+// Each cycle: the live broker is evicted and put on cooldown for one dwell, the
+// previous victim's cooldown expires (cooldown == dwell in the firmware, so a
+// victim becomes eligible exactly when the next eviction fires), then the
+// scheduler picks who gets the freed budget.
+// ---------------------------------------------------------------------------
+struct Sim {
+    std::vector<TlsCandidate> c;
+    std::vector<int>          served;      // promotions per slot
+    uint32_t epoch = 0;
+    int      live  = -1;                   // slot currently holding the budget
+    int      cooling_slot = -1;            // slot whose cooldown is active
+
+    explicit Sim(uint8_t n) : c(n), served(n, 0) {
+        for (auto& x : c) { x.eligible = true; x.cooling = false; x.last_served_epoch = 0; }
+    }
+
+    void cycle() {
+        // Previous victim's cooldown expires as the next eviction lands.
+        if (cooling_slot >= 0) c[cooling_slot].cooling = false;
+        // Evict the live broker; it becomes a candidate again but is cooling.
+        if (live >= 0) {
+            c[live].eligible = true;
+            c[live].cooling  = true;
+            cooling_slot     = live;
+            live             = -1;
+        }
+        uint8_t pick = selectTlsPromotion(c.data(), (uint8_t)c.size(),
+                                          /*tls_live=*/0, /*max_live=*/1);
+        if (pick != kNoSlot) {
+            live = pick;
+            c[pick].eligible = false;              // now live, not a candidate
+            c[pick].last_served_epoch = ++epoch;   // stamp service
+            served[pick]++;
+        }
+    }
+    void run(int cycles) { for (int i = 0; i < cycles; ++i) cycle(); }
+};
+
+// ---------------------------------------------------------------------------
+// N=2 -- the arity #175 was validated at. Passes with index-order selection,
+// which is exactly why the defect shipped unnoticed.
+// ---------------------------------------------------------------------------
+TEST(BrokerRotation, TwoBrokersAlternateFairly) {
+    Sim s(2);
+    s.run(20);
+    EXPECT_GT(s.served[0], 0);
+    EXPECT_GT(s.served[1], 0);
+    EXPECT_LE(std::abs(s.served[0] - s.served[1]), 1);
+}
+
+// ---------------------------------------------------------------------------
+// N=3 -- the defect. Slot 2 must get turns; today it never does.
+// Field-confirmed on hv3-bench: s1=36 s2=35 s3=0 over 481 samples.
+// ---------------------------------------------------------------------------
+TEST(BrokerRotation, ThreeBrokersAllGetServed) {
+    Sim s(3);
+    s.run(30);
+    EXPECT_GT(s.served[0], 0);
+    EXPECT_GT(s.served[1], 0);
+    EXPECT_GT(s.served[2], 0) << "slot 2 starved -- index-ordered promotion";
+}
+
+// ---------------------------------------------------------------------------
+// N=4 -- starvation widens: everything at index >= 2 is locked out.
+// ---------------------------------------------------------------------------
+TEST(BrokerRotation, FourBrokersAllGetServed) {
+    Sim s(4);
+    s.run(40);
+    for (int i = 0; i < 4; ++i)
+        EXPECT_GT(s.served[i], 0) << "slot " << i << " never promoted";
+}
+
+// ---------------------------------------------------------------------------
+// Fairness, not just liveness: over many cycles no broker should get wildly
+// more turns than another.
+// ---------------------------------------------------------------------------
+TEST(BrokerRotation, ThreeBrokersShareRoughlyEvenly) {
+    Sim s(3);
+    s.run(60);
+    int lo = s.served[0], hi = s.served[0];
+    for (int v : s.served) { lo = v < lo ? v : lo; hi = v > hi ? v : hi; }
+    EXPECT_LE(hi - lo, 1) << "uneven: " << s.served[0] << "/" << s.served[1]
+                          << "/" << s.served[2];
+}
+
+// ---------------------------------------------------------------------------
+// A broker that has never been served must outrank one served recently, even
+// when it sits at a higher slot index. This is the property index-order lacks.
+// ---------------------------------------------------------------------------
+TEST(BrokerRotation, NeverServedOutranksRecentlyServed) {
+    TlsCandidate c[3];
+    c[0].eligible = true; c[0].last_served_epoch = 9;   // served most recently
+    c[1].eligible = true; c[1].last_served_epoch = 8;
+    c[2].eligible = true; c[2].last_served_epoch = 0;   // never served
+    EXPECT_EQ(selectTlsPromotion(c, 3, 0, 1), 2u);
+}
+
+// ---------------------------------------------------------------------------
+// Oldest-served wins among slots that have all been served.
+// ---------------------------------------------------------------------------
+TEST(BrokerRotation, OldestServedWins) {
+    TlsCandidate c[3];
+    c[0].eligible = true; c[0].last_served_epoch = 7;
+    c[1].eligible = true; c[1].last_served_epoch = 3;   // oldest
+    c[2].eligible = true; c[2].last_served_epoch = 5;
+    EXPECT_EQ(selectTlsPromotion(c, 3, 0, 1), 1u);
+}
+
+// ---------------------------------------------------------------------------
+// Invariants that must survive the fix (these pass today -- regression guards).
+// ---------------------------------------------------------------------------
+TEST(BrokerRotation, CoolingSlotIsNeverSelected) {
+    TlsCandidate c[2];
+    c[0].eligible = true; c[0].cooling = true; c[0].last_served_epoch = 0;
+    c[1].eligible = true; c[1].cooling = false; c[1].last_served_epoch = 5;
+    EXPECT_EQ(selectTlsPromotion(c, 2, 0, 1), 1u);
+}
+
+TEST(BrokerRotation, FullBudgetPromotesNothing) {
+    TlsCandidate c[2];
+    c[0].eligible = true;
+    c[1].eligible = true;
+    EXPECT_EQ(selectTlsPromotion(c, 2, 1, 1), kNoSlot);
+}
+
+TEST(BrokerRotation, NoEligibleCandidatesReturnsNoSlot) {
+    TlsCandidate c[3];   // all default: eligible = false
+    EXPECT_EQ(selectTlsPromotion(c, 3, 0, 1), kNoSlot);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/test_mqtt_ring/test_mqtt_ring.cpp
+++ b/test/test_mqtt_ring/test_mqtt_ring.cpp
@@ -55,6 +55,97 @@ TEST(MqttRingLog, OversizeRejected) {
     EXPECT_EQ(ring.head(), 0u);
 }
 
+// ---------------------------------------------------------------------------
+// #710: publish-ring overrun must be COUNTED, not silently clamped.
+//
+// The ring drops messages when the writer overruns a stalled reader (a broker
+// rotated out for a TLS dwell). Today that loss is invisible: the cursor is
+// silently clamped to the oldest retained message, nothing is counted, nothing
+// is logged, and lapped() -- the only indicator -- is derived from the current
+// cursor, so it reads false again the moment the reader catches up.
+// ---------------------------------------------------------------------------
+
+TEST(MqttRingLogDrops, CountIsExactAfterOverrun) {
+    MqttRingLog ring;
+    uint8_t m[4]; fill(m, sizeof(m), 0x11);
+
+    // Overrun reader 0 by exactly 4 messages.
+    const int N = MQTT_RING_SLOTS + 4;
+    for (int i = 0; i < N; i++) ring.append(m, sizeof(m));
+    // head=N, tail=N-SLOTS+1, so seqs 1..4 are destroyed before reader 0 read them.
+    ASSERT_TRUE(ring.lapped(0));
+
+    uint8_t out[MQTT_RING_MSG_MAX]; size_t out_len = 0; uint32_t seq = 0;
+    ASSERT_TRUE(ring.peek(0, out, sizeof(out), out_len, seq));
+    EXPECT_EQ(seq, (uint32_t)(N - MQTT_RING_SLOTS + 1));  // jumped to oldest kept
+    ring.commit(0);                                       // the clamp that loses 4
+
+    EXPECT_EQ(ring.droppedCount(0), 4u);
+}
+
+TEST(MqttRingLogDrops, CountSurvivesReaderCatchingUp) {
+    MqttRingLog ring;
+    uint8_t m[4]; fill(m, sizeof(m), 0x22);
+
+    const int N = MQTT_RING_SLOTS + 4;
+    for (int i = 0; i < N; i++) ring.append(m, sizeof(m));
+
+    uint8_t out[MQTT_RING_MSG_MAX]; size_t out_len = 0; uint32_t seq = 0;
+    while (ring.peek(0, out, sizeof(out), out_len, seq)) ring.commit(0);
+
+    // The transient flag has erased its own evidence -- this is the defect.
+    EXPECT_FALSE(ring.lapped(0));
+    EXPECT_EQ(ring.lag(0), 0u);
+    // The durable counter must NOT erase.
+    EXPECT_EQ(ring.droppedCount(0), 4u);
+}
+
+TEST(MqttRingLogDrops, NoDropsWhenReaderKeepsUp) {
+    MqttRingLog ring;
+    uint8_t m[4]; fill(m, sizeof(m), 0x33);
+    uint8_t out[MQTT_RING_MSG_MAX]; size_t out_len = 0; uint32_t seq = 0;
+
+    for (int i = 0; i < MQTT_RING_SLOTS * 3; i++) {
+        ring.append(m, sizeof(m));
+        ASSERT_TRUE(ring.peek(0, out, sizeof(out), out_len, seq));
+        ring.commit(0);
+    }
+    EXPECT_FALSE(ring.lapped(0));
+    EXPECT_EQ(ring.droppedCount(0), 0u);
+}
+
+TEST(MqttRingLogDrops, CountIsPerReaderNotGlobal) {
+    MqttRingLog ring;
+    uint8_t m[4]; fill(m, sizeof(m), 0x44);
+    uint8_t out[MQTT_RING_MSG_MAX]; size_t out_len = 0; uint32_t seq = 0;
+
+    // Reader 0 keeps up; reader 1 never reads.
+    for (int i = 0; i < MQTT_RING_SLOTS + 5; i++) {
+        ring.append(m, sizeof(m));
+        if (ring.peek(0, out, sizeof(out), out_len, seq)) ring.commit(0);
+    }
+    ring.commit(1);   // reader 1 finally advances, discovering the loss
+
+    EXPECT_EQ(ring.droppedCount(0), 0u);
+    EXPECT_EQ(ring.droppedCount(1), 5u);
+}
+
+TEST(MqttRingLogDrops, RepeatedOverrunsAccumulate) {
+    MqttRingLog ring;
+    uint8_t m[4]; fill(m, sizeof(m), 0x55);
+    uint8_t out[MQTT_RING_MSG_MAX]; size_t out_len = 0; uint32_t seq = 0;
+
+    // First overrun: lose 2, then resume.
+    for (int i = 0; i < MQTT_RING_SLOTS + 2; i++) ring.append(m, sizeof(m));
+    while (ring.peek(0, out, sizeof(out), out_len, seq)) ring.commit(0);
+    ASSERT_EQ(ring.droppedCount(0), 2u);
+
+    // Second overrun: lose 3 more. Counter accumulates, never resets.
+    for (int i = 0; i < MQTT_RING_SLOTS + 3; i++) ring.append(m, sizeof(m));
+    while (ring.peek(0, out, sizeof(out), out_len, seq)) ring.commit(0);
+    EXPECT_EQ(ring.droppedCount(0), 5u);
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -420,22 +420,46 @@ extends = env:Heltec_v3_companion_radio_ble
 monitor_rts = 0
 monitor_dtr = 0
 ; MAX_GROUP_CHANNELS reserves the LAST slot for the locked system CLI
-; channel. Phase-1 strip (#42): 41 -> 11 (user slots
+; channel. #701: now 5 (user slots 0-3 + system slot 4). Phase-1 was 41 -> 11 (user slots
 ; 0-9 + system slot 10; was 0-39 + slot 40 pre-strip), plus the inherited
 ; companion defaults are overridden down to observer minima to free
-; static .bss: MAX_CONTACTS 350->50, OFFLINE_QUEUE_SIZE 256->16.
+; static .bss. #701 (second pass, 2026-08-13): MAX_CONTACTS 50->5,
+; MAX_ANON_CONTACTS 8->3, MAX_GROUP_CHANNELS 11->5 -- frees ~9.6 KB of .bss,
+; which on ESP32 lands directly in the heap pool. This is a DELIBERATE TRADE-OFF,
+; not the removal of dead storage. The observer pipeline itself needs none of it
+; -- ObserverPipeline::onRawReceived publishes received bytes hex-encoded and
+; never decrypts, resolves a sender, or reads the contact list (grep
+; src/helpers/wifi_observer/ for "contacts" -> nothing). But these envs are ALSO
+; OFFBAND_OBSERVER_BLE_COMPANION, and the companion half DOES use both arrays
+; for phone messaging. So this buys observer heap by CAPPING COMPANION CAPACITY:
+; on these builds a user gets 5 contacts and 4 user channels, full stop.
+; Upgrade is graceful, not corrupting -- addContact() bounds on
+; MAX_ANON_CONTACTS+MAX_CONTACTS and setChannel() on MAX_GROUP_CHANNELS, so a
+; device holding more simply truncates on load (favourites + most-recent
+; survive) -- but from the user's side that IS silent data loss. Do not raise
+; these back without re-measuring against OFFBAND_TLS_HEAP_FLOOR_BYTES.
+; Motivating report: a broker HELD-no-heap on a Heltec V4.
+; Prior first pass (#42): MAX_CONTACTS 350->50, OFFLINE_QUEUE_SIZE 256->16.
 ; The MAX_GROUP_CHANNELS redefinition lands via a second -D rather than
 ; -U-then-redefine -- PlatformIO reorders -U to the end of the flag list
 ; which would re-undefine after both -Ds applied, leaving the macro
 ; completely undefined. -Wno-builtin-macro-redefined silences the gcc warning.
+; #701: OFFBAND_MAX_BROKERS 10 -> 6. The seed fills slots 0-4 (ConfigSchema.cpp)
+; and slot 5 stays empty for an operator-supplied broker; ten was never used and
+; each slot costs ~1.2 KB of static .bss. Slot access is bounds-checked
+; (slot >= OFFBAND_MAX_BROKERS returns false) and the NVS load loops are bounded,
+; so a device previously holding a broker in slots 6-9 truncates gracefully --
+; but that IS silent config loss from the operator's side.
 build_flags =
   ${env:Heltec_v3_companion_radio_ble.build_flags}
-  -DMAX_GROUP_CHANNELS=11
+  -DMAX_GROUP_CHANNELS=5
   -Wno-builtin-macro-redefined
   -D OFFBAND_OBSERVER
   -D OFFBAND_OBSERVER_BLE_COMPANION
   -D WITH_MQTT_UPLINK
-  -D MAX_CONTACTS=50
+  -D MAX_CONTACTS=5
+  -D MAX_ANON_CONTACTS=3
+  -D OFFBAND_MAX_BROKERS=6
   -D OFFLINE_QUEUE_SIZE=16
 build_src_filter =
   ${env:Heltec_v3_companion_radio_ble.build_src_filter}

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -598,21 +598,46 @@ extends = env:heltec_v4_companion_radio_ble
 monitor_rts = 0
 monitor_dtr = 0
 ; MAX_GROUP_CHANNELS reserves the LAST slot for the locked system CLI
-; channel. Phase-1 strip (#42): 41 -> 11 (user slots
+; channel. #701: now 5 (user slots 0-3 + system slot 4). Phase-1 was 41 -> 11 (user slots
 ; 0-9 + system slot 10), plus the inherited companion defaults overridden
-; to observer minima to free static .bss: MAX_CONTACTS 350->50,
+; to observer minima to free static .bss. #701 (second pass, 2026-08-13):
+; MAX_CONTACTS 50->5, MAX_ANON_CONTACTS 8->3, MAX_GROUP_CHANNELS 11->5
+; (4 user slots + the locked system-CLI slot) -- frees ~9.6 KB of .bss, which on
+; ESP32 lands directly in the heap pool. This is a DELIBERATE TRADE-OFF, not the
+; removal of dead storage. The observer pipeline itself needs none of it --
+; ObserverPipeline::onRawReceived publishes the received bytes hex-encoded and
+; never decrypts, resolves a sender, or reads the contact list (grep
+; src/helpers/wifi_observer/ for "contacts" -> nothing). But these envs are ALSO
+; OFFBAND_OBSERVER_BLE_COMPANION, and the companion half DOES use both arrays
+; for phone messaging. So this buys observer heap by CAPPING COMPANION CAPACITY:
+; on these builds a user gets 5 contacts and 4 user channels, full stop.
+; Upgrade is graceful, not corrupting -- addContact() bounds on
+; MAX_ANON_CONTACTS+MAX_CONTACTS and setChannel() on MAX_GROUP_CHANNELS, so a
+; device holding more simply truncates on load (favourites + most-recent
+; survive) -- but from the user's side that IS silent data loss. Do not raise
+; these back without re-measuring against OFFBAND_TLS_HEAP_FLOOR_BYTES.
+; Motivating report: a broker HELD-no-heap on a Heltec V4.
+; Prior first pass (#42): MAX_CONTACTS 350->50,
 ; OFFLINE_QUEUE_SIZE 256->16. The MAX_GROUP_CHANNELS redefinition lands
 ; via a second -D (parent _ble defines =40); PlatformIO reorders -U to the
 ; end, so an explicit undef would leave the macro unset. See V3
 ; platformio.ini for the full rationale.
+; #701: OFFBAND_MAX_BROKERS 10 -> 6. The seed fills slots 0-4 (ConfigSchema.cpp)
+; and slot 5 stays empty for an operator-supplied broker; ten was never used and
+; each slot costs ~1.2 KB of static .bss. Slot access is bounds-checked
+; (slot >= OFFBAND_MAX_BROKERS returns false) and the NVS load loops are bounded,
+; so a device previously holding a broker in slots 6-9 truncates gracefully --
+; but that IS silent config loss from the operator's side.
 build_flags =
   ${env:heltec_v4_companion_radio_ble.build_flags}
-  -DMAX_GROUP_CHANNELS=11
+  -DMAX_GROUP_CHANNELS=5
   -Wno-builtin-macro-redefined
   -D OFFBAND_OBSERVER
   -D OFFBAND_OBSERVER_BLE_COMPANION
   -D WITH_MQTT_UPLINK
-  -D MAX_CONTACTS=50
+  -D MAX_CONTACTS=5
+  -D MAX_ANON_CONTACTS=3
+  -D OFFBAND_MAX_BROKERS=6
   -D OFFLINE_QUEUE_SIZE=16
 build_src_filter =
   ${env:heltec_v4_companion_radio_ble.build_src_filter}
@@ -640,12 +665,14 @@ monitor_rts = 0
 monitor_dtr = 0
 build_flags =
   ${env:heltec_v4_tft_companion_radio_ble.build_flags}
-  -DMAX_GROUP_CHANNELS=11
+  -DMAX_GROUP_CHANNELS=5
   -Wno-builtin-macro-redefined
   -D OFFBAND_OBSERVER
   -D OFFBAND_OBSERVER_BLE_COMPANION
   -D WITH_MQTT_UPLINK
-  -D MAX_CONTACTS=50
+  -D MAX_CONTACTS=5
+  -D MAX_ANON_CONTACTS=3
+  -D OFFBAND_MAX_BROKERS=6
   -D OFFLINE_QUEUE_SIZE=16
   ; observer uses the NimBLE stack; the TFT companion base defaults to Bluedroid
   -D CONFIG_BT_NIMBLE_ENABLED=1

--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -254,21 +254,46 @@ extends = env:Xiao_S3_WIO_companion_radio_ble
 monitor_rts = 0
 monitor_dtr = 0
 ; MAX_GROUP_CHANNELS reserves the LAST slot for the locked system CLI
-; channel. Phase-1 strip (#42): 41 -> 11 (user slots
+; channel. #701: now 5 (user slots 0-3 + system slot 4). Phase-1 was 41 -> 11 (user slots
 ; 0-9 + system slot 10), plus the inherited companion defaults overridden
-; to observer minima to free static .bss: MAX_CONTACTS 350->50,
+; to observer minima to free static .bss. #701 (second pass, 2026-08-13):
+; MAX_CONTACTS 50->5, MAX_ANON_CONTACTS 8->3, MAX_GROUP_CHANNELS 11->5
+; (4 user slots + the locked system-CLI slot) -- frees ~9.6 KB of .bss, which on
+; ESP32 lands directly in the heap pool. This is a DELIBERATE TRADE-OFF, not the
+; removal of dead storage. The observer pipeline itself needs none of it --
+; ObserverPipeline::onRawReceived publishes the received bytes hex-encoded and
+; never decrypts, resolves a sender, or reads the contact list (grep
+; src/helpers/wifi_observer/ for "contacts" -> nothing). But these envs are ALSO
+; OFFBAND_OBSERVER_BLE_COMPANION, and the companion half DOES use both arrays
+; for phone messaging. So this buys observer heap by CAPPING COMPANION CAPACITY:
+; on these builds a user gets 5 contacts and 4 user channels, full stop.
+; Upgrade is graceful, not corrupting -- addContact() bounds on
+; MAX_ANON_CONTACTS+MAX_CONTACTS and setChannel() on MAX_GROUP_CHANNELS, so a
+; device holding more simply truncates on load (favourites + most-recent
+; survive) -- but from the user's side that IS silent data loss. Do not raise
+; these back without re-measuring against OFFBAND_TLS_HEAP_FLOOR_BYTES.
+; Motivating report: a broker HELD-no-heap on a Heltec V4.
+; Prior first pass (#42): MAX_CONTACTS 350->50,
 ; OFFLINE_QUEUE_SIZE 256->16. The MAX_GROUP_CHANNELS redefinition lands
 ; via a second -D (parent _ble defines =40); PlatformIO reorders -U to the
 ; end, so an explicit undef would leave the macro unset. See V3
 ; platformio.ini for the full rationale.
+; #701: OFFBAND_MAX_BROKERS 10 -> 6. The seed fills slots 0-4 (ConfigSchema.cpp)
+; and slot 5 stays empty for an operator-supplied broker; ten was never used and
+; each slot costs ~1.2 KB of static .bss. Slot access is bounds-checked
+; (slot >= OFFBAND_MAX_BROKERS returns false) and the NVS load loops are bounded,
+; so a device previously holding a broker in slots 6-9 truncates gracefully --
+; but that IS silent config loss from the operator's side.
 build_flags =
   ${env:Xiao_S3_WIO_companion_radio_ble.build_flags}
-  -DMAX_GROUP_CHANNELS=11
+  -DMAX_GROUP_CHANNELS=5
   -Wno-builtin-macro-redefined
   -D OFFBAND_OBSERVER
   -D OFFBAND_OBSERVER_BLE_COMPANION
   -D WITH_MQTT_UPLINK
-  -D MAX_CONTACTS=50
+  -D MAX_CONTACTS=5
+  -D MAX_ANON_CONTACTS=3
+  -D OFFBAND_MAX_BROKERS=6
   -D OFFLINE_QUEUE_SIZE=16
 build_src_filter =
   ${env:Xiao_S3_WIO_companion_radio_ble.build_src_filter}


### PR DESCRIPTION
Closes #701, #707, #708, #709, #710, #715. Part of epic #177.

One PR per the repo cadence (*commit per task, PR per epic, tag per landing*) — all six are children of #177 and three of them touch `MqttBrokerPool.cpp`, so separate PRs would serialise behind each other's rebases and six full `ci-green` runs.

## Why this exists

Observer multi-broker rotation was designed and validated at **two** TLS brokers. Almost everything about it degrades silently at three: the fairness mechanism, the publish-ring depth, and the state vocabulary. All six changes are that same root cause surfacing in different places.

## The changes

| # | What | Evidence |
|---|---|---|
| #708 | Promotion was first-eligible-by-slot-index; everything above the two lowest slots starved | hv3-bench: **36 / 35 / 0** promotions over 481 samples — slot 3 never once. Now an even 3-way cycle |
| #707 | Slot 0 lost its always-on status when 1.4.0 moved it to `wss` — a tcp broker is exempt from rotation, and that exemption *was* the mechanism | **178 evictions** of the primary in one 6.9 h soak → **0** after |
| #709 | Wire key `jwt_audience` vs schema/profile `jwt_aud` — every JWT broker unconfigurable from a profile | 3 of 5 slots failed to apply on a real device |
| #710 | Ring overrun clamped silently: no counter, no log, and the one indicator erased itself on drain | monotonic counter + `[ring]` line; ring 16→32 sized from CoreScope fleet data |
| #715 | One state covered three causes and was named after the rarest; normal rotation displayed as a memory error | 2 of 3 brokers permanently showed a fault that did not exist |
| #701 | Observer `.bss` trim funding the above | 14,660 B freed; 8,192 B spent on the ring |

## Verification

- **Hardware**: #707 and #708 both proven on hv3-bench against captured before/after baselines on the same board and broker set.
- **Tests**: 18 unit tests where there were 4 — `test_mqtt_ring` 9/9, `test_broker_rotation` 9/9. The rotation tests are red-first against the old algorithm reproduced verbatim, and `TwoBrokersAlternateFairly` passes before *and* after, proving deployed N=2 behaviour is unchanged.
- **Non-observer control**: `Heltec_v3_companion_radio_ble` byte-for-byte identical, 181,548 B.
- **Review**: gemini-2.5-pro, two rounds. Round 1 → SHIP WITH FIXES (1 BLOCKER refuted with reasoning, 1 MAJOR + 1 MINOR applied). Round 2 → **SHIP**, no blockers or majors.

## Things a reviewer should push on

- **#708 shipped a regression mid-development** — non-promoted candidates weren't deferred, so nothing entered a held state, rotation stopped entirely, and one broker held the budget 8.2 h. Caught only on hardware; unit tests were green throughout. Fixed, and the caller contract is now documented at the selection function.
- **One review finding was deliberately not applied as proposed.** Round 1 wanted `ring_.resync()` inside `reconcileSlot()`; that runs on the worker task, and *"the worker task does NOT touch the ring"* is the invariant keeping the ring lock-free. Implemented as a worker→loopTask hand-off instead. Round 2 reviewed and endorsed it.
- **#715 is half-done by design.** The wire value is unchanged, so the **app still shows the old wording**. Changing it needs the client to accept a new token first — specced on #715.
- **#701 caps companion capacity on observer envs**: 5 contacts, 4 user channels. Upgrades truncate gracefully but that is still user-visible data loss.

## Not in this PR

- #720 — a broker reconnecting faster than the dwell resets `went_up_ms` and can block rotation entirely. Pre-existing since #175, found while dispositioning round 2, not yet observed in the field.
- Existing devices need the matching config profile (already published) — firmware seeds only apply to fresh NVS.
