### PR TITLE
docs(#177): add #696 to the changelog and cut the 1.5.0-beta1 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
 ## [Unreleased]
 
+## [1.5.0-beta1] - 2026-08-15
+
+### Added
+- **`wifi clear` and a visible reason for WiFi disconnects** (#696): an observer on an
+  open, passwordless network could sit at `StaConnecting` indefinitely with no reason
+  available anywhere, and a stored PSK could not be cleared without an NVS wipe that
+  destroys the device identity. `wifi clear [pwd|all]` now removes stored credentials
+  properly, and STA disconnect reasons appear in the `wifi status` reply as well as the
+  retry log — the status reply being the load-bearing half, since a remote reporter
+  cannot read a serial console. Association behaviour is unchanged.
+
 ### Fixed
 - **Observer multi-broker rotation actually rotates** (#708): with more than two TLS
   brokers enabled, promotion was a first-eligible-by-slot-index scan whose only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
 ## [Unreleased]
 
-## [1.5.0-beta1] - 2026-08-15
+## [1.5.0] - 2026-08-15
 
 ### Added
 - **`wifi clear` and a visible reason for WiFi disconnects** (#696): an observer on an


### PR DESCRIPTION
Pre-tag changelog for `offband-v1.5.0-beta1`.

The beta ships **everything on `firmware-base` since 1.4.0**, not only the #177 epic. Auditing that range turned up one user-facing change missing from the notes:

- **#696** `wifi clear` + STA disconnect reason surfaced in `wifi status` — added under **Added**.

Remaining commits in the range are RadioCore documentation (#694, #626) and are not release-note material.

Also renames `[Unreleased]` → `[1.5.0-beta1] - 2026-08-15` so the release workflow picks up the right section (it maps `1.5.0-beta1` → the `1.5.0` base section).

Docs only — no code change.