### PR TITLE
fix: three 'get' keys returned an empty reply; four CLI callers transmitted uninitialised stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,21 @@ jobs:
       - name: Font generator self-test
         run: python scripts/test_gen_jbm_font.py
 
+      # #764. `get radio` returned an empty reply for ten months: #299's conversion
+      # hoisted three `isKey` guards without their bodies, leaving the real handlers
+      # on unreachable arms below. It compiles, it is not dead code to any compiler,
+      # and the serial console hides it -- that caller zeroes its buffer and skips
+      # empty replies. Only the radio transport showed it, as stack garbage (#765).
+      #
+      # BLOCKING, unlike the advisory check below: this guard carries its own unit
+      # tests (including every false positive an earlier version produced), and the
+      # tree is clean under it, so it cannot wrongly fail somebody else's PR.
+      - name: CLI dispatch guard self-test
+        run: python scripts/test_cli_dispatch.py
+
+      - name: No empty or shadowed arms in the CLI dispatch chains
+        run: python scripts/check_cli_dispatch.py
+
       # ADVISORY until #648 (the capability inventory) validates what this asserts.
       # ci-green is a hard merge gate for every PR in the repo (#477), so a check
       # built on unvalidated assumptions must not block other people's work. The

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -736,9 +736,11 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
       uint8_t temp[166];
       char *command = (char *)&data[5];
       char *reply = (char *)&temp[5];
-      if (is_retry) {
-        *reply = 0;
-      } else {
+      // #765: zero BEFORE dispatch, not only on the retry path. `temp` is
+      // uninitialised stack, so a handler that writes nothing would otherwise
+      // leave strlen() below reading -- and transmitting -- whatever was there.
+      *reply = 0;
+      if (!is_retry) {
         handleCommand(sender_timestamp, command, reply);
       }
       int text_len = strlen(reply);

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -463,12 +463,14 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
                           PUB_KEY_SIZE);
 
       uint8_t temp[166];
+      // #765: `temp` is uninitialised stack. Every branch below except the admin
+      // dispatch already zeroed it, so the one path that calls handleCommand was
+      // the one path that could transmit stack bytes. Zero it up front instead.
+      temp[5] = 0; // no reply
       bool send_ack;
       if (flags == TXT_TYPE_CLI_DATA) {
         if (client->isAdmin()) {
-          if (is_retry) {
-            temp[5] = 0; // no reply
-          } else {
+          if (!is_retry) {
             handleCommand(sender_timestamp, (char *)&data[5], (char *)&temp[5]);
             temp[4] = (TXT_TYPE_CLI_DATA << 2); // attempt and flags,  (NOTE: legacy was: TXT_TYPE_PLAIN)
           }

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -586,6 +586,7 @@ void SensorMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_i
         uint8_t temp[166];
         char *command = (char *) &data[5];
         char *reply = (char *) &temp[5];
+        *reply = 0;   // #765: uninitialised stack otherwise; strlen() below would transmit it
         handleCommand(sender_timestamp, command, reply);
 
         int text_len = strlen(reply);

--- a/examples/simple_sensor/main.cpp
+++ b/examples/simple_sensor/main.cpp
@@ -162,6 +162,7 @@ void loop() {
   if (len > 0 && command[len - 1] == '\r') {  // received complete line
     command[len - 1] = 0;  // replace newline with C string null terminator
     char reply[160];
+    reply[0] = 0;   // #765: the `if (reply[0])` guard below reads this either way
     the_mesh.handleCommand(0, command, reply);  // NOTE: there is no sender_timestamp via serial!
     if (reply[0]) {
       Serial.print("  -> "); Serial.println(reply);

--- a/scripts/check_cli_dispatch.py
+++ b/scripts/check_cli_dispatch.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Static guard for the CLI dispatch chains (#764).
+
+`d4d417ee` converted `handleGetCmd` from prefix `memcmp` to exact-token `isKey`.
+For most keys it hoisted the new guard *and* moved the body. For three keys it
+hoisted the guard and left the body behind on the old arm:
+
+    } else if (isKey(config, "radio")) {          // matches, writes nothing
+    } else if (memcmp(config, "radio", 5) == 0) { // the body, now shadowed
+      sprintf(reply, "> %s,%s,%d,%d", ...);
+
+`get radio` then returned an empty reply for ten months. Nothing caught it: it
+compiles, it is not dead code by any compiler's reckoning, and the symptom is
+invisible on the serial console because that caller zeroes its buffer and
+suppresses empty replies. Over the radio the caller did not, so users got
+uninitialised stack (#765).
+
+Two checks, both scoped to *contiguous if/else-if chains* -- the same key in two
+separate chains is normal and is not flagged:
+
+  A. EMPTY BODY   -- an arm that matches a string key but writes nothing.
+  B. SHADOWED KEY -- an arm whose key was already claimed by an earlier arm in
+                     the same chain that tests nothing except that key. The
+                     later arm can never see its own exact key.
+
+Arity guards are respected. `n >= 3 && strcmp(parts[1], "home")` does not shadow
+`n == 2 && strcmp(parts[1], "home")`, because the earlier arm tests more than the
+key alone.
+
+Escape hatch, for the rare arm that is deliberately empty:
+
+    } else if (isKey(config, "x")) {   // cli-dispatch-guard: allow-empty <reason>
+    }
+
+KNOWN LIMITS (raised in review; none apply to the current tree, all would need a
+new coding style to hit):
+
+  * Keys must be string literals. `isKey(config, RADIO_KEY)` with a macro, or a
+    ternary picking between two literals, is invisible here -- this reads source,
+    not preprocessed output. Every dispatch arm in the tree spells its key out.
+  * Bodies are checked as written, so an arm whose only statement sits inside
+    `#ifdef` is NOT reported: the directive lines make the body non-empty. The
+    companion scan for that case found no instance, and the arms that do use
+    conditional compilation (`pwrmgt.*`) all carry an `#else`.
+
+Usage:  python scripts/check_cli_dispatch.py [--json-out FILE] [files...]
+Exit 0 clean, 1 on any finding.
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Dispatch chains live in these files. Listed explicitly rather than globbed so
+# that a new CLI surface is a deliberate addition here, not a silent omission.
+DEFAULT_TARGETS = [
+    "src/helpers/CommonCLI.cpp",
+    "src/helpers/config/WifiConfigProvider.cpp",
+    "src/helpers/wifi_telemetry/RemoteCommand.cpp",
+    "examples/companion_radio/MyMesh.cpp",
+    "examples/simple_repeater/main.cpp",
+    "examples/simple_repeater/MyMesh.cpp",
+    "examples/simple_room_server/MyMesh.cpp",
+    "examples/simple_secure_chat/main.cpp",
+    "examples/simple_sensor/SensorMesh.cpp",
+]
+
+ALLOW_EMPTY = "cli-dispatch-guard: allow-empty"
+
+# A key test: func(subject, "literal"). memcmp/strncmp carry a length we ignore --
+# the length is exactly what made these arms prefix-match in the first place.
+_KEY_CALL = re.compile(
+    r'\b(isKey|memcmp|strcmp|strncmp|strcasecmp|strcmp_P)\s*\(\s*'
+    r'([A-Za-z_][\w\.\[\]]*(?:->\w+)*)\s*,\s*"((?:[^"\\]|\\.)*)"'
+)
+
+
+def strip_comments(src):
+    """Blank comments, preserving every offset so line numbers stay exact.
+    String literals are left intact -- they carry the keys we match on."""
+    out = list(src)
+    i, n = 0, len(src)
+    in_str = in_chr = False
+    while i < n:
+        c, nxt = src[i], (src[i + 1] if i + 1 < n else "")
+        if in_str or in_chr:
+            if c == "\\":
+                i += 2
+                continue
+            if (in_str and c == '"') or (in_chr and c == "'"):
+                in_str = in_chr = False
+            i += 1
+            continue
+        if c == '"':
+            in_str = True
+        elif c == "'":
+            in_chr = True
+        elif c == "/" and nxt == "/":
+            while i < n and src[i] != "\n":
+                out[i] = " "
+                i += 1
+            continue
+        elif c == "/" and nxt == "*":
+            while i < n - 1 and not (src[i] == "*" and src[i + 1] == "/"):
+                if src[i] != "\n":
+                    out[i] = " "
+                i += 1
+            if i < n - 1:
+                out[i] = out[i + 1] = " "
+                i += 2
+            continue
+        i += 1
+    return "".join(out)
+
+
+def _match_delim(s, start, open_c, close_c):
+    """`start` indexes `open_c`. Return the index just past its partner."""
+    depth = 0
+    i, n = start, len(s)
+    while i < n:
+        if s[i] == open_c:
+            depth += 1
+        elif s[i] == close_c:
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return -1
+
+
+def _skip_ws(s, i):
+    while i < len(s) and s[i].isspace():
+        i += 1
+    return i
+
+
+def keys_in(cond):
+    """[(func, subject, key)] for every key test in a condition."""
+    return [(m.group(1), m.group(2), m.group(3)) for m in _KEY_CALL.finditer(cond)]
+
+
+def tests_only_key(cond, key):
+    """True when the condition tests `key` and nothing else.
+
+    Such an arm claims the key outright, so any later arm naming the same key is
+    unreachable for it. An arm carrying an extra conjunct -- an arity check, a
+    permission check -- claims only part of the key space and shadows nothing.
+    """
+    residue = cond
+    while True:
+        # Re-scan each pass: excising a call shifts every offset after it.
+        m = next((m for m in _KEY_CALL.finditer(residue) if m.group(3) == key), None)
+        if m is None:
+            break
+        paren = residue.find("(", m.start())
+        end = _match_delim(residue, paren, "(", ")")
+        if end == -1:
+            break
+        # Absorb a trailing comparison so `memcmp(...) == 0` leaves nothing behind.
+        rest = re.sub(r'^\s*[!=]=\s*0', "", residue[end:], count=1)
+        residue = residue[:m.start()] + rest
+    return re.sub(r'[\s()!]', "", residue) == ""
+
+
+def parse_chains(src, base=0):
+    """Every contiguous if / else-if / else chain, including nested ones.
+
+    Returns [[arm, ...]] where an arm is (offset, cond, body, has_braces).
+    Chains are the unit of analysis: two arms only interact if they are rungs of
+    the same ladder.
+    """
+    chains = []
+    i, n = 0, len(src)
+    while i < n:
+        m = re.compile(r'\bif\b').search(src, i)
+        if not m:
+            break
+        # An `else if` is a continuation, not the head of a new chain.
+        before = src[:m.start()].rstrip()
+        if before.endswith("else"):
+            i = m.end()
+            continue
+        j = _skip_ws(src, m.end())
+        if j >= n or src[j] != "(":
+            i = m.end()
+            continue
+
+        arms, pos, ok = [], m.start(), True
+        while True:
+            k = re.compile(r'\bif\b').search(src, pos)
+            if not k:
+                ok = False
+                break
+            p = _skip_ws(src, k.end())
+            if p >= n or src[p] != "(":
+                ok = False
+                break
+            cend = _match_delim(src, p, "(", ")")
+            if cend == -1:
+                ok = False
+                break
+            cond = src[p + 1:cend - 1]
+            b = _skip_ws(src, cend)
+            if b < n and src[b] == "{":
+                bend = _match_delim(src, b, "{", "}")
+                if bend == -1:
+                    ok = False
+                    break
+                body, braced = src[b + 1:bend - 1], True
+            else:  # brace-less single statement
+                bend = src.find(";", b)
+                if bend == -1:
+                    ok = False
+                    break
+                bend += 1
+                body, braced = src[b:bend], False
+            arms.append((base + k.start(), cond, body, braced))
+
+            after = _skip_ws(src, bend)
+            em = re.compile(r'\belse\b').match(src, after)
+            if not em:
+                break
+            nxt = _skip_ws(src, em.end())
+            if re.compile(r'\bif\b').match(src, nxt):
+                pos = nxt
+                continue
+            # Terminal `else`: consume it so the outer scan resumes past the chain.
+            if nxt < n and src[nxt] == "{":
+                e = _match_delim(src, nxt, "{", "}")
+                bend = e if e != -1 else bend
+            break
+
+        if ok and arms:
+            chains.append(arms)
+            for off, _c, body, braced in arms:
+                if braced:
+                    # Recurse so nested chains are analysed in their own right.
+                    inner = src.find(body, off - base) if body else -1
+                    if body.strip() and inner != -1:
+                        chains.extend(parse_chains(body, base + inner))
+            i = max(bend, m.end())
+        else:
+            i = m.end()
+    return chains
+
+
+def analyze_source(text, path="<memory>"):
+    """Findings for one translation unit. Pure -- takes text, returns dicts."""
+    src = strip_comments(text)
+    raw_lines = text.splitlines()
+
+    def line_no(off):
+        return src.count("\n", 0, off) + 1
+
+    def line_text(off):
+        n = line_no(off)
+        return raw_lines[n - 1].strip() if n <= len(raw_lines) else ""
+
+    findings = []
+    for arm_list in parse_chains(src):
+        claimed = {}  # (subject, key) -> line of the arm that owns it outright
+        for off, cond, body, braced in arm_list:
+            found = keys_in(cond)
+            if not found:
+                continue  # not a key-dispatch arm; empty body is its own business
+            ln = line_no(off)
+
+            # A lone `;` is the brace-less spelling of "do nothing".
+            if not body.strip().strip(";").strip():
+                if ALLOW_EMPTY not in line_text(off):
+                    findings.append({
+                        "file": path, "line": ln, "kind": "empty-body",
+                        "keys": sorted({k for _f, _s, k in found}),
+                        "text": line_text(off),
+                        "detail": ("arm matches {} but writes nothing; the caller "
+                                   "sends whatever was already in the reply buffer"
+                                   .format(", ".join(sorted({k for _f, _s, k in found})))),
+                    })
+
+            for _func, subject, key in found:
+                slot = (subject, key)
+                if slot in claimed:
+                    findings.append({
+                        "file": path, "line": ln, "kind": "shadowed-key",
+                        "keys": [key], "text": line_text(off),
+                        "detail": ('key "{}" is already claimed outright at line {} '
+                                   "of the same chain; this arm can never see it"
+                                   .format(key, claimed[slot])),
+                    })
+                elif tests_only_key(cond, key):
+                    claimed[slot] = ln
+    return findings
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("files", nargs="*", help="defaults to the known dispatch files")
+    ap.add_argument("--json-out", help="write findings as JSON for CI to archive")
+    args = ap.parse_args(argv)
+
+    root = Path(__file__).resolve().parent.parent
+    targets = [Path(f) for f in args.files] if args.files else \
+              [root / t for t in DEFAULT_TARGETS]
+
+    findings, scanned = [], 0
+    for t in targets:
+        if not t.exists():
+            print(f"check_cli_dispatch: missing {t}", file=sys.stderr)
+            return 2
+        rel = t.relative_to(root).as_posix() if t.is_absolute() and root in t.parents \
+              else t.as_posix()
+        findings.extend(analyze_source(t.read_text(encoding="utf-8", errors="replace"), rel))
+        scanned += 1
+
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(findings, indent=2), encoding="utf-8")
+
+    if not findings:
+        print(f"check_cli_dispatch: {scanned} file(s) clean")
+        return 0
+
+    for f in sorted(findings, key=lambda x: (x["file"], x["line"])):
+        print(f"{f['file']}:{f['line']}: {f['kind']}: {f['detail']}")
+        print(f"    {f['text']}")
+    print(f"\n{len(findings)} finding(s) across {scanned} file(s). See #764.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_cli_dispatch.py
+++ b/scripts/test_cli_dispatch.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Tests for check_cli_dispatch (#764).
+
+Pure, no hardware, no compiler. Run: python scripts/test_cli_dispatch.py
+  or python -m pytest scripts/test_cli_dispatch.py
+
+Half of these tests exist because a first, naive version of this guard reported
+four findings that were not bugs: a deliberately empty body, two arms separated
+by an arity check, and the same key used in genuinely unrelated chains. A guard
+that cries wolf gets switched off, so the false-positive cases are pinned here
+just as firmly as the true ones.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_cli_dispatch as g
+
+
+def kinds(src):
+    return sorted(f["kind"] for f in g.analyze_source(src))
+
+
+def keys(src, kind):
+    return sorted(k for f in g.analyze_source(src) if f["kind"] == kind for k in f["keys"])
+
+
+# ------------------------------------------------------------ the real bug ---
+
+REGRESSION = '''
+void handleGetCmd(char* config, char* reply) {
+  if (isKey(config, "af")) {
+    sprintf(reply, "> %s", af);
+  } else if (isKey(config, "radio")) {
+  } else if (memcmp(config, "radio", 5) == 0) {
+    sprintf(reply, "> %s,%s", freq, bw);
+  }
+}
+'''
+
+
+def test_catches_the_shape_that_broke_get_radio():
+    """The #764 regression verbatim: guard hoisted, body left behind."""
+    assert kinds(REGRESSION) == ["empty-body", "shadowed-key"]
+
+
+def test_names_the_offending_key():
+    assert keys(REGRESSION, "empty-body") == ["radio"]
+    assert keys(REGRESSION, "shadowed-key") == ["radio"]
+
+
+def test_reports_the_line_of_the_empty_arm():
+    empty = [f for f in g.analyze_source(REGRESSION) if f["kind"] == "empty-body"][0]
+    assert REGRESSION.splitlines()[empty["line"] - 1].strip().startswith("} else if")
+
+
+def test_repaired_form_is_clean():
+    """What the fix looks like: body restored, shadowed duplicate removed."""
+    assert kinds('''
+    if (isKey(config, "af")) {
+      sprintf(reply, "> %s", af);
+    } else if (isKey(config, "radio")) {
+      sprintf(reply, "> %s,%s", freq, bw);
+    }
+    ''') == []
+
+
+def test_whitespace_only_body_is_still_empty():
+    assert "empty-body" in kinds('''
+    if (isKey(config, "a")) { x(); } else if (isKey(config, "radio")) {
+
+    }
+    ''')
+
+
+def test_braceless_empty_arm_is_caught():
+    assert "empty-body" in kinds('if (isKey(c, "a")) x(); else if (isKey(c, "radio")) ;')
+
+
+# ------------------------------------------------------ must NOT fire on ... ---
+
+def test_deliberate_empty_body_without_a_key_is_ignored():
+    """CommonCLI.cpp:1041 -- the arm calls a function that fills `reply` itself.
+    No string key, so it is not a dispatch arm and is none of our business."""
+    assert kinds('''
+    if (!wifi_is_persistent()) {
+      strcpy(reply, "ERR");
+    } else if (!_board->startOTAUpdateOverSTA(name, password, reply)) {
+    }
+    ''') == []
+
+
+def test_arity_guard_prevents_shadowing():
+    """CommonCLI.cpp:1883/1891 -- `home` twice, split by argument count. Both
+    arms are live; flagging either would be wrong."""
+    assert kinds('''
+    if (n >= 3 && strcmp(parts[1], "home") == 0) {
+      setHome(parts[2]);
+    } else if (n == 2 && strcmp(parts[1], "home") == 0) {
+      getHome();
+    }
+    ''') == []
+
+
+def test_same_key_in_separate_chains_is_fine():
+    """companion MyMesh.cpp -- `ExtraFS/` appears in three unrelated handlers."""
+    assert kinds('''
+    void a() {
+      if (memcmp(path, "UserData/", 9) == 0) { path += 8; }
+      else if (memcmp(path, "ExtraFS/", 8) == 0) { path += 7; }
+    }
+    void b() {
+      if (memcmp(path, "UserData/", 9) == 0) { path += 8; }
+      else if (memcmp(path, "ExtraFS/", 8) == 0) { path += 7; }
+    }
+    ''') == []
+
+
+def test_different_subjects_do_not_collide():
+    """`reboot` matched on cmd_frame in one chain and cli_command in another."""
+    assert kinds('''
+    if (cmd_frame[0] == CMD_REBOOT && memcmp(&cmd_frame[1], "reboot", 6) == 0) {
+      board.reboot();
+    } else if (strcmp(cli_command, "reboot") == 0) {
+      board.reboot();
+    }
+    ''') == []
+
+
+def test_allow_empty_pragma_is_honoured():
+    assert kinds('''
+    if (isKey(config, "a")) { x(); }
+    else if (isKey(config, "drain")) {   // cli-dispatch-guard: allow-empty consumed upstream
+    }
+    ''') == []
+
+
+def test_distinct_keys_are_not_shadowed():
+    assert kinds('''
+    if (isKey(config, "radio.rxgain")) { a(); }
+    else if (isKey(config, "radio")) { b(); }
+    else if (isKey(config, "radio.fem.rxgain")) { c(); }
+    ''') == []
+
+
+def test_extra_conjunct_does_not_claim_the_key():
+    """`sender_timestamp == 0 && isKey(config, "prv.key")` -- serial-only arms
+    claim part of the key space, so a later general arm stays reachable."""
+    assert kinds('''
+    if (sender_timestamp == 0 && isKey(config, "prv.key")) { a(); }
+    else if (isKey(config, "prv.key")) { b(); }
+    ''') == []
+
+
+# ------------------------------------------------------------- mechanics ----
+
+def test_comments_cannot_fake_a_body():
+    """A comment is not code: an arm whose only content is a comment writes
+    nothing, and must be reported."""
+    assert "empty-body" in kinds('''
+    if (isKey(config, "a")) { x(); } else if (isKey(config, "radio")) {
+      // TODO: fill this in
+    }
+    ''')
+
+
+def test_braces_in_comments_do_not_confuse_the_parser():
+    assert kinds('''
+    if (isKey(config, "a")) {
+      /* } else if (isKey(config, "radio")) { */
+      x();
+    }
+    ''') == []
+
+
+def test_nested_chain_is_analysed():
+    assert "empty-body" in kinds('''
+    if (ready) {
+      if (isKey(config, "a")) { x(); }
+      else if (isKey(config, "radio")) { }
+    }
+    ''')
+
+
+def test_tests_only_key_distinguishes_bare_from_guarded():
+    assert g.tests_only_key('isKey(config, "radio")', "radio")
+    assert g.tests_only_key('memcmp(config, "radio", 5) == 0', "radio")
+    assert not g.tests_only_key('n == 2 && strcmp(parts[1], "radio") == 0', "radio")
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"FAIL {name}: {e}")
+    print(f"\n{failures} failure(s)")
+    sys.exit(1 if failures else 0)

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -1580,10 +1580,9 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
   } else if (isKey(config, "int.thresh")) {
     sprintf(reply, "> %d", (uint32_t) _prefs->interference_threshold);
   } else if (isKey(config, "agc.reset.interval")) {
-  } else if (memcmp(config, "cad", 3) == 0) {
-    sprintf(reply, "> %s", _prefs->cad_enabled ? "on" : "off");
-  } else if (memcmp(config, "agc.reset.interval", 18) == 0) {
     sprintf(reply, "> %d", ((uint32_t) _prefs->agc_reset_interval) * 4);
+  } else if (isKey(config, "cad")) {
+    sprintf(reply, "> %s", _prefs->cad_enabled ? "on" : "off");
   } else if (isKey(config, "multi.acks")) {
     sprintf(reply, "> %d", (uint32_t) _prefs->multi_acks);
   } else if (isKey(config, "allow.read.only")) {
@@ -1607,20 +1606,15 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
     sprintf(reply, "> %s", StrHelper::ftoa(_prefs->node_lat));
   } else if (isKey(config, "lon")) {
     sprintf(reply, "> %s", StrHelper::ftoa(_prefs->node_lon));
-#if defined(USE_SX1262) || defined(USE_SX1268) || defined(USE_LR1110)
   } else if (isKey(config, "radio.rxgain")) {
     sprintf(reply, "> %s", _prefs->rx_boosted_gain ? "on" : "off");
-#endif
-  } else if (isKey(config, "radio")) {
-  } else if (memcmp(config, "radio.rxgain", 12) == 0) {
-    sprintf(reply, "> %s", _prefs->rx_boosted_gain ? "on" : "off");
-  } else if (memcmp(config, "radio.fem.rxgain", 16) == 0) {
+  } else if (isKey(config, "radio.fem.rxgain")) {
     if (!_board->canControlLoRaFemLna()) {
       strcpy(reply, "Error: unsupported");
     } else {
       sprintf(reply, "> %s", _board->isLoRaFemLnaEnabled() ? "on" : "off");
     }
-  } else if (memcmp(config, "radio", 5) == 0) {
+  } else if (isKey(config, "radio")) {
     char freq[16], bw[16];
     strcpy(freq, StrHelper::ftoa3(_prefs->freq));
     strcpy(bw, StrHelper::ftoa3(_prefs->bw));
@@ -1740,11 +1734,6 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
     strcpy(reply, "ERROR: Power management not supported");
 #endif
   } else if (isKey(config, "pwrmgt.bootmv")) {
-  } else if (memcmp(config, "pwrmgt.bootreason", 17) == 0) {
-    sprintf(reply, "> Reset: %s; Shutdown: %s",
-      _board->getResetReasonString(_board->getResetReason()),
-      _board->getShutdownReasonString(_board->getShutdownReason()));
-  } else if (memcmp(config, "pwrmgt.bootmv", 13) == 0) {
 #ifdef NRF52_POWER_MANAGEMENT
     sprintf(reply, "> %u mV", _board->getBootVoltage());
 #else
@@ -1758,7 +1747,7 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
                                           offband::wifiObserverPool())) {
     // handled by the broker-config CLI
 #endif
-  } else if (memcmp(config, "extra.sf", 8) == 0) {
+  } else if (isKey(config, "extra.sf")) {
     char* tmp = reply;
     for (int i = 0; i < 3 && _prefs->extra_sf[i] != 0; i++) {
       tmp += sprintf(tmp, "%s%d", (i == 0) ? "" : ",", _prefs->extra_sf[i]);


### PR DESCRIPTION
Closes #764
Closes #765

**What:** three `get` commands have returned an empty reply since 2026-07-18, and over the client CLI that empty reply came back as stack garbage.
**Where:** `src/helpers/CommonCLI.cpp` `handleGetCmd()`, plus four `handleCommand` call sites.
**Reported by:** a user upgrading from MC 1.15.0 stock who ran `get radio` in the app.

This is **not** a prefs-migration failure. A 1.15.0 Path A record is 291 bytes, which has always been in the layout table, and a migration refusal produces valid default text rather than garbage.

## Root cause

`d4d417ee fix(#299): exact-token match for CLI get keys` converted the get chain from prefix `memcmp` to exact-token `isKey`. For most keys it hoisted the new guard *and* moved the body. For three keys it hoisted the guard and left the body on the old arm, which the new one now shadows:

```c
} else if (isKey(config, "radio")) {          // matches, writes nothing
} else if (memcmp(config, "radio", 5) == 0) { // the real body, unreachable
```

It compiles. No compiler considers it dead code. And the serial console hides it, because that caller zeroes its buffer and suppresses empty replies — so on serial the symptom is silence, not garbage. Only the radio transport shows it.

## Why the transports disagreed — the second defect

| Path | Buffer | Symptom |
|---|---|---|
| Serial (`simple_repeater/main.cpp:1157`) | `char reply[160]; reply[0] = 0;` | silent |
| Over-the-air (`simple_repeater/MyMesh.cpp:736`) | `uint8_t temp[166]`, zeroed only on the retry branch | **uninitialised stack transmitted** |

An audit of every `handleCommand` call site found **four** defective, not one:

- `simple_repeater/MyMesh.cpp` — over-the-air
- `simple_room_server/MyMesh.cpp` — over-the-air, admin branch only; the other branches happen to zero it
- `simple_sensor/SensorMesh.cpp` — over-the-air, never zeroed on any path
- `simple_sensor/main.cpp` — **serial**, missing `reply[0] = 0`

`simple_sensor` was the only role missing it on both transports, so it had no safe transport to fall back on. Fixing the three keys removes today's triggers but not the mechanism — any handler that returns without writing would resurrect it — which is why the buffers are fixed here too.

## Changes

1. Three bodies restored onto their `isKey` arms; shadowed `memcmp` duplicates removed.
2. `cad` and `extra.sf` converted to `isKey` — two arms the original conversion missed that still prefix-matched junk suffixes.
3. `#if defined(USE_SX1262)…` dropped from the `radio.rxgain` getter. `rx_boosted_gain` is an unconditional field and its `set` counterpart is unguarded, so the getter should be too. Upstream MeshCore agrees.
4. Reply buffer zeroed at the four call sites above.
5. `scripts/check_cli_dispatch.py` + 17 unit tests, wired **blocking** into `config-lint`.

## The guard

Two checks, both scoped to contiguous if/else-if chains: a key-matching arm with an empty body, and a key claimed twice in one chain where the earlier arm tests nothing but that key. Chain- and arity-aware, so `home`/`default` split by argument count, and `ExtraFS/` appearing in three separate handlers, stay green.

It reports **8 findings on the unfixed tree and none after**. The 17 tests pin both the regression shape and every false positive an earlier draft produced — a guard that cries wolf gets switched off.

## Verification

- **Builds 5/5 SUCCESS:** `Heltec_WSL3_sensor`, `heltec_v4_repeater_telemetry`, `heltec_v4_room_server`, `heltec_v4_companion_observer_wifi`, `RAK_4631_repeater` (the nRF52 leg that exercises the `pwrmgt.bootmv` `#ifdef` restructure).
- Guard clean; 17/17 unit tests pass.
- Gemini review completed. One point adopted — a sharper rationale for the `radio.rxgain` guard removal. Two findings verified wrong: it reported `get pwrmgt.bootreason` as deleted, but that handler is intact at `CommonCLI.cpp:1728` (it sat above the diff hunk's context), and its predicted preprocessor false-positive does not occur, since directive lines make a body non-empty.

**Not hardware-verified** — owner elected to skip the flash to get this to the reporting user. The `get radio` output path itself is unchanged code, simply reachable again.

## Scope checked and cleared

`set` chain, companion `0xC5` dispatch, observer CLI, `simple_secure_chat`, `WifiConfigProvider`, `RemoteCommand`. A separate scan for the related failure mode — an arm whose only `reply` write sits inside an unguarded `#ifdef` — found no instances; every conditional arm carries an `#else`.

---
Agent: **FoggyCanyon** (Agent Mail, `app-c-dev-crosswire`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
