### PR TITLE
feat(#786): RC32 bench instrumentation — fuel gauge, INA probe, command queue, runtime analysis

### DIFF
--- a/docs/rc32-beta-checklist.md
+++ b/docs/rc32-beta-checklist.md
@@ -1,0 +1,114 @@
+# RC32 beta binary — working checklist
+
+> **Mirror of [#773](https://github.com/OffbandMesh/meshcore-firmware/issues/773).**
+> The issue is the source of truth (board discipline); this file exists so the checklist is
+> readable when GitHub is unavailable — it was unreachable during the 2026-08-17 incident,
+> which is why this copy exists. If the two disagree, the issue wins. Update both together.
+
+Snapshot: 2026-08-17, after the overnight #702 / #763 / #766 session.
+
+---
+
+## Path to a tester binary
+
+Ordered — each item unblocks the next.
+
+- [x] **1. Merge #772** — four rc32 envs added to `.github/release-envs.txt`.
+      **Merged `36b6936a`, 2026-08-17T15:14Z**, confirmed on `firmware-base`.
+      *Without this the release pipeline emitted no RC32 asset at all.*
+
+- [ ] **2. Land `fix/704-rc32-no-gps`** — 4 commits, unmerged, **no PR yet**.
+      **This is the real blocker on tester safety**, not #772:
+
+      4c0d212b  disable GPS on heltec_rc32 -- its enable pin is the VDD_SPI strap
+      bfcafb97  strip peripherals the RC32 does not have
+      25c1ef80  align heltec_rc32 to Heltec's own board definition
+      3467ef54  DISPLAY_ROTATION=0 -- landscape, owner-confirmed
+
+      Both the GPS and rotation changes are already hardware-confirmed. They simply never
+      landed. Until they do, the stock env ships with GPS **enabled** on a pin that is the
+      VDD_SPI strap.
+
+- [ ] **3. Add rc32 envs to `ci.yml`** — no rc32 env is in the CI matrix, so `ci-green` does
+      not cover them and nothing catches a break on push. Mirror the four release envs.
+
+- [ ] **4. Hardware-verify the STOCK env on `rc32-bench-1`** — one flash, then confirm boot,
+      display, BLE pairing, radio.
+      **No RC32 companion env has ever been booted in stock form.** Every bench result to
+      date came from `..._ble_diag`, which locally sets `ENV_INCLUDE_GPS=0` and
+      `DISPLAY_ROTATION=0` — masking exactly what #704 fixes. This is the step that would
+      otherwise burn the tester.
+
+- [ ] **5. Confirm the tester's sub-variant** — RC32-**L62** (HT-RA62A LoRa) vs RC32-**68**
+      (HT-HC01_V2 Wi-Fi HaLow). Different pinouts; only L62 is supported. A HaLow unit needs
+      a new variant — new work, not a build. Ask before promising anything.
+
+- [ ] **6. Cut `offband-v1.5.0-beta3`** — requires the release preview and an explicit human
+      "ship it" per `VERSIONING.md`. Must come **after** items 2 and 4.
+
+- [ ] **7. Send the tester the release link** — not a CI artifact, not a file from the bench.
+
+---
+
+## Carried debt from the overnight session
+
+- [ ] **#763 — level-gate the UART0 mirror.**
+      It is a synchronous bounded busy-wait at 115200 baud and now runs regardless of capture
+      state. With `BLE_DEBUG_LOGGING=1` it blocked inside `setup()`: boot 2 s → 118 s → never
+      completing. Contained today (`OFFBAND_MESHLOG_UART0` is set on one env only) but must be
+      fixed before the mirror spreads. Options recorded on the issue: give the mirror its own
+      level ceiling, or make it drop rather than wait when the FIFO is full (matching #447).
+
+- [ ] **#754 — CrashLog boot telemetry is a tautology.**
+      `rtc_count` is compared against `nvs_count` but sourced from the same place, so the
+      check always passes and reports health it never verified. Open, unresolved.
+
+- [ ] **Commit the diagnostic tooling.** Uncommitted in the primary clone on `firmware-base`;
+      needs its own branch + issue:
+      - `tools/diag/rc32-boot-740/scripts/battery_runtime.py` (new)
+      - `tools/diag/rc32-boot-740/rc32_uart_sniffer_v3/rc32_uart_sniffer_v3.ino` (modified —
+        board-agnostic pin map via `SNIFFER_GENERIC_S3`)
+      - this file
+
+---
+
+## Heltec beta deliverables
+
+- [ ] **Submit the feedback form.** Drafted and saved, gitignored, at
+      `docs/radiocore/vendor/RC32-beta-feedback-submitted-2026-08-17.md`.
+      Name and Discord ID are the owner's to fill; nothing is submitted by an agent.
+
+- [ ] **Finish the discharge run and attach the curve to Q01.**
+      Capture runs on a detached process (COM16 → `tools/diag/rc32-boot-740/evidence/763-power-telemetry.log`).
+      Analyse with `tools/diag/rc32-boot-740/scripts/battery_runtime.py`.
+      Attach a **trimmed CSV**, not the raw multi-hour log.
+      The average-mA figure is worth as much as the runtime — it is the input for the
+      solar/car build, and the number Heltec cannot answer.
+
+---
+
+## Next board
+
+- [ ] **RCC6 bring-up (#624).**
+      No variant exists in-tree and upstream MeshCore has none, so we would be first.
+      The starting point is real now: the carrier schematic reads reliably via PyMuPDF
+      coordinate extraction — row-pair net labels against pin labels, then render the region
+      to confirm visually. Text extraction alone repeatedly misled during #766; do not trust
+      the flattened dumps.
+      **Caveat:** the UART0 beacon/mirror is **unverified on ESP32-C6** — RISC-V, different
+      register layout. It reads `UART_TXFIFO_CNT_S` from the target's own `soc/uart_reg.h` so
+      it should adapt, but that is untested.
+
+---
+
+## Closed overnight, for context
+
+- **#702** — RST no-boot. Root cause `Serial.setTxTimeoutMs(0)`: `tries--` underflows to
+  4.29e9, making the escape hatch unreachable (~50 days). Offband-introduced — not upstream,
+  not Heltec. Fixed.
+- **#766** — RC32 battery read. **Not a firmware defect:** reversed battery leads. Every
+  configured value matches the schematic (`ADC_IN`=GPIO7, `ADC_Ctrl`=GPIO15 active-high,
+  R36 390K / R38 100K = 4.9).
+- **#769 / PR #770** — UART0 mirror, capture decoupling, battery telemetry. Merged.
+- **#771 / PR #772** — rc32 envs in the release matrix. Merged.
+- **#762** — display work: colour splash, dark palette, antialiased font. Merged.

--- a/tools/diag/rc32-boot-740/rc32_uart_sniffer_v3/rc32_uart_sniffer_v3.ino
+++ b/tools/diag/rc32-boot-740/rc32_uart_sniffer_v3/rc32_uart_sniffer_v3.ino
@@ -14,11 +14,15 @@
 // ---------------------------------------------------------------------------
 // WIRING
 // ---------------------------------------------------------------------------
-//   RC32 pin 12 (U0TXD / GPIO43) -> Feather RX      [v2, existing]
-//   RC32 pin 20 (GND)            -> Feather GND     [v2, existing]
-//   RC32 pin 18 (RST)            -> Feather A0      [v3, new]
-//   RC32 pin  5 (GPIO0 / BOOT)   -> Feather A1      [v3, new]
-//   Feather TX                   -> NOT CONNECTED
+//                                  Feather        generic S3 WROOM
+//   RC32 pin 12 (U0TXD / GPIO43) -> RX             GPIO18     [v2, existing]
+//   RC32 pin 20 (GND)            -> GND            GND        [v2, existing]
+//   RC32 pin 18 (RST)            -> A0             GPIO17     [v3, new]
+//   RC32 pin  5 (GPIO0 / BOOT)   -> A1             GPIO16     [v3, new]
+//   sniffer TX                   -> NOT CONNECTED (either board)
+//
+// GND is not optional and is not a formality: without a common reference the
+// UART sees garbage or nothing at all, which reads exactly like a dead board.
 //
 // ---------------------------------------------------------------------------
 // OPEN-DRAIN ONLY -- THIS IS NOT OPTIONAL
@@ -55,10 +59,95 @@
 #define HB_FAST_FOR  30000    // then slow down so it cannot drown real data
 #define HB_SLOW_MS   10000
 
-// Symbolic Feather pin names -- resolved by the board variant header. Do not
-// substitute raw GPIO numbers; they differ across Feather S3 variants.
-#define PIN_RC32_RST   A0
-#define PIN_RC32_BOOT  A1
+// ---------------------------------------------------------------------------
+// PIN MAP -- Feather by default, generic ESP32-S3 WROOM via one #define
+// ---------------------------------------------------------------------------
+// On the Feather these are symbolic names resolved by the board variant header,
+// and raw GPIO numbers must NOT be substituted -- they differ across Feather S3
+// variants.
+//
+// On a generic ESP32-S3 WROOM DevKitC those same names are wrong in a way that
+// looks like a wiring fault rather than a config error: `RX` resolves to
+// GPIO44, which IS U0RXD and is wired to the onboard USB-UART bridge. Sniffing
+// on it puts two drivers on the console UART. So the generic build uses explicit
+// GPIOs chosen to be free on every S3 WROOM module variant.
+//
+// Avoided deliberately on the generic map:
+//   GPIO0/3/45/46  strapping pins
+//   GPIO19/20      native USB D-/D+
+//   GPIO26..32     SPI flash
+//   GPIO33..37     octal PSRAM -- unusable on N8R8 / N16R8 modules, which is
+//                  most of what ships as "ESP32-S3 WROOM"
+//   GPIO43/44      UART0 / USB-UART bridge
+//   GPIO48         onboard RGB LED
+//
+// Build for a generic board by defining SNIFFER_GENERIC_S3 (uncomment below).
+//#define SNIFFER_GENERIC_S3 1
+
+#if defined(SNIFFER_GENERIC_S3)
+  #define PIN_SNIFF_RX   18
+  #define PIN_RC32_RST   17
+  #define PIN_RC32_BOOT  16
+#else
+  #define PIN_SNIFF_RX   RX
+  #define PIN_RC32_RST   A0
+  #define PIN_RC32_BOOT  A1
+#endif
+
+// ---------------------------------------------------------------------------
+// MAX17048 FUEL GAUGE ON Wire1  (#780 / Heltec beta Q01)
+// ---------------------------------------------------------------------------
+// WHY. The RC32 reports battery VOLTAGE only, and turning voltage into charge
+// requires a discharge curve we do not have for this cell -- the estimator in
+// scripts/battery_runtime.py has to guess with a nominal table, and its two
+// methods disagreed by seven hours on the first run. A MAX17048 reports modelled
+// charge directly, which is the quantity we were failing to infer.
+//
+// TOPOLOGY. The gauge sits between the battery and the RC32: the cell feeds the
+// gauge, the gauge passes power through to the RC32, and the SNIFFER reads it
+// over I2C. The device under test is not modified and does not know it is being
+// measured.
+//
+// Do NOT use the Feather's ONBOARD MAX17048 for this. It measures whatever is on
+// the Feather's own battery JST, and connecting the RC32's cell there would let
+// the USB-powered Feather CHARGE it -- which does not merely perturb a discharge
+// test, it prevents one from ever finishing.
+//
+// WHY Wire1, AND WHY IT MUST BE Wire1.
+//   * House convention: Wire is onboard devices, Wire1 is anything plugged in.
+//   * It is also forced here. The MAX1704x has NO address-select pin -- it is
+//     hard-wired to 0x36 -- and the Feather already carries one onboard at 0x36
+//     on Wire. Two devices, one address, one bus is unresolvable.
+//
+// CONSEQUENCE FOR WIRING: the STEMMA QT connector is physically on Wire. Plugging
+// the external gauge into it lands it on the SAME bus as the onboard one and
+// collides. The external gauge must be hand-wired to the Wire1 pins below.
+//
+// BRING-UP ORDER IS NOT OPTIONAL. On ESP32 the pins are arguments to begin();
+// on nRF52 they must be set BEFORE begin(). Getting it the wrong way round does
+// not warn, it simply fails to come up -- the same class of failure as
+// "HSPI Does not have default pins on ESP32S3". Pattern copied from
+// src/helpers/sensors/EnvironmentSensorManager.cpp:637, which is the canonical
+// version in this project.
+#define SNIFF_GAUGE 1
+
+// Free on the sniffer: RX carries the sniff line, A0/A1 carry RST/BOOT.
+// A2/A3 are unused. Change these to match however you actually wire it.
+#ifndef PIN_GAUGE_SDA
+  #define PIN_GAUGE_SDA A2
+#endif
+#ifndef PIN_GAUGE_SCL
+  #define PIN_GAUGE_SCL A3
+#endif
+
+#define MAX1704X_ADDR    0x36
+#define MAX1704X_VCELL   0x02
+#define MAX1704X_SOC     0x04
+#define MAX1704X_VERSION 0x08
+
+// Sampling cadence. Matches the RC32's own [pwr] line so the two series line up
+// in the capture without interpolation.
+#define GAUGE_PERIOD_MS 30000
 
 // RST: R31 10K + C32 1uF gives a ~10 ms RC on CHIP_PU. 100 ms is comfortably
 // past it. (Holding RST for 1 s was tested by the owner and changes nothing --
@@ -72,6 +161,173 @@ static uint32_t hb_next = 0, hb_n = 0;
 static uint32_t rx_bytes = 0;
 static char cmd_buf[32];
 static uint8_t cmd_len = 0;
+
+#if SNIFF_GAUGE
+#include <Wire.h>
+static bool     gauge_present = false;
+static uint32_t gauge_next    = 0;
+
+// Read one 16-bit big-endian register. Returns false on any bus error rather
+// than handing back a plausible-looking zero -- a fuel gauge that silently
+// reports 0% would be worse than one that reports nothing.
+static bool gaugeRead16At(uint8_t addr, uint8_t reg, uint16_t* out) {
+  Wire1.beginTransmission(addr);
+  Wire1.write(reg);
+  if (Wire1.endTransmission(false) != 0) return false;
+  if (Wire1.requestFrom(addr, (uint8_t)2) != 2) return false;
+  uint8_t hi = Wire1.read(), lo = Wire1.read();
+  *out = ((uint16_t)hi << 8) | lo;
+  return true;
+}
+
+static bool gaugeRead16(uint8_t reg, uint16_t* out) {
+  return gaugeRead16At(MAX1704X_ADDR, reg, out);
+}
+
+// Forward declaration: gaugeBegin() calls this, and it is defined below.
+// Arduino's automatic prototype generation is unreliable for `static` functions,
+// so it is declared explicitly rather than relying on the preprocessor.
+static void inaProbe();
+
+static void gaugeBegin() {
+  // ESP32 takes the pins as arguments to begin(). nRF52 needs setPins() FIRST.
+  // See the header comment -- this order is the whole trap.
+#if defined(NRF52_PLATFORM) || defined(ARDUINO_ARCH_NRF52)
+  Wire1.setPins(PIN_GAUGE_SDA, PIN_GAUGE_SCL);
+  Wire1.setClock(100000);
+  Wire1.begin();
+#else
+  Wire1.begin(PIN_GAUGE_SDA, PIN_GAUGE_SCL, 100000);
+#endif
+
+  // Targeted probe, NOT a bus scan. A blind scan is what wedges the I2C
+  // peripheral on the C6 (#294 -- hangs at 0x0d and never returns, so setup()
+  // never reaches loop()). We know the address; there is no reason to sweep.
+  uint16_t ver = 0;
+  gauge_present = gaugeRead16(MAX1704X_VERSION, &ver);
+
+  Serial.print("=== fuel gauge on Wire1 (SDA=");
+  Serial.print((int)PIN_GAUGE_SDA);
+  Serial.print(" SCL=");
+  Serial.print((int)PIN_GAUGE_SCL);
+  Serial.print("): ");
+  if (gauge_present) {
+    Serial.print("FOUND at 0x36, VERSION=0x");
+    Serial.println(ver, HEX);
+  } else {
+    Serial.println("NOT FOUND -- check wiring, and that it is NOT in the STEMMA");
+    Serial.println("    port (that is Wire, where the onboard gauge already sits at 0x36)");
+  }
+
+  inaProbe();
+}
+
+// ---------------------------------------------------------------------------
+// INA CURRENT MONITOR -- IDENTIFICATION ONLY (for now)
+// ---------------------------------------------------------------------------
+// The MAX17048 answers "how full is the cell". An INA answers "how much is it
+// drawing right now". Together they close the loop: measured charge, measured
+// current, measured time -- no nominal tables and no bracketed range.
+//
+// This probes the four parts the Offband firmware already supports, because
+// which one is present changes how current is decoded and guessing wrong
+// produces confident nonsense rather than an error:
+//
+//   INA219  0x40  12-bit, external shunt, current needs a calibration write
+//   INA260  0x41  16-bit + INTEGRATED 2 mOhm shunt, current readable directly
+//   INA3221 0x42  3-channel, lower precision
+//   INA226  0x44  16-bit, external shunt, current needs calibration
+//
+// Identification is positive, not inferred from address alone: TI parts carry a
+// Manufacturer ID at 0xFE (0x5449, "TI") and a Die ID at 0xFF. Address tells you
+// where something answered; the die ID tells you WHAT answered, and on a bus
+// where addresses are configurable by strap those are different questions.
+//
+// Targeted probe of four known addresses -- NOT a bus scan. Blind scanning is
+// what wedges the C6 I2C peripheral (#294).
+//
+// Deliberately identification-only: the current decode is written once the part
+// is known, rather than shipping three decoders that never run and cannot be
+// tested.
+static void inaProbe() {
+  // Address sweep is deliberately narrow: 0x40..0x4F is the INA family's
+  // strap-selectable range. Still a bounded, known range, not a blind bus scan
+  // (#294 -- a blind scan wedges the C6 I2C peripheral and never returns).
+  bool any = false;
+  for (uint8_t addr = 0x40; addr <= 0x4F; addr++) {
+    Wire1.beginTransmission(addr);
+    if (Wire1.endTransmission() != 0) continue;
+    if (addr == MAX1704X_ADDR) continue;   // not an INA
+    any = true;
+
+    // TWO ID register locations, because the families disagree:
+    //   INA226 / INA260 / INA3221 -> MFG 0xFE, DIE 0xFF
+    //   INA228 / INA237 / INA238  -> MFG 0x3E, DEVICE 0x3F
+    // Probing only 0xFE/0xFF would find an INA228 at 0x40, get nothing back,
+    // and misreport it as an INA219 (which genuinely has no ID registers).
+    // Same address, wrong chip, wrong decode, plausible-looking output.
+    uint16_t mfg_hi = 0, die_hi = 0, mfg_lo = 0, dev_lo = 0;
+    bool have_hi = gaugeRead16At(addr, 0xFE, &mfg_hi) && gaugeRead16At(addr, 0xFF, &die_hi);
+    bool have_lo = gaugeRead16At(addr, 0x3E, &mfg_lo) && gaugeRead16At(addr, 0x3F, &dev_lo);
+
+    Serial.print("=== INA candidate at 0x");
+    Serial.print(addr, HEX);
+
+    const char* id = "";
+    if (have_lo && mfg_lo == 0x5449) {
+      // DEVICE_ID is [15:4] part, [3:0] revision -- mask the revision off.
+      uint16_t part = (uint16_t)(dev_lo >> 4);
+      id = (part == 0x228) ? " -> INA228"
+         : (part == 0x237) ? " -> INA237"
+         : (part == 0x238) ? " -> INA238"
+         : " -> TI part, unrecognised DEVICE_ID";
+      Serial.print("  mfg=0x"); Serial.print(mfg_lo, HEX);
+      Serial.print(" dev=0x");  Serial.print(dev_lo, HEX);
+    } else if (have_hi) {
+      id = (die_hi == 0x2260) ? " -> INA226"
+         : (die_hi == 0x2270) ? " -> INA260"
+         : (die_hi == 0x3220) ? " -> INA3221"
+         : " -> unrecognised DIE_ID";
+      Serial.print("  mfg=0x"); Serial.print(mfg_hi, HEX);
+      Serial.print(" die=0x");  Serial.print(die_hi, HEX);
+    } else {
+      id = " -> no ID registers (consistent with INA219)";
+    }
+    Serial.println(id);
+  }
+  if (!any) Serial.println("=== no INA found on Wire1 (swept 0x40..0x4F)");
+}
+
+static void gaugeTick(uint32_t now) {
+  if (!gauge_present || (int32_t)(now - gauge_next) < 0) return;
+  gauge_next = now + GAUGE_PERIOD_MS;
+
+  uint16_t vcell = 0, soc = 0;
+  if (!gaugeRead16(MAX1704X_VCELL, &vcell) || !gaugeRead16(MAX1704X_SOC, &soc)) {
+    Serial.println("[gauge] read FAILED");
+    return;
+  }
+
+  // MAX17048: VCELL LSB = 78.125 uV, charge = SOC / 256 %.
+  // Raw values are printed alongside the decode deliberately. If this turns out
+  // to be a MAX17043 the scaling differs (12-bit VCELL, 1.25 mV/LSB) and the raw
+  // number is what lets that be corrected after the fact instead of silently
+  // logging a wrong voltage for hours.
+  uint32_t mv = ((uint32_t)vcell * 78125UL) / 1000000UL;
+  uint32_t pct_x10 = ((uint32_t)soc * 10UL) / 256UL;
+
+  Serial.print("[gauge] mv=");
+  Serial.print(mv);
+  Serial.print(" charge=");
+  Serial.print(pct_x10 / 10);
+  Serial.print('.');
+  Serial.print(pct_x10 % 10);
+  Serial.print("%  raw_vcell=0x");
+  Serial.print(vcell, HEX);
+  Serial.print(" raw_soc=0x");
+  Serial.println(soc, HEX);
+}
+#endif  // SNIFF_GAUGE
 
 // Dead-man release. If this sketch ever hangs or crashes between od_assert()
 // and od_release(), the RC32 would be held in reset (or download mode)
@@ -141,17 +397,21 @@ void setup() {
   Serial.begin(115200);
   while (!Serial && millis() < 3000) { }
 
-  Serial1.begin(SNIFF_BAUD, SERIAL_8N1, RX, -1);   // RX only -- TX is -1
+  Serial1.begin(SNIFF_BAUD, SERIAL_8N1, PIN_SNIFF_RX, -1);   // RX only -- TX is -1
 
   Serial.println();
   Serial.println("================================================");
   Serial.println("=== RC32 UART0 SNIFFER  BUILD ID: SNIFFER-v3 ===");
-  Serial.printf ("=== listening on Feather RX, %d 8N1\n", SNIFF_BAUD);
+  Serial.printf ("=== listening on GPIO%d, %d 8N1\n", (int)PIN_SNIFF_RX, SNIFF_BAUD);
   Serial.println("=== heartbeat 1/s for 30s, then 1/10s");
   Serial.println("=== any line without [hb] or >>> is RC32 data");
   Serial.println("=== RST->A0  BOOT->A1  (open-drain, pull-low only)");
   Serial.println("=== cmds: RST BOOTRST BOOT PING HELP");
   Serial.println("================================================");
+
+#if SNIFF_GAUGE
+  gaugeBegin();
+#endif
 }
 
 void loop() {
@@ -160,6 +420,14 @@ void loop() {
     Serial.write(Serial1.read());
     rx_bytes++;
   }
+
+#if SNIFF_GAUGE
+  // After the relay, never before it. An I2C transaction takes a few hundred
+  // microseconds and the RC32's UART has no flow control -- servicing the gauge
+  // ahead of the relay would risk dropping the bytes this whole instrument
+  // exists to capture.
+  gaugeTick(millis());
+#endif
 
   // Host commands.
   while (Serial.available()) {

--- a/tools/diag/rc32-boot-740/scripts/battery_runtime.py
+++ b/tools/diag/rc32-boot-740/scripts/battery_runtime.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Estimate RC32 battery runtime from a captured [pwr] telemetry log (#766 / Q01).
+
+WHY THIS EXISTS
+---------------
+A 2500 mAh cell on this board plausibly runs 30-60 hours. Waiting for the board to
+die is the most accurate measurement and also the least useful one, because it can
+outlast the window in which the answer is needed. This projects the endpoint from
+the part of the curve we already have.
+
+WHAT IT WILL NOT DO
+-------------------
+Extrapolate a straight line from early data. A freshly charged LiPo sheds its
+surface charge quickly under first load -- the RC32 dropped 19 mV in the first 90
+seconds, which linearly extrapolated predicts death within the hour. It then
+settles onto a long, nearly flat plateau where the true slope is an order of
+magnitude smaller. Any estimate that ignores this is not conservative, it is
+simply wrong, so the script discards a leading warm-up window by default and says
+so in its output.
+
+METHOD
+------
+Two independent estimates, deliberately, because they fail in different ways:
+
+  1. SLOPE PROJECTION -- least-squares fit of mV vs time over a recent window,
+     extrapolated to the cutoff. Honest about the near term; degrades in the
+     plateau where dV/dt is small and noise dominates.
+
+  2. CHARGE ACCOUNTING -- map voltage to state-of-charge through a nominal LiPo
+     curve, measure how much SoC was consumed over the observed interval, and
+     scale by the rated capacity to get average current. Runtime then follows
+     from the charge remaining above the cutoff. Insensitive to plateau
+     flatness, but only as good as the SoC table.
+
+Agreement between the two is the confidence signal. Divergence means the cell is
+somewhere the nominal table describes badly, and the answer should be reported as
+a range rather than a number.
+
+The SoC table is NOMINAL for a generic single-cell LiPo under light load. It is
+not calibrated against this cell, and it is the largest error term here -- treat
+charge-accounting output as an estimate with maybe +/-20% on it, not a
+measurement. The only calibrated number in the whole pipeline is elapsed time.
+"""
+
+import argparse
+import re
+import sys
+from datetime import datetime, timezone
+
+# Nominal open-circuit-ish LiPo discharge curve, light load: (volts, charge level 0..1).
+# NOTE: "SoC" is avoided in this file. In a firmware repo it reads as System-on-Chip
+# (the ESP32-S3 is one), and this is State-of-Charge -- an unhelpful collision.
+# Monotonic in both columns; interpolated linearly between rows. The steep regions at
+# each end and the flat middle are the whole point -- a single linear ratio would
+# misestimate both.
+SOC_TABLE = [
+    (4.20, 1.00), (4.15, 0.95), (4.11, 0.90), (4.08, 0.85), (4.02, 0.80),
+    (3.98, 0.75), (3.95, 0.70), (3.91, 0.65), (3.87, 0.60), (3.85, 0.55),
+    (3.84, 0.50), (3.82, 0.45), (3.80, 0.40), (3.79, 0.35), (3.77, 0.30),
+    (3.75, 0.25), (3.73, 0.20), (3.71, 0.15), (3.69, 0.10), (3.61, 0.05),
+    (3.40, 0.00),
+]
+
+LINE_RE = re.compile(r"^\[(?P<ts>[0-9T:.\-]+)Z\]\s+\[(?P<ms>\d+)\]\s+\[pwr\]\s+mv=(?P<mv>\d+)\s+up=(?P<up>\d+)s")
+
+
+def raw_soc(volts):
+    """Table charge level (0..1) for a cell voltage, by linear interpolation."""
+    if volts >= SOC_TABLE[0][0]:
+        return 1.0
+    if volts <= SOC_TABLE[-1][0]:
+        return 0.0
+    for (v_hi, s_hi), (v_lo, s_lo) in zip(SOC_TABLE, SOC_TABLE[1:]):
+        if v_lo <= volts <= v_hi:
+            span = v_hi - v_lo
+            if span <= 0:
+                return s_lo
+            return s_lo + (volts - v_lo) / span * (s_hi - s_lo)
+    return 0.0
+
+
+def make_soc(full_mv):
+    """Charge level anchored so that `full_mv` reads as 100%.
+
+    WHY THIS EXISTS. The raw table tops out at 4.20 V, but a real pack rarely
+    presents that to the ADC at the start of a run. Chargers terminate at 4.20 V
+    and the cell then relaxes; the reading is taken under load, so it sags further;
+    and the divider itself carries the tolerance of R36/R38 plus the ADC.
+
+    On this run the owner confirmed the pack was **fully charged** at 4130 mV. The
+    unanchored table called that 85%, i.e. it opened the accounting already claiming
+    ~375 mAh had been consumed before the board drew anything. That error propagates
+    straight into the current estimate -- it inflates mAh-consumed, and therefore
+    inflates average draw, and therefore shortens the projected runtime. It was a
+    large part of why the two methods disagreed.
+
+    Anchoring renormalises the curve so the observed full-charge voltage is 100% and
+    the cutoff stays 0%, preserving the table's SHAPE (which is the part worth having)
+    while discarding its assumption about where full sits. Since the table defines
+    3.40 V as 0, that reduces to dividing through by the table value at `full_mv`.
+
+    This is still a nominal curve with a measured anchor, not a calibrated cell.
+    """
+    denom = raw_soc(full_mv)
+    if denom <= 0:
+        return raw_soc
+    return lambda v: min(1.0, raw_soc(v) / denom)
+
+
+def parse(path):
+    """Yield (datetime, uptime_seconds, millivolts) for each [pwr] line."""
+    out = []
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            m = LINE_RE.match(line.strip())
+            if not m:
+                continue
+            ts = datetime.fromisoformat(m.group("ts")).replace(tzinfo=timezone.utc)
+            out.append((ts, int(m.group("up")), int(m.group("mv"))))
+    return out
+
+
+def fit(points):
+    """Least-squares slope/intercept of mv vs hours. Returns (slope, intercept)."""
+    n = len(points)
+    if n < 2:
+        return 0.0, points[0][1] if points else 0.0
+    sx = sum(p[0] for p in points)
+    sy = sum(p[1] for p in points)
+    sxx = sum(p[0] * p[0] for p in points)
+    sxy = sum(p[0] * p[1] for p in points)
+    denom = n * sxx - sx * sx
+    if abs(denom) < 1e-12:
+        return 0.0, sy / n
+    slope = (n * sxy - sx * sy) / denom
+    return slope, (sy - slope * sx) / n
+
+
+def hms(hours):
+    if hours != hours or hours in (float("inf"), float("-inf")) or hours < 0:
+        return "n/a"
+    h = int(hours)
+    return f"{h}h {int(round((hours - h) * 60)):02d}m"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("log")
+    ap.add_argument("--capacity-mah", type=float, default=2500.0)
+    ap.add_argument("--cutoff-mv", type=int, default=3400,
+                    help="AUTO_SHUTDOWN_MILLIVOLTS -- the firmware's own end of run")
+    ap.add_argument("--warmup-min", type=float, default=30.0,
+                    help="leading minutes discarded as surface-charge decay")
+    ap.add_argument("--window-h", type=float, default=3.0,
+                    help="trailing hours used for the slope fit")
+    ap.add_argument("--full-mv", type=int, default=None,
+                    help="observed voltage at 100%% charge; anchors the curve. "
+                         "Defaults to the first sample of the discharge, which is "
+                         "correct when the pack was started fully charged.")
+    args = ap.parse_args()
+
+    rows = parse(args.log)
+    if not rows:
+        print("no [pwr] lines found -- is this the right log?")
+        return 1
+
+    # The run is the TRAILING CONTIGUOUS segment of plausible cell readings -- not
+    # every sample that happens to fall in range.
+    #
+    # This log contains samples from before the battery was wired correctly, when
+    # reversed leads left VBAT unpowered and the ADC read a clean 0 mV (#766). Those
+    # zeros are inside any naive "<= 4350" filter, and including them anchors the fit
+    # at 0 mV and reports the battery CHARGING at +6482 mV/h. A discharge estimator
+    # that can output a positive slope is reporting a parsing bug as physics.
+    #
+    # So: valid means a real single cell (2500..4350 mV). Anything outside that is a
+    # host supply above or an unpowered/absent cell below, and either one ENDS the
+    # segment -- we keep only what follows the last such break.
+    VALID_LO, VALID_HI = 2500, 4350
+    start_idx = 0
+    for i, r in enumerate(rows):
+        if not (VALID_LO <= r[2] <= VALID_HI):
+            start_idx = i + 1
+    batt = rows[start_idx:]
+    if not batt:
+        last = rows[-1][2]
+        if last > VALID_HI:
+            print(f"{len(rows)} [pwr] lines, latest {last} mV -- still on USB, no discharge yet.")
+        else:
+            print(f"{len(rows)} [pwr] lines, latest {last} mV -- no valid cell reading "
+                  f"(battery absent or miswired?).")
+        return 1
+    if start_idx:
+        print(f"note             : ignoring {start_idx} sample(s) before the current "
+              f"discharge began (USB rail or unpowered VBAT)")
+
+    t0 = batt[0][0]
+    elapsed_h = (batt[-1][0] - t0).total_seconds() / 3600.0
+    now_mv = batt[-1][2]
+
+    print(f"samples          : {len(batt)} on battery ({len(rows)} total)")
+    print(f"start            : {t0.isoformat()}  {batt[0][2]} mV")
+    print(f"latest           : {batt[-1][0].isoformat()}  {now_mv} mV")
+    print(f"elapsed          : {hms(elapsed_h)}")
+    print(f"cutoff           : {args.cutoff_mv} mV (AUTO_SHUTDOWN_MILLIVOLTS)")
+
+    if now_mv <= args.cutoff_mv:
+        print(f"\nRUN COMPLETE -- reached cutoff. Runtime = {hms(elapsed_h)}")
+        return 0
+
+    usable = [(( ts - t0).total_seconds() / 3600.0, mv)
+              for ts, _up, mv in batt
+              if (ts - t0).total_seconds() >= args.warmup_min * 60]
+    if len(usable) < 4:
+        print(f"\ntoo early: need >{args.warmup_min:.0f} min past start before the surface-charge")
+        print("decay settles. Re-run later; nothing before then is worth extrapolating.")
+        return 0
+
+    # 1. slope projection over the trailing window
+    t_end = usable[-1][0]
+    window = [p for p in usable if p[0] >= t_end - args.window_h] or usable
+    slope, _ = fit(window)
+    print(f"\nslope (last {hms(min(args.window_h, t_end - window[0][0]))}) : {slope:+.1f} mV/h")
+
+    if slope < -0.5:
+        remain_slope = (now_mv - args.cutoff_mv) / (-slope)
+        print(f"  -> projection  : {hms(remain_slope)} remaining, "
+              f"total {hms(elapsed_h + remain_slope)}")
+    else:
+        remain_slope = None
+        print("  -> projection  : slope too flat to extrapolate (plateau); "
+              "use charge accounting")
+
+    # 2. charge accounting
+    full_mv = args.full_mv if args.full_mv else batt[0][2]
+    soc = make_soc(full_mv / 1000.0)
+    print(f"anchor           : {full_mv} mV treated as 100% charge"
+          f"{'' if args.full_mv else ' (first sample of the discharge)'}")
+    soc_start, soc_now = soc(usable[0][1] / 1000.0), soc(now_mv / 1000.0)
+    used_frac = soc_start - soc_now
+    span_h = t_end - usable[0][0]
+    if used_frac > 0.005 and span_h > 0:
+        mah_used = used_frac * args.capacity_mah
+        avg_ma = mah_used / span_h
+        mah_left = soc_now * args.capacity_mah
+        remain_charge = mah_left / avg_ma if avg_ma > 0 else float("inf")
+        print(f"\ncharge accounting:")
+        print(f"  charge level   : {soc_start*100:.0f}% -> {soc_now*100:.0f}%"
+              f"  ({mah_used:.0f} mAh over {hms(span_h)})")
+        print(f"  avg draw       : {avg_ma:.1f} mA")
+        print(f"  -> projection  : {hms(remain_charge)} remaining, "
+              f"total {hms(elapsed_h + remain_charge)}")
+
+        if remain_slope is not None:
+            lo, hi = sorted((remain_slope, remain_charge))
+            spread = hi / lo if lo > 0 else float("inf")
+            verdict = ("methods agree" if spread < 1.5 else
+                       "methods diverge -- report a RANGE, not a number")
+            print(f"\n  {verdict}: total runtime {hms(elapsed_h + lo)} .. "
+                  f"{hms(elapsed_h + hi)}")
+    else:
+        print("\ncharge accounting: SoC has not moved measurably yet -- still on the")
+        print("plateau. Elapsed time is real; the projection is not, yet.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/diag/rc32-boot-740/scripts/capture.py
+++ b/tools/diag/rc32-boot-740/scripts/capture.py
@@ -27,13 +27,30 @@ USAGE
 -----
     python capture.py --port COM16 --out ../evidence/rst-session.log
     python capture.py --list
-    python capture.py --port COM16 --send RST        # SNIFFER-v3 only
+    python capture.py --port COM16 --send  RST   # standalone only, see below
+    python capture.py --port COM16 --out ../evidence/rst-session.log --queue RST
 
-The --send path writes one command line and returns; the long-running capture
-should already be attached in another process to record what it triggers.
+ISSUING COMMANDS WHILE CAPTURING
+--------------------------------
+SNIFFER-v3 accepts RST / BOOT / BOOTRST / PING / HELP on its USB serial. There
+are two ways to send one, and only one of them works during a capture.
+
+`--send` opens the port itself. It CANNOT be used while a capture is running:
+Windows holds a serial port exclusively, so the second open fails with access
+denied. This docstring previously claimed the opposite -- that --send could run
+alongside a capture in another process -- which was wrong, and made the command
+surface useless exactly when it mattered, since a reset is only worth issuing if
+something is recording what it triggers.
+
+`--queue` is the one to use during a capture. It writes the command to a small
+queue file (`<out>.cmd`) which the RUNNING capture picks up within ~1 s and
+forwards over the port it already owns. The injection is logged as
+`<<< INJECT <cmd>` immediately above whatever it causes, so a captured session
+documents its own stimulus.
 """
 
 import argparse
+import os
 import datetime
 import sys
 import time
@@ -97,18 +114,70 @@ def do_send(port: str, baud: int, cmd: str) -> int:
     return 0
 
 
-def do_capture(port: str, baud: int, out_path: str) -> int:
+def drain_cmd_file(cmd_path: str, s, f) -> None:
+    """Forward one queued command from cmd_path to the sniffer, then remove it.
+
+    WHY THIS EXISTS. The --send path opens the port itself, which cannot work
+    while a capture is running: on Windows a serial port is held EXCLUSIVELY, so
+    the second open fails with access denied. The module docstring used to claim
+    the two could run side by side ("the long-running capture should already be
+    attached in another process"). That was wrong, and it made the command
+    surface and the capture mutually exclusive at exactly the moment you want
+    both -- issuing a reset is only useful if something is recording what it
+    triggers.
+
+    So the process that already owns the port does the writing. A command is
+    queued by dropping a line into a file; this forwards it and deletes it.
+
+    The injection is recorded in the log itself, immediately above whatever it
+    causes. Combined with the sketch's own ">>>" stamps that makes a capture
+    self-documenting: the stimulus always appears directly above the resulting
+    ROM banner, which is the "what caused this boot?" ambiguity these markers
+    were added to kill (#740).
+
+    Failure is loud and the file is still removed -- a command that cannot be
+    delivered must not silently retry forever on every loop iteration.
+    """
+    try:
+        if not os.path.exists(cmd_path):
+            return
+        with open(cmd_path, "r", encoding="utf-8", errors="replace") as cf:
+            cmd = cf.readline().strip()
+        os.remove(cmd_path)
+        if not cmd:
+            return
+        f.write(f"[{ts()}] <<< INJECT {cmd}\n")
+        s.write((cmd + "\n").encode())
+        s.flush()
+    except Exception as e:
+        f.write(f"[{ts()}] <<< INJECT FAILED: {e!r}\n")
+        try:
+            if os.path.exists(cmd_path):
+                os.remove(cmd_path)
+        except Exception:
+            pass
+
+
+def do_capture(port: str, baud: int, out_path: str, cmd_path: str = None) -> int:
+    if cmd_path is None:
+        cmd_path = out_path + ".cmd"
     print(f"[{ts()}] capture -> {out_path}  (port {port} @ {baud})", flush=True)
+    print(f"[{ts()}] command queue: {cmd_path}", flush=True)
     # Line-buffered append. Append, never truncate: an accidental re-run must
     # not destroy an overnight capture.
     with open(out_path, "a", buffering=1, encoding="utf-8", errors="replace") as f:
         f.write(f"\n===== capture started {ts()} port={port} baud={baud} =====\n")
+        f.write(f"===== command queue: {cmd_path} =====\n")
         s = None
         while True:
             try:
                 if s is None:
                     s = open_port(port, baud)
                     f.write(f"[{ts()}] <port opened>\n")
+                # Checked every loop iteration. readline() returns on its 1 s
+                # timeout even when the wire is silent, so a queued command is
+                # picked up within ~1 s regardless of traffic.
+                drain_cmd_file(cmd_path, s, f)
                 raw = s.readline()
                 if not raw:
                     continue                  # 1 s timeout tick, not a disconnect
@@ -136,18 +205,34 @@ def main() -> int:
     ap.add_argument("--baud", type=int, default=115200)
     ap.add_argument("--out", help="capture file (appended)")
     ap.add_argument("--list", action="store_true", help="list serial ports and exit")
-    ap.add_argument("--send", help="send one command line to SNIFFER-v3 and exit")
+    ap.add_argument("--send", help="send one command line to SNIFFER-v3 and exit "
+                                   "(standalone only -- fails if a capture holds the port; "
+                                   "use --queue instead while capturing)")
+    ap.add_argument("--queue", help="queue a command for a RUNNING capture to forward "
+                                    "(writes <out>.cmd; needs --out to locate the queue)")
+    ap.add_argument("--cmd-file", default=None,
+                    help="override the command-queue path (default: <out>.cmd)")
     a = ap.parse_args()
 
     if a.list:
         return do_list()
     if not a.port:
         ap.error("--port is required (use --list to find it)")
+    if a.queue:
+        if not a.out:
+            print("--queue needs --out so the queue file can be located", file=sys.stderr)
+            return 2
+        qp = a.cmd_file or (a.out + ".cmd")
+        with open(qp, "w", encoding="utf-8") as qf:
+            qf.write(a.queue.strip() + "\n")
+        print(f"queued: {a.queue.strip()} -> {qp}")
+        return 0
+
     if a.send:
         return do_send(a.port, a.baud, a.send)
     if not a.out:
         ap.error("--out is required for capture")
-    return do_capture(a.port, a.baud, a.out)
+    return do_capture(a.port, a.baud, a.out, a.cmd_file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #786.

Tooling built and hardware-verified during the 2026-08-17 RC32 session. **Diagnostics only —
no firmware source is touched**, so there is no risk to any shipping env. Landing it so RCC6
(#624) and RC52 (#625) inherit a working bench rather than rebuilding one.

## Sniffer sketch

- **Board-agnostic pin map** (`SNIFFER_GENERIC_S3`). On a generic ESP32-S3 WROOM the symbolic
  `RX` resolves to **GPIO44 — U0RXD**, wired to the onboard USB-UART bridge. Sniffing there
  puts two drivers on the console UART and presents as a wiring fault rather than a config
  error.
- **MAX17048 fuel gauge on `Wire1`** — voltage + modelled charge every 30 s, matching the
  RC32's `[pwr]` cadence so the two series align without interpolation. `Wire1` is house
  convention *and* forced: the MAX1704x has no address-select pin and the Feather already
  carries one onboard at 0x36.
- **INA identification probe** over 0x40–0x4F, reading ID registers at **both** `0xFE/0xFF`
  (INA226/260/3221) **and** `0x3E/0x3F` (INA228/237/238). Address is not identity when
  addresses are strap-selectable — probing one location only would find an INA228 at 0x40 and
  misreport it as an INA219. Identification only; the current decode gets written once the
  part is known rather than shipping three untested decoders.
- Bring-up copies `EnvironmentSensorManager.cpp:637`: ESP32 passes pins **to** `begin()`,
  nRF52 sets them **before**. Wrong order fails silently.
- Targeted probes throughout, **never a bus scan** — #294 records a blind scan wedging the C6
  I2C peripheral at 0x0d and never returning. RCC6 is a C6.

## Capture command queue

`--send` opens the port itself, so it could never run while a capture held it — Windows serial
ports are exclusive. The docstring claimed the opposite, making the command surface useless
exactly when it mattered: issuing a reset is only worth doing if something is recording what it
triggers.

`--queue RST` now writes `<out>.cmd`; the running capture forwards it over the port it already
owns and logs `<<< INJECT <cmd>` directly above the result.

**Verified on hardware:**

```
[2026-08-17T20:39:00.654Z] <<< INJECT PING
[2026-08-17T20:39:00.655Z] >>> PONG SNIFFER-v3  @up=5428s
```

## Runtime analysis (`battery_runtime.py`)

Two methods that fail differently — slope fit and charge accounting — reporting a **range**
when they disagree rather than a confident wrong number. Three guards, each from an actual
error made during the session:

- **Warm-up discard.** A freshly charged cell shed 19 mV in 90 s; extrapolated linearly that
  predicts death within the hour.
- **Curve anchoring.** The owner's pack was full at 4130 mV; the unanchored table called that
  85% and opened the accounting already claiming ~375 mAh consumed.
- **Trailing-run selection.** Pre-run zeros from the reversed battery leads (#766) otherwise
  anchor the fit — with them included it reported the battery *charging* at +6482 mV/h. An
  estimator that can emit a positive discharge slope is reporting a parsing bug as physics.

## Checklist mirror

`docs/rc32-beta-checklist.md` mirrors #773. GitHub was mid-incident and #773 was unreachable
exactly when it was needed. The issue stays source of truth and the file says so in its header.

## Verification

Hardware-verified on `rc32-bench-1` + `feather-sniffer`: gauge readings cross-check against the
RC32's own ADC within **20–28 mV** (independently validating the 390K/100K + 4.9 sense chain
from #766), command injection round-trips, and the analysis correctly refuses to project from
insufficient data.

Live capture logs under `evidence/` are deliberately not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)