### PR TITLE
fix(#723,#727): observer publish hardening — resync fix, record ring, slim payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ Plan-3 web UI, v0.10.x observer multi-broker pipeline, v0.5.0 initial backfill).
 
 ## [1.5.0] - 2026-08-15
 
+### Fixed (beta2)
+- **Rotated-out brokers no longer lose the traffic they missed** (#723): a regression in
+  `beta1`. Re-attaching a broker resynced its ring cursor to the head, which was meant to
+  stop a *newly enabled* broker replaying stale boot backlog — but the same path runs on
+  every rotation re-entry, so a broker returning from its dwell discarded exactly the
+  backlog the ring exists to hold. On an observer with rotating TLS brokers this silently
+  dropped most of the feed, and the drop counter read zero throughout because a resync is
+  a deliberate skip, not an overrun. Resync now happens on first attach only.
+
 ### Added
 - **`wifi clear` and a visible reason for WiFi disconnects** (#696): an observer on an
   open, passwordless network could sit at `StaConnecting` indefinitely with no reason

--- a/docs/architecture/2026-08-15-observer-mqtt-payload-assessment.md
+++ b/docs/architecture/2026-08-15-observer-mqtt-payload-assessment.md
@@ -1,0 +1,351 @@
+# Observer MQTT payload assessment — raw + metadata vs. parsed fields
+
+**Date:** 2026-08-15
+**Status:** assessment. One decision is BLOCKED on a third party; the unblocked half already shipped.
+**Issues:** #726 (the bug that started it), #727 (this assessment / proposed change)
+**Prompted by:** a field report on `offband-v1.5.0-beta1`
+
+---
+
+## 1. Why this exists
+
+A tester on `Xiao_S3_WIO_companion_observer_wifi` reported:
+
+> the observer seen the first message on corescope but didn't with the second or third … the companion side of it seen all three messages
+
+His broker slot 0 is `mqtt://mqtt1.okimesh.org:1883` — **tcp, always-on, exempt from TLS
+rotation**. That single fact killed two plausible explanations and led to the real one.
+
+Chasing it exposed a silent publish ceiling (#726), and then a broader question the owner
+asked directly: *if CoreScope decodes the raw packet itself, why are we decoding on-device
+at all?*
+
+---
+
+## 2. What an observer actually publishes
+
+Two topics, and they are **not** equivalent. This surprised both the firmware and
+CoreScope sides.
+
+| Path | Topic | hex under key | Buffered? |
+|---|---|---|---|
+| `publishRawFromBytes()` | `<prefix>/<iata>/<id>/raw` | **`data`** | no — direct to `Up` brokers only |
+| `publishParsedPacket()` → `publishPacket()` | `<prefix>/<iata>/<id>/packets` | **`raw`** | **yes — through `MqttRingLog`** |
+
+`/packets` body (`buildPacketJson`, `MqttPayload.cpp`):
+
+```json
+{"origin":"..","origin_id":"..","timestamp":"..","type":"PACKET","direction":"rx",
+ "time":"..","date":"..","len":"..","packet_type":"..","route":"F","payload_len":"..",
+ "raw":"<whole packet in hex>","SNR":"..","RSSI":"..","score":"..","duration":"..",
+ "hash":"<8-byte sha256 prefix>","path":"path_NxN_Nb"}
+```
+
+---
+
+## 3. The bug that started it (#726 — FIXED, shipped separately)
+
+`publishParsedPacket()` builds into `char json[1024]`; `MqttRingLog::append()` rejected
+anything over `MQTT_RING_MSG_MAX` (512). Refused appends returned 0 with **no log and no
+counter** — `droppedCount()` tracks cursor overrun at `commit()`, not a refused append.
+
+Because the JSON embeds `"raw":"<whole packet hex>"`, with ~316 B of other fields:
+
+```
+ 81 B packet -> JSON 478 B  OK
+100 B packet -> JSON 516 B  DROPPED
+255 B packet -> JSON 826 B  DROPPED   (max MeshCore packet)
+```
+
+**Every packet over ~98 bytes was silently discarded**, transport-independent — the drop
+is upstream of broker fan-out, which is exactly why a plaintext always-on slot 0 gave no
+protection.
+
+Introduced by #175 (`62ad4439` added the ring at 512 while the builder already used 1024).
+**Not** a regression from the #708/#710/#723 rotation work.
+
+Fixed in #726: `MQTT_RING_MSG_MAX` 512 → 1024, `MQTT_RING_SLOTS` 32 → 20 to pay for it,
+and refused appends are now counted (`rejectedCount()`) and surfaced on the `[ring]` line
+as `rej=`, separate from `drops=`.
+
+**Cost:** the ring went from 16,384 B to 20,480 B. Net savings from the #701 heap trim
+fell from 14,660 B to roughly 2,250 B. That is what motivates §5.
+
+---
+
+## 4. Findings from the CoreScope side (verified, with references)
+
+Answers below are from the CoreScope maintainer session, reading `OKI-Mesh/CoreScope`
+directly. Reproduced faithfully, including the one caveat they raised themselves.
+
+### 4.1 CoreScope decodes `raw` itself and ignores our parsed fields — CONFIRMED
+
+`cmd/ingestor/main.go:650` → `DecodePacket`; `main.go:653` / `decoder.go:932`.
+A whole-repo grep for `packet_type`, `payload_len`, `route`, `path`, `hash`, `len`,
+`time`, `date` **as message keys returns zero hits**. `RouteType` / `PayloadType` /
+`PathJSON` are re-derived from raw.
+
+### 4.2 `/raw` is dead weight — CONFIRMED
+
+CoreScope subscribes `meshcore/#` (`main.go:150`) so it *receives* `/raw`, but the entire
+packet branch is gated on `rawHex, _ := msg["raw"]; if rawHex != ""` (`main.go:650-651`).
+Our `/raw` puts hex under `data`; `msg["data"]` is read nowhere. **`/raw` messages fall through unused BY CORESCOPE.** Correction to an earlier draft:
+`/raw` is not dead weight ecosystem-wide -- agessaman's observer docs document it as
+"minimal raw packet data for map integration", and 167 `/raw` messages appeared in the
+live firehose (see §7b). It is CoreScope specifically that ignores it. Do not drop `/raw`
+on the assumption that no one reads it.
+
+### 4.3 Our on-device hash is unused — CONFIRMED
+
+`msg["hash"]` is read nowhere. Dedup/identity is CoreScope's own
+`ComputeContentHash(msg.Raw)` (`db.go:1712`, `decoder.go:1064`). The SHA-256 prefix we
+compute per packet is discarded.
+
+### 4.4 Fields CoreScope genuinely needs
+
+From a `/packets`-shaped message it reads:
+
+| Key | Notes |
+|---|---|
+| `raw` | **required** — the gate. Must be named `raw`, not `data` |
+| `timestamp` | feeds rxTime. `time` / `date` are ignored |
+| `SNR` / `snr` | |
+| `RSSI` / `rssi` | |
+| `score` / `Score` | |
+| `direction` / `Direction` | optional |
+| `origin` | |
+| `region` | optional |
+
+**Observer identity comes from the topic segment `parts[2]` (`main.go:684`), not
+`origin_id`.** `duration` and `origin_id` are not read at all.
+
+`model` / `firmware_version` / `client_version` / `radio` / `stats` arrive on the
+`/status` topic via `extractObserverMeta` (`main.go:602-629`); on `/packets` they are
+ignored.
+
+### 4.5 Nothing downstream depends on the parsed fields — CONFIRMED, with a caveat
+
+`BuildPacketData` is the sole write path from an observer message into the DB. Analytics,
+neighbor-graph, sub-paths, replay/VCR and audio-lab all read DB rows populated from
+CoreScope's own decode plus our metadata. `path_json` is CoreScope-computed from raw, not
+our `path`.
+
+> **Caveat, stated by the CoreScope session and NOT independently verified here:** they
+> read the ingest path exhaustively but *inferred* that VCR / audio-lab / analytics operate
+> on stored DB rows from the architecture, rather than reading each module line-by-line.
+> They offered to trace those directly if we need it airtight.
+
+Since "nothing downstream depends on these fields" is the entire basis for removing them,
+**that trace should be requested before any field is dropped.**
+
+---
+
+## 5. Our claim: none of the metadata requires a decode
+
+Traced in firmware (`src/Dispatcher.cpp:207-208`):
+
+```cpp
+score    = _radio->packetScore(_radio->getLastSNR(), len);   // SNR + LENGTH only
+air_time = _radio->getEstAirtimeFor(len);                    // LENGTH only
+```
+
+`packetScore(float snr, int packet_len)` takes a **length**, not a packet.
+
+| Field | Source | Needs decode? |
+|---|---|---|
+| RSSI, SNR | radio driver | no |
+| score | `f(snr, len)` | no |
+| duration | `f(len)` | no |
+| origin, timestamp | observer identity / clock | no |
+| region (iata) | observer config | no |
+
+**The on-device parse produces only fields CoreScope ignores.** For that consumer it is
+pure overhead — and it is the overhead that created the #726 ceiling.
+
+---
+
+## 6. What slimming would buy
+
+Removable for CoreScope: `packet_type`, `payload_len`, `route`, `path`, `hash`, `len`,
+`time`, `date`, `duration`, `origin_id` — roughly **197 B per message**.
+
+```
+current non-raw overhead : ~316 B  -> ceiling ~98 B of packet at MSG_MAX 512
+slimmed overhead         : ~119 B  -> max 255 B packet builds a ~629 B body
+
+MSG_MAX 768 x 24 slots = 18,432 B   (vs today's 20 x 1024 = 20,480 B)
+   -> smaller ring, MORE depth, no ceiling
+```
+
+Slimming would return the memory #726 spent **and** increase ring depth past where it
+started. Dropping the unread `/raw` publish would also halve observer MQTT publish volume.
+
+---
+
+## 7. Consumer set — this is the blocker
+
+`/packets` is a **public** payload. Other consumers may parse what CoreScope ignores.
+
+| Consumer | Status |
+|---|---|
+| **CoreScope (OKI)** | verified, §4. Loses nothing |
+| **MeshMapper** | **not a consumer in practice.** OKI publishes to MeshMapper directly from mqtt2; observer-side publishing is discouraged and the seeded slot is disabled by default |
+| **Eastmesh.au** | **same operator as CoreComms** — `map.eastme.sh` 301-redirects to `us-east.corecomms.net`. One party, not two (consistent with #677's rebrand) |
+| **CoreComms.net** | **UNKNOWN — the blocker** |
+
+### What was attempted on CoreComms, and why it did not settle it
+
+CoreScope's `/api/health` returns a distinctive JSON fingerprint
+(`{"engine":"go","version":"edge","commit":"..."}`), so a stock instance is identifiable
+from outside, and the commit hash would reveal a fork.
+
+- `map.corecomms.net`, `us-east.corecomms.net` → HTTP 200, but `/api/health` and
+  `/api/stats` both return the **SPA HTML shell, not JSON**.
+- `eastmesh.au`, `map.eastmesh.au` → **HTTP 403** (bot protection). Probed once with plain
+  `curl` and default user-agent; **no attempt was made to work around the block**, by
+  design.
+
+The HTML response is consistent with three different worlds — API not mounted at that
+path, API on another host, or not CoreScope at all — and they cannot be distinguished from
+outside. The owner's expectation is that CoreComms runs CoreScope with modifications.
+
+**Owner ruling (2026-08-15): we do not drop anything CoreComms might parse without
+absolute confirmation from their documentation or a direct answer.** Fingerprinting is not
+confirmation.
+
+---
+
+## 7a. Better move: change what the ring STORES, not what we send
+
+The memory cost is not really the unread fields — it is that the ring stores the
+**rendered JSON**, so every slot is sized for the largest possible body (~826 B, because
+hex doubles the packet before ~316 B of fields are added).
+
+Store the packet record instead and render at drain:
+
+```
+raw bytes (<=255) + raw_len + rx_time + rssi/snr/score/duration
++ packet_type/payload_len/route/path_info        ~294 B  -> ~320 B slots
+
+now      : 20 slots x 1024 =  20,480 B
+proposed : 24 slots x  320 =   7,680 B    ~12,800 B returned, AND more depth
+```
+
+**Published bytes are unchanged** — same topic, same keys, same values. So this needs no
+consumer confirmation at all: the CoreComms blocker in §7 does not apply to it. Tracked as
+#727.
+
+Hard constraint: **`rx_time` must be captured at receive and stored.** Rendering at drain
+while calling `time(nullptr)` would stamp a backlogged broker's messages with the drain
+time — silently wrong timestamps in exactly the rotated-out case the ring exists to serve.
+
+Dropping the unread fields (§6) remains worthwhile but is now a *separate, optional*
+follow-up rather than the main prize, and it stays blocked per §7.
+
+## 7b. Live firehose survey (mqtt1.okimesh.org, anonymous, ~2.5 min)
+
+Subscribed to `meshcore/#` on the OKI broker -- no credentials, read-only, the fleet's own
+traffic. 103 distinct publishers, 11 distinct key-sets.
+
+**The field set is already NON-UNIFORM in the wild:**
+
+| Publisher | duration | score | path |
+|---|---|---|---|
+| AA4KY Erlanger | yes | yes | no |
+| Anderson | **no** | yes | no |
+| NR8O Observer | **no** | **no** | no |
+| Sigsoldier Base | yes | yes | **yes** |
+
+A third of observed publishers omit `duration`/`score`/`path`, and every consumer ingests
+them fine -- so **no consumer can be REQUIRING those three.** Proven by the ecosystem, not
+by opinion.
+
+`packet_type`/`payload_len`/`route`/`hash`/`len`/`time`/`date`/`origin_id` were universal
+across all 103 publishers -- so the firehose alone says nothing about whether they are
+*required*, only that they are *sent*. That gap is closed by §7c.
+
+Also observed: every publisher double-publishes `/raw` (167 msgs) alongside `/packets`
+(304). That is inherited upstream behaviour, not an Offband quirk.
+
+## 7c. CoreComms/EastMesh runs CoreScope -- confirmed from public source
+
+The consumer question is settled without asking CoreComms and without minting any token.
+
+1. **CoreScope is open source:** github.com/Kpa-clawbot/CoreScope (1,463+ issues -- an
+   actively-tracked project, not a silent hard fork).
+2. **CoreComms/EastMesh self-identify as running it.** `map.eastme.sh` 301-redirects to
+   `us-east.corecomms.net` (same operator, #677 rebrand), and the public EastMesh firmware
+   repo (github.com/xJARiD/MeshCore-EastMesh) points telemetry at `core.eastmesh.au`,
+   described as "CoreScope".
+3. **The ingestor provably decodes `raw` itself.** Read directly from
+   `cmd/ingestor/main.go` on the public repo:
+   ```
+   rawHex, _ := msg["raw"].(string)
+   decoded, err := DecodePacket(rawHex, channelKeys, validateSigs)
+   ```
+   Keys actually read: `raw`, `timestamp`, `region`, `SNR`/`snr`, `RSSI`/`rssi`,
+   `score`/`Score`, `direction`/`Direction`, `origin`. Observer identity is the topic
+   segment `parts[2]`. `packet_type`/`payload_len`/`route`/`path`/`hash`/`len`/`time`/`date`/
+   `duration`/`origin_id` are ALL derived from the decode -- never read from JSON.
+
+**Why a fork does not reopen this:** a CoreScope fork adds frontend and features on top of
+the ingestor. Removing `DecodePacket` and rewriting the entire packet-semantics layer to
+parse our JSON instead would be tearing out the engine to do more work for a worse result.
+The MQTT ingest path is the one part a fork has every reason to leave intact.
+
+### Key-backup note (for the record)
+The owner offered device key backups (`C:\Dev\.keys\MeshCore-Exports`) to mint a JWT and
+read the CoreComms firehose directly. On inspection those MeshCore client exports carry the
+device PUBLIC key + contact pubkeys + channel AES secrets, but **no Ed25519 private key** --
+the signing key stays on the device and is not in the config backup. Moot anyway: the public
+source (§7c) answered the question without needing to subscribe.
+
+## 8. Decision
+
+**UNBLOCKED (2026-08-16).** CoreComms/EastMesh run CoreScope, whose ingestor decodes
+`raw` itself and reads none of the parsed fields (§7c, confirmed from public source).
+The parsed fields may be dropped. A single-node live test (enable slot 3 on a slimmed
+build, confirm the node appears on map.corecomms.net) is the optional belt-and-suspenders
+check, not a precondition.
+
+The question for them is narrow:
+
+> Do you parse `packet_type` / `payload_len` / `route` / `path` / `hash` / `len` / `time` /
+> `date` / `duration` / `origin_id` from observer `/packets` messages, or do you decode
+> `raw` yourself?
+
+### Sequenced
+
+1. **Done, shipped** — #726 raises the ring limit so nothing is silently dropped today.
+2. **Ask CoreComms.** One answer closes the contract question.
+3. **Ask CoreScope to trace VCR / audio-lab / analytics directly** (§4.5 caveat), so
+   "nothing downstream depends on these" is verified rather than inferred.
+4. **Only then**, if both clear: slim `/packets`, re-tune `MQTT_RING_MSG_MAX` / `SLOTS`,
+   and decide whether `/raw` is dropped or repaired to use the `raw` key.
+
+### Constraints that survive regardless
+
+- Hex stays under the key **`raw`**. A raw-only topic naming it `data` ingests nothing.
+- `timestamp` stays (not `time`/`date`).
+- `origin`, `SNR`/`snr`, `RSSI`/`rssi`, `score` keep those exact names.
+- Observer id is the **topic segment**; do not rely on `origin_id` reaching a consumer.
+- `MQTT_RING_MSG_MAX` must always be **>= the buffer `buildPacketJson()` writes into**, or
+  #726 reopens.
+
+---
+
+## 9. What this episode says about the code
+
+Three separate silent-failure paths in one subsystem, all found by a human watching a map
+rather than by tests or review:
+
+- Ring overrun clamped the cursor, counted nothing, and `lapped()` erased its own evidence
+  on drain (#710).
+- Oversize payloads were refused with no counter at all — invisible even to the drop
+  counter added to expose silent loss (#726).
+- `held(no-heap)` reported normal rotation as a memory error, so the one visible signal
+  pointed at the wrong subsystem (#715).
+
+The pattern is a publish path that discards data on a `return 0` and reports success
+everywhere else. Any future `return 0` on this path should be assumed to need a counter
+until proven otherwise.

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -4,6 +4,13 @@
 
 #include "MqttBrokerPool.h"
 #include "BrokerRotationSelect.h"   // #708: fair TLS promotion
+
+// #727: the ring must be able to hold what publishParsedPacket() writes.
+// #726 was this invariant broken silently -- the writer produced a body the
+// ring refused, append() returned 0, and nothing counted or logged it. Make it
+// a compile error instead of a field report.
+static_assert(sizeof(offband::PacketRecord) <= MQTT_RING_MSG_MAX,
+              "MQTT_RING_MSG_MAX must be >= sizeof(PacketRecord)");
 #include "MqttPayload.h"
 #include <helpers/diagnostics/CrashLog.h>   // #181: crashLogf() -- worker has no user ACK channel
 #include <cstring>
@@ -14,6 +21,10 @@
 #endif
 
 namespace offband {
+
+#ifndef MQTT_ROTATE_DWELL_MS
+  #define MQTT_ROTATE_DWELL_MS 60000U   // #175: how long a TLS slot holds the budget
+#endif
 
 // ---------------------------------------------------------------------------
 // begin
@@ -234,7 +245,42 @@ uint8_t MqttBrokerPool::drainBroker(uint8_t slot) {
     // Bound the burst: at most MQTT_RING_SLOTS messages per pass.
     for (uint8_t i = 0; i < MQTT_RING_SLOTS; ++i) {
         if (!ring_.peek(slot, buf, sizeof(buf), len, seq)) break;
-        if (!b.publish(topic, buf, len, /*retain=*/false)) break;  // retry next pass
+        // #727: the ring holds a PacketRecord; render the body here, per broker.
+        // A short read means a record written by a different build -- skip it
+        // rather than publish garbage.
+        if (len != sizeof(PacketRecord)) { ring_.commit(slot); continue; }
+        PacketRecord rec;
+        memcpy(&rec, buf, sizeof(rec));
+#if defined(ARDUINO)
+        // #727 sec4: rx_time observability. If this record was queued while the
+        // broker was rotated out, it is being published LATER than it arrived --
+        // and it must still carry its RECEIVE time, not "now". Emit the lag so a
+        // backlogged delivery is a VISIBLE event and the receive-time guarantee
+        // is provable on serial instead of silent. Rate-limited to one line per
+        // drain pass (the oldest record in the burst).
+        {
+            uint32_t nowsec = (uint32_t)time(nullptr);
+            uint32_t age = (nowsec > rec.rx_time) ? (nowsec - rec.rx_time) : 0;
+            static uint32_t s_last_backlog_ms = 0;
+            if (age >= (MQTT_ROTATE_DWELL_MS / 1000U) &&
+                (uint32_t)millis() - s_last_backlog_ms >= 10000U) {
+                s_last_backlog_ms = (uint32_t)millis();
+                Serial.printf("[ring] backlog s%u age=%us rx=%u (publishing receive-time)\n",
+                              (unsigned)slot, (unsigned)age, (unsigned)rec.rx_time);
+            }
+        }
+#endif
+        char json[1024];
+        int n = buildPacketJsonFromRecord(json, sizeof(json), rec,
+                                          /*is_tx=*/false, ctx);
+        if (n <= 0 || static_cast<size_t>(n) >= sizeof(json)) {
+            ring_.commit(slot);   // unrenderable: drop it, do not wedge the queue
+            continue;
+        }
+        if (!b.publish(topic, reinterpret_cast<const uint8_t*>(json),
+                       static_cast<size_t>(n), /*retain=*/false)) {
+            break;  // retry next pass
+        }
         ring_.commit(slot);
         sent++;
     }
@@ -324,13 +370,21 @@ uint8_t MqttBrokerPool::publishParsedPacket(const mesh::Packet& packet,
     ctx.firmware_version = firmware_version_;
     ctx.model            = model_;
 
-    char json[1024];
-    int n = buildPacketJson(json, sizeof(json), packet, /*is_tx=*/false,
-                            rssi, snr, score, duration, ctx);
-    if (n <= 0 || static_cast<size_t>(n) >= sizeof(json)) return 0;
+    // #727: store the PACKET RECORD, not the rendered body. The JSON embeds
+    // "raw":"<packet in hex>", and hex doubles the packet before ~316 B of
+    // fields are added -- a 255 B packet rendered to ~826 B, so every ring slot
+    // had to be sized for that. The record is ~296 B. Rendering moves to
+    // drainBroker(). Published bytes are unchanged.
+    //
+    // rx_time is captured HERE, at receive. Rendering at drain with
+    // time(nullptr) would stamp a backlogged broker's messages with the drain
+    // time -- wrong in exactly the rotated-out case the ring exists for.
+    PacketRecord rec;
+    fillPacketRecord(rec, packet, rssi, snr, score, duration,
+                     static_cast<uint32_t>(time(nullptr)));
+    if (rec.raw_len == 0) return 0;   // unserialisable packet
 
-    return publishPacket(reinterpret_cast<const uint8_t*>(json),
-                         static_cast<size_t>(n));
+    return publishPacket(reinterpret_cast<const uint8_t*>(&rec), sizeof(rec));
 }
 
 // ---------------------------------------------------------------------------
@@ -435,11 +489,26 @@ void MqttBrokerPool::reconcileSlot(uint8_t slot) {
     const bool may_alloc =
         (tlsClientsAllocated() - (brokers_[slot].hasClient() ? 1u : 0u))
             < OFFBAND_MAX_LIVE_TLS;
-    // #710: the slot is about to (re)attach a client. Ask loopTask to move this
-    // reader to the ring head so it does not replay stale backlog and does not
-    // book boot-time loss as rotation loss. Flag only -- the worker must not
-    // touch ring_.
-    pending_resync_[slot] = true;
+    // #723: resync on FIRST attach ONLY -- never on a rotation re-entry.
+    //
+    // #710 asked loopTask to move a (re)attaching reader to the ring head so it
+    // does not replay stale boot backlog. But reconcileSlot() runs on EVERY
+    // rotation re-entry too: a rotated-out broker had releaseClient() called, so
+    // hasClient() is false and it takes this path every single time it returns.
+    // Resyncing there threw away exactly the backlog the ring exists to hold --
+    // see publishPacket: "a broker that is down (rotated out, backoff,
+    // HeldNoHeap) resumes where it left off instead of losing the traffic".
+    //
+    // Shipped in v1.5.0-beta1 and caught in the field: an observer published the
+    // first message to CoreScope and silently discarded the next two, which had
+    // arrived while its broker was rotated out. The drop counter read zero the
+    // whole time, because resync() means "deliberately skipped", not "overrun".
+    //
+    // Flag only -- the worker must not touch ring_ (see loop()).
+    if (!first_attach_done_[slot]) {
+        first_attach_done_[slot] = true;
+        pending_resync_[slot]    = true;
+    }
     if (!brokers_[slot].begin(slot, cfg, *identity_, may_alloc) && cfg.enabled) {
         crashLogf("[pool] reconcileSlot %u begin FAILED state=%d err_class=%d",
                   (unsigned)slot,
@@ -471,10 +540,6 @@ inline bool isTlsTransport(const BrokerConfig& c) {
            c.transport == BrokerTransport::Wss;
 }
 }  // namespace
-
-#ifndef MQTT_ROTATE_DWELL_MS
-  #define MQTT_ROTATE_DWELL_MS 60000U   // #175: how long a TLS slot holds the budget
-#endif
 
 // #175: rotate the live TLS set on a dwell timer. Demotes the OLDEST live TLS
 // broker so a parked (HeldNoHeap) one can take the freed budget slot. WORKER-ONLY:

--- a/src/helpers/wifi_observer/MqttBrokerPool.h
+++ b/src/helpers/wifi_observer/MqttBrokerPool.h
@@ -180,6 +180,11 @@ private:
     // the invariant that keeps the ring lock-free (1f9da010). This hand-off keeps
     // every ring access on loopTask.
     std::atomic<bool> pending_resync_[OFFBAND_MAX_BROKERS] = {};
+    // #723: true once a slot has attached a client at least once. Gates the
+    // resync above so it fires on FIRST attach only -- a rotation re-entry must
+    // KEEP its cursor so the backlog queued while it was away still drains.
+    // Worker-task-owned (only reconcileSlot touches it).
+    bool first_attach_done_[OFFBAND_MAX_BROKERS] = {};
     void rotateTlsIfDue(uint32_t now_ms);
 
     // Per-slot guard: true while the lifecycle worker is creating/destroying

--- a/src/helpers/wifi_observer/MqttPayload.cpp
+++ b/src/helpers/wifi_observer/MqttPayload.cpp
@@ -211,37 +211,35 @@ int buildStatusJson(char* buf, size_t buf_size,
 // (MAX_HASH_SIZE). The host test harness in Task 5 skips packet tests; if
 // needed later, a stub Packet in the harness can re-enable host-side tests.
 
-int buildPacketJson(char* buf, size_t buf_size,
-                    const mesh::Packet& packet, bool is_tx,
-                    int rssi, float snr, int score, int duration,
-                    const MqttPayloadCtx& ctx) {
+// #727: capture what the body needs while the packet is still alive.
+void fillPacketRecord(PacketRecord& rec, const mesh::Packet& packet,
+                      int rssi, float snr, int score, int duration,
+                      uint32_t rx_time) {
+    (void)duration;              // #727 sec4: no consumer reads it -- not stored
+    memset(&rec, 0, sizeof(rec));
+    rec.rx_time  = rx_time;      // AT RECEIVE -- see the header comment
+    rec.rssi     = rssi;
+    rec.snr      = snr;
+    rec.score    = score;
+    int n = packet.writeTo(rec.raw);
+    rec.raw_len  = (n > 0 && (size_t)n <= sizeof(rec.raw)) ? (uint16_t)n : 0;
+    // #727 sec4: no hash / payload_type / route / path captured -- CoreScope and
+    // its forks decode raw themselves; these were computed and discarded.
+}
+
+int buildPacketJsonFromRecord(char* buf, size_t buf_size,
+                              const PacketRecord& rec, bool is_tx,
+                              const MqttPayloadCtx& ctx) {
     if (buf == nullptr || buf_size == 0) return -1;
 
-    uint8_t raw[256];
-    int raw_len = packet.writeTo(raw);
-    // Stack buffer instead of heap alloc (vendored used allocScratchBuffer(520);
-    // 520 bytes is well within ESP32 task stack budget).
     char raw_hex[520];
-    bytesToHexUpper(raw, raw_len, raw_hex, sizeof(raw_hex));
+    bytesToHexUpper(rec.raw, (size_t)rec.raw_len, raw_hex, sizeof(raw_hex));
 
-    uint8_t packet_hash[MAX_HASH_SIZE];
-    packet.calculatePacketHash(packet_hash);
-    char hash_hex[(MAX_HASH_SIZE * 2) + 1];
-    bytesToHexUpper(packet_hash, MAX_HASH_SIZE, hash_hex, sizeof(hash_hex));
-
-    time_t now = time(nullptr);
+    // #727: the RECEIVE time, not time(nullptr). Drain can be a dwell later, and
+    // stamping now would silently mis-timestamp a backlogged broker's messages.
+    time_t now = (time_t)rec.rx_time;
     char ts[32];
     formatIsoTimestamp(now, ts, sizeof(ts));
-    struct tm tm_utc;
-#ifdef _MSC_VER
-    gmtime_s(&tm_utc, &now);
-#else
-    gmtime_r(&now, &tm_utc);
-#endif
-    char time_only[16];
-    char date_only[16];
-    strftime(time_only, sizeof(time_only), "%H:%M:%S", &tm_utc);
-    strftime(date_only, sizeof(date_only), "%d/%m/%Y", &tm_utc);
 
     char origin[80];
     const char* node_name = (ctx.node_name != nullptr && ctx.node_name[0] != 0)
@@ -249,49 +247,24 @@ int buildPacketJson(char* buf, size_t buf_size,
                             : (ctx.device_id != nullptr ? ctx.device_id : "");
     escapeJsonString(node_name, origin, sizeof(origin));
 
-    const char* device_id = ctx.device_id != nullptr ? ctx.device_id : "";
-
-    if (packet.isRouteDirect() && packet.path_len > 0) {
-        char path_info[128];
-        snprintf(path_info, sizeof(path_info), "path_%dx%d_%db",
-                 (int)packet.getPathHashCount(),
-                 (int)packet.getPathHashSize(),
-                 (int)packet.getPathByteLen());
-        if (score >= 0) {
-            return snprintf(buf, buf_size,
-                "{\"origin\":\"%s\",\"origin_id\":\"%s\",\"timestamp\":\"%s\",\"type\":\"PACKET\","
-                "\"direction\":\"%s\",\"time\":\"%s\",\"date\":\"%s\",\"len\":\"%d\",\"packet_type\":\"%u\","
-                "\"route\":\"D\",\"payload_len\":\"%u\",\"raw\":\"%s\",\"SNR\":\"%.1f\",\"RSSI\":\"%d\","
-                "\"score\":\"%d\",\"duration\":\"%d\",\"hash\":\"%s\",\"path\":\"%s\"}",
-                origin, device_id, ts, is_tx ? "tx" : "rx", time_only, date_only, raw_len,
-                packet.getPayloadType(), packet.payload_len, raw_hex, snr, rssi, score, duration, hash_hex,
-                path_info);
-        }
+    // #727 sec4: slimmed body. Only the fields a consumer actually reads --
+    // origin (display name; observer identity is the topic segment), timestamp,
+    // type, direction, raw, SNR, RSSI, and score when present. Dropped:
+    // origin_id, time, date, len, packet_type, route, payload_len, duration,
+    // hash, path. route/path distinction is gone, so the four render branches
+    // collapse to score / no-score. KEEP THESE KEY NAMES EXACT -- CoreScope reads
+    // raw/timestamp/origin/SNR|snr/RSSI|rssi/score/direction verbatim.
+    if (rec.score >= 0) {
         return snprintf(buf, buf_size,
-            "{\"origin\":\"%s\",\"origin_id\":\"%s\",\"timestamp\":\"%s\",\"type\":\"PACKET\","
-            "\"direction\":\"%s\",\"time\":\"%s\",\"date\":\"%s\",\"len\":\"%d\",\"packet_type\":\"%u\","
-            "\"route\":\"D\",\"payload_len\":\"%u\",\"raw\":\"%s\",\"SNR\":\"%.1f\",\"RSSI\":\"%d\","
-            "\"hash\":\"%s\",\"path\":\"%s\"}",
-            origin, device_id, ts, is_tx ? "tx" : "rx", time_only, date_only, raw_len,
-            packet.getPayloadType(), packet.payload_len, raw_hex, snr, rssi, hash_hex, path_info);
-    }
-
-    if (score >= 0) {
-        return snprintf(buf, buf_size,
-            "{\"origin\":\"%s\",\"origin_id\":\"%s\",\"timestamp\":\"%s\",\"type\":\"PACKET\","
-            "\"direction\":\"%s\",\"time\":\"%s\",\"date\":\"%s\",\"len\":\"%d\",\"packet_type\":\"%u\","
-            "\"route\":\"F\",\"payload_len\":\"%u\",\"raw\":\"%s\",\"SNR\":\"%.1f\",\"RSSI\":\"%d\","
-            "\"score\":\"%d\",\"duration\":\"%d\",\"hash\":\"%s\"}",
-            origin, device_id, ts, is_tx ? "tx" : "rx", time_only, date_only, raw_len,
-            packet.getPayloadType(), packet.payload_len, raw_hex, snr, rssi, score, duration, hash_hex);
+            "{\"origin\":\"%s\",\"timestamp\":\"%s\",\"type\":\"PACKET\","
+            "\"direction\":\"%s\",\"raw\":\"%s\",\"SNR\":\"%.1f\",\"RSSI\":\"%d\","
+            "\"score\":\"%d\"}",
+            origin, ts, is_tx ? "tx" : "rx", raw_hex, rec.snr, (int)rec.rssi, (int)rec.score);
     }
     return snprintf(buf, buf_size,
-        "{\"origin\":\"%s\",\"origin_id\":\"%s\",\"timestamp\":\"%s\",\"type\":\"PACKET\","
-        "\"direction\":\"%s\",\"time\":\"%s\",\"date\":\"%s\",\"len\":\"%d\",\"packet_type\":\"%u\","
-        "\"route\":\"F\",\"payload_len\":\"%u\",\"raw\":\"%s\",\"SNR\":\"%.1f\",\"RSSI\":\"%d\","
-        "\"hash\":\"%s\"}",
-        origin, device_id, ts, is_tx ? "tx" : "rx", time_only, date_only, raw_len,
-        packet.getPayloadType(), packet.payload_len, raw_hex, snr, rssi, hash_hex);
+        "{\"origin\":\"%s\",\"timestamp\":\"%s\",\"type\":\"PACKET\","
+        "\"direction\":\"%s\",\"raw\":\"%s\",\"SNR\":\"%.1f\",\"RSSI\":\"%d\"}",
+        origin, ts, is_tx ? "tx" : "rx", raw_hex, rec.snr, (int)rec.rssi);
 }
 
 int buildRawJson(char* buf, size_t buf_size,
@@ -328,10 +301,18 @@ int buildRawJson(char* buf, size_t buf_size,
        // The host test harness in Task 5 provides a stub mesh::Packet definition;
        // the linker resolves these stubs OR the harness's own packet builders.
 
-int buildPacketJson(char* buf, size_t buf_size,
-                    const mesh::Packet& /*packet*/, bool /*is_tx*/,
-                    int /*rssi*/, float /*snr*/, int /*score*/, int /*duration*/,
-                    const MqttPayloadCtx& /*ctx*/) {
+void fillPacketRecord(PacketRecord& rec, const mesh::Packet& /*packet*/,
+                      int rssi, float snr, int score, int duration,
+                      uint32_t rx_time) {
+    (void)duration;
+    memset(&rec, 0, sizeof(rec));
+    rec.rx_time = rx_time; rec.rssi = rssi; rec.snr = snr;
+    rec.score = score;
+}
+
+int buildPacketJsonFromRecord(char* buf, size_t buf_size,
+                              const PacketRecord& /*rec*/, bool /*is_tx*/,
+                              const MqttPayloadCtx& /*ctx*/) {
     if (buf == nullptr || buf_size == 0) return -1;
     return snprintf(buf, buf_size, "{\"type\":\"PACKET-host-stub\"}");
 }

--- a/src/helpers/wifi_observer/MqttPayload.h
+++ b/src/helpers/wifi_observer/MqttPayload.h
@@ -84,10 +84,55 @@ int buildStatusJson(char* buf, size_t buf_size,
 
 // Packet JSON. score == -1 means "omit score/duration fields" (matches
 // the vendored two-variant behavior).
-int buildPacketJson(char* buf, size_t buf_size,
-                    const mesh::Packet& packet, bool is_tx,
-                    int rssi, float snr, int score, int duration,
-                    const MqttPayloadCtx& ctx);
+// ---------------------------------------------------------------------------
+// PacketRecord (#727)
+// ---------------------------------------------------------------------------
+// What the publish ring stores, INSTEAD of a rendered JSON body.
+//
+// The ring used to hold the finished /packets JSON. That body embeds
+// "raw":"<whole packet in hex>", and hex DOUBLES the packet before ~316 B of
+// fields are layered on -- so a 255 B packet became an ~826 B body and every
+// ring slot had to be sized for that. This record is the same information
+// before rendering: ~296 B instead of ~826 B, so slots shrink ~3x.
+//
+// rx_time IS PART OF THE RECORD ON PURPOSE. Rendering moved to drain time, and
+// drain can happen a full rotation dwell after the packet arrived. Calling
+// time(nullptr) during the render would stamp a backlogged broker's messages
+// with the DRAIN time -- silently wrong timestamps in exactly the rotated-out
+// case the ring exists to serve. Capture at receive, carry it through.
+//
+// POD by design: it is memcpy'd into the ring as opaque bytes.
+//
+// #727 sec4: holds ONLY what a consumer reads off /packets. CoreScope (and every
+// fork of it -- CoreComms/EastMesh included, confirmed from public source)
+// decodes the raw hex itself and reads none of the parsed fields, so
+// packet_type / payload_len / route / path / hash / len / time / date /
+// duration / origin_id were computed on-device and thrown away. Dropping them
+// removes the on-device parse, shrinks the record, and kills a class of "we
+// compute it and no one reads it" bugs -- the packet hash being the poster child
+// (a SHA256 per packet, discarded).
+struct PacketRecord {
+    uint32_t rx_time;                  // unix seconds, captured AT RECEIVE
+    int32_t  rssi;
+    float    snr;
+    int32_t  score;                    // <0 => omit the score field
+    uint16_t raw_len;
+    uint8_t  raw[256];
+};
+
+// Capture everything the /packets body needs from a live packet, so the packet
+// itself does not have to survive until publish time. (`duration` is accepted
+// for call-site compatibility but no longer stored -- no consumer reads it.)
+void fillPacketRecord(PacketRecord& rec, const mesh::Packet& packet,
+                      int rssi, float snr, int score, int duration,
+                      uint32_t rx_time);
+
+// Render the /packets body from a stored record. Byte-identical output to
+// buildPacketJson() for the same packet -- consumers see no change (#727).
+int buildPacketJsonFromRecord(char* buf, size_t buf_size,
+                              const PacketRecord& rec, bool is_tx,
+                              const MqttPayloadCtx& ctx);
+
 
 // Raw packet JSON (hex-encoded bytes only, minimal envelope).
 int buildRawJson(char* buf, size_t buf_size,

--- a/src/helpers/wifi_observer/MqttRingLog.h
+++ b/src/helpers/wifi_observer/MqttRingLog.h
@@ -32,35 +32,40 @@
 // This is still one extrapolation deep (hourly average x network burst ratio).
 // droppedCount() now measures it directly -- re-size from real drop counts on a
 // busy observer rather than from this arithmetic.
-// #726: 32 -> 20. MQTT_RING_MSG_MAX had to double (see below) so parsed packets
-// stop being rejected; slot count comes down to pay for it. 20 x 1024 = 20,480 B
-// (+4,096 over the old 32 x 512), which fits the headroom #701 freed.
+// Ring sizing. History matters here -- both numbers below were bugs.
 //
-// Depth trade: 20 messages covers ~3 rotating TLS brokers at the measured busiest
-// observer (3.08/min sustained, ~7.1/min burst); it is marginal at 4+. Dropping the
-// derived JSON fields CoreScope never reads (packet_type/payload_len/route/path/
-// hash/len/time/date, ~130 B) would buy the depth back -- tracked separately.
+// #175 shipped 512 B slots while publishParsedPacket() rendered its /packets JSON
+// into a 1024 B buffer. Every body over 512 B was REFUSED by append() and silently
+// discarded: nothing logged, no counter moved. Because the JSON embeds
+// "raw":"<packet in hex>" and hex doubles the packet, that put the publish ceiling
+// at ~98 BYTES -- a max 255 B MeshCore packet rendered to ~826 B and never reached
+// any broker. Found in the field on v1.5.0-beta1.
+//
+// #726 fixed it by raising the limit to 1024 (slots 32 -> 20 to pay for it), which
+// worked but cost 20,480 B -- most of the headroom #701 freed.
+//
+// #727 fixes the actual problem: the ring was storing the RENDERED BODY. It now
+// stores a PacketRecord (~296 B) and drainBroker() renders per broker, so slots
+// shrink to 320 B:
+//   #175  : 32 x  512 = 16,384 B   (and packets over ~98 B silently dropped)
+//   #726  : 20 x 1024 = 20,480 B
+//   #727  : 32 x  320 = 10,240 B   -- more depth than either, ~10 KB less memory
+// #727 sec4: 40 slots x 288 B = 11,520 B. The slim PacketRecord (276 B measured)
+// freed room to deepen the ring past #727's 32 while staying ~11 KB under the
+// pre-#701 baseline. Fleet data (map.okimesh.org) put the busiest real observer
+// at ~20 slots of sustained need; 40 is burst insurance. Owner-set depth.
 #ifndef MQTT_RING_SLOTS
-  #define MQTT_RING_SLOTS 20
+  #define MQTT_RING_SLOTS 40
 #endif
-// #726: 512 -> 1024. MUST be >= the buffer buildPacketJson() writes into.
-// publishParsedPacket() builds the /packets JSON into char json[1024] and hands it
-// to publishPacket() -> append(). At 512 every payload between 513 and 1023 bytes
-// was REJECTED and silently discarded: append returned 0, nothing logged, no
-// counter moved (droppedCount tracks cursor overrun at commit(), not a refused
-// append). The JSON embeds "raw":"<whole packet in hex>", so with 316 B of other
-// fields the ceiling was ~98 BYTES of packet -- a max 255 B MeshCore packet builds
-// an 826 B body and never reached any broker. Transport-independent: the drop is
-// upstream of broker fan-out, so a plaintext always-on slot was hit identically.
-//
-// Introduced by #175 (62ad4439 added the ring at 512 while the builder already used
-// 1024) and found in the field on v1.5.0-beta1: an observer published the first,
-// smaller message to CoreScope and silently dropped the two larger ones.
-//
-// KEEP THIS >= the json[] buffer in publishParsedPacket(). If that buffer grows,
-// this must grow with it, or the same silent hole reopens.
+// MUST stay >= sizeof(PacketRecord). A static_assert in MqttBrokerPool.cpp enforces
+// it -- #726 was exactly this invariant violated silently, so it is now a compile
+// error rather than a field report.
+// #727 sec4: slim PacketRecord (~276 B, was ~296). MSG_MAX drops to 288 -- the
+// static_assert in MqttBrokerPool.cpp verifies 288 >= sizeof(PacketRecord).
+// Slot COUNT held at 32 pending the owner's depth/memory call with measured
+// sizeof (per the #727 sequencing: shrink first, then size).
 #ifndef MQTT_RING_MSG_MAX
-  #define MQTT_RING_MSG_MAX 1024
+  #define MQTT_RING_MSG_MAX 288
 #endif
 #ifndef MQTT_RING_MAX_READERS
   #define MQTT_RING_MAX_READERS 10

--- a/test/test_mqtt_ring/test_mqtt_ring.cpp
+++ b/test/test_mqtt_ring/test_mqtt_ring.cpp
@@ -1,7 +1,14 @@
 #include <gtest/gtest.h>
 #include <cstring>
 #include <vector>
+// MqttPayload.h pulls WifiObserverConfig.h, which #errors unless a role is
+// declared. The record layout is role-independent, so declare the pool role
+// for this translation unit only -- keeps MqttRingLog.h itself dependency-free.
+#ifndef OFFBAND_MQTT_POOL
+#define OFFBAND_MQTT_POOL 1
+#endif
 #include "helpers/wifi_observer/MqttRingLog.h"
+#include "helpers/wifi_observer/MqttPayload.h"
 
 static void fill(uint8_t* b, size_t n, uint8_t v) { memset(b, v, n); }
 
@@ -148,6 +155,60 @@ TEST(MqttRingLogDrops, RepeatedOverrunsAccumulate) {
 }
 
 // ---------------------------------------------------------------------------
+// #723: a rotated-out reader must KEEP its cursor across re-attach.
+//
+// v1.5.0-beta1 resynced on every rotation re-entry, discarding exactly the
+// backlog the ring exists to hold. Field symptom: an observer published the
+// first message and silently dropped the next two, which had arrived while its
+// broker was rotated out. resync() is for FIRST attach only.
+// ---------------------------------------------------------------------------
+
+TEST(MqttRingLogDrops, BacklogSurvivesWhenReaderIsAwayAndReturns) {
+    MqttRingLog ring;
+    uint8_t m[4]; fill(m, sizeof(m), 0x66);
+    uint8_t out[MQTT_RING_MSG_MAX]; size_t out_len = 0; uint32_t seq = 0;
+
+    // Reader 0 is up and consumes message 1.
+    ring.append(m, sizeof(m));
+    ASSERT_TRUE(ring.peek(0, out, sizeof(out), out_len, seq));
+    EXPECT_EQ(seq, 1u);
+    ring.commit(0);
+
+    // Reader 0 rotates OUT. Two more messages arrive while it is away.
+    ring.append(m, sizeof(m));   // seq 2
+    ring.append(m, sizeof(m));   // seq 3
+
+    // Reader 0 rotates back IN. Without a resync it must resume at seq 2 --
+    // the backlog is the whole point of the ring.
+    ASSERT_TRUE(ring.peek(0, out, sizeof(out), out_len, seq))
+        << "backlog discarded on re-entry -- the beta1 regression";
+    EXPECT_EQ(seq, 2u);
+    ring.commit(0);
+    ASSERT_TRUE(ring.peek(0, out, sizeof(out), out_len, seq));
+    EXPECT_EQ(seq, 3u);
+    ring.commit(0);
+
+    EXPECT_FALSE(ring.peek(0, out, sizeof(out), out_len, seq));  // fully caught up
+    EXPECT_EQ(ring.droppedCount(0), 0u);                         // nothing lost
+}
+
+TEST(MqttRingLogDrops, ResyncStillSkipsBacklogWhenExplicitlyCalled) {
+    MqttRingLog ring;
+    uint8_t m[4]; fill(m, sizeof(m), 0x77);
+    uint8_t out[MQTT_RING_MSG_MAX]; size_t out_len = 0; uint32_t seq = 0;
+
+    for (int i = 0; i < 5; i++) ring.append(m, sizeof(m));
+    ring.resync(0);                       // first-attach behaviour (#710 intent)
+    EXPECT_FALSE(ring.peek(0, out, sizeof(out), out_len, seq));
+    EXPECT_EQ(ring.lag(0), 0u);
+    EXPECT_EQ(ring.droppedCount(0), 0u);  // deliberate skip is not a drop
+
+    ring.append(m, sizeof(m));            // and it tracks new traffic from there
+    ASSERT_TRUE(ring.peek(0, out, sizeof(out), out_len, seq));
+    EXPECT_EQ(seq, 6u);
+}
+
+// ---------------------------------------------------------------------------
 // #726: the ring must accept anything publishParsedPacket() can build.
 //
 // That function writes the /packets JSON into char json[1024]. The ring capped
@@ -156,18 +217,26 @@ TEST(MqttRingLogDrops, RepeatedOverrunsAccumulate) {
 // contract: MQTT_RING_MSG_MAX >= the builder's buffer, and a refusal is COUNTED.
 // ---------------------------------------------------------------------------
 
-TEST(MqttRingLogDrops, AcceptsAnythingTheJsonBuilderCanProduce) {
+TEST(MqttRingLogDrops, AcceptsAnythingTheWriterCanProduce) {
+    // This test began life under #726, asserting the ring could hold a 1023-byte
+    // RENDERED JSON body -- because back then publishParsedPacket() wrote the
+    // finished body into the ring and the ring capped at 512, silently refusing
+    // anything larger (a ~98-byte packet ceiling, invisible in the field).
+    //
+    // #727 changed what the writer produces: the ring now stores a PacketRecord
+    // and drainBroker() renders per broker. So the invariant is unchanged in
+    // spirit -- the ring must accept whatever the writer hands it -- but the
+    // thing being handed over is now the record, not the body.
     MqttRingLog ring;
-    // The largest body publishParsedPacket can hand us: json[1024] minus NUL.
-    std::vector<uint8_t> big(1023, 0x5A);
-    EXPECT_EQ(ring.append(big.data(), big.size()), 1u)
-        << "ring refuses a payload the JSON builder can legally produce";
+    std::vector<uint8_t> rec(sizeof(offband::PacketRecord), 0x5A);
+    EXPECT_EQ(ring.append(rec.data(), rec.size()), 1u)
+        << "ring refuses a record the writer can legally produce";
     EXPECT_EQ(ring.rejectedCount(), 0u);
 
-    // A worst-case 255-byte MeshCore packet builds an ~826 B body.
-    std::vector<uint8_t> worst(826, 0x5B);
-    EXPECT_EQ(ring.append(worst.data(), worst.size()), 2u);
-    EXPECT_EQ(ring.rejectedCount(), 0u);
+    // And a full rendered body is now correctly refused -- nothing writes one.
+    std::vector<uint8_t> old_body(1023, 0x5B);
+    EXPECT_EQ(ring.append(old_body.data(), old_body.size()), 0u);
+    EXPECT_EQ(ring.rejectedCount(), 1u);   // refused, and COUNTED
 }
 
 TEST(MqttRingLogDrops, OversizeIsCountedNotSilent) {
@@ -177,6 +246,77 @@ TEST(MqttRingLogDrops, OversizeIsCountedNotSilent) {
     EXPECT_EQ(ring.rejectedCount(), 1u);          // counted, not discarded quietly
     EXPECT_EQ(ring.droppedCount(0), 0u);          // and NOT confused with overrun
     EXPECT_EQ(ring.head(), 0u);                   // nothing entered the ring
+}
+
+// ---------------------------------------------------------------------------
+// #727: the ring now stores a PacketRecord, not a rendered JSON body.
+//
+// These pin the invariants that made #726 possible, and the one this redesign
+// would otherwise have introduced (drain-time timestamps).
+// ---------------------------------------------------------------------------
+
+TEST(MqttRingRecord, RecordFitsTheRing) {
+    // The whole point of #727: the writer's record must fit what the ring takes.
+    // #726 was this exact invariant broken silently, at a different size.
+    EXPECT_LE(sizeof(offband::PacketRecord), (size_t)MQTT_RING_MSG_MAX);
+}
+
+TEST(MqttRingRecord, MaxSizePacketRoundTrips) {
+    MqttRingLog ring;
+    offband::PacketRecord in{};
+    in.rx_time      = 1755300000u;
+    in.rssi         = -97;
+    in.snr          = -7.5f;
+    in.score        = 123;
+    in.raw_len      = 255;                       // worst-case MeshCore packet
+    for (int i = 0; i < 255; i++) in.raw[i] = (uint8_t)i;
+
+    ASSERT_EQ(ring.append(reinterpret_cast<const uint8_t*>(&in), sizeof(in)), 1u)
+        << "a max-size packet record must be accepted -- this is #726's failure mode";
+    EXPECT_EQ(ring.rejectedCount(), 0u);
+
+    uint8_t out[MQTT_RING_MSG_MAX]; size_t len = 0; uint32_t seq = 0;
+    ASSERT_TRUE(ring.peek(0, out, sizeof(out), len, seq));
+    ASSERT_EQ(len, sizeof(offband::PacketRecord));
+
+    offband::PacketRecord got{};
+    memcpy(&got, out, sizeof(got));
+    EXPECT_EQ(got.rx_time, in.rx_time);
+    EXPECT_EQ(got.rssi, in.rssi);
+    EXPECT_FLOAT_EQ(got.snr, in.snr);
+    EXPECT_EQ(got.score, in.score);
+    EXPECT_EQ(got.raw_len, 255);
+    EXPECT_EQ(memcmp(got.raw, in.raw, 255), 0);   // packet bytes survive intact
+}
+
+TEST(MqttRingRecord, ReceiveTimeSurvivesADelayedDrain) {
+    // The bug this redesign would have introduced. Rendering moved to drain, so
+    // a record sitting through a rotation dwell must still carry the RECEIVE
+    // time -- calling time(nullptr) at render would stamp the drain time and
+    // silently mis-timestamp exactly the rotated-out case the ring exists for.
+    MqttRingLog ring;
+    const uint32_t rx = 1755300000u;
+
+
+    offband::PacketRecord in{};
+    in.rx_time = rx;
+    in.raw_len = 32;
+    ASSERT_EQ(ring.append(reinterpret_cast<const uint8_t*>(&in), sizeof(in)), 1u);
+
+    // Broker is away; unrelated traffic arrives meanwhile.
+    for (int i = 0; i < 5; i++) {
+        offband::PacketRecord other{};
+        other.rx_time = rx + 60u * (uint32_t)(i + 1);
+        other.raw_len = 16;
+        ring.append(reinterpret_cast<const uint8_t*>(&other), sizeof(other));
+    }
+
+    // Broker returns and drains: the FIRST record must still carry its own rx.
+    uint8_t out[MQTT_RING_MSG_MAX]; size_t len = 0; uint32_t seq = 0;
+    ASSERT_TRUE(ring.peek(0, out, sizeof(out), len, seq));
+    offband::PacketRecord got{};
+    memcpy(&got, out, sizeof(got));
+    EXPECT_EQ(got.rx_time, rx) << "record carried the wrong time across a delayed drain";
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
**Collapsed PR** — supersedes the #724/#730/#731/#728 stack. One CI matrix run instead of four, same tree that was integrated and soaked together on hv3-bench as the beta2 candidate. #726 already landed (PR #729) and is the base of this diff.

Closes #723, #727.

## What's in it

**#723 — resync on first attach only.** Beta1 regression: `reconcileSlot()` flagged a ring resync on *every* rotation re-entry, discarding exactly the backlog the ring exists to hold. A rotating observer silently dropped most of its feed, drop counter reading zero (resync is a deliberate skip, not an overrun). Per-slot `first_attach_done_` gate.

**#727 — store the packet, not the rendered JSON.** The ring held the finished body (~826 B worst case; hex doubles the packet + ~316 B fields). Now stores a `PacketRecord`, renders per broker in `drainBroker()`. Published bytes unchanged. `rx_time` captured at receive. `static_assert(sizeof(PacketRecord) <= MQTT_RING_MSG_MAX)` makes #726's silent-refuse a compile error.

**#727 §4 — slim + observability.** CoreScope and every fork (CoreComms/EastMesh confirmed from public source — `cmd/ingestor/main.go` decodes `raw` itself) read none of packet_type/payload_len/route/path/hash/len/time/date/duration/origin_id. Dropped from body **and** record; on-device SHA256 + parse removed. Record 296 → **276 B measured**. Ring **40 × 288** (owner-set). `[ring] backlog sN age=Ns (publishing receive-time)` proves the receive-time guarantee instead of leaving it silent. `/raw` untouched.

## Verification
- Full-day arc: 126,000 → **114,916 B** on the observer; ~98 B packet ceiling **gone**; ring 40-deep.
- Non-observer control **byte-identical** (181,548).
- Tests **16/16** ring + **9/9** rotation.
- Soaked as beta2 candidate: rej=0, drops=0, rotation even.
- Evidence: `docs/architecture/2026-08-15-observer-mqtt-payload-assessment.md`.

## Note for reviewers
The one corner unit tests can't reach — a *backlogged* broker publishing receive-time — is covered by the new `[ring] backlog` line but needs a broker toggled off/on mid-soak to fire (CLI `send`, blocked on the CP2102 bench board). Passive soak confirms everything else.