### PR TITLE
fix(#726): publish ring accepts full-size bodies — end the silent ~98-byte packet ceiling

### DIFF
--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -169,7 +169,11 @@ void MqttBrokerPool::loop(uint32_t now_ms) {
         if (now_ms - s_ring_log_ms >= 60000U) {
             s_ring_log_ms = now_ms;
             char L[160];
-            int o = snprintf(L, sizeof(L), "[ring] head=%u drops", (unsigned)ring_.head());
+            // #726: rej= counts payloads REFUSED by append (too large for the ring),
+            // which is a different failure from drops= (reader fell behind). Confusing
+            // the two is what let an ~98-byte publish ceiling hide for months.
+            int o = snprintf(L, sizeof(L), "[ring] head=%u rej=%u drops",
+                             (unsigned)ring_.head(), (unsigned)ring_.rejectedCount());
             for (uint8_t s = 0; s < OFFBAND_MAX_BROKERS && o < (int)sizeof(L) - 16; ++s) {
                 if (!brokers_[s].isConfigured()) continue;
                 o += snprintf(L + o, (size_t)(sizeof(L) - o), " s%u=%u",

--- a/src/helpers/wifi_observer/MqttRingLog.h
+++ b/src/helpers/wifi_observer/MqttRingLog.h
@@ -32,11 +32,35 @@
 // This is still one extrapolation deep (hourly average x network burst ratio).
 // droppedCount() now measures it directly -- re-size from real drop counts on a
 // busy observer rather than from this arithmetic.
+// #726: 32 -> 20. MQTT_RING_MSG_MAX had to double (see below) so parsed packets
+// stop being rejected; slot count comes down to pay for it. 20 x 1024 = 20,480 B
+// (+4,096 over the old 32 x 512), which fits the headroom #701 freed.
+//
+// Depth trade: 20 messages covers ~3 rotating TLS brokers at the measured busiest
+// observer (3.08/min sustained, ~7.1/min burst); it is marginal at 4+. Dropping the
+// derived JSON fields CoreScope never reads (packet_type/payload_len/route/path/
+// hash/len/time/date, ~130 B) would buy the depth back -- tracked separately.
 #ifndef MQTT_RING_SLOTS
-  #define MQTT_RING_SLOTS 32
+  #define MQTT_RING_SLOTS 20
 #endif
+// #726: 512 -> 1024. MUST be >= the buffer buildPacketJson() writes into.
+// publishParsedPacket() builds the /packets JSON into char json[1024] and hands it
+// to publishPacket() -> append(). At 512 every payload between 513 and 1023 bytes
+// was REJECTED and silently discarded: append returned 0, nothing logged, no
+// counter moved (droppedCount tracks cursor overrun at commit(), not a refused
+// append). The JSON embeds "raw":"<whole packet in hex>", so with 316 B of other
+// fields the ceiling was ~98 BYTES of packet -- a max 255 B MeshCore packet builds
+// an 826 B body and never reached any broker. Transport-independent: the drop is
+// upstream of broker fan-out, so a plaintext always-on slot was hit identically.
+//
+// Introduced by #175 (62ad4439 added the ring at 512 while the builder already used
+// 1024) and found in the field on v1.5.0-beta1: an observer published the first,
+// smaller message to CoreScope and silently dropped the two larger ones.
+//
+// KEEP THIS >= the json[] buffer in publishParsedPacket(). If that buffer grows,
+// this must grow with it, or the same silent hole reopens.
 #ifndef MQTT_RING_MSG_MAX
-  #define MQTT_RING_MSG_MAX 512
+  #define MQTT_RING_MSG_MAX 1024
 #endif
 #ifndef MQTT_RING_MAX_READERS
   #define MQTT_RING_MAX_READERS 10
@@ -48,14 +72,22 @@ public:
         memset(len_, 0, sizeof(len_));
         memset(seq_, 0, sizeof(seq_));
         for (int i = 0; i < MQTT_RING_MAX_READERS; i++) { cursor_[i] = 0; dropped_[i] = 0; }
+        rejected_ = 0;
     }
 
     // Append a payload. Returns its sequence number (1-based), or 0 if rejected
     // (empty or larger than MQTT_RING_MSG_MAX). Overwrites the oldest slot when
     // full -- a reader that has not kept up loses the overrun (documented,
     // best-effort; see lapped()).
+    // #726: count refused appends. An oversize payload never enters the ring at
+    // all, so droppedCount() (cursor overrun) cannot see it -- that is exactly how
+    // the 512-byte ceiling stayed invisible for so long. Separate counter, so
+    // "too big to publish" and "reader fell behind" are never confused again.
+    uint32_t rejectedCount() const { return rejected_; }
+
     uint32_t append(const uint8_t* payload, size_t len) {
-        if (payload == nullptr || len == 0 || len > MQTT_RING_MSG_MAX) return 0;
+        if (payload == nullptr || len == 0) return 0;
+        if (len > MQTT_RING_MSG_MAX) { rejected_++; return 0; }
         uint32_t s = ++head_;
         uint32_t idx = (s - 1) % MQTT_RING_SLOTS;
         memcpy(buf_[idx], payload, len);
@@ -157,5 +189,6 @@ private:
     uint32_t seq_[MQTT_RING_SLOTS];
     uint32_t cursor_[MQTT_RING_MAX_READERS];
     uint32_t dropped_[MQTT_RING_MAX_READERS];   // #710: monotonic overrun loss
+    uint32_t rejected_ = 0;                     // #726: payloads too big to append
     uint32_t head_ = 0;
 };

--- a/test/test_mqtt_ring/test_mqtt_ring.cpp
+++ b/test/test_mqtt_ring/test_mqtt_ring.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <cstring>
+#include <vector>
 #include "helpers/wifi_observer/MqttRingLog.h"
 
 static void fill(uint8_t* b, size_t n, uint8_t v) { memset(b, v, n); }
@@ -144,6 +145,38 @@ TEST(MqttRingLogDrops, RepeatedOverrunsAccumulate) {
     for (int i = 0; i < MQTT_RING_SLOTS + 3; i++) ring.append(m, sizeof(m));
     while (ring.peek(0, out, sizeof(out), out_len, seq)) ring.commit(0);
     EXPECT_EQ(ring.droppedCount(0), 5u);
+}
+
+// ---------------------------------------------------------------------------
+// #726: the ring must accept anything publishParsedPacket() can build.
+//
+// That function writes the /packets JSON into char json[1024]. The ring capped
+// at 512, so every payload from 513..1023 bytes was refused and discarded with
+// no log and no counter -- a ~98-byte packet ceiling, invisible. These pin the
+// contract: MQTT_RING_MSG_MAX >= the builder's buffer, and a refusal is COUNTED.
+// ---------------------------------------------------------------------------
+
+TEST(MqttRingLogDrops, AcceptsAnythingTheJsonBuilderCanProduce) {
+    MqttRingLog ring;
+    // The largest body publishParsedPacket can hand us: json[1024] minus NUL.
+    std::vector<uint8_t> big(1023, 0x5A);
+    EXPECT_EQ(ring.append(big.data(), big.size()), 1u)
+        << "ring refuses a payload the JSON builder can legally produce";
+    EXPECT_EQ(ring.rejectedCount(), 0u);
+
+    // A worst-case 255-byte MeshCore packet builds an ~826 B body.
+    std::vector<uint8_t> worst(826, 0x5B);
+    EXPECT_EQ(ring.append(worst.data(), worst.size()), 2u);
+    EXPECT_EQ(ring.rejectedCount(), 0u);
+}
+
+TEST(MqttRingLogDrops, OversizeIsCountedNotSilent) {
+    MqttRingLog ring;
+    std::vector<uint8_t> toobig(MQTT_RING_MSG_MAX + 1, 0x5C);
+    EXPECT_EQ(ring.append(toobig.data(), toobig.size()), 0u);
+    EXPECT_EQ(ring.rejectedCount(), 1u);          // counted, not discarded quietly
+    EXPECT_EQ(ring.droppedCount(0), 0u);          // and NOT confused with overrun
+    EXPECT_EQ(ring.head(), 0u);                   // nothing entered the ring
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Closes #726. **First in a 3-PR stack:** #726 → #727 → #727 §4. Merge in order.

`publishParsedPacket()` built the /packets JSON into a 1024-byte buffer; the ring capped at 512 and **silently refused** anything larger — no log, no counter. The body embeds `raw":"<packet hex>"`, so the real ceiling was **~98 bytes of packet**. Found in the field on beta1: a tester's observer published the first small message to CoreScope and dropped two larger ones.

- `MQTT_RING_MSG_MAX` 512 → 1024; slots 32 → 20 to pay for it.
- Refused appends now **counted** (`rejectedCount()`) and surfaced on `[ring]` as `rej=`, distinct from `drops=`.
- Introduced by #175, not by the #708/#710 rotation work.

Superseded in sizing by #727 (next in stack), which stops storing the rendered body entirely — but this lands the correctness fix and the counter on its own.

Tests: new cases in test_mqtt_ring. Soaked in the beta2 candidate on hv3-bench (rej=0, drops=0).