### PR TITLE
fix(#723): resync on first attach only — beta1 regression discarded the publish backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
 ## [1.5.0] - 2026-08-15
 
+### Fixed (beta2)
+- **Rotated-out brokers no longer lose the traffic they missed** (#723): a regression in
+  `beta1`. Re-attaching a broker resynced its ring cursor to the head, which was meant to
+  stop a *newly enabled* broker replaying stale boot backlog — but the same path runs on
+  every rotation re-entry, so a broker returning from its dwell discarded exactly the
+  backlog the ring exists to hold. On an observer with rotating TLS brokers this silently
+  dropped most of the feed, and the drop counter read zero throughout because a resync is
+  a deliberate skip, not an overrun. Resync now happens on first attach only.
+
 ### Added
 - **`wifi clear` and a visible reason for WiFi disconnects** (#696): an observer on an
   open, passwordless network could sit at `StaConnecting` indefinitely with no reason

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -431,11 +431,26 @@ void MqttBrokerPool::reconcileSlot(uint8_t slot) {
     const bool may_alloc =
         (tlsClientsAllocated() - (brokers_[slot].hasClient() ? 1u : 0u))
             < OFFBAND_MAX_LIVE_TLS;
-    // #710: the slot is about to (re)attach a client. Ask loopTask to move this
-    // reader to the ring head so it does not replay stale backlog and does not
-    // book boot-time loss as rotation loss. Flag only -- the worker must not
-    // touch ring_.
-    pending_resync_[slot] = true;
+    // #723: resync on FIRST attach ONLY -- never on a rotation re-entry.
+    //
+    // #710 asked loopTask to move a (re)attaching reader to the ring head so it
+    // does not replay stale boot backlog. But reconcileSlot() runs on EVERY
+    // rotation re-entry too: a rotated-out broker had releaseClient() called, so
+    // hasClient() is false and it takes this path every single time it returns.
+    // Resyncing there threw away exactly the backlog the ring exists to hold --
+    // see publishPacket: "a broker that is down (rotated out, backoff,
+    // HeldNoHeap) resumes where it left off instead of losing the traffic".
+    //
+    // Shipped in v1.5.0-beta1 and caught in the field: an observer published the
+    // first message to CoreScope and silently discarded the next two, which had
+    // arrived while its broker was rotated out. The drop counter read zero the
+    // whole time, because resync() means "deliberately skipped", not "overrun".
+    //
+    // Flag only -- the worker must not touch ring_ (see loop()).
+    if (!first_attach_done_[slot]) {
+        first_attach_done_[slot] = true;
+        pending_resync_[slot]    = true;
+    }
     if (!brokers_[slot].begin(slot, cfg, *identity_, may_alloc) && cfg.enabled) {
         crashLogf("[pool] reconcileSlot %u begin FAILED state=%d err_class=%d",
                   (unsigned)slot,

--- a/src/helpers/wifi_observer/MqttBrokerPool.h
+++ b/src/helpers/wifi_observer/MqttBrokerPool.h
@@ -180,6 +180,11 @@ private:
     // the invariant that keeps the ring lock-free (1f9da010). This hand-off keeps
     // every ring access on loopTask.
     std::atomic<bool> pending_resync_[OFFBAND_MAX_BROKERS] = {};
+    // #723: true once a slot has attached a client at least once. Gates the
+    // resync above so it fires on FIRST attach only -- a rotation re-entry must
+    // KEEP its cursor so the backlog queued while it was away still drains.
+    // Worker-task-owned (only reconcileSlot touches it).
+    bool first_attach_done_[OFFBAND_MAX_BROKERS] = {};
     void rotateTlsIfDue(uint32_t now_ms);
 
     // Per-slot guard: true while the lifecycle worker is creating/destroying

--- a/test/test_mqtt_ring/test_mqtt_ring.cpp
+++ b/test/test_mqtt_ring/test_mqtt_ring.cpp
@@ -146,6 +146,60 @@ TEST(MqttRingLogDrops, RepeatedOverrunsAccumulate) {
     EXPECT_EQ(ring.droppedCount(0), 5u);
 }
 
+// ---------------------------------------------------------------------------
+// #723: a rotated-out reader must KEEP its cursor across re-attach.
+//
+// v1.5.0-beta1 resynced on every rotation re-entry, discarding exactly the
+// backlog the ring exists to hold. Field symptom: an observer published the
+// first message and silently dropped the next two, which had arrived while its
+// broker was rotated out. resync() is for FIRST attach only.
+// ---------------------------------------------------------------------------
+
+TEST(MqttRingLogDrops, BacklogSurvivesWhenReaderIsAwayAndReturns) {
+    MqttRingLog ring;
+    uint8_t m[4]; fill(m, sizeof(m), 0x66);
+    uint8_t out[MQTT_RING_MSG_MAX]; size_t out_len = 0; uint32_t seq = 0;
+
+    // Reader 0 is up and consumes message 1.
+    ring.append(m, sizeof(m));
+    ASSERT_TRUE(ring.peek(0, out, sizeof(out), out_len, seq));
+    EXPECT_EQ(seq, 1u);
+    ring.commit(0);
+
+    // Reader 0 rotates OUT. Two more messages arrive while it is away.
+    ring.append(m, sizeof(m));   // seq 2
+    ring.append(m, sizeof(m));   // seq 3
+
+    // Reader 0 rotates back IN. Without a resync it must resume at seq 2 --
+    // the backlog is the whole point of the ring.
+    ASSERT_TRUE(ring.peek(0, out, sizeof(out), out_len, seq))
+        << "backlog discarded on re-entry -- the beta1 regression";
+    EXPECT_EQ(seq, 2u);
+    ring.commit(0);
+    ASSERT_TRUE(ring.peek(0, out, sizeof(out), out_len, seq));
+    EXPECT_EQ(seq, 3u);
+    ring.commit(0);
+
+    EXPECT_FALSE(ring.peek(0, out, sizeof(out), out_len, seq));  // fully caught up
+    EXPECT_EQ(ring.droppedCount(0), 0u);                         // nothing lost
+}
+
+TEST(MqttRingLogDrops, ResyncStillSkipsBacklogWhenExplicitlyCalled) {
+    MqttRingLog ring;
+    uint8_t m[4]; fill(m, sizeof(m), 0x77);
+    uint8_t out[MQTT_RING_MSG_MAX]; size_t out_len = 0; uint32_t seq = 0;
+
+    for (int i = 0; i < 5; i++) ring.append(m, sizeof(m));
+    ring.resync(0);                       // first-attach behaviour (#710 intent)
+    EXPECT_FALSE(ring.peek(0, out, sizeof(out), out_len, seq));
+    EXPECT_EQ(ring.lag(0), 0u);
+    EXPECT_EQ(ring.droppedCount(0), 0u);  // deliberate skip is not a drop
+
+    ring.append(m, sizeof(m));            // and it tracks new traffic from there
+    ASSERT_TRUE(ring.peek(0, out, sizeof(out), out_len, seq));
+    EXPECT_EQ(seq, 6u);
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
Closes #723. **P0 regression shipped in `offband-v1.5.0-beta1`.**

`reconcileSlot()` flagged a ring resync so a newly-attached broker would not replay stale boot backlog (#710). But it also runs on **every rotation re-entry** — a rotated-out broker had `releaseClient()` called, so `hasClient()` is false and it takes that path every time it returns. The resync threw away exactly what the ring exists to hold:

> #175 (`publishPacket`): append ONCE … so a broker that is down (rotated out, backoff, HeldNoHeap) **resumes where it left off instead of losing the traffic**.

At three rotating brokers that discards roughly two-thirds of the feed, and **the drop counter reads zero** — `resync()` means "deliberately skipped", not "overrun", so the loss is invisible to the instrument added to expose it.

**Fix:** per-slot `first_attach_done_` gate. First attach still skips boot backlog (#710's intent); rotation re-entry keeps its cursor.

### Test honesty
The two tests added here exercise `MqttRingLog`, which was never wrong — the ring discarded nothing on its own. **They pass on beta1 code too.** They document intent; they would not have caught this. The defect is in the pool's call *frequency*, which the native harness cannot reach. Same blind spot as #708's regression: tests cover the extracted function, the defect lives in the caller.

### Scope note
This does **not** explain the field report that prompted it. That observer's slot 0 is `tcp`, which is exempt from rotation and never re-enters `reconcileSlot()`. That symptom is still unexplained and needs `mqtt status` from the device — it should not be attributed to this fix.