### PR TITLE
bug(#718): make the framed serial write atomic and honour a refused frame

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -127,6 +127,12 @@ namespace offband { MqttBrokerPool& wifiObserverPool(); }
 #define CAPLOG_RESP_ACK               0x10  // control:  [0xC4,0x10, req_op, ok(0|1)]
 #define CAPLOG_RESP_STATUS            0x11  // status:   [0xC4,0x11, enabled, level, used(4B LE), cap(4B LE)]
 
+// #718: abort an in-flight download after this long with the transport refusing every
+// frame. Measured from the last ACCEPTED chunk, so a slow but advancing drain never
+// trips it. Shorter than the client's 30 s downloadCaplog timeout so the device frees
+// its own state first and the client sees a clean stop rather than a wedged radio.
+#define CAPLOG_STALL_ABORT_MS         15000UL
+
 // Stats sub-types for CMD_GET_STATS
 #define STATS_TYPE_CORE               0
 #define STATS_TYPE_RADIO              1
@@ -1279,6 +1285,7 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
   _caplog_streaming = false;  // #396: no caplog download in flight
   _caplog_off = 0;
   _caplog_resume = false;
+  _caplog_last_progress = 0;  // #718: stall clock
   offline_queue_len = 0;
   app_target_ver = 0;
   clearPendingReqs();
@@ -1833,6 +1840,7 @@ void MyMesh::handleCmdFrame(size_t len) {
       _serial->writeFrame(out_frame, 6);
       _caplog_off = 0;
       _caplog_streaming = true;
+      _caplog_last_progress = millis();   // #718: stall clock starts now
       return;
     }
     // unknown sub-code -> explicit error (never silently fall through to download)
@@ -3406,14 +3414,35 @@ void MyMesh::caplogDrain() {
   size_t n = meshLogSnapshot(&out_frame[2], cap, _caplog_off);
   if (n == 0) {                                    // buffer exhausted -> END
     out_frame[1] = CAPLOG_SUB_END;
-    _serial->writeFrame(out_frame, 2);
+    // #718: if the terminator cannot be sent, stay streaming and retry next pass.
+    // Tearing the stream down on a refused END would leave the client waiting for a
+    // terminator that is never re-sent, i.e. a hang instead of a clean finish.
+    if (_serial->writeFrame(out_frame, 2) == 0) return;
     _caplog_streaming = false;
     meshLogSetEnabled(_caplog_resume);             // resume capture if it was on
     return;
   }
   out_frame[1] = CAPLOG_SUB_CHUNK;
-  _serial->writeFrame(out_frame, 2 + n);
+  // #718: a transport may REFUSE a frame it cannot deliver whole -- BLE when the send
+  // queue is full, serial when the non-blocking TX FIFO lacks room. Advancing the read
+  // offset on a refusal silently skips those bytes forever, which is how a download
+  // ends short of the total announced at START. The ring is frozen for the duration of
+  // the download, so simply not advancing re-offers the SAME bytes on the next pass.
+  if (_serial->writeFrame(out_frame, 2 + n) == 0) {
+    // ...but a host that never drains would then refuse forever, leaving the stream
+    // open and the caplog subsystem wedged (the handleCmdFrame guard rejects
+    // ENABLE/DISABLE/ERASE/DOWNLOAD while _caplog_streaming). Abort on a STALL --
+    // elapsed since the last ACCEPTED chunk, so a slow-but-advancing drain is safe.
+    if (millis() - _caplog_last_progress > CAPLOG_STALL_ABORT_MS) {
+      _caplog_streaming = false;
+      meshLogSetEnabled(_caplog_resume);
+      MESH_DEBUG_PRINTLN("caplog: transport stalled %lums, download aborted (#718)",
+                         (unsigned long)CAPLOG_STALL_ABORT_MS);
+    }
+    return;
+  }
   _caplog_off += n;
+  _caplog_last_progress = millis();
 }
 
 void MyMesh::enterCLIRescue() {

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -349,6 +349,13 @@ private:
   bool    _caplog_streaming;
   size_t  _caplog_off;
   bool    _caplog_resume;   // capture-enabled state to restore when the download ends
+  // #718: millis() of the last CHUNK the transport actually accepted. A transport may
+  // now REFUSE a frame it cannot deliver whole, and the drain re-offers the same bytes
+  // rather than skipping them -- so a host that stops draining would otherwise leave
+  // _caplog_streaming true forever, which also blocks ENABLE/DISABLE/ERASE (the guard
+  // in handleCmdFrame). Timed on PROGRESS, not total duration, so a legitimately slow
+  // but advancing download is never cut off.
+  uint32_t _caplog_last_progress;
   uint8_t app_target_ver;
   uint8_t *sign_data;
   uint32_t sign_data_len;

--- a/platformio.ini
+++ b/platformio.ini
@@ -243,6 +243,7 @@ build_src_filter =
   ; fails to link. (#628)
   +<../src/MeshLog.cpp>
   +<../src/helpers/ConfigSerializer.cpp>
+  +<../src/helpers/ArduinoSerialInterface.cpp>   ; #718: framed-write atomicity is unit-tested
 lib_deps =
   google/googletest @ 1.17.0
 

--- a/src/helpers/ArduinoSerialInterface.cpp
+++ b/src/helpers/ArduinoSerialInterface.cpp
@@ -32,8 +32,37 @@ size_t ArduinoSerialInterface::writeFrame(const uint8_t src[], size_t len) {
   hdr[1] = (len & 0xFF);  // LSB
   hdr[2] = (len >> 8);    // MSB
 
-  _serial->write(hdr, 3);
-  return _serial->write(src, len);
+  // #718: ALL OR NOTHING. This transport is deliberately non-blocking on a companion
+  // USB build -- main.cpp sets Serial.setTxTimeoutMs(0) (#149) so a host that stops
+  // draining cannot stall the loop and starve BLE servicing. A non-blocking write
+  // therefore returns SHORT when the TX FIFO is full.
+  //
+  // Dropping bytes is correct for the debug mirror and CORRUPTING here: this is a
+  // length-prefixed protocol. Emitting the header and then a partial payload leaves
+  // the receiver counting toward bytes that never arrive, so it consumes the NEXT
+  // frame's header as filler and the stream desyncs. Observed over USB serial as a
+  // caplog download delivering 545 of an announced 1067 bytes with a complete
+  // '>' 0xB0 0x00 0xC4 0x02 header spliced inside a payload.
+  //
+  // So: refuse rather than truncate. Returning 0 without touching the wire keeps the
+  // stream parseable and lets the caller retry the SAME frame on a later pass, which
+  // is non-blocking in exactly the way #149 requires.
+  const size_t frame_len = 3 + len;
+  const int writable = _serial->availableForWrite();
+  if (writable >= 0 && (size_t)writable < frame_len) {
+    return 0;   // caller MUST NOT treat this as sent
+  }
+
+  // These two short-write branches should be RARE rather than impossible: capacity was
+  // just checked, but availableForWrite() is a snapshot and nothing here holds a lock,
+  // so a concurrent writer (the debug console shares this Stream on some roles) can
+  // consume room in between. Returning 0 is still right -- the caller retries, and the
+  // receiver's decoder resyncs on the next '>' rather than trusting a bad length.
+  if (_serial->write(hdr, 3) != 3) {
+    return 0;
+  }
+  const size_t n = _serial->write(src, len);
+  return n == len ? n : 0;
 }
 
 size_t ArduinoSerialInterface::checkRecvFrame(uint8_t dest[]) {

--- a/src/helpers/ArduinoSerialInterface.h
+++ b/src/helpers/ArduinoSerialInterface.h
@@ -29,6 +29,18 @@ public:
   bool isConnected() const override;
 
   bool isWriteBusy() const override;
+  // #718 CONTRACT: returns `len` on success, or 0 meaning THE FRAME WAS NOT SENT and
+  // nothing was written to the wire. It never returns a short count -- a partial frame
+  // would desync the length-prefixed protocol for every frame that follows.
+  //
+  // A caller that needs delivery MUST retry the same frame; a caller that fires and
+  // forgets now silently drops the frame under back-pressure instead of corrupting the
+  // stream, which is the better of the two failures but IS a behaviour change.
+  //
+  // REQUIRES the underlying Stream to implement availableForWrite() meaningfully.
+  // The base Stream returns 0, which this reads as "no room" and would refuse forever;
+  // every transport actually bound here (HWCDC, USBCDC, HardwareSerial, Adafruit USB
+  // CDC) implements it. Do not bind a Stream that does not.
   size_t writeFrame(const uint8_t src[], size_t len) override;
   size_t checkRecvFrame(uint8_t dest[]) override;
 

--- a/test/mocks/Arduino.h
+++ b/test/mocks/Arduino.h
@@ -27,15 +27,21 @@ inline void interrupts() {}
 
 // Sink for MeshLog's console mirror. Discards output -- the tests assert on the
 // capture ring, never on what reached the console.
-class MockSerial : public Print {
+//
+// #718: derives from Stream, not Print. ArduinoSerialInterface compares its
+// target against `&Serial` (isConsoleSharedWithProtocol, #411) via a
+// static_cast<Stream*>, which does not compile if the mock Serial is not a
+// Stream -- and that comparison is on the path of anything that unit-tests the
+// framed serial transport natively.
+class MockSerial : public Stream {
 public:
   size_t write(uint8_t) override { return 1; }
   size_t write(const uint8_t*, size_t size) override { return size; }
   void begin(unsigned long) {}
   // MeshLog throttles its console mirror on this; a large constant means
   // "never backpressure", which is what a discarding sink should report.
-  int availableForWrite() { return 1024; }
-  void flush() {}
+  int availableForWrite() override { return 1024; }
+  void flush() override {}
   operator bool() const { return true; }
 };
 inline MockSerial Serial;

--- a/test/test_serial_framing/test_frame_atomicity.cpp
+++ b/test/test_serial_framing/test_frame_atomicity.cpp
@@ -1,0 +1,172 @@
+// #718: the framed companion protocol must never emit a PARTIAL frame.
+//
+// THE DEFECT THIS PINS
+//   ArduinoSerialInterface::writeFrame() writes a 3-byte header declaring `len`,
+//   then writes the payload. On a companion USB build the underlying Stream is
+//   deliberately NON-BLOCKING (examples/companion_radio/main.cpp:171 sets
+//   Serial.setTxTimeoutMs(0) per #149, so a stalled host cannot starve BLE
+//   servicing). A non-blocking write returns SHORT when the TX FIFO is full.
+//
+//   The header is already on the wire at that point, so the receiver waits for a
+//   payload that never fully arrives and consumes the NEXT frame's header as
+//   filler. Observed on rc32-bench-1 over USB serial: a caplog download announced
+//   1067 bytes, delivered 545, and the delivered bytes contained a spliced
+//   '>' 0xB0 0x00 0xC4 0x02 -- a complete frame header sitting inside a payload.
+//
+//   Dropping bytes is CORRECT for the debug mirror and CORRUPTING for a
+//   length-prefixed protocol. The fix must be atomic without becoming blocking:
+//   refuse the write entirely when the whole frame will not fit.
+
+#include <gtest/gtest.h>
+
+#include <vector>
+#include <cstdint>
+
+#include "Stream.h"
+#include "helpers/ArduinoSerialInterface.h"
+
+namespace {
+
+/// A Stream that accepts at most `capacity` bytes, then short-writes like a full
+/// non-blocking TX FIFO. Records everything actually emitted so a test can prove
+/// no partial frame ever reached the wire.
+class ConstrainedStream : public Stream {
+public:
+  size_t capacity = 0;             // bytes this stream will accept right now
+  std::vector<uint8_t> wire;       // everything actually written
+
+  int availableForWrite() override { return (int)capacity; }
+
+  size_t write(const uint8_t* buffer, size_t size) override {
+    const size_t n = size < capacity ? size : capacity;   // short write, no blocking
+    wire.insert(wire.end(), buffer, buffer + n);
+    capacity -= n;
+    return n;
+  }
+
+  size_t write(uint8_t b) override { return write(&b, 1); }
+
+  int available() override { return 0; }
+  int read() override { return -1; }
+  int peek() override { return -1; }
+};
+
+/// Walk `wire` as the host decoder does: '>' + uint16 len + len payload bytes.
+/// Returns false if any frame is incomplete or a header appears inside a payload.
+bool wireIsWellFramed(const std::vector<uint8_t>& wire, size_t* frames_out = nullptr) {
+  size_t i = 0, frames = 0;
+  while (i < wire.size()) {
+    if (wire[i] != '>') return false;                       // stray byte where a frame must start
+    if (i + 3 > wire.size()) return false;                  // truncated header
+    const size_t len = (size_t)wire[i + 1] | ((size_t)wire[i + 2] << 8);
+    if (i + 3 + len > wire.size()) return false;            // header promises more than was emitted
+    i += 3 + len;
+    ++frames;
+  }
+  if (frames_out) *frames_out = frames;
+  return true;
+}
+
+const uint8_t kPayload[] = {0xC4, 0x02, 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'};
+constexpr size_t kPayloadLen = sizeof(kPayload);
+constexpr size_t kFrameLen = 3 + kPayloadLen;
+
+}  // namespace
+
+// A stream with room for the whole frame emits it intact and reports the payload size.
+TEST(SerialFrameAtomicity, FullCapacityEmitsOneCompleteFrame) {
+  ConstrainedStream s;
+  s.capacity = 1024;
+  ArduinoSerialInterface iface;
+  iface.begin(s);
+
+  const size_t written = iface.writeFrame(kPayload, kPayloadLen);
+
+  EXPECT_EQ(written, kPayloadLen);
+  EXPECT_EQ(s.wire.size(), kFrameLen);
+  size_t frames = 0;
+  EXPECT_TRUE(wireIsWellFramed(s.wire, &frames));
+  EXPECT_EQ(frames, 1u);
+}
+
+// THE REGRESSION CASE. Capacity is enough for the header and part of the payload.
+// Pre-fix this emits '>' + len + a partial payload, which desyncs the receiver.
+// The frame must be refused outright: nothing on the wire, and a 0 return so the
+// caller knows not to advance.
+TEST(SerialFrameAtomicity, RegressionSevenEighteen_PartialCapacityMustEmitNothing) {
+  ConstrainedStream s;
+  s.capacity = 3 + (kPayloadLen / 2);        // header fits, payload does not
+  ArduinoSerialInterface iface;
+  iface.begin(s);
+
+  const size_t written = iface.writeFrame(kPayload, kPayloadLen);
+
+  EXPECT_EQ(written, 0u) << "a frame that cannot be fully emitted must report failure";
+  EXPECT_TRUE(s.wire.empty())
+      << "emitted " << s.wire.size() << " bytes of a partial frame; the receiver will "
+         "consume the next frame's header as payload filler (#718)";
+}
+
+// Not even the header may go out on its own: a lone header is exactly what makes
+// the receiver start counting toward a payload that never arrives.
+TEST(SerialFrameAtomicity, RegressionSevenEighteen_HeaderAloneIsNeverEmitted) {
+  ConstrainedStream s;
+  s.capacity = 3;                             // room for the header and nothing else
+  ArduinoSerialInterface iface;
+  iface.begin(s);
+
+  EXPECT_EQ(iface.writeFrame(kPayload, kPayloadLen), 0u);
+  EXPECT_TRUE(s.wire.empty()) << "header emitted with no payload behind it";
+}
+
+TEST(SerialFrameAtomicity, ZeroCapacityEmitsNothing) {
+  ConstrainedStream s;
+  s.capacity = 0;
+  ArduinoSerialInterface iface;
+  iface.begin(s);
+
+  EXPECT_EQ(iface.writeFrame(kPayload, kPayloadLen), 0u);
+  EXPECT_TRUE(s.wire.empty());
+}
+
+// The end-to-end property the field failure violated: a sequence of frames emitted
+// against a stream that keeps running out of room must leave the wire parseable and
+// every refused frame must be re-offered by the caller, so no payload byte is lost.
+TEST(SerialFrameAtomicity, RegressionSevenEighteen_WireStaysParseableUnderRepeatedRefusal) {
+  ConstrainedStream s;
+  ArduinoSerialInterface iface;
+  iface.begin(s);
+
+  constexpr size_t kFrames = 12;
+  size_t delivered = 0, refusals = 0, attempts = 0;
+
+  // Capacity is keyed off the ATTEMPT, not the frame, so a refused frame sees more
+  // room on its retry -- modelling a FIFO that drains between passes. Keying it off
+  // the frame index would deadlock: a refusal that does not advance `f` would keep
+  // recomputing the same too-small capacity forever.
+  for (size_t f = 0; f < kFrames; ++attempts) {
+    ASSERT_LT(attempts, kFrames * 4u) << "drain made no progress; refusal path deadlocked";
+    s.capacity = (attempts % 3 == 0) ? (kFrameLen - 2) : (kFrameLen * 2);
+
+    const size_t n = iface.writeFrame(kPayload, kPayloadLen);
+    if (n == 0) {
+      ++refusals;                 // caller must retry the SAME frame, not skip it
+      continue;
+    }
+    delivered += n;
+    ++f;
+  }
+
+  EXPECT_GT(refusals, 0u) << "test did not exercise the refusal path";
+  EXPECT_EQ(delivered, kFrames * kPayloadLen) << "payload bytes were lost";
+
+  size_t frames = 0;
+  ASSERT_TRUE(wireIsWellFramed(s.wire, &frames))
+      << "wire is not parseable: a partial frame desynced the stream";
+  EXPECT_EQ(frames, kFrames);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## What this changes

Makes the framed companion protocol's serial write **atomic without becoming blocking**, and stops `caplogDrain()` skipping bytes a transport refused. Affects every role using `ArduinoSerialInterface` (USB/UART companions) plus the BLE drain path.

Addresses #718 — **that issue stays OPEN**: this is bench-verified but not device-verified.

### The bug

The companion protocol is length-prefixed, but on a companion USB build its transport is deliberately non-blocking: `main.cpp:171` sets `Serial.setTxTimeoutMs(0)` (#149) so a host that stops draining cannot stall the loop and starve BLE servicing. A non-blocking write returns **short** when the TX FIFO is full.

`writeFrame()` wrote the 3-byte header unconditionally, then the payload. On a short payload write the header was already on the wire, so the receiver counted toward bytes that never arrived and consumed the **next frame's header as filler**. `caplogDrain()` compounded it by advancing its read offset regardless, so the skipped bytes were never re-sent.

Observed on `rc32-bench-1` (DustyBarn, #704): a caplog download announced 1067 bytes, delivered 545, with a complete `'>' 0xB0 0x00 0xC4 0x02` frame header spliced inside a payload.

Dropping bytes is **correct for the debug mirror** and **corrupting for a length-prefixed protocol**. That is the whole defect.

### The fix

- `writeFrame()` checks `availableForWrite()` and returns **0 without touching the wire** if the whole frame will not fit. It never returns a short count. New contract documented on the declaration: **0 means NOT SENT, retry**.
- `caplogDrain()` treats 0 as a refusal and does **not** advance `_caplog_off`, re-offering the same bytes next pass. The ring is frozen for the download and ERASE is already rejected while streaming (verified in `handleCmdFrame`), so the retry serves identical data.
- The END terminator is retried rather than tearing the stream down, which would have left the client waiting for a terminator never re-sent.
- **Stall abort:** refusing without advancing means a host that never drains would keep the stream open forever — and `_caplog_streaming` also gates ENABLE/DISABLE/ERASE/DOWNLOAD, wedging the subsystem. Aborts after `CAPLOG_STALL_ABORT_MS` (15 s) measured from the **last accepted chunk**, so a slow-but-advancing drain is never cut off, and the device frees its state before the client's 30 s timeout.

This also closes, **for both transports**, the hole recorded in #711: BLE `writeFrame()` returns 0 on a full send queue and the drain was skipping those bytes too.

## Tests

**Has the test been watched failing? Yes — 3 of 5 cases fail against the unfixed code, 5/5 pass with it.**

`test/test_serial_framing` drives the **real** `ArduinoSerialInterface` against a `Stream` that short-writes like a full FIFO, then walks the emitted bytes with an **independent** decoder (`wireIsWellFramed`) to prove no partial frame ever reached the wire. The decoder is a separate implementation from the encoder under test, so the check is not circular.

Required adding `ArduinoSerialInterface.cpp` to `[env:native]` and promoting the `MockSerial` mock from `Print` to `Stream` — the extract-to-test pattern, raising the natively-tested surface by one more unit.

- [x] Tests added/updated, and shown to fail without the fix
- [ ] No test: state why here (only the owner waives a test)

## Verification

- [x] Builds: `heltec_rc32_companion_radio_usb`, `heltec_v4_companion_radio_ble`, `RAK_4631_companion_radio_usb`, `Heltec_v2_companion_radio_ble` (DRAM-tight, **not** in the CI matrix)
- [x] `pio test` green for every native env: 149 / 8 / 7
- [ ] **NOT hardware-verified.** That the short write produced the rc32 capture is the best-supported reading and no competing mechanism survives it, but it is untested on device. DustyBarn holds the reproducer (`pull_ring.py`) and has been asked to re-run it once this lands.

## Review

- [x] Gemini-reviewed (`gemini-2.5-pro`).

It identified the **starvation stall as a high-severity defect introduced by the fix** — correct, and the reason `CAPLOG_STALL_ABORT_MS` exists. Its documentation points (return contract, `availableForWrite()` dependency) are adopted, and its "should be impossible" note on the short-header branch is softened to *rare*, since the capacity check is an unlocked snapshot and the debug console shares the Stream on some roles. Its ERASE-mid-stream concern was checked and is already guarded.

## Notes

**Behaviour change worth flagging:** fire-and-forget callers of `writeFrame()` now silently drop a frame under back-pressure instead of corrupting the stream. That is strictly the better failure — corruption is persistent and cascading, a dropped reply is transient — but any caller that needs guaranteed delivery must now retry on 0.

**New hard dependency:** the bound `Stream` must implement `availableForWrite()` meaningfully. Base `Stream` returns 0, which reads as "no room" and would refuse forever. Every transport actually bound here implements it; documented on the declaration.

Not in scope: DustyBarn's separate ungated-console-writer concern for shared-UART roles (they are filing it under #704), and their finding that the ring holds nothing before ~45 s at boot.

Agent: TopazElk (session cb83eacb)
