### PR TITLE
fix: pio-flash bootloader discovery for devices whose USB port survives download entry

### DIFF
--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -981,8 +981,12 @@ def _discover_bootloader_port(before: list, vendor: str, running_pid: str,
     running_serial = norm_serial(running_serial)
     deadline = time.time() + timeout
     last_seen: list = []
-    while time.time() < deadline:
-        now = enumerate_ports()
+
+    def _match_transitioned(now: list):
+        """Match a device that DID change ports. Returns the port, or None.
+
+        Refuses outright on ambiguity -- never returns a guess."""
+        nonlocal last_seen
         new = [p for p in now if p["com"] not in before_coms]
         if running_serial:
             by_serial = [
@@ -1014,7 +1018,82 @@ def _discover_bootloader_port(before: list, vendor: str, running_pid: str,
                 f"multiple new {vendor} bootloader ports appeared ({coms}); "
                 "refusing rather than guessing. Disconnect other devices and retry."
             )
+        return None
+
+    while time.time() < deadline:
+        hit = _match_transitioned(enumerate_ports())
+        if hit:
+            return hit
         time.sleep(0.5)
+
+    # Deadline expired. Take ONE more enumeration and check it for a transitioned
+    # port BEFORE considering the same-port fallback below.
+    #
+    # Without this there is a race: a slow device can complete its transition
+    # just as the loop expires, at which point the old app-mode port is still
+    # present and the fallback would claim it by serial. esptool would then fail
+    # to sync and the operation would abort -- safe, but a spurious failure for a
+    # device that was about to be ready. Checking transitioned-first here means
+    # the same-port fallback only ever runs when there is genuinely no new port.
+    # (Raised by adversarial review of #807.)
+    now = enumerate_ports()
+    hit = _match_transitioned(now)
+    if hit:
+        return hit
+
+    # ---------------------------------------------------------------------
+    # #807: SAME-PORT FALLBACK for native USB-Serial-JTAG parts.
+    #
+    # Everything above requires a port TRANSITION -- `new` is built by
+    # subtracting `before_coms`, so a device that keeps its COM port can never
+    # produce a candidate, no matter how healthy it is. That assumption holds
+    # for bridge-attached boards (the CP2102/CH340 keeps its own port while the
+    # SoC behind it reboots) and for nRF52 (app CDC -> separate DFU port).
+    #
+    # It does NOT hold when the USB device IS the SoC. On ESP32-C3/C6/S3 in
+    # USB-Serial/JTAG mode the download-mode peripheral lives in the same
+    # silicon: the port does not drop, the PID stays 303A:1001, and the serial
+    # is unchanged. Enumeration before and after the trigger is byte-identical,
+    # so the loop above spins for the full timeout and refuses a device that is
+    # sitting right there. Observed on rcc6-bench-1 (ESP32-C6) and reported on
+    # rc32-bench-1 (ESP32-S3) -- both native-USB.
+    #
+    # IDENTITY IS NOT RELAXED. We fall back ONLY on serial equality, which is
+    # the same guarantee the fast path uses: the SoC serial is constant across
+    # USB-mode changes, so a port carrying this device's serial IS this device
+    # (#503). We deliberately do NOT fall back on vendor+PID -- a class match
+    # must never be able to claim the flash target -- and we still refuse on
+    # ambiguity rather than pick.
+    #
+    # WHAT THIS DOES NOT PROVE. Because enumeration is identical either way, a
+    # same-port match cannot confirm the device actually entered download mode.
+    # It only says "this is the right device, on this port". esptool performs
+    # its own sync on the next step and fails loudly if the ROM loader is not
+    # answering, so a failed trigger surfaces there rather than being silently
+    # flashed over. Say so out loud instead of implying a verified transition.
+    if running_serial:
+        same = [
+            p for p in now
+            if norm_serial(p.get("usb_serial")) == running_serial
+        ]
+        if len(same) > 1:
+            coms = ", ".join(f"{p['com']}({p['vid_pid']})" for p in same)
+            refuse(
+                f"multiple present ports carry the device serial ({coms}) after "
+                "the trigger -- enumeration is inconsistent; refusing rather "
+                "than guessing."
+            )
+        if len(same) == 1:
+            err(
+                f"NOTE: no NEW port appeared within {timeout}s, but {same[0]['com']} "
+                f"({same[0]['vid_pid']}) is still present carrying this device's "
+                "serial. Native-USB part whose port survives download-mode entry "
+                "-- proceeding on serial identity (#807). This does NOT confirm "
+                "download mode was entered; esptool will sync next and will fail "
+                "loudly if the ROM loader is not answering."
+            )
+            return same[0]
+
     refuse(
         f"no bootloader port appeared within {timeout}s after the trigger "
         f"(matched neither the device serial {running_serial or '(none)'} nor a "
@@ -1026,8 +1105,14 @@ def _discover_bootloader_port(before: list, vendor: str, running_pid: str,
 
 def _enter_bootloader_and_discover(running_port: dict, platform: str) -> dict:
     """Trigger bootloader entry on the verified running port, then discover the
-    device on its new (bootloader) COM. Unified for both chip families - they
-    all change identity + COM entering bootloader (#34)."""
+    device on its bootloader COM.
+
+    #34 assumed every family changes identity + COM entering bootloader. That is
+    true for bridge-attached boards and nRF52, but NOT for native USB-Serial/JTAG
+    parts (ESP32-C3/C6/S3), where the USB device is the SoC itself and the port,
+    PID and serial all survive the transition. `_discover_bootloader_port` now
+    falls back to the still-present running port on serial equality for exactly
+    that case -- see #807."""
     vendor = NRF52_VENDOR if platform == "nrf52" else ESP32S3_VENDOR
     running_pid = running_port["vid_pid"].split(":")[1]
     out(f"Triggering bootloader entry on {running_port['com']} "

--- a/scripts/test_pio_flash_bootloader_discovery.py
+++ b/scripts/test_pio_flash_bootloader_discovery.py
@@ -1,0 +1,228 @@
+"""Bootloader-port discovery tests for pio-flash (#807).
+
+The defect these pin: `_discover_bootloader_port()` built its candidate set by
+subtracting the pre-trigger port list -- `new = [p for p in now if p["com"] not
+in before_coms]` -- and then applied every match rule to `new` only. That
+requires the device to CHANGE COM ports entering download mode.
+
+That assumption holds for the hardware it was written against:
+
+  * bridge-attached boards (CP2102/CH340) -- the bridge keeps its own port while
+    the SoC behind it reboots, so a distinct download port appears; and
+  * nRF52 -- the app CDC port is replaced by a separate DFU port.
+
+It does NOT hold when the USB device IS the SoC. On ESP32-C3/C6/S3 in
+USB-Serial/JTAG mode the download-mode peripheral is in the same silicon: the
+port does not drop, the PID stays 303A:1001, and the serial is unchanged.
+Enumeration before and after the trigger is byte-identical, so `new` is empty by
+construction, no candidate can ever be evaluated, and the function spins for the
+full timeout before refusing a device that is sitting right there.
+
+Observed on `rcc6-bench-1` (ESP32-C6): `bootstrap` and `backup` both connected
+fine -- because those let esptool do its own reset-and-connect -- while `confirm`
+refused with "no bootloader port appeared within 20s". Reported on `rc32-bench-1`
+(ESP32-S3) as the same wall.
+
+Why these are unit tests: reproducing this on hardware means owning a native-USB
+part AND a bridge part AND an nRF52 and power-cycling each through download mode
+per run. The behaviour is entirely a function of two port lists, so it is pinned
+here instead. Hardware verification is complementary, not replaced.
+
+WHAT MUST NOT REGRESS. The fallback is gated on SERIAL EQUALITY ONLY. A class
+match (vendor + PID) must never be able to claim the flash target, and ambiguity
+must still refuse rather than pick -- that is the #503 guarantee, and weakening
+it here would let the tool write firmware to the wrong board.
+
+Run: python -m pytest scripts/test_pio_flash_bootloader_discovery.py -q
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "pio_flash", Path(__file__).resolve().parent / "pio-flash.py"
+)
+pio_flash = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(pio_flash)
+
+_discover = pio_flash._discover_bootloader_port
+
+# Real values from rcc6-bench-1, so a reader can tie these back to the incident.
+C6_SERIAL = "58:8C:81:2F:91:F8"
+C6_PID = "303A:1001"
+ESP_VENDOR = "303A"
+
+
+def port(com, vid_pid, serial="", hash_="8&3B623357"):
+    return {
+        "com": com,
+        "vid_pid": vid_pid,
+        "usb_serial": serial,
+        "instance_hash": hash_,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _fast_and_isolated(monkeypatch):
+    """Neutralise sleep so the timeout path costs nothing, and make refuse()
+    raise instead of exiting so failures are assertable."""
+    monkeypatch.setattr(pio_flash.time, "sleep", lambda *_: None)
+
+    def _raise(msg):
+        raise AssertionError(f"REFUSED: {msg}")
+
+    monkeypatch.setattr(pio_flash, "refuse", _raise)
+    monkeypatch.setattr(pio_flash, "err", lambda *_a, **_k: None)
+    monkeypatch.setattr(pio_flash, "out", lambda *_a, **_k: None)
+
+
+def _enumerates(monkeypatch, sequence):
+    """Feed enumerate_ports() a fixed list (or a sequence of lists)."""
+    if sequence and isinstance(sequence[0], dict):
+        monkeypatch.setattr(pio_flash, "enumerate_ports", lambda: list(sequence))
+    else:
+        it = iter(sequence)
+        last = {}
+
+        def _next():
+            nonlocal last
+            try:
+                last = list(next(it))
+            except StopIteration:
+                pass
+            return list(last)
+
+        monkeypatch.setattr(pio_flash, "enumerate_ports", _next)
+
+
+# --------------------------------------------------------------------------
+# The #807 defect itself
+# --------------------------------------------------------------------------
+
+def test_same_port_device_is_found_by_serial(monkeypatch):
+    """ESP32-C6: port, PID and serial all survive download entry.
+
+    Enumeration is identical before and after the trigger. The pre-#807 code
+    refused here; the device must now be found on its unchanged port.
+    """
+    ports = [port("COM45", C6_PID, C6_SERIAL)]
+    _enumerates(monkeypatch, ports)
+
+    found = _discover(before=ports, vendor=ESP_VENDOR, running_pid="1001",
+                      timeout=0, running_serial=C6_SERIAL)
+
+    assert found["com"] == "COM45"
+
+
+def test_same_port_fallback_requires_serial(monkeypatch):
+    """No serial -> no fallback. Identity must never be inferred from position.
+
+    A native-USB part with no readable serial is genuinely unidentifiable after
+    the trigger; refusing is correct. This is the guard that stops the fallback
+    degrading into "flash whatever is on that port".
+    """
+    ports = [port("COM45", C6_PID, serial="")]
+    _enumerates(monkeypatch, ports)
+
+    with pytest.raises(AssertionError, match="no bootloader port appeared"):
+        _discover(before=ports, vendor=ESP_VENDOR, running_pid="1001",
+                  timeout=0, running_serial="")
+
+
+def test_same_port_fallback_refuses_on_duplicate_serial(monkeypatch):
+    """Two present ports carrying one serial is inconsistent -- refuse, do not pick."""
+    ports = [
+        port("COM45", C6_PID, C6_SERIAL),
+        port("COM46", C6_PID, C6_SERIAL, hash_="8&OTHER"),
+    ]
+    _enumerates(monkeypatch, ports)
+
+    with pytest.raises(AssertionError, match="multiple present ports carry"):
+        _discover(before=ports, vendor=ESP_VENDOR, running_pid="1001",
+                  timeout=0, running_serial=C6_SERIAL)
+
+
+def test_same_port_fallback_never_matches_by_class(monkeypatch):
+    """A same-class port with a DIFFERENT serial must not be claimed (#503).
+
+    This is the wrong-device-flash guard. Another 303A:1001 board sitting on the
+    bus shares vendor and PID; only the serial separates them.
+    """
+    ports = [port("COM45", C6_PID, "AA:BB:CC:DD:EE:FF")]
+    _enumerates(monkeypatch, ports)
+
+    with pytest.raises(AssertionError, match="no bootloader port appeared"):
+        _discover(before=ports, vendor=ESP_VENDOR, running_pid="1001",
+                  timeout=0, running_serial=C6_SERIAL)
+
+
+# --------------------------------------------------------------------------
+# Pre-existing behaviour that must survive the change
+# --------------------------------------------------------------------------
+
+def test_transitioning_device_still_matched_by_serial(monkeypatch):
+    """Bridge/nRF52 shape: a NEW port carrying the same serial still wins.
+
+    The fast path must be preferred -- the fallback only runs after the loop
+    finds nothing, so a genuine transition must never reach it.
+    """
+    before = [port("COM10", "239A:0029", C6_SERIAL)]
+    after = before + [port("COM11", "239A:1234", C6_SERIAL, hash_="8&NEW")]
+    _enumerates(monkeypatch, after)
+
+    found = _discover(before=before, vendor="239A", running_pid="0029",
+                      timeout=1, running_serial=C6_SERIAL)
+
+    assert found["com"] == "COM11"
+
+
+def test_new_serialless_port_with_changed_pid_still_matched(monkeypatch):
+    """The serial-less class fallback for modes that expose no serial is intact."""
+    before = [port("COM10", "239A:0029", serial="")]
+    after = before + [port("COM11", "239A:0x50", serial="", hash_="8&NEW")]
+    _enumerates(monkeypatch, after)
+
+    found = _discover(before=before, vendor="239A", running_pid="0029",
+                      timeout=1, running_serial="")
+
+    assert found["com"] == "COM11"
+
+
+def test_slow_transition_wins_over_same_port_fallback(monkeypatch):
+    """Race guard: a device that transitions JUST as the loop expires.
+
+    Raised by adversarial review. While the loop is running only the old
+    app-mode port is visible; the real bootloader port appears on the final
+    post-deadline enumeration. The same-port fallback must NOT claim the stale
+    app port -- the transitioned port has to win, or slow devices fail
+    spuriously with an esptool sync error.
+    """
+    old = port("COM45", C6_PID, C6_SERIAL)
+    late = port("COM46", "303A:0002", C6_SERIAL, hash_="8&LATE")
+
+    # Deterministic clock so the timing is pinned rather than raced:
+    #   t=0.0  deadline computed as 0.0 + timeout
+    #   t=0.0  loop check passes -> ONE iteration, which sees only the old port
+    #   t=99.0 loop check fails  -> exit, then the post-deadline enumeration runs
+    ticks = iter([0.0, 0.0, 99.0])
+    monkeypatch.setattr(pio_flash.time, "time", lambda: next(ticks, 99.0))
+
+    # First enumeration (inside the loop) shows only the old port; the second
+    # (after the deadline) is where the transition finally appears.
+    _enumerates(monkeypatch, [[old], [old, late]])
+
+    found = _discover(before=[old], vendor=ESP_VENDOR, running_pid="1001",
+                      timeout=1, running_serial=C6_SERIAL)
+
+    assert found["com"] == "COM46", "stale app-mode port claimed over the real bootloader port"
+
+
+def test_nothing_present_still_refuses(monkeypatch):
+    """Device genuinely gone -> refuse. The fallback must not invent a target."""
+    _enumerates(monkeypatch, [])
+
+    with pytest.raises(AssertionError, match="no bootloader port appeared"):
+        _discover(before=[], vendor=ESP_VENDOR, running_pid="1001",
+                  timeout=0, running_serial=C6_SERIAL)


### PR DESCRIPTION
Closes #810. Parent **#807** stays open until this merges.

## The defect

`_discover_bootloader_port()` built its candidate set by subtracting the pre-trigger port list, then applied every match rule to that set alone:

```python
new = [p for p in now if p["com"] not in before_coms]
```

That requires the device to **change COM ports** entering download mode. True for bridge-attached boards — the CP2102/CH340 keeps its own port while the SoC behind it reboots — and for nRF52, where the app CDC port is replaced by a separate DFU port.

It is not true when the USB device **is** the SoC. On ESP32-C3/C6/S3 in USB-Serial/JTAG mode the download-mode peripheral is in the same silicon: the port does not drop, the PID stays `303A:1001`, and the serial is unchanged. Enumeration before and after the trigger is byte-identical, so `new` is empty by construction, no candidate can ever be evaluated, and the function spins for the full timeout before refusing a device that is sitting right there.

Observed on `rcc6-bench-1` (ESP32-C6): `bootstrap` and `backup` both connect fine — they let esptool do its own reset-and-connect — while `confirm` refused with *"no bootloader port appeared within 20s"*. Reported as the same wall on `rc32-bench-1` (ESP32-S3).

## The fix

After the transition loop expires, fall back to the still-present running port, gated on **serial equality only**.

Identity is not relaxed. This is the same guarantee the fast path uses, and the fallback explicitly **cannot** match on vendor+PID — a class match still may never claim the flash target (#503). Ambiguity still refuses rather than picks.

A same-port match cannot confirm download mode was actually entered, since enumeration is identical either way. It only establishes which device is on which port. esptool syncs next and fails loudly if the ROM loader is not answering, so a failed trigger surfaces there rather than being silently flashed over — and the code says so out loud rather than implying a verified transition.

## Review findings — fixed, not dismissed

Gemini 2.5 Pro reviewed adversarially against "can this select the wrong physical board". It confirmed the fallback cannot, and that #503 is intact:

> *"This new path is strictly more secure than the pre-existing fallback for new ports (which allows a class-based match on serial-less ports). By adding an identity-only path, you have made the tool safer and more correct, not less."*

It raised **one race**: a slow device completing its transition just as the loop expires would have had the stale app-mode port claimed by the fallback, failing esptool sync for a device that was about to be ready. Safe, but a spurious failure.

Closed by taking one final enumeration after the deadline and checking it for a transitioned port **before** considering the same-port fallback. The loop body is extracted to `_match_transitioned()` so both paths share one implementation instead of duplicating the match rules.

Audit log: `docs/llm-consultations/2026-08-18-807-review-gemini-gemini-2.5-pro.log`

## Tests

8 cases in `scripts/test_pio_flash_bootloader_discovery.py`.

**Three fail against the pre-fix code and pass after** — verified by stashing the fix and re-running, not assumed:

- `test_same_port_device_is_found_by_serial`
- `test_same_port_fallback_refuses_on_duplicate_serial`
- `test_slow_transition_wins_over_same_port_fallback`

The rest pin what must not regress: no serial means no fallback; a differing serial is never claimed by class; genuine transitions still win; the serial-less changed-PID path still works; an absent device still refuses.

Unit tests rather than hardware because reproducing this needs a native-USB part **and** a bridge part **and** an nRF52 cycled through download mode per run. Behaviour is purely a function of two port lists. Hardware verification is complementary, not replaced — and is the next step on `rcc6-bench-1`.

## Pre-existing failure, not from this change

`scripts/test_pio_flash_device_match.py::test_legacy_hash_still_matches_when_no_serial_recorded` fails on `firmware-base` today. Verified failing against `fd8df8cb`, so it predates both this change and #808. Untouched here.

Worth noting separately: #808 merged reporting `ci-green 48/48` with that test already red, which suggests the matrix does not run the `scripts/test_pio_flash_*.py` suite at all. Filing separately rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
