### PR TITLE
ci: add Heltec E290 companion envs (ble + usb) to CI and release matrices

### DIFF
--- a/.github/release-envs.txt
+++ b/.github/release-envs.txt
@@ -85,6 +85,11 @@ t1000e_companion_radio_usb
 t1000e_repeater
 t1000e_room_server
 
+# Heltec Vision Master E290 (ESP32-S3, 2.9" e-ink) -- companion only (#733);
+# repeater/room_server/espnow/kiss deferred by owner
+Heltec_E290_companion_ble
+Heltec_E290_companion_usb
+
 # Heltec T096 (nRF52)
 Heltec_t096_companion_radio_ble
 Heltec_t096_companion_radio_usb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,12 @@ jobs:
           - Heltec_v3_repeater
           - heltec_v4_tft_companion_radio_ble
           - heltec_v4_tft_companion_radio_wifi
+          # #733: Heltec Vision Master E290 (ESP32-S3 + SX1262, 2.9" e-ink) --
+          # first e-ink board; community-tester enablement off the upstream-1.17
+          # variant. Owner scope (2026-08-13): companion ble+usb only, repeater
+          # deferred. Both smoke-built green before this matrix add (#683 lesson).
+          - Heltec_E290_companion_ble
+          - Heltec_E290_companion_usb
           - heltec_v4_companion_radio_wifi
           - RAK_4631_companion_radio_usb
           - RAK_4631_companion_radio_ble


### PR DESCRIPTION
#733 (owner-directed scope: companion ble+usb, repeater deferred). Both envs smoke-built green locally before the matrix add; this PR's own matrix run is the real proof. First e-ink board in the fleet — tester notes live on the issue.

Agent: WhiteFalcon (session cb12cdd2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)