### PR TITLE
bug(#741): CrashLog must never block boot -- fixes a ~50-day serial stall on 15 boards

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -184,8 +184,27 @@ void setup() {
   // Serial is a UART HardwareSerial (e.g. Heltec V3 = esp32-s3-devkitc-1) it doesn't
   // exist -- and isn't needed there (no HWCDC head-of-line blocking). Guarding on plain
   // ESP32 broke the V3 observer build.
+  // ⚠ #741/#756: THIS MUST NOT BE ZERO. Zero is what caused the bug it was
+  // meant to prevent.
+  //
+  // HWCDC::write (framework-arduinoespressif32/cores/esp32/HWCDC.cpp:440-470):
+  //
+  //     uint32_t tries = tx_timeout_ms;
+  //     while (connected && to_send) {
+  //         if (last_toSend == to_send) { tries--; delay(1); }
+  //         if (tries == 0) { connected = false; }   // the escape hatch
+  //     }
+  //
+  // With tx_timeout_ms == 0, `tries--` UNDERFLOWS 0 -> 4,294,967,295 and the
+  // escape can never fire: ~50 days of 1 ms iterations. Observed on
+  // rc32-bench-1 blocking 49.9 minutes inside crashLogBegin(), resuming only
+  // when a host opened the port (#702).
+  //
+  // 1 ms preserves the original #149/#216 intent -- do not stall the main loop
+  // on serial -- while leaving `tries` able to reach zero and bail out.
+  // DO NOT "optimise" this back to 0.
 #if defined(ESP32) && defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT
-  Serial.setTxTimeoutMs(0);
+  Serial.setTxTimeoutMs(1);
 #endif
 
   // #149: stamp the running build on the serial console at boot. Every test build

--- a/src/helpers/diagnostics/CrashLog.cpp
+++ b/src/helpers/diagnostics/CrashLog.cpp
@@ -209,6 +209,37 @@ static void crashLogSerialLine(const char* s) {
     crashLogSerialWrite("\r\n", 2);
 }
 
+// Emit `count` bytes of ring content, bounded and non-blocking, skipping the
+// embedded NULs that pad an unwrapped ring. `at(i)` supplies byte i so the two
+// callers can differ in indexing (linear snapshot vs wrapping ring) without
+// duplicating the transmit logic.
+//
+// #756 review (Gemini): the NUL skip is NOT new -- both dumps have always
+// stripped them (`if (c != '\0')`). My first pass at chunking
+// emitPreviousBootDump dropped that filter, which would have started emitting
+// raw NULs into terminals that previously never saw them, AND left the two
+// dumps behaving differently. One helper, original semantics, both callers.
+template <typename AtFn>
+static void crashLogEmitRing(size_t count, AtFn at) {
+    size_t i = 0;
+    while (i < count) {
+        int room = Serial.availableForWrite();
+        if (room <= 0) break;                       // full -> stop, never wait
+
+        char chunk[64];
+        size_t n = 0;
+        const size_t cap = (sizeof(chunk) < (size_t)room) ? sizeof(chunk) : (size_t)room;
+        while (n < cap && i < count) {
+            char c = at(i);
+            ++i;
+            if (c == '\0') continue;                // padding, not content
+            chunk[n++] = c;
+        }
+        if (n == 0) continue;                       // whole chunk was padding
+        if (crashLogSerialWrite(chunk, n) == 0) break;   // no progress -> stop
+    }
+}
+
 static void emitPreviousBootDump(const char* why) {
     if (s_prev_len == 0) { return; }
     // Cheap early-out: if nobody is listening there is nothing to emit TO, and
@@ -230,16 +261,7 @@ static void emitPreviousBootDump(const char* why) {
     // rest is dropped. A partial dump is the acceptable outcome; a wedged boot
     // is not. The deferred re-dump (#378/#463) still gets a second chance later
     // once a monitor has attached.
-    size_t i = 0;
-    while (i < s_prev_len) {
-        int room = Serial.availableForWrite();
-        if (room <= 0) break;                    // buffer full -> stop, do not wait
-        size_t chunk = s_prev_len - i;
-        if (chunk > (size_t)room) chunk = (size_t)room;
-        size_t wrote = crashLogSerialWrite(&s_prev_snapshot[i], chunk);
-        if (wrote == 0) break;                   // no progress -> stop, do not spin
-        i += wrote;
-    }
+    crashLogEmitRing(s_prev_len, [](size_t i) { return s_prev_snapshot[i]; });
 
     crashLogSerialLine("");
     crashLogSerialLine("=== END CRASH LOG ======================================");
@@ -359,21 +381,9 @@ void crashLogDump() {
     // blocking shape as emitPreviousBootDump(). Chunked and bounded; stops
     // rather than waits. crashLogDump() is also called from the shutdown
     // handler, where blocking would stall the reset itself.
-    size_t i = 0;
-    while (i < count) {
-        int room = Serial.availableForWrite();
-        if (room <= 0) break;                    // full -> stop, never wait
-        char chunk[64];
-        size_t n = 0;
-        while (n < sizeof(chunk) && n < (size_t)room && i < count) {
-            char c = s_data[(start + i) % kCrashLogDataSize];
-            ++i;
-            if (c == '\0') continue;
-            chunk[n++] = c;
-        }
-        if (n == 0) continue;
-        if (crashLogSerialWrite(chunk, n) == 0) break;   // no progress -> stop
-    }
+    crashLogEmitRing(count, [start](size_t i) {
+        return s_data[(start + i) % kCrashLogDataSize];
+    });
     crashLogSerialLine("--- end ---");
 #endif
 }

--- a/src/helpers/diagnostics/CrashLog.cpp
+++ b/src/helpers/diagnostics/CrashLog.cpp
@@ -160,22 +160,89 @@ static char   s_prev_snapshot[kCrashLogDataSize];
 static size_t s_prev_len     = 0;
 static bool   s_prev_pending = false;   // a deferred re-dump is still owed
 
+// ---------------------------------------------------------------------------
+// #741/#756: CrashLog must NEVER block the boot it exists to diagnose.
+//
+// THE BUG THIS PREVENTS. On a native-USB-CDC board (15 of them -- RC32, HV4,
+// HV4-R8, tracker_v2, E213, E290, T190, EoRa-S3, S3-zero, meshnology_w12,
+// station-g2/g3, t3_s3, t_beam_1w, t_beams3) `Serial` is HWCDC. Its write loop
+// (framework-arduinoespressif32/cores/esp32/HWCDC.cpp:440-470) is:
+//
+//     uint32_t tries = tx_timeout_ms;      // we had set this to 0
+//     while (connected && to_send) {
+//         if (last_toSend == to_send) { tries--; delay(1); }   // 0-1 = 4294967295
+//         if (tries == 0) { connected = false; }               // now unreachable
+//     }
+//
+// With tx_timeout_ms == 0 the counter UNDERFLOWS and the escape hatch can never
+// fire -- roughly 50 days of 1 ms iterations. The trigger is CDC reporting
+// "connected" (plugged in and enumerated) while nothing DRAINS: a wall charger,
+// a power bank, a car USB socket. Observed on rc32-bench-1 blocking for 49.9
+// minutes inside crashLogBegin, resuming the instant a host opened the port.
+//
+// Cruelly, attaching a console to investigate DRAINS the buffer and unblocks the
+// board, so it always "worked when you looked at it" (#702, days lost).
+//
+// THE RULE: a truncated crash log is strictly better than a device that never
+// boots. Write what fits, drop the rest, never wait.
+// ---------------------------------------------------------------------------
+
+// Bounded, non-blocking. Returns bytes actually written; callers must not care.
+//   no host attached -> drop everything
+//   host attached    -> write at most availableForWrite(), drop the remainder
+//
+// `if (Serial)` is the right test on all three transports we ship:
+//   ESP32 HWCDC              -> isCDC_Connected()
+//   nRF52 Adafruit_USBD_CDC  -> tud_cdc_n_connected()
+//   HardwareSerial (UART)    -> true once begun (writing to a pin is free anyway)
+static size_t crashLogSerialWrite(const char* data, size_t len) {
+    if (len == 0) return 0;
+    if (!Serial) return 0;                       // no host -> drop, never wait
+    int room = Serial.availableForWrite();
+    if (room <= 0) return 0;                     // no space -> drop, never wait
+    if (len > (size_t)room) len = (size_t)room;  // bound to what fits
+    return Serial.write((const uint8_t*)data, len);
+}
+
+static void crashLogSerialLine(const char* s) {
+    crashLogSerialWrite(s, strlen(s));
+    crashLogSerialWrite("\r\n", 2);
+}
+
 static void emitPreviousBootDump(const char* why) {
     if (s_prev_len == 0) { return; }
-    Serial.println();
-    Serial.println("=========================================================");
-    Serial.printf ("=== CRASH LOG FROM PREVIOUS BOOT (%s) ===\n", why);
-    Serial.printf ("=== reset_reason=%d (%s) ===\n",
-                   currentResetReasonCode(),
-                   resetReasonString(currentResetReasonCode()));
-    Serial.println("=========================================================");
-    for (size_t i = 0; i < s_prev_len; ++i) {
-        char c = s_prev_snapshot[i];
-        if (c != '\0') Serial.write(c);
+    // Cheap early-out: if nobody is listening there is nothing to emit TO, and
+    // the whole point is not to spend boot time on it.
+    if (!Serial) return;
+
+    char hdr[160];
+    crashLogSerialLine("");
+    crashLogSerialLine("=========================================================");
+    snprintf(hdr, sizeof(hdr), "=== CRASH LOG FROM PREVIOUS BOOT (%s) ===", why);
+    crashLogSerialLine(hdr);
+    snprintf(hdr, sizeof(hdr), "=== reset_reason=%d (%s) ===",
+             currentResetReasonCode(), resetReasonString(currentResetReasonCode()));
+    crashLogSerialLine(hdr);
+    crashLogSerialLine("=========================================================");
+
+    // Was a per-byte Serial.write() over up to 4080 bytes -- the call site that
+    // blocked. Now chunked and bounded: each chunk writes only what fits and the
+    // rest is dropped. A partial dump is the acceptable outcome; a wedged boot
+    // is not. The deferred re-dump (#378/#463) still gets a second chance later
+    // once a monitor has attached.
+    size_t i = 0;
+    while (i < s_prev_len) {
+        int room = Serial.availableForWrite();
+        if (room <= 0) break;                    // buffer full -> stop, do not wait
+        size_t chunk = s_prev_len - i;
+        if (chunk > (size_t)room) chunk = (size_t)room;
+        size_t wrote = crashLogSerialWrite(&s_prev_snapshot[i], chunk);
+        if (wrote == 0) break;                   // no progress -> stop, do not spin
+        i += wrote;
     }
-    Serial.println();
-    Serial.println("=== END CRASH LOG ======================================");
-    Serial.println();
+
+    crashLogSerialLine("");
+    crashLogSerialLine("=== END CRASH LOG ======================================");
 }
 #endif
 
@@ -204,7 +271,7 @@ void crashLogBegin() {
         // Fresh power-on (or brown-out / corrupted retained memory).
         s_prev_len     = 0;
         s_prev_pending = false;
-        Serial.println("[CrashLog] fresh boot; no previous-boot log to recover.");
+        crashLogSerialLine("[CrashLog] fresh boot; no previous-boot log to recover.");
     }
 
     // Re-initialize header for THIS boot's writes. The data[] is
@@ -268,7 +335,7 @@ void crashLogf(const char* fmt, ...) {
 #ifndef OFFBAND_CRASHLOG_HOST
     // Live monitoring path -- ALWAYS, even before begin() (the ring isn't ready
     // yet, but the line must not vanish).
-    Serial.write((const uint8_t*)line, total);
+    crashLogSerialWrite(line, total);
 
     // Crash-survival ring -- only once begin() has initialized the header.
     if (s_begin_called) {
@@ -285,15 +352,29 @@ void crashLogf(const char* fmt, ...) {
 
 void crashLogDump() {
 #ifndef OFFBAND_CRASHLOG_HOST
-    Serial.println("--- crashLogDump (current buffer) ---");
+    crashLogSerialLine("--- crashLogDump (current buffer) ---");
     size_t start = s_header.wrapped ? s_header.write_index : 0;
     size_t count = s_header.wrapped ? kCrashLogDataSize : s_header.write_index;
-    for (size_t i = 0; i < count; ++i) {
-        char c = s_data[(start + i) % kCrashLogDataSize];
-        if (c == '\0') continue;
-        Serial.write(c);
+    // #756: was a per-byte Serial.write() over the whole ring -- same unbounded
+    // blocking shape as emitPreviousBootDump(). Chunked and bounded; stops
+    // rather than waits. crashLogDump() is also called from the shutdown
+    // handler, where blocking would stall the reset itself.
+    size_t i = 0;
+    while (i < count) {
+        int room = Serial.availableForWrite();
+        if (room <= 0) break;                    // full -> stop, never wait
+        char chunk[64];
+        size_t n = 0;
+        while (n < sizeof(chunk) && n < (size_t)room && i < count) {
+            char c = s_data[(start + i) % kCrashLogDataSize];
+            ++i;
+            if (c == '\0') continue;
+            chunk[n++] = c;
+        }
+        if (n == 0) continue;
+        if (crashLogSerialWrite(chunk, n) == 0) break;   // no progress -> stop
     }
-    Serial.println("--- end ---");
+    crashLogSerialLine("--- end ---");
 #endif
 }
 
@@ -351,7 +432,7 @@ static int crashlog_vprintf(const char* fmt, va_list ap) {
     if (len >= sizeof(line)) len = sizeof(line) - 1;  // truncation
 
     // Write to serial (live monitoring path).
-    Serial.write((const uint8_t*)line, len);
+    crashLogSerialWrite(line, len);
 
     // Write to ring buffer (crash-survival path). Only if begin() ran;
     // pre-begin ESP-IDF logs (during framework init) don't have a buffer
@@ -397,11 +478,16 @@ void crashLogInstallEspLogHook() {
 static void crashlog_shutdown_handler(void) {
     // Last-gasp dump before reset finalizes. Fires on panic, watchdog,
     // ESP.restart(), and similar soft-reset paths.
-    Serial.println();
-    Serial.println("=== CRASHLOG SHUTDOWN HANDLER FIRED ===");
+    //
+    // #756: same defect class as the boot path, and arguably worse here -- a
+    // blocking write in a shutdown handler stalls the RESET itself, turning a
+    // clean reboot into a wedge. Bounded writes throughout, and NO Serial.flush():
+    // flush waits for the host to drain, which is exactly the wait we must never
+    // perform. If nobody is listening there is nothing to flush to.
+    crashLogSerialLine("");
+    crashLogSerialLine("=== CRASHLOG SHUTDOWN HANDLER FIRED ===");
     crashLogDump();
-    Serial.println("=== END SHUTDOWN DUMP ===");
-    Serial.flush();
+    crashLogSerialLine("=== END SHUTDOWN DUMP ===");
 }
 
 void crashLogInstallShutdownHandler() {
@@ -590,7 +676,7 @@ void heartbeatTick(uint32_t now_ms) {
               (unsigned)heap);
     if (n > 0) {
         size_t total = ((size_t)n < sizeof(line)) ? (size_t)n : sizeof(line) - 1;
-        Serial.write((const uint8_t*)line, total);   // live monitoring, every second
+        crashLogSerialWrite(line, total);   // live monitoring, every second
 
         // Ring-write only when the beat carries new signal: every 30 s, or the moment
         // free heap drops sharply (>8 KB since the last beat) -- a memory-pressure


### PR DESCRIPTION
Closes #756. Root cause for #702. Epic #741. Follow-up: #759.

## What was wrong

`Serial.setTxTimeoutMs(0)` — a mitigation **we** added in #149/#216 to stop serial blocking the
main loop — is what made the block infinite.

`[verified: framework-arduinoespressif32/cores/esp32/HWCDC.cpp:440-470]`

```c
uint32_t tries = tx_timeout_ms;          // we set this to 0
while (connected && to_send) {
    if (last_toSend == to_send) { tries--; delay(1); }   // 0-1 = 4,294,967,295
    if (tries == 0) { connected = false; }               // escape, now unreachable
}
```

`tries` underflows on the first no-progress iteration. Escaping needs ~4.29e9 further 1 ms
iterations — **about 50 days**.

**It was never a hang.** `rc32-bench-1` sat inside `crashLogBegin()` for **49.9 minutes** and
completed the instant esptool opened the port. Proven by arithmetic: blocked 2995 s, `millis()`
at resume 2995506 ms, same boot, no reset.

Trigger is CDC reporting *connected* (plugged in, enumerated) with nothing **draining** — a wall
charger, a power bank, a car USB socket. And the cruelty: **attaching a console to investigate
drains the buffer and unblocks the board**, so it always "worked when you looked at it". That is
why #702 cost days of contaminated observations.

## Blast radius: 15 boards

`heltec-rc32` · `heltec_v4` · `heltec_v4_r8` · `heltec_tracker_v2` · `heltec_e213` · `heltec_e290` ·
`heltec_t190` · `ebyte_eora-s3` · `esp32-s3-zero` · `meshnology_w12` · `station-g2` ·
`station-g3-esp32` · `t3_s3_v1_x` · `t_beam_1w` · `t_beams3_supreme`

**Not affected:** nRF52 (`Adafruit_USBD_CDC::write` gates its loop on `tud_cdc_n_connected()` —
safe by construction) and UART-bridge boards like Heltec V3 (writing to a pin nobody reads is free).
We did not defer the others; **we got lucky** — they also need a previous-boot ring worth dumping.

## The fix

| | |
|---|---|
| **1** | `crashLogSerialWrite()` gates on `if (Serial)` — correct on all three transports: HWCDC → `isCDC_Connected()`, nRF52 → `tud_cdc_n_connected()`, `HardwareSerial` → true once begun |
| **2** | Every write bounded to `availableForWrite()`, remainder dropped. Both per-byte dump loops chunked via one shared `crashLogEmitRing()` — they **stop rather than wait** |
| **3** | `setTxTimeoutMs(0)` → **`(1)`**. Not removal: `0` is the value that disarms the guard. `1` keeps the #149/#216 intent and lets `tries` reach zero. Carries a do-not-set-to-0 comment |
| **4** | Shutdown handler routed through the same helper; **`Serial.flush()` removed** — flush waits for the host to drain, precisely the wait we must never perform |

**Principle: a diagnostic must never be able to block the thing it is diagnosing.** A truncated
crash log is strictly better than a device that never boots.

## Hardware verification

Owner reset `rc32-bench-1` twice on this build with **CrashLog enabled** — the configuration that
produced fourteen consecutive dead boots:

| | Power | `crashLogStandardInit` | Result |
|---|---|---|---|
| 03:37:03Z | USB | 2 ms | `setup:DONE` |
| **03:38:14Z** | **battery, no USB** | **2 ms** | **`setup:DONE` @ 2.3 s** |

Both `rst:0x1 (POWERON)`, byte-identical to the failing captures. The battery case is strongest:
no USB at all, so the gate short-circuits before a byte is attempted.

⚠ **Honest scope of that verification:** hardware-verified at `76ce7c45`. The review fix on top
(`d4356194`) is build-verified only — it changes NUL filtering in the dump path and does not touch
the blocking path.

## Builds

| Env | | |
|---|---|---|
| `heltec_rc32_companion_radio_usb` | SUCCESS | native USB-CDC |
| `heltec_rc32_companion_radio_usb_diag` | SUCCESS | + beacons |
| `Heltec_v3_companion_observer_wifi` | SUCCESS | **UART path** |
| `RAK_4631_companion_radio_ble` | SUCCESS | **nRF52 path** |

## Gemini review

Caught a regression I introduced: my first pass at chunking `emitPreviousBootDump()` **dropped the
NUL-skip both dumps have always had**, which would have emitted raw NULs into terminals that never
saw them and left the two dump paths inconsistent. Fixed with one shared `crashLogEmitRing()`.

**One finding deliberately not fixed here, filed as #759:** the shutdown handler calls Arduino
`Serial`, violating the `esp_register_shutdown_handler` contract (handlers must not use OS
primitives). Pre-existing; materially reduced here; the correct fix is a different mechanism — the
raw register-level writer from #740.

Agent: BlueElk (session f148bd05)