### PR TITLE
task(#743): NV3001B display -- bulk SPI fills and a back buffer

### DIFF
--- a/src/helpers/ui/NV3001BDisplay.cpp
+++ b/src/helpers/ui/NV3001BDisplay.cpp
@@ -397,6 +397,43 @@ void NV3001BDisplay::initPanel() {
 #undef CMD2
 }
 
+// #743: allocate the back buffer. PSRAM first -- the RC32 has 8 MB embedded and
+// SPI at 8 MHz (~1.1 MB/s) is the bottleneck for the blit, not PSRAM read speed,
+// so this costs nothing measurable and keeps 55 KB of internal DRAM free.
+// Falls back to internal, then to direct-to-panel if both fail.
+void NV3001BDisplay::allocFrameBuffer() {
+  const size_t px = (size_t)NV3001B_SCREEN_WIDTH * NV3001B_SCREEN_HEIGHT;
+  const size_t bytes = px * sizeof(uint16_t);
+
+#if defined(BOARD_HAS_PSRAM)
+  frame_buf = (uint16_t*)ps_malloc(bytes);
+#endif
+  if (!frame_buf) frame_buf = (uint16_t*)malloc(bytes);
+
+  if (!frame_buf) {
+    // Loud, not silent (SAFELANE 6). The display still works, just unbuffered
+    // and flickering, so this must not be diagnosed as "the fix didn't work".
+    Serial.printf("NV3001B: back buffer alloc FAILED (%u B) -- direct panel writes, expect flicker\n",
+                  (unsigned)bytes);
+  }
+}
+
+// One transfer for the whole frame. Pixels are already byte-swapped in the
+// buffer, so this is a straight byte blit with no per-pixel work.
+void NV3001BDisplay::blitFrameBuffer() {
+  if (!frame_buf || !is_on) return;
+
+  setAddrWindow(0, 0, NV3001B_SCREEN_WIDTH, NV3001B_SCREEN_HEIGHT);
+
+  spi.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
+  digitalWrite(PIN_TFT_DC, HIGH);
+  digitalWrite(PIN_TFT_CS, LOW);
+  spi.writeBytes((const uint8_t*)frame_buf,
+                 (uint32_t)NV3001B_SCREEN_WIDTH * NV3001B_SCREEN_HEIGHT * sizeof(uint16_t));
+  digitalWrite(PIN_TFT_CS, HIGH);
+  spi.endTransaction();
+}
+
 void NV3001BDisplay::fillPhysicalRect(int x, int y, int w, int h) {
   if (!is_on || w <= 0 || h <= 0) return;
 
@@ -411,6 +448,19 @@ void NV3001BDisplay::fillPhysicalRect(int x, int y, int w, int h) {
   if (x + w > NV3001B_SCREEN_WIDTH) w = NV3001B_SCREEN_WIDTH - x;
   if (y + h > NV3001B_SCREEN_HEIGHT) h = NV3001B_SCREEN_HEIGHT - y;
   if (w <= 0 || h <= 0) return;
+
+  // #743: buffered path. This is the ONLY function that touches the panel, so
+  // intercepting it here buffers every draw -- including drawChar(), which calls
+  // this once per lit font pixel and previously cost up to 35 SPI transactions
+  // per character.
+  if (frame_buf) {
+    const uint16_t swapped = (uint16_t)((color >> 8) | (color << 8));
+    for (int row = 0; row < h; row++) {
+      uint16_t* p = frame_buf + (size_t)(y + row) * NV3001B_SCREEN_WIDTH + x;
+      for (int col = 0; col < w; col++) p[col] = swapped;
+    }
+    return;
+  }
 
   setAddrWindow(x, y, w, h);
   writeColor(color, (uint32_t)w * h);
@@ -458,8 +508,10 @@ bool NV3001BDisplay::begin() {
 
   initPanel();
   is_on = true;
+  allocFrameBuffer();   // #743: before the first fill, so it lands in the buffer
   color = 0x0000;
   fillPhysicalRect(0, 0, NV3001B_SCREEN_WIDTH, NV3001B_SCREEN_HEIGHT);
+  blitFrameBuffer();    // push the initial clear -- begin() has no endFrame()
   color = 0xffff;
   text_size = 1;
   cursor_x = 0;
@@ -486,6 +538,10 @@ void NV3001BDisplay::clear() {
   color = UIColor::window_bkg;
   fillPhysicalRect(0, 0, NV3001B_SCREEN_WIDTH, NV3001B_SCREEN_HEIGHT);
   color = saved;
+  // #743: clear() is a standalone operation, not part of a startFrame/endFrame
+  // pair, so it must push its own result -- otherwise with the back buffer
+  // active it would silently do nothing visible.
+  blitFrameBuffer();
 }
 
 void NV3001BDisplay::startFrame(ColorVal bkg) {
@@ -567,5 +623,10 @@ uint16_t NV3001BDisplay::getTextWidth(const char* str) {
   return (uint16_t)((len * 6 * textPixelScaleX(text_size)) / DISPLAY_SCALE_X);
 }
 
+// #743: the frame is drawn into RAM by fillPhysicalRect(); push it here in one
+// transfer. Previously empty -- which is why the panel was erased and redrawn in
+// front of the user on every update. Every sibling driver (SSD1306, SH1106,
+// ST7735, LGFX) already does this; NV3001B and ST7789LCD were the exceptions.
 void NV3001BDisplay::endFrame() {
+  blitFrameBuffer();
 }

--- a/src/helpers/ui/NV3001BDisplay.cpp
+++ b/src/helpers/ui/NV3001BDisplay.cpp
@@ -247,17 +247,37 @@ void NV3001BDisplay::setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t 
   writeCommand(NV3001B_RAMWR);
 }
 
+// #745: bulk fill. This is the primitive behind startFrame(), clear() and
+// fillRect(), so it runs on every UI update -- and startFrame() blanks the whole
+// panel, which is 220 x 128 = 28,160 px.
+//
+// It used to push ONE BYTE PER spi.transfer() call:
+//
+//     while (count--) { spi.transfer(hi); spi.transfer(lo); }
+//
+// i.e. 56,320 separate transfer calls for a single full-screen fill, each with
+// its own per-call overhead on top of the 8 MHz clock. That cost is paid on
+// every render and is a large part of the visible flicker.
+//
+// SPIClass::writePattern() is the core primitive built for exactly this case: it
+// packs whole copies of the pattern into the 64-byte hardware FIFO and loops
+// (framework-arduinoespressif32/libraries/SPI/src/SPI.cpp:306). A 2-byte pattern
+// gives 32 pixels per FIFO load, so the same full-screen fill becomes ~880 FIFO
+// transactions instead of 56,320 byte transfers -- and it needs no intermediate
+// buffer, so there is no RAM cost.
+//
+// NOTE writePattern() refuses sizes > 64 bytes (max FIFO); 2 is well inside that.
+// A DMA path could go faster still, but that wants the back buffer from #743 to
+// be worth it -- this change is deliberately buffer-free and self-contained.
 void NV3001BDisplay::writeColor(uint16_t rgb, uint32_t count) {
-  uint8_t hi = rgb >> 8;
-  uint8_t lo = rgb & 0xff;
+  if (count == 0) return;
+
+  const uint8_t pattern[2] = { (uint8_t)(rgb >> 8), (uint8_t)(rgb & 0xff) };
 
   spi.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
   digitalWrite(PIN_TFT_DC, HIGH);
   digitalWrite(PIN_TFT_CS, LOW);
-  while (count--) {
-    spi.transfer(hi);
-    spi.transfer(lo);
-  }
+  spi.writePattern(pattern, sizeof(pattern), count);
   digitalWrite(PIN_TFT_CS, HIGH);
   spi.endTransaction();
 }

--- a/src/helpers/ui/NV3001BDisplay.h
+++ b/src/helpers/ui/NV3001BDisplay.h
@@ -33,6 +33,18 @@ class NV3001BDisplay : public DisplayDriver {
   int cursor_x = 0;
   int cursor_y = 0;
 
+  // #743: back buffer. Every panel write funnels through fillPhysicalRect(), so
+  // when this is non-null the draw path writes here instead of over SPI and
+  // endFrame() blits the whole thing in one transfer. Pixels are stored
+  // BYTE-SWAPPED (panel wants big-endian RGB565) so the blit is a plain
+  // writeBytes with no per-pixel conversion.
+  // Null is a supported state: allocation failure degrades to the original
+  // direct-to-panel behaviour rather than losing the display (SAFELANE 6).
+  uint16_t* frame_buf = nullptr;
+
+  void allocFrameBuffer();
+  void blitFrameBuffer();
+
   void writeCommand(uint8_t cmd);
   void writeBytes(const uint8_t* data, size_t len);
   void writeCommandData(uint8_t cmd, const uint8_t* data, size_t len);


### PR DESCRIPTION
Closes #745, closes #747. Epic: #743.

Two independent fixes to the RC32 display driver. Both are `NV3001BDisplay` only — **no API
change, no call-site change, no screen change.**

## 1. `writeColor` used one `spi.transfer()` per byte (#745)

`writeColor()` is the fill primitive behind `startFrame()`, `clear()` and `fillRect()`, and
`startFrame()` blanks the whole 220x128 panel on every render. It pushed **one byte per call** —
56,320 separate `spi.transfer()` calls for a single full-screen fill, each with its own overhead
on top of the 8 MHz clock.

Now uses `SPIClass::writePattern()`, which packs whole copies of the pattern into the 64-byte
hardware FIFO and loops `[verified: framework-arduinoespressif32/libraries/SPI/src/SPI.cpp:306]`.
A 2-byte pattern is 32 px per FIFO load, so the same fill is **~880 FIFO transactions instead of
56,320 byte transfers** — with no intermediate buffer, so no RAM cost.

## 2. There was no back buffer (#747)

`startFrame()` blanked the physical panel and `endFrame()` was **empty**, so the panel was erased
and redrawn in front of the user on every update.

`[verified]` Every sibling driver already buffers — `SSD1306Display` (115 envs), `SH1106Display`
(13), `ST7735Display` (15), `ST7789Display` (3), `LGFXDisplay` (1). `NV3001BDisplay` and
`ST7789LCDDisplay` (14 envs) were the two exceptions. **`ST7789LCDDisplay` still is** — its
`endFrame()` is a commented-out `// display.display();`. Out of scope here, noted on #743.

`fillPhysicalRect()` is the **only** function that touches the panel, so intercepting that one
function buffers everything — including `drawChar()`, which calls it once per lit font pixel and
previously cost up to 35 SPI transactions per character. That is now 35 memory writes.

| | |
|---|---|
| Buffer | 220 x 128 x 2 = 56,320 B, heap-allocated — **static RAM unchanged** (124,776 B) |
| Placement | PSRAM first (8 MB embedded); 8 MHz SPI is the blit bottleneck, not PSRAM read speed, so internal DRAM stays free. Falls back to internal, then to the original direct path. |
| Format | Pixels stored **byte-swapped**, so the blit is a plain `writeBytes` with no per-pixel conversion |
| Alloc failure | **Supported state** — degrades to direct-to-panel and reports it on Serial, so it can never be misdiagnosed as "the fix did not work" (SAFELANE 6) |
| `clear()` | Blits its own result — it is standalone, not inside a `startFrame`/`endFrame` pair, so it would otherwise draw into RAM and never appear |

## Verification

| Env | |
|---|---|
| `heltec_rc32_companion_radio_usb` | SUCCESS |
| `heltec_rc32_repeater` | SUCCESS |

Flashed to `rc32-bench-1` (app-slot, NVS preserved) as
`rc32-display-v1.5.0-1869a42.bin`.

⚠ **Visible-flicker confirmation is still outstanding** and is epic-level acceptance on #743, not
a claim of this PR. `NV3001BDisplay` is used by exactly one env, so blast radius is RC32 only.

Note the flashed image is the `_diag_nocrashlog` env, because the shipping companion env still
hangs at `crashLogStandardInit` (#702 / epic #741) and would not reach the display at all.

Agent: BlueElk (session f148bd05)