### PR TITLE
refactor(#727): slim /packets to what consumers read; ring 40x288; rx_time observable

### DIFF
--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -22,6 +22,10 @@ static_assert(sizeof(offband::PacketRecord) <= MQTT_RING_MSG_MAX,
 
 namespace offband {
 
+#ifndef MQTT_ROTATE_DWELL_MS
+  #define MQTT_ROTATE_DWELL_MS 60000U   // #175: how long a TLS slot holds the budget
+#endif
+
 // ---------------------------------------------------------------------------
 // begin
 // ---------------------------------------------------------------------------
@@ -247,6 +251,25 @@ uint8_t MqttBrokerPool::drainBroker(uint8_t slot) {
         if (len != sizeof(PacketRecord)) { ring_.commit(slot); continue; }
         PacketRecord rec;
         memcpy(&rec, buf, sizeof(rec));
+#if defined(ARDUINO)
+        // #727 sec4: rx_time observability. If this record was queued while the
+        // broker was rotated out, it is being published LATER than it arrived --
+        // and it must still carry its RECEIVE time, not "now". Emit the lag so a
+        // backlogged delivery is a VISIBLE event and the receive-time guarantee
+        // is provable on serial instead of silent. Rate-limited to one line per
+        // drain pass (the oldest record in the burst).
+        {
+            uint32_t nowsec = (uint32_t)time(nullptr);
+            uint32_t age = (nowsec > rec.rx_time) ? (nowsec - rec.rx_time) : 0;
+            static uint32_t s_last_backlog_ms = 0;
+            if (age >= (MQTT_ROTATE_DWELL_MS / 1000U) &&
+                (uint32_t)millis() - s_last_backlog_ms >= 10000U) {
+                s_last_backlog_ms = (uint32_t)millis();
+                Serial.printf("[ring] backlog s%u age=%us rx=%u (publishing receive-time)\n",
+                              (unsigned)slot, (unsigned)age, (unsigned)rec.rx_time);
+            }
+        }
+#endif
         char json[1024];
         int n = buildPacketJsonFromRecord(json, sizeof(json), rec,
                                           /*is_tx=*/false, ctx);
@@ -502,10 +525,6 @@ inline bool isTlsTransport(const BrokerConfig& c) {
            c.transport == BrokerTransport::Wss;
 }
 }  // namespace
-
-#ifndef MQTT_ROTATE_DWELL_MS
-  #define MQTT_ROTATE_DWELL_MS 60000U   // #175: how long a TLS slot holds the budget
-#endif
 
 // #175: rotate the live TLS set on a dwell timer. Demotes the OLDEST live TLS
 // broker so a parked (HeldNoHeap) one can take the freed budget slot. WORKER-ONLY:

--- a/src/helpers/wifi_observer/MqttPayload.cpp
+++ b/src/helpers/wifi_observer/MqttPayload.cpp
@@ -22,11 +22,6 @@
 
 namespace offband {
 
-// #727: MqttPayload.h restates the hash size to avoid including MeshCore.h.
-// Pin it to the real definition here, where MeshCore.h IS in scope.
-static_assert(kPacketHashSize == MAX_HASH_SIZE,
-              "kPacketHashSize must track MeshCore's MAX_HASH_SIZE");
-
 // ---------------------------------------------------------------------------
 // Helpers — ported verbatim from MqttUplink.cpp:371-456
 // ---------------------------------------------------------------------------
@@ -220,21 +215,16 @@ int buildStatusJson(char* buf, size_t buf_size,
 void fillPacketRecord(PacketRecord& rec, const mesh::Packet& packet,
                       int rssi, float snr, int score, int duration,
                       uint32_t rx_time) {
+    (void)duration;              // #727 sec4: no consumer reads it -- not stored
     memset(&rec, 0, sizeof(rec));
     rec.rx_time  = rx_time;      // AT RECEIVE -- see the header comment
     rec.rssi     = rssi;
     rec.snr      = snr;
     rec.score    = score;
-    rec.duration = duration;
     int n = packet.writeTo(rec.raw);
     rec.raw_len  = (n > 0 && (size_t)n <= sizeof(rec.raw)) ? (uint16_t)n : 0;
-    packet.calculatePacketHash(rec.hash);
-    rec.payload_type    = packet.getPayloadType();
-    rec.payload_len     = packet.payload_len;
-    rec.route_direct    = packet.isRouteDirect() ? 1 : 0;
-    rec.path_hash_count = (uint8_t)packet.getPathHashCount();
-    rec.path_hash_size  = (uint8_t)packet.getPathHashSize();
-    rec.path_byte_len   = (uint8_t)packet.getPathByteLen();
+    // #727 sec4: no hash / payload_type / route / path captured -- CoreScope and
+    // its forks decode raw themselves; these were computed and discarded.
 }
 
 int buildPacketJsonFromRecord(char* buf, size_t buf_size,
@@ -242,34 +232,14 @@ int buildPacketJsonFromRecord(char* buf, size_t buf_size,
                               const MqttPayloadCtx& ctx) {
     if (buf == nullptr || buf_size == 0) return -1;
 
-    const int   raw_len = (int)rec.raw_len;
-    const int   rssi    = (int)rec.rssi;
-    const float snr     = rec.snr;
-    const int   score   = (int)rec.score;
-    const int   duration = (int)rec.duration;
-
-    // Stack buffer instead of heap alloc (vendored used allocScratchBuffer(520);
-    // 520 bytes is well within ESP32 task stack budget).
     char raw_hex[520];
-    bytesToHexUpper(rec.raw, (size_t)raw_len, raw_hex, sizeof(raw_hex));
+    bytesToHexUpper(rec.raw, (size_t)rec.raw_len, raw_hex, sizeof(raw_hex));
 
-    char hash_hex[(MAX_HASH_SIZE * 2) + 1];
-    bytesToHexUpper(rec.hash, MAX_HASH_SIZE, hash_hex, sizeof(hash_hex));
-
-    // #727: the RECEIVE time, not time(nullptr). Drain can be a dwell later.
+    // #727: the RECEIVE time, not time(nullptr). Drain can be a dwell later, and
+    // stamping now would silently mis-timestamp a backlogged broker's messages.
     time_t now = (time_t)rec.rx_time;
     char ts[32];
     formatIsoTimestamp(now, ts, sizeof(ts));
-    struct tm tm_utc;
-#ifdef _MSC_VER
-    gmtime_s(&tm_utc, &now);
-#else
-    gmtime_r(&now, &tm_utc);
-#endif
-    char time_only[16];
-    char date_only[16];
-    strftime(time_only, sizeof(time_only), "%H:%M:%S", &tm_utc);
-    strftime(date_only, sizeof(date_only), "%d/%m/%Y", &tm_utc);
 
     char origin[80];
     const char* node_name = (ctx.node_name != nullptr && ctx.node_name[0] != 0)
@@ -277,49 +247,24 @@ int buildPacketJsonFromRecord(char* buf, size_t buf_size,
                             : (ctx.device_id != nullptr ? ctx.device_id : "");
     escapeJsonString(node_name, origin, sizeof(origin));
 
-    const char* device_id = ctx.device_id != nullptr ? ctx.device_id : "";
-
-    if (rec.route_direct && rec.path_byte_len > 0) {
-        char path_info[128];
-        snprintf(path_info, sizeof(path_info), "path_%dx%d_%db",
-                 (int)rec.path_hash_count,
-                 (int)rec.path_hash_size,
-                 (int)rec.path_byte_len);
-        if (score >= 0) {
-            return snprintf(buf, buf_size,
-                "{\"origin\":\"%s\",\"origin_id\":\"%s\",\"timestamp\":\"%s\",\"type\":\"PACKET\","
-                "\"direction\":\"%s\",\"time\":\"%s\",\"date\":\"%s\",\"len\":\"%d\",\"packet_type\":\"%u\","
-                "\"route\":\"D\",\"payload_len\":\"%u\",\"raw\":\"%s\",\"SNR\":\"%.1f\",\"RSSI\":\"%d\","
-                "\"score\":\"%d\",\"duration\":\"%d\",\"hash\":\"%s\",\"path\":\"%s\"}",
-                origin, device_id, ts, is_tx ? "tx" : "rx", time_only, date_only, raw_len,
-                rec.payload_type, rec.payload_len, raw_hex, snr, rssi, score, duration, hash_hex,
-                path_info);
-        }
+    // #727 sec4: slimmed body. Only the fields a consumer actually reads --
+    // origin (display name; observer identity is the topic segment), timestamp,
+    // type, direction, raw, SNR, RSSI, and score when present. Dropped:
+    // origin_id, time, date, len, packet_type, route, payload_len, duration,
+    // hash, path. route/path distinction is gone, so the four render branches
+    // collapse to score / no-score. KEEP THESE KEY NAMES EXACT -- CoreScope reads
+    // raw/timestamp/origin/SNR|snr/RSSI|rssi/score/direction verbatim.
+    if (rec.score >= 0) {
         return snprintf(buf, buf_size,
-            "{\"origin\":\"%s\",\"origin_id\":\"%s\",\"timestamp\":\"%s\",\"type\":\"PACKET\","
-            "\"direction\":\"%s\",\"time\":\"%s\",\"date\":\"%s\",\"len\":\"%d\",\"packet_type\":\"%u\","
-            "\"route\":\"D\",\"payload_len\":\"%u\",\"raw\":\"%s\",\"SNR\":\"%.1f\",\"RSSI\":\"%d\","
-            "\"hash\":\"%s\",\"path\":\"%s\"}",
-            origin, device_id, ts, is_tx ? "tx" : "rx", time_only, date_only, raw_len,
-            rec.payload_type, rec.payload_len, raw_hex, snr, rssi, hash_hex, path_info);
-    }
-
-    if (score >= 0) {
-        return snprintf(buf, buf_size,
-            "{\"origin\":\"%s\",\"origin_id\":\"%s\",\"timestamp\":\"%s\",\"type\":\"PACKET\","
-            "\"direction\":\"%s\",\"time\":\"%s\",\"date\":\"%s\",\"len\":\"%d\",\"packet_type\":\"%u\","
-            "\"route\":\"F\",\"payload_len\":\"%u\",\"raw\":\"%s\",\"SNR\":\"%.1f\",\"RSSI\":\"%d\","
-            "\"score\":\"%d\",\"duration\":\"%d\",\"hash\":\"%s\"}",
-            origin, device_id, ts, is_tx ? "tx" : "rx", time_only, date_only, raw_len,
-            rec.payload_type, rec.payload_len, raw_hex, snr, rssi, score, duration, hash_hex);
+            "{\"origin\":\"%s\",\"timestamp\":\"%s\",\"type\":\"PACKET\","
+            "\"direction\":\"%s\",\"raw\":\"%s\",\"SNR\":\"%.1f\",\"RSSI\":\"%d\","
+            "\"score\":\"%d\"}",
+            origin, ts, is_tx ? "tx" : "rx", raw_hex, rec.snr, (int)rec.rssi, (int)rec.score);
     }
     return snprintf(buf, buf_size,
-        "{\"origin\":\"%s\",\"origin_id\":\"%s\",\"timestamp\":\"%s\",\"type\":\"PACKET\","
-        "\"direction\":\"%s\",\"time\":\"%s\",\"date\":\"%s\",\"len\":\"%d\",\"packet_type\":\"%u\","
-        "\"route\":\"F\",\"payload_len\":\"%u\",\"raw\":\"%s\",\"SNR\":\"%.1f\",\"RSSI\":\"%d\","
-        "\"hash\":\"%s\"}",
-        origin, device_id, ts, is_tx ? "tx" : "rx", time_only, date_only, raw_len,
-        rec.payload_type, rec.payload_len, raw_hex, snr, rssi, hash_hex);
+        "{\"origin\":\"%s\",\"timestamp\":\"%s\",\"type\":\"PACKET\","
+        "\"direction\":\"%s\",\"raw\":\"%s\",\"SNR\":\"%.1f\",\"RSSI\":\"%d\"}",
+        origin, ts, is_tx ? "tx" : "rx", raw_hex, rec.snr, (int)rec.rssi);
 }
 
 int buildRawJson(char* buf, size_t buf_size,
@@ -359,9 +304,10 @@ int buildRawJson(char* buf, size_t buf_size,
 void fillPacketRecord(PacketRecord& rec, const mesh::Packet& /*packet*/,
                       int rssi, float snr, int score, int duration,
                       uint32_t rx_time) {
+    (void)duration;
     memset(&rec, 0, sizeof(rec));
     rec.rx_time = rx_time; rec.rssi = rssi; rec.snr = snr;
-    rec.score = score; rec.duration = duration;
+    rec.score = score;
 }
 
 int buildPacketJsonFromRecord(char* buf, size_t buf_size,

--- a/src/helpers/wifi_observer/MqttPayload.h
+++ b/src/helpers/wifi_observer/MqttPayload.h
@@ -102,30 +102,27 @@ int buildStatusJson(char* buf, size_t buf_size,
 // case the ring exists to serve. Capture at receive, carry it through.
 //
 // POD by design: it is memcpy'd into the ring as opaque bytes.
-// MeshCore's MAX_HASH_SIZE, restated rather than #included: this header only
-// forward-declares mesh::Packet on purpose, to stay light. A static_assert in
-// MqttPayload.cpp pins this to the real value, so the two cannot drift.
-static constexpr size_t kPacketHashSize = 8;
-
+//
+// #727 sec4: holds ONLY what a consumer reads off /packets. CoreScope (and every
+// fork of it -- CoreComms/EastMesh included, confirmed from public source)
+// decodes the raw hex itself and reads none of the parsed fields, so
+// packet_type / payload_len / route / path / hash / len / time / date /
+// duration / origin_id were computed on-device and thrown away. Dropping them
+// removes the on-device parse, shrinks the record, and kills a class of "we
+// compute it and no one reads it" bugs -- the packet hash being the poster child
+// (a SHA256 per packet, discarded).
 struct PacketRecord {
     uint32_t rx_time;                  // unix seconds, captured AT RECEIVE
     int32_t  rssi;
     float    snr;
-    int32_t  score;
-    int32_t  duration;
-    uint8_t  hash[kPacketHashSize];      // precomputed: the packet is not kept
-    uint8_t  payload_type;
-    uint8_t  payload_len;
-    uint8_t  route_direct;             // 1 = direct route, 0 = flood
-    uint8_t  path_hash_count;
-    uint8_t  path_hash_size;
-    uint8_t  path_byte_len;
+    int32_t  score;                    // <0 => omit the score field
     uint16_t raw_len;
     uint8_t  raw[256];
 };
 
 // Capture everything the /packets body needs from a live packet, so the packet
-// itself does not have to survive until publish time.
+// itself does not have to survive until publish time. (`duration` is accepted
+// for call-site compatibility but no longer stored -- no consumer reads it.)
 void fillPacketRecord(PacketRecord& rec, const mesh::Packet& packet,
                       int rssi, float snr, int score, int duration,
                       uint32_t rx_time);

--- a/src/helpers/wifi_observer/MqttRingLog.h
+++ b/src/helpers/wifi_observer/MqttRingLog.h
@@ -50,14 +50,22 @@
 //   #175  : 32 x  512 = 16,384 B   (and packets over ~98 B silently dropped)
 //   #726  : 20 x 1024 = 20,480 B
 //   #727  : 32 x  320 = 10,240 B   -- more depth than either, ~10 KB less memory
+// #727 sec4: 40 slots x 288 B = 11,520 B. The slim PacketRecord (276 B measured)
+// freed room to deepen the ring past #727's 32 while staying ~11 KB under the
+// pre-#701 baseline. Fleet data (map.okimesh.org) put the busiest real observer
+// at ~20 slots of sustained need; 40 is burst insurance. Owner-set depth.
 #ifndef MQTT_RING_SLOTS
-  #define MQTT_RING_SLOTS 32
+  #define MQTT_RING_SLOTS 40
 #endif
 // MUST stay >= sizeof(PacketRecord). A static_assert in MqttBrokerPool.cpp enforces
 // it -- #726 was exactly this invariant violated silently, so it is now a compile
 // error rather than a field report.
+// #727 sec4: slim PacketRecord (~276 B, was ~296). MSG_MAX drops to 288 -- the
+// static_assert in MqttBrokerPool.cpp verifies 288 >= sizeof(PacketRecord).
+// Slot COUNT held at 32 pending the owner's depth/memory call with measured
+// sizeof (per the #727 sequencing: shrink first, then size).
 #ifndef MQTT_RING_MSG_MAX
-  #define MQTT_RING_MSG_MAX 320
+  #define MQTT_RING_MSG_MAX 288
 #endif
 #ifndef MQTT_RING_MAX_READERS
   #define MQTT_RING_MAX_READERS 10

--- a/test/test_mqtt_ring/test_mqtt_ring.cpp
+++ b/test/test_mqtt_ring/test_mqtt_ring.cpp
@@ -214,9 +214,6 @@ TEST(MqttRingRecord, MaxSizePacketRoundTrips) {
     in.rssi         = -97;
     in.snr          = -7.5f;
     in.score        = 123;
-    in.duration     = 456;
-    in.payload_type = 4;
-    in.payload_len  = 237;
     in.raw_len      = 255;                       // worst-case MeshCore packet
     for (int i = 0; i < 255; i++) in.raw[i] = (uint8_t)i;
 


### PR DESCRIPTION
Closes #727 (§4). **Third in the stack** (base = task/727-ring-stores-record).

CoreScope — and every fork, CoreComms/EastMesh confirmed from public source — decodes `raw` itself and reads none of packet_type/payload_len/route/path/hash/len/time/date/duration/origin_id. Dropped from the emitted body and the record:

- `PacketRecord` 296 → **276 B measured**; on-device SHA256 + packet-parse **removed** (dead work, not hidden).
- Emitted body: origin, timestamp, type, direction, raw, SNR, RSSI, score — exact names CoreScope reads.
- Ring 40 × 288 = 11,520 B (owner-set depth; fleet data put the busiest real observer at ~20 slots sustained).
- **rx_time observability** (SAFELANE no-silent-failures): `[ring] backlog sN age=Ns (publishing receive-time)` fires when a rotated-out broker publishes a queued record — proves receive-time is carried.
- /raw untouched (documented map-integration data).

Evidence: `docs/architecture/2026-08-15-observer-mqtt-payload-assessment.md` §7b/§7c. Tests 16/16 ring + 9/9 rotation. Full-day net: 126,000 → 114,916 B, ceiling gone, 40-deep ring.