### PR TITLE
refactor(#727): store the packet in the publish ring, not the rendered JSON

### DIFF
--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -4,6 +4,13 @@
 
 #include "MqttBrokerPool.h"
 #include "BrokerRotationSelect.h"   // #708: fair TLS promotion
+
+// #727: the ring must be able to hold what publishParsedPacket() writes.
+// #726 was this invariant broken silently -- the writer produced a body the
+// ring refused, append() returned 0, and nothing counted or logged it. Make it
+// a compile error instead of a field report.
+static_assert(sizeof(offband::PacketRecord) <= MQTT_RING_MSG_MAX,
+              "MQTT_RING_MSG_MAX must be >= sizeof(PacketRecord)");
 #include "MqttPayload.h"
 #include <helpers/diagnostics/CrashLog.h>   // #181: crashLogf() -- worker has no user ACK channel
 #include <cstring>
@@ -234,7 +241,23 @@ uint8_t MqttBrokerPool::drainBroker(uint8_t slot) {
     // Bound the burst: at most MQTT_RING_SLOTS messages per pass.
     for (uint8_t i = 0; i < MQTT_RING_SLOTS; ++i) {
         if (!ring_.peek(slot, buf, sizeof(buf), len, seq)) break;
-        if (!b.publish(topic, buf, len, /*retain=*/false)) break;  // retry next pass
+        // #727: the ring holds a PacketRecord; render the body here, per broker.
+        // A short read means a record written by a different build -- skip it
+        // rather than publish garbage.
+        if (len != sizeof(PacketRecord)) { ring_.commit(slot); continue; }
+        PacketRecord rec;
+        memcpy(&rec, buf, sizeof(rec));
+        char json[1024];
+        int n = buildPacketJsonFromRecord(json, sizeof(json), rec,
+                                          /*is_tx=*/false, ctx);
+        if (n <= 0 || static_cast<size_t>(n) >= sizeof(json)) {
+            ring_.commit(slot);   // unrenderable: drop it, do not wedge the queue
+            continue;
+        }
+        if (!b.publish(topic, reinterpret_cast<const uint8_t*>(json),
+                       static_cast<size_t>(n), /*retain=*/false)) {
+            break;  // retry next pass
+        }
         ring_.commit(slot);
         sent++;
     }
@@ -324,13 +347,21 @@ uint8_t MqttBrokerPool::publishParsedPacket(const mesh::Packet& packet,
     ctx.firmware_version = firmware_version_;
     ctx.model            = model_;
 
-    char json[1024];
-    int n = buildPacketJson(json, sizeof(json), packet, /*is_tx=*/false,
-                            rssi, snr, score, duration, ctx);
-    if (n <= 0 || static_cast<size_t>(n) >= sizeof(json)) return 0;
+    // #727: store the PACKET RECORD, not the rendered body. The JSON embeds
+    // "raw":"<packet in hex>", and hex doubles the packet before ~316 B of
+    // fields are added -- a 255 B packet rendered to ~826 B, so every ring slot
+    // had to be sized for that. The record is ~296 B. Rendering moves to
+    // drainBroker(). Published bytes are unchanged.
+    //
+    // rx_time is captured HERE, at receive. Rendering at drain with
+    // time(nullptr) would stamp a backlogged broker's messages with the drain
+    // time -- wrong in exactly the rotated-out case the ring exists for.
+    PacketRecord rec;
+    fillPacketRecord(rec, packet, rssi, snr, score, duration,
+                     static_cast<uint32_t>(time(nullptr)));
+    if (rec.raw_len == 0) return 0;   // unserialisable packet
 
-    return publishPacket(reinterpret_cast<const uint8_t*>(json),
-                         static_cast<size_t>(n));
+    return publishPacket(reinterpret_cast<const uint8_t*>(&rec), sizeof(rec));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/helpers/wifi_observer/MqttPayload.cpp
+++ b/src/helpers/wifi_observer/MqttPayload.cpp
@@ -22,6 +22,11 @@
 
 namespace offband {
 
+// #727: MqttPayload.h restates the hash size to avoid including MeshCore.h.
+// Pin it to the real definition here, where MeshCore.h IS in scope.
+static_assert(kPacketHashSize == MAX_HASH_SIZE,
+              "kPacketHashSize must track MeshCore's MAX_HASH_SIZE");
+
 // ---------------------------------------------------------------------------
 // Helpers — ported verbatim from MqttUplink.cpp:371-456
 // ---------------------------------------------------------------------------
@@ -211,25 +216,48 @@ int buildStatusJson(char* buf, size_t buf_size,
 // (MAX_HASH_SIZE). The host test harness in Task 5 skips packet tests; if
 // needed later, a stub Packet in the harness can re-enable host-side tests.
 
-int buildPacketJson(char* buf, size_t buf_size,
-                    const mesh::Packet& packet, bool is_tx,
-                    int rssi, float snr, int score, int duration,
-                    const MqttPayloadCtx& ctx) {
+// #727: capture what the body needs while the packet is still alive.
+void fillPacketRecord(PacketRecord& rec, const mesh::Packet& packet,
+                      int rssi, float snr, int score, int duration,
+                      uint32_t rx_time) {
+    memset(&rec, 0, sizeof(rec));
+    rec.rx_time  = rx_time;      // AT RECEIVE -- see the header comment
+    rec.rssi     = rssi;
+    rec.snr      = snr;
+    rec.score    = score;
+    rec.duration = duration;
+    int n = packet.writeTo(rec.raw);
+    rec.raw_len  = (n > 0 && (size_t)n <= sizeof(rec.raw)) ? (uint16_t)n : 0;
+    packet.calculatePacketHash(rec.hash);
+    rec.payload_type    = packet.getPayloadType();
+    rec.payload_len     = packet.payload_len;
+    rec.route_direct    = packet.isRouteDirect() ? 1 : 0;
+    rec.path_hash_count = (uint8_t)packet.getPathHashCount();
+    rec.path_hash_size  = (uint8_t)packet.getPathHashSize();
+    rec.path_byte_len   = (uint8_t)packet.getPathByteLen();
+}
+
+int buildPacketJsonFromRecord(char* buf, size_t buf_size,
+                              const PacketRecord& rec, bool is_tx,
+                              const MqttPayloadCtx& ctx) {
     if (buf == nullptr || buf_size == 0) return -1;
 
-    uint8_t raw[256];
-    int raw_len = packet.writeTo(raw);
+    const int   raw_len = (int)rec.raw_len;
+    const int   rssi    = (int)rec.rssi;
+    const float snr     = rec.snr;
+    const int   score   = (int)rec.score;
+    const int   duration = (int)rec.duration;
+
     // Stack buffer instead of heap alloc (vendored used allocScratchBuffer(520);
     // 520 bytes is well within ESP32 task stack budget).
     char raw_hex[520];
-    bytesToHexUpper(raw, raw_len, raw_hex, sizeof(raw_hex));
+    bytesToHexUpper(rec.raw, (size_t)raw_len, raw_hex, sizeof(raw_hex));
 
-    uint8_t packet_hash[MAX_HASH_SIZE];
-    packet.calculatePacketHash(packet_hash);
     char hash_hex[(MAX_HASH_SIZE * 2) + 1];
-    bytesToHexUpper(packet_hash, MAX_HASH_SIZE, hash_hex, sizeof(hash_hex));
+    bytesToHexUpper(rec.hash, MAX_HASH_SIZE, hash_hex, sizeof(hash_hex));
 
-    time_t now = time(nullptr);
+    // #727: the RECEIVE time, not time(nullptr). Drain can be a dwell later.
+    time_t now = (time_t)rec.rx_time;
     char ts[32];
     formatIsoTimestamp(now, ts, sizeof(ts));
     struct tm tm_utc;
@@ -251,12 +279,12 @@ int buildPacketJson(char* buf, size_t buf_size,
 
     const char* device_id = ctx.device_id != nullptr ? ctx.device_id : "";
 
-    if (packet.isRouteDirect() && packet.path_len > 0) {
+    if (rec.route_direct && rec.path_byte_len > 0) {
         char path_info[128];
         snprintf(path_info, sizeof(path_info), "path_%dx%d_%db",
-                 (int)packet.getPathHashCount(),
-                 (int)packet.getPathHashSize(),
-                 (int)packet.getPathByteLen());
+                 (int)rec.path_hash_count,
+                 (int)rec.path_hash_size,
+                 (int)rec.path_byte_len);
         if (score >= 0) {
             return snprintf(buf, buf_size,
                 "{\"origin\":\"%s\",\"origin_id\":\"%s\",\"timestamp\":\"%s\",\"type\":\"PACKET\","
@@ -264,7 +292,7 @@ int buildPacketJson(char* buf, size_t buf_size,
                 "\"route\":\"D\",\"payload_len\":\"%u\",\"raw\":\"%s\",\"SNR\":\"%.1f\",\"RSSI\":\"%d\","
                 "\"score\":\"%d\",\"duration\":\"%d\",\"hash\":\"%s\",\"path\":\"%s\"}",
                 origin, device_id, ts, is_tx ? "tx" : "rx", time_only, date_only, raw_len,
-                packet.getPayloadType(), packet.payload_len, raw_hex, snr, rssi, score, duration, hash_hex,
+                rec.payload_type, rec.payload_len, raw_hex, snr, rssi, score, duration, hash_hex,
                 path_info);
         }
         return snprintf(buf, buf_size,
@@ -273,7 +301,7 @@ int buildPacketJson(char* buf, size_t buf_size,
             "\"route\":\"D\",\"payload_len\":\"%u\",\"raw\":\"%s\",\"SNR\":\"%.1f\",\"RSSI\":\"%d\","
             "\"hash\":\"%s\",\"path\":\"%s\"}",
             origin, device_id, ts, is_tx ? "tx" : "rx", time_only, date_only, raw_len,
-            packet.getPayloadType(), packet.payload_len, raw_hex, snr, rssi, hash_hex, path_info);
+            rec.payload_type, rec.payload_len, raw_hex, snr, rssi, hash_hex, path_info);
     }
 
     if (score >= 0) {
@@ -283,7 +311,7 @@ int buildPacketJson(char* buf, size_t buf_size,
             "\"route\":\"F\",\"payload_len\":\"%u\",\"raw\":\"%s\",\"SNR\":\"%.1f\",\"RSSI\":\"%d\","
             "\"score\":\"%d\",\"duration\":\"%d\",\"hash\":\"%s\"}",
             origin, device_id, ts, is_tx ? "tx" : "rx", time_only, date_only, raw_len,
-            packet.getPayloadType(), packet.payload_len, raw_hex, snr, rssi, score, duration, hash_hex);
+            rec.payload_type, rec.payload_len, raw_hex, snr, rssi, score, duration, hash_hex);
     }
     return snprintf(buf, buf_size,
         "{\"origin\":\"%s\",\"origin_id\":\"%s\",\"timestamp\":\"%s\",\"type\":\"PACKET\","
@@ -291,7 +319,7 @@ int buildPacketJson(char* buf, size_t buf_size,
         "\"route\":\"F\",\"payload_len\":\"%u\",\"raw\":\"%s\",\"SNR\":\"%.1f\",\"RSSI\":\"%d\","
         "\"hash\":\"%s\"}",
         origin, device_id, ts, is_tx ? "tx" : "rx", time_only, date_only, raw_len,
-        packet.getPayloadType(), packet.payload_len, raw_hex, snr, rssi, hash_hex);
+        rec.payload_type, rec.payload_len, raw_hex, snr, rssi, hash_hex);
 }
 
 int buildRawJson(char* buf, size_t buf_size,
@@ -328,10 +356,17 @@ int buildRawJson(char* buf, size_t buf_size,
        // The host test harness in Task 5 provides a stub mesh::Packet definition;
        // the linker resolves these stubs OR the harness's own packet builders.
 
-int buildPacketJson(char* buf, size_t buf_size,
-                    const mesh::Packet& /*packet*/, bool /*is_tx*/,
-                    int /*rssi*/, float /*snr*/, int /*score*/, int /*duration*/,
-                    const MqttPayloadCtx& /*ctx*/) {
+void fillPacketRecord(PacketRecord& rec, const mesh::Packet& /*packet*/,
+                      int rssi, float snr, int score, int duration,
+                      uint32_t rx_time) {
+    memset(&rec, 0, sizeof(rec));
+    rec.rx_time = rx_time; rec.rssi = rssi; rec.snr = snr;
+    rec.score = score; rec.duration = duration;
+}
+
+int buildPacketJsonFromRecord(char* buf, size_t buf_size,
+                              const PacketRecord& /*rec*/, bool /*is_tx*/,
+                              const MqttPayloadCtx& /*ctx*/) {
     if (buf == nullptr || buf_size == 0) return -1;
     return snprintf(buf, buf_size, "{\"type\":\"PACKET-host-stub\"}");
 }

--- a/src/helpers/wifi_observer/MqttPayload.h
+++ b/src/helpers/wifi_observer/MqttPayload.h
@@ -84,10 +84,58 @@ int buildStatusJson(char* buf, size_t buf_size,
 
 // Packet JSON. score == -1 means "omit score/duration fields" (matches
 // the vendored two-variant behavior).
-int buildPacketJson(char* buf, size_t buf_size,
-                    const mesh::Packet& packet, bool is_tx,
-                    int rssi, float snr, int score, int duration,
-                    const MqttPayloadCtx& ctx);
+// ---------------------------------------------------------------------------
+// PacketRecord (#727)
+// ---------------------------------------------------------------------------
+// What the publish ring stores, INSTEAD of a rendered JSON body.
+//
+// The ring used to hold the finished /packets JSON. That body embeds
+// "raw":"<whole packet in hex>", and hex DOUBLES the packet before ~316 B of
+// fields are layered on -- so a 255 B packet became an ~826 B body and every
+// ring slot had to be sized for that. This record is the same information
+// before rendering: ~296 B instead of ~826 B, so slots shrink ~3x.
+//
+// rx_time IS PART OF THE RECORD ON PURPOSE. Rendering moved to drain time, and
+// drain can happen a full rotation dwell after the packet arrived. Calling
+// time(nullptr) during the render would stamp a backlogged broker's messages
+// with the DRAIN time -- silently wrong timestamps in exactly the rotated-out
+// case the ring exists to serve. Capture at receive, carry it through.
+//
+// POD by design: it is memcpy'd into the ring as opaque bytes.
+// MeshCore's MAX_HASH_SIZE, restated rather than #included: this header only
+// forward-declares mesh::Packet on purpose, to stay light. A static_assert in
+// MqttPayload.cpp pins this to the real value, so the two cannot drift.
+static constexpr size_t kPacketHashSize = 8;
+
+struct PacketRecord {
+    uint32_t rx_time;                  // unix seconds, captured AT RECEIVE
+    int32_t  rssi;
+    float    snr;
+    int32_t  score;
+    int32_t  duration;
+    uint8_t  hash[kPacketHashSize];      // precomputed: the packet is not kept
+    uint8_t  payload_type;
+    uint8_t  payload_len;
+    uint8_t  route_direct;             // 1 = direct route, 0 = flood
+    uint8_t  path_hash_count;
+    uint8_t  path_hash_size;
+    uint8_t  path_byte_len;
+    uint16_t raw_len;
+    uint8_t  raw[256];
+};
+
+// Capture everything the /packets body needs from a live packet, so the packet
+// itself does not have to survive until publish time.
+void fillPacketRecord(PacketRecord& rec, const mesh::Packet& packet,
+                      int rssi, float snr, int score, int duration,
+                      uint32_t rx_time);
+
+// Render the /packets body from a stored record. Byte-identical output to
+// buildPacketJson() for the same packet -- consumers see no change (#727).
+int buildPacketJsonFromRecord(char* buf, size_t buf_size,
+                              const PacketRecord& rec, bool is_tx,
+                              const MqttPayloadCtx& ctx);
+
 
 // Raw packet JSON (hex-encoded bytes only, minimal envelope).
 int buildRawJson(char* buf, size_t buf_size,

--- a/src/helpers/wifi_observer/MqttRingLog.h
+++ b/src/helpers/wifi_observer/MqttRingLog.h
@@ -32,35 +32,32 @@
 // This is still one extrapolation deep (hourly average x network burst ratio).
 // droppedCount() now measures it directly -- re-size from real drop counts on a
 // busy observer rather than from this arithmetic.
-// #726: 32 -> 20. MQTT_RING_MSG_MAX had to double (see below) so parsed packets
-// stop being rejected; slot count comes down to pay for it. 20 x 1024 = 20,480 B
-// (+4,096 over the old 32 x 512), which fits the headroom #701 freed.
+// Ring sizing. History matters here -- both numbers below were bugs.
 //
-// Depth trade: 20 messages covers ~3 rotating TLS brokers at the measured busiest
-// observer (3.08/min sustained, ~7.1/min burst); it is marginal at 4+. Dropping the
-// derived JSON fields CoreScope never reads (packet_type/payload_len/route/path/
-// hash/len/time/date, ~130 B) would buy the depth back -- tracked separately.
+// #175 shipped 512 B slots while publishParsedPacket() rendered its /packets JSON
+// into a 1024 B buffer. Every body over 512 B was REFUSED by append() and silently
+// discarded: nothing logged, no counter moved. Because the JSON embeds
+// "raw":"<packet in hex>" and hex doubles the packet, that put the publish ceiling
+// at ~98 BYTES -- a max 255 B MeshCore packet rendered to ~826 B and never reached
+// any broker. Found in the field on v1.5.0-beta1.
+//
+// #726 fixed it by raising the limit to 1024 (slots 32 -> 20 to pay for it), which
+// worked but cost 20,480 B -- most of the headroom #701 freed.
+//
+// #727 fixes the actual problem: the ring was storing the RENDERED BODY. It now
+// stores a PacketRecord (~296 B) and drainBroker() renders per broker, so slots
+// shrink to 320 B:
+//   #175  : 32 x  512 = 16,384 B   (and packets over ~98 B silently dropped)
+//   #726  : 20 x 1024 = 20,480 B
+//   #727  : 32 x  320 = 10,240 B   -- more depth than either, ~10 KB less memory
 #ifndef MQTT_RING_SLOTS
-  #define MQTT_RING_SLOTS 20
+  #define MQTT_RING_SLOTS 32
 #endif
-// #726: 512 -> 1024. MUST be >= the buffer buildPacketJson() writes into.
-// publishParsedPacket() builds the /packets JSON into char json[1024] and hands it
-// to publishPacket() -> append(). At 512 every payload between 513 and 1023 bytes
-// was REJECTED and silently discarded: append returned 0, nothing logged, no
-// counter moved (droppedCount tracks cursor overrun at commit(), not a refused
-// append). The JSON embeds "raw":"<whole packet in hex>", so with 316 B of other
-// fields the ceiling was ~98 BYTES of packet -- a max 255 B MeshCore packet builds
-// an 826 B body and never reached any broker. Transport-independent: the drop is
-// upstream of broker fan-out, so a plaintext always-on slot was hit identically.
-//
-// Introduced by #175 (62ad4439 added the ring at 512 while the builder already used
-// 1024) and found in the field on v1.5.0-beta1: an observer published the first,
-// smaller message to CoreScope and silently dropped the two larger ones.
-//
-// KEEP THIS >= the json[] buffer in publishParsedPacket(). If that buffer grows,
-// this must grow with it, or the same silent hole reopens.
+// MUST stay >= sizeof(PacketRecord). A static_assert in MqttBrokerPool.cpp enforces
+// it -- #726 was exactly this invariant violated silently, so it is now a compile
+// error rather than a field report.
 #ifndef MQTT_RING_MSG_MAX
-  #define MQTT_RING_MSG_MAX 1024
+  #define MQTT_RING_MSG_MAX 320
 #endif
 #ifndef MQTT_RING_MAX_READERS
   #define MQTT_RING_MAX_READERS 10

--- a/test/test_mqtt_ring/test_mqtt_ring.cpp
+++ b/test/test_mqtt_ring/test_mqtt_ring.cpp
@@ -1,7 +1,14 @@
 #include <gtest/gtest.h>
 #include <cstring>
 #include <vector>
+// MqttPayload.h pulls WifiObserverConfig.h, which #errors unless a role is
+// declared. The record layout is role-independent, so declare the pool role
+// for this translation unit only -- keeps MqttRingLog.h itself dependency-free.
+#ifndef OFFBAND_MQTT_POOL
+#define OFFBAND_MQTT_POOL 1
+#endif
 #include "helpers/wifi_observer/MqttRingLog.h"
+#include "helpers/wifi_observer/MqttPayload.h"
 
 static void fill(uint8_t* b, size_t n, uint8_t v) { memset(b, v, n); }
 
@@ -156,18 +163,26 @@ TEST(MqttRingLogDrops, RepeatedOverrunsAccumulate) {
 // contract: MQTT_RING_MSG_MAX >= the builder's buffer, and a refusal is COUNTED.
 // ---------------------------------------------------------------------------
 
-TEST(MqttRingLogDrops, AcceptsAnythingTheJsonBuilderCanProduce) {
+TEST(MqttRingLogDrops, AcceptsAnythingTheWriterCanProduce) {
+    // This test began life under #726, asserting the ring could hold a 1023-byte
+    // RENDERED JSON body -- because back then publishParsedPacket() wrote the
+    // finished body into the ring and the ring capped at 512, silently refusing
+    // anything larger (a ~98-byte packet ceiling, invisible in the field).
+    //
+    // #727 changed what the writer produces: the ring now stores a PacketRecord
+    // and drainBroker() renders per broker. So the invariant is unchanged in
+    // spirit -- the ring must accept whatever the writer hands it -- but the
+    // thing being handed over is now the record, not the body.
     MqttRingLog ring;
-    // The largest body publishParsedPacket can hand us: json[1024] minus NUL.
-    std::vector<uint8_t> big(1023, 0x5A);
-    EXPECT_EQ(ring.append(big.data(), big.size()), 1u)
-        << "ring refuses a payload the JSON builder can legally produce";
+    std::vector<uint8_t> rec(sizeof(offband::PacketRecord), 0x5A);
+    EXPECT_EQ(ring.append(rec.data(), rec.size()), 1u)
+        << "ring refuses a record the writer can legally produce";
     EXPECT_EQ(ring.rejectedCount(), 0u);
 
-    // A worst-case 255-byte MeshCore packet builds an ~826 B body.
-    std::vector<uint8_t> worst(826, 0x5B);
-    EXPECT_EQ(ring.append(worst.data(), worst.size()), 2u);
-    EXPECT_EQ(ring.rejectedCount(), 0u);
+    // And a full rendered body is now correctly refused -- nothing writes one.
+    std::vector<uint8_t> old_body(1023, 0x5B);
+    EXPECT_EQ(ring.append(old_body.data(), old_body.size()), 0u);
+    EXPECT_EQ(ring.rejectedCount(), 1u);   // refused, and COUNTED
 }
 
 TEST(MqttRingLogDrops, OversizeIsCountedNotSilent) {
@@ -177,6 +192,80 @@ TEST(MqttRingLogDrops, OversizeIsCountedNotSilent) {
     EXPECT_EQ(ring.rejectedCount(), 1u);          // counted, not discarded quietly
     EXPECT_EQ(ring.droppedCount(0), 0u);          // and NOT confused with overrun
     EXPECT_EQ(ring.head(), 0u);                   // nothing entered the ring
+}
+
+// ---------------------------------------------------------------------------
+// #727: the ring now stores a PacketRecord, not a rendered JSON body.
+//
+// These pin the invariants that made #726 possible, and the one this redesign
+// would otherwise have introduced (drain-time timestamps).
+// ---------------------------------------------------------------------------
+
+TEST(MqttRingRecord, RecordFitsTheRing) {
+    // The whole point of #727: the writer's record must fit what the ring takes.
+    // #726 was this exact invariant broken silently, at a different size.
+    EXPECT_LE(sizeof(offband::PacketRecord), (size_t)MQTT_RING_MSG_MAX);
+}
+
+TEST(MqttRingRecord, MaxSizePacketRoundTrips) {
+    MqttRingLog ring;
+    offband::PacketRecord in{};
+    in.rx_time      = 1755300000u;
+    in.rssi         = -97;
+    in.snr          = -7.5f;
+    in.score        = 123;
+    in.duration     = 456;
+    in.payload_type = 4;
+    in.payload_len  = 237;
+    in.raw_len      = 255;                       // worst-case MeshCore packet
+    for (int i = 0; i < 255; i++) in.raw[i] = (uint8_t)i;
+
+    ASSERT_EQ(ring.append(reinterpret_cast<const uint8_t*>(&in), sizeof(in)), 1u)
+        << "a max-size packet record must be accepted -- this is #726's failure mode";
+    EXPECT_EQ(ring.rejectedCount(), 0u);
+
+    uint8_t out[MQTT_RING_MSG_MAX]; size_t len = 0; uint32_t seq = 0;
+    ASSERT_TRUE(ring.peek(0, out, sizeof(out), len, seq));
+    ASSERT_EQ(len, sizeof(offband::PacketRecord));
+
+    offband::PacketRecord got{};
+    memcpy(&got, out, sizeof(got));
+    EXPECT_EQ(got.rx_time, in.rx_time);
+    EXPECT_EQ(got.rssi, in.rssi);
+    EXPECT_FLOAT_EQ(got.snr, in.snr);
+    EXPECT_EQ(got.score, in.score);
+    EXPECT_EQ(got.raw_len, 255);
+    EXPECT_EQ(memcmp(got.raw, in.raw, 255), 0);   // packet bytes survive intact
+}
+
+TEST(MqttRingRecord, ReceiveTimeSurvivesADelayedDrain) {
+    // The bug this redesign would have introduced. Rendering moved to drain, so
+    // a record sitting through a rotation dwell must still carry the RECEIVE
+    // time -- calling time(nullptr) at render would stamp the drain time and
+    // silently mis-timestamp exactly the rotated-out case the ring exists for.
+    MqttRingLog ring;
+    const uint32_t rx = 1755300000u;
+
+
+    offband::PacketRecord in{};
+    in.rx_time = rx;
+    in.raw_len = 32;
+    ASSERT_EQ(ring.append(reinterpret_cast<const uint8_t*>(&in), sizeof(in)), 1u);
+
+    // Broker is away; unrelated traffic arrives meanwhile.
+    for (int i = 0; i < 5; i++) {
+        offband::PacketRecord other{};
+        other.rx_time = rx + 60u * (uint32_t)(i + 1);
+        other.raw_len = 16;
+        ring.append(reinterpret_cast<const uint8_t*>(&other), sizeof(other));
+    }
+
+    // Broker returns and drains: the FIRST record must still carry its own rx.
+    uint8_t out[MQTT_RING_MSG_MAX]; size_t len = 0; uint32_t seq = 0;
+    ASSERT_TRUE(ring.peek(0, out, sizeof(out), len, seq));
+    offband::PacketRecord got{};
+    memcpy(&got, out, sizeof(got));
+    EXPECT_EQ(got.rx_time, rx) << "record carried the wrong time across a delayed drain";
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Closes #727. **Second in the stack** (base = task/726-ring-msg-1024; retargets to firmware-base once #729 merges).

The ring held the finished JSON, so slots were sized for the worst-case ~826 B body. Store a `PacketRecord` (~296 B) and render per broker in `drainBroker()`:

    #175  : 32 x  512 = 16,384 B   (packets over ~98 B silently dropped)
    #726  : 20 x 1024 = 20,480 B
    #727  : 32 x  320 = 10,240 B   -- more depth, ~10 KB less memory

**Published bytes unchanged.** `rx_time` captured at receive (rendering at drain with `time(nullptr)` would mis-timestamp a backlogged broker). Guards: `static_assert(sizeof(PacketRecord) <= MQTT_RING_MSG_MAX)`, hash-size pin, and a short-read skip across firmware upgrades.

Tests 14/14 ring + 9/9 rotation. Soaked in beta2 candidate.