### PR TITLE
ci(#771): add heltec_rc32 envs to the release matrix

### DIFF
--- a/.github/release-envs.txt
+++ b/.github/release-envs.txt
@@ -90,6 +90,19 @@ t1000e_room_server
 Heltec_E290_companion_ble
 Heltec_E290_companion_usb
 
+# Heltec RadioCore RC32-L62 (ESP32-S3 + HT-RA62A LoRa) -- #771
+# Applies to the L62 (LoRa) carrier only. RC32-68 carries the HT-HC01_V2 Wi-Fi
+# HaLow module on a DIFFERENT pinout and has no variant in this tree.
+# heltec_rc32_companion_radio_wifi -- NOT releasable: bakes a placeholder
+#   WIFI_SSID at compile time; unblocked by #325. Same gate class as the other
+#   companion_radio_wifi envs. (Unlike those, it is not CI-built either -- no
+#   rc32 env is in ci.yml yet; tracked separately.)
+# The _diag / _diag_nocrashlog envs are diagnostic instruments, not products.
+heltec_rc32_companion_radio_ble
+heltec_rc32_companion_radio_usb
+heltec_rc32_repeater
+heltec_rc32_room_server
+
 # Heltec T096 (nRF52)
 Heltec_t096_companion_radio_ble
 Heltec_t096_companion_radio_usb


### PR DESCRIPTION
Closes #771.

## Why

`grep rc32 .github/release-envs.txt` returned nothing. The release pipeline produced **no
RC32 binary at all**, so there was nothing to hand a RadioCore beta tester through the normal
`offband-v*` tag → release-assets channel — only ad-hoc files, which is exactly what the
consolidated-distribution rule exists to prevent.

## What

Adds the four standard envs, matching the shape every other board uses:

```
heltec_rc32_companion_radio_ble
heltec_rc32_companion_radio_usb
heltec_rc32_repeater
heltec_rc32_room_server
```

Deliberately excluded, each for an existing reason:

- `companion_radio_wifi` — bakes a placeholder `WIFI_SSID` at compile time; same gate class
  as the other wifi companions, unblocked by #325
- `_diag` / `_diag_nocrashlog` — diagnostic instruments, not products
- `without_display`, `sensor`, `terminal_chat`, `kiss_modem` — follow the existing convention
  of staying out of the curated set

## Verification

- All four envs built locally before the change: **SUCCESS**
- Every env named in `release-envs.txt` resolves to a real `[env:]` section — **91/91**

## ⚠ Sequencing — read before cutting any release

**The first release that includes RC32 must be cut AFTER #704 lands.**
`fix/704-rc32-no-gps` is still unmerged and carries four commits the stock env needs:

```
4c0d212b fix(#704): disable GPS on heltec_rc32 -- its enable pin is the VDD_SPI strap
bfcafb97 fix(#704): strip peripherals the RC32 does not have
25c1ef80 fix(#704): align heltec_rc32 to Heltec's own board definition
3467ef54 fix(#704): DISPLAY_ROTATION=0 -- landscape, owner-confirmed
```

Merging this PR alone does not make an RC32 release safe — it makes one *possible*. Until
#704 merges, the stock env ships with GPS enabled on a pin that is the VDD_SPI strap.

Also note **no RC32 companion env has been hardware-verified in stock form.** All recent
bench work ran on `..._ble_diag`, which locally overrides `ENV_INCLUDE_GPS=0` and
`DISPLAY_ROTATION=0` — masking precisely what #704 fixes.

## Known gap, tracked separately

No rc32 env is in `ci.yml`, so nothing verifies these build on push. That is the larger of
the two gaps; this PR closes the release half only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)