### PR TITLE
bug: flaky TLS broker steals equal rotation budget — sticky penalty + terminal Failed + client reaper (#739)

### DIFF
--- a/src/helpers/wifi_observer/BrokerHealth.h
+++ b/src/helpers/wifi_observer/BrokerHealth.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <cstdint>
+
+// Broker connection-health tracker (#739).
+//
+// Dependency-free (no Arduino/ESP headers) so it builds under [env:native] and
+// is unit-testable in isolation -- same pattern as MqttRingLog.h and
+// BrokerRotationSelect.h. The pool owns a BrokerHealth per broker and feeds it
+// two events; this owns the POLICY of how a broker's reliability translates into
+// backoff, rehabilitation, and a terminal give-up.
+//
+// WHY THIS EXISTS. Before #739 the only backoff state was retry_count, reset to 0
+// on any success (MqttBroker::onConnected). That works for a DEAD broker but not
+// a FLAKY one: an intermittent broker succeeds just often enough to zero its
+// penalty, so it oscillates at the 5 s schedule floor forever and keeps claiming
+// rotation turns equal to a reliable broker. Measured on hv3-bench: two remote
+// JWT brokers at ~50% failure kept 46% of the soak with NO TLS broker up.
+//
+// The penalty is STICKY IN BOTH DIRECTIONS:
+//   - a single success does NOT clear it (only a proven clean streak does), so a
+//     flaky broker cannot cheaply reset;
+//   - a broker must earn its way back with kSuccessBar CONSECUTIVE clean dwells,
+//     at which point it is fully rehabilitated to a healthy running state.
+// A failure escalates the penalty and zeroes any clean-streak progress. Past
+// kTerminalPenalty the broker is declared Failed -- dropped from rotation and
+// surfaced loudly -- instead of churning a rotation turn forever.
+
+namespace offband {
+
+// Consecutive clean full-dwells required to fully rehabilitate a broker whose
+// penalty is non-zero. One dwell is ~60 s, so 3 = ~3 min of unbroken service.
+#ifndef OFFBAND_BROKER_SUCCESS_BAR
+  #define OFFBAND_BROKER_SUCCESS_BAR 3u
+#endif
+
+// Penalty level at which a broker is declared terminally Failed and removed from
+// the rotation candidate set. The backoff schedule has 5 steps (5..120 s); this
+// gives several full escalations before giving up.
+#ifndef OFFBAND_BROKER_TERMINAL_PENALTY
+  #define OFFBAND_BROKER_TERMINAL_PENALTY 8u
+#endif
+
+struct BrokerHealth {
+    uint16_t fail_penalty = 0;   // escalation level; indexes the backoff schedule
+    uint16_t clean_streak = 0;   // consecutive clean full-dwells since last failure
+
+    // A connection failed (disconnect-with-error, handshake failure, refused).
+    // Escalates the penalty and discards any clean-streak progress -- a single
+    // failure means the broker has NOT proven stable.
+    void onFailure() {
+        if (fail_penalty < 0xFFFF) fail_penalty++;
+        clean_streak = 0;
+    }
+
+    // The broker held the budget for a FULL dwell and was rotated out cleanly
+    // (no error). This is the only event that earns rehabilitation -- NOT a bare
+    // connect, which a flaky broker does constantly. Only kSuccessBar of these in
+    // a row clears the penalty.
+    void onCleanDwell() {
+        if (fail_penalty == 0) return;        // already healthy, nothing to earn
+        if (++clean_streak >= OFFBAND_BROKER_SUCCESS_BAR) {
+            fail_penalty = 0;                 // rehabilitated
+            clean_streak = 0;
+        }
+    }
+
+    // True once the broker has failed enough to be given up on. The pool moves it
+    // to BrokerState::Failed, drops it from rotation, and logs loudly.
+    bool isTerminal() const { return fail_penalty >= OFFBAND_BROKER_TERMINAL_PENALTY; }
+
+    // Healthy = never penalised (or fully rehabilitated). A broker with any
+    // pending penalty is "recovering" and rotation should prefer healthy peers.
+    bool isHealthy() const { return fail_penalty == 0; }
+
+    void reset() { fail_penalty = 0; clean_streak = 0; }
+};
+
+}  // namespace offband

--- a/src/helpers/wifi_observer/MqttBroker.cpp
+++ b/src/helpers/wifi_observer/MqttBroker.cpp
@@ -278,9 +278,17 @@ bool MqttBroker::tryConnect(uint32_t now_ms, bool tls_budget_ok) {
     if (rt_.state == BrokerState::Connecting || rt_.state == BrokerState::Up) {
         return true;
     }
+    // #739: Failed is terminal -- give up until the operator re-enables/reconfigures.
+    // Never burns a rotation turn or a connect attempt.
+    if (rt_.state == BrokerState::Failed) {
+        return false;
+    }
     if (rt_.state == BrokerState::Backoff) {
         uint32_t elapsed = now_ms - rt_.last_attempt_ms;
-        if (elapsed < brokerBackoffMs(rt_.retry_count)) {
+        // #739: backoff length tracks the STICKY penalty, not retry_count (which a
+        // single success zeroes). A flaky broker escalates instead of oscillating
+        // at the schedule floor.
+        if (elapsed < brokerBackoffMs(health_.fail_penalty)) {
             return false;
         }
     }
@@ -336,9 +344,9 @@ bool MqttBroker::tryConnect(uint32_t now_ms, bool tls_budget_ok) {
         // to esp-mqtt's default 120 (-> CONNACK 0x02, #506).
         populateBaseConfig(mqcfg);
         if (!auth_->apply(mqcfg, now_ms)) {
-            rt_.state = BrokerState::Backoff;
             rt_.retry_count++;
             rt_.last_error_class = BrokerErrorClass::Auth;
+            noteFailure();   // #739
             return false;
         }
         esp_mqtt_set_config(client_, &mqcfg);
@@ -363,9 +371,9 @@ bool MqttBroker::tryConnect(uint32_t now_ms, bool tls_budget_ok) {
     }
     esp_err_t err = esp_mqtt_client_start(client_);
     if (err != ESP_OK) {
-        rt_.state = BrokerState::Backoff;
         rt_.retry_count++;
         rt_.last_error_class = BrokerErrorClass::Other;
+        noteFailure();   // #739
         return false;
     }
     started_ = true;
@@ -536,10 +544,19 @@ void MqttBroker::onConnected(uint32_t now_ms) {
 void MqttBroker::onDisconnected(uint32_t now_ms, BrokerErrorClass err) {
     // Move to Backoff (esp_mqtt will not auto-retry; pool's tryConnect
     // honors backoff schedule and re-initiates).
-    rt_.state = BrokerState::Backoff;
     rt_.last_error_ms = now_ms;
     rt_.retry_count++;
     rt_.last_error_class = err;
+    noteFailure();   // #739: escalate penalty; may promote Backoff -> Failed
+}
+
+// #739: single choke point for a connection failure. Escalates the health
+// penalty (sticky -- a bare later success will not clear it) and picks the
+// resulting state: Failed once the penalty passes the terminal threshold,
+// otherwise Backoff. Callers have already set last_error_* / retry_count.
+void MqttBroker::noteFailure() {
+    health_.onFailure();
+    rt_.state = health_.isTerminal() ? BrokerState::Failed : BrokerState::Backoff;
 }
 
 void MqttBroker::onError(uint32_t now_ms, BrokerErrorClass err) {

--- a/src/helpers/wifi_observer/MqttBroker.cpp
+++ b/src/helpers/wifi_observer/MqttBroker.cpp
@@ -535,6 +535,11 @@ bool MqttBroker::hasClient() const {
 }
 
 void MqttBroker::onConnected(uint32_t now_ms) {
+    // #739/#746: never let a connect event resurrect a terminally-Failed broker.
+    // Primary defense is the pool reaping a Failed broker's client (nothing to
+    // reconnect); this is belt-and-suspenders for a connect event in flight when
+    // the broker went Failed. Failed clears only by operator re-enable/reconfigure.
+    if (rt_.state == BrokerState::Failed) return;
     rt_.state = BrokerState::Up;
     rt_.went_up_ms = now_ms;   // #175: dwell clock for TLS rotation
     rt_.retry_count = 0;

--- a/src/helpers/wifi_observer/MqttBroker.h
+++ b/src/helpers/wifi_observer/MqttBroker.h
@@ -7,6 +7,7 @@
 #pragma once
 #include "ConfigSchema.h"
 #include "MqttAuth.h"
+#include "BrokerHealth.h"   // #739: connection-health / penalty tracker
 #include "MqttPayload.h"
 
 #ifdef ARDUINO
@@ -42,6 +43,13 @@ enum class BrokerState : uint8_t {
                       // problem caused repeated real-world misdiagnosis -- including
                       // the field report that sent us heap-trimming for a scheduling
                       // defect. Do NOT re-merge these.
+    Failed      = 7,  // #739: given up on after OFFBAND_BROKER_TERMINAL_PENALTY
+                      // escalations. A distinct TERMINAL state -- the pool drops it
+                      // from the rotation candidate set and logs loudly, so a
+                      // persistently-unreachable configured broker stops consuming a
+                      // rotation turn every backoff cycle. NOT an operator disable
+                      // (that stays Down); the operator must re-enable/reconfigure
+                      // to clear it. Distinct so the client can render it later.
 };
 
 enum class BrokerErrorClass : uint8_t {
@@ -147,6 +155,11 @@ public:
     uint8_t                    slot()    const { return slot_; }
     const BrokerConfig&        config()  const { return cfg_; }
     const BrokerRuntimeState&  runtime() const { return rt_; }
+    // #739: read-only health for status/rotation; noteCleanDwell() is called by
+    // the pool when this broker is rotated out after holding a FULL dwell Up
+    // with no error -- the only event that earns rehabilitation.
+    const BrokerHealth&        health() const { return health_; }
+    void                       noteCleanDwell() { health_.onCleanDwell(); }
 
     // #175: true if the esp_mqtt client handle currently exists. shutdown()
     // destroys it (client_ = nullptr) to free the ~60KB TLS context without
@@ -168,11 +181,13 @@ private:
     // 0x02 diagnosed in #506. Centralizing it makes every build site identical.
     // Auth is applied by the caller AFTER this (auth_->apply()).
     void populateBaseConfig(esp_mqtt_client_config_t& mqcfg) const;
+    void noteFailure();   // #739: escalate penalty, set Backoff or Failed
 #endif
 
     uint8_t              slot_  = 0xFF;
     BrokerConfig         cfg_;
     BrokerRuntimeState   rt_;
+    BrokerHealth         health_;   // #739: sticky failure penalty + rehab
     MqttAuth*            auth_  = nullptr;  // owned
 
 #if defined(ARDUINO) && defined(ESP_PLATFORM)

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -607,6 +607,10 @@ void MqttBrokerPool::rotateTlsIfDue(uint32_t now_ms) {
     // the scheduler permanently (verified on hardware: en 5->4, victim absent
     // from [rot] for the rest of the run). releaseClient() keeps slot_/cfg_ so
     // the cooldown -> budget -> reconcileSlot -> tryConnect path can bring it back.
+    // #739: the victim held the budget a full dwell Up with no error (an errored
+    // broker would be Backoff/Failed, not the Up broker we selected) -- credit a
+    // clean dwell toward its rehabilitation before releasing it.
+    brokers_[victim].noteCleanDwell();
     brokers_[victim].releaseClient();
     reconciling_[victim] = false;
 #if defined(ARDUINO)
@@ -679,13 +683,13 @@ void MqttBrokerPool::workerLoop() {
                               "[rot] heap=%u tls=%u live=%u/%u dwleft=%us |",
                               (unsigned)ESP.getFreeHeap(), (unsigned)tls_cfg, (unsigned)tls_live,
                               (unsigned)OFFBAND_MAX_LIVE_TLS, (unsigned)dwleft);
-                static const char* AB[] = {"DN","CO","UP","BK","HC","HH","HB"};  // #715: HB=held(budget)
+                static const char* AB[] = {"DN","CO","UP","BK","HC","HH","HB","FL"};  // #715 HB=held(budget), #739 FL=failed
                 for (uint8_t s = 0; s < OFFBAND_MAX_BROKERS && o < (int)sizeof(L) - 24; ++s) {
                     const MqttBroker& b = brokers_[s];
                     if (!b.isConfigured() || !isTlsTransport(b.config())) continue;
                     uint8_t stv = (uint8_t)b.runtime().state;
                     o += snprintf(L + o, (size_t)(sizeof(L) - o), " s%u:%s", (unsigned)s,
-                                  stv < 7 ? AB[stv] : "?");
+                                  stv < 8 ? AB[stv] : "?");
                     if (b.runtime().state == BrokerState::Up)
                         o += snprintf(L + o, (size_t)(sizeof(L) - o), "/%us",
                                       (unsigned)((now - b.runtime().went_up_ms) / 1000U));

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -732,6 +732,20 @@ void MqttBrokerPool::workerLoop() {
             if (reconciling_[s]) continue;
             MqttBroker& b = brokers_[s];
             if (!b.isConfigured()) continue;
+            // #739/#746: a terminally-Failed broker must hold NO client -- otherwise
+            // esp-mqtt auto-reconnect (which stays ON for normal brokers, its
+            // reconnect being the pool's safety net) would fire onConnected and
+            // resurrect it. Destroy its client HERE on the worker task (releaseClient
+            // is a blocking esp_mqtt_client_destroy -- worker-only, #53). Idempotent:
+            // once client-less, hasClient() is false and this no-ops. It is never
+            // re-driven (Failed is absent from the condition below), so it stays down
+            // until the operator re-enables/reconfigures. This is the SURGICAL fix --
+            // the global disable_auto_reconnect broke normal reconnection (soak: 96%
+            // no-TLS-up, a healthy broker terminally failed).
+            if (b.runtime().state == BrokerState::Failed) {
+                if (b.hasClient()) b.releaseClient();
+                continue;
+            }
             b.loop(now);
             BrokerState st = b.runtime().state;
             // Re-drive idle/held slots. HeldNoClock releases when the clock is

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -108,6 +108,7 @@ static const char* stateStr(BrokerState s) {
         // "held(no-heap)" wording sent operators hunting for a memory problem.
         case BrokerState::HeldNoHeap:  return "held(low-heap)";
         case BrokerState::HeldBudget:  return "waiting-turn";
+        case BrokerState::Failed:      return "failed(gave-up)";
         default:                       return "?";
     }
 }
@@ -131,6 +132,11 @@ static const char* brokerStateWire(BrokerState s) {
         // that is the remaining half of #715, not an oversight.
         case BrokerState::HeldNoHeap:  return "held_no_heap";
         case BrokerState::HeldBudget:  return "held_no_heap";
+        // #739: Failed is TERMINAL, but the wire token is a coordinated
+        // fast-follow with the client. Until then map to "backoff" (nearest
+        // existing token) so no client breaks on an unknown state. Serial/CLI
+        // show the true "failed(gave-up)" via stateStr.
+        case BrokerState::Failed:      return "backoff";
         default:                       return "down";
     }
 }

--- a/test/test_broker_health/test_broker_health.cpp
+++ b/test/test_broker_health/test_broker_health.cpp
@@ -1,0 +1,103 @@
+#include <gtest/gtest.h>
+#include "helpers/wifi_observer/BrokerHealth.h"
+
+using offband::BrokerHealth;
+
+// A broker that never fails is never penalised, and a clean dwell on a healthy
+// broker is a no-op (nothing to earn).
+TEST(BrokerHealth, HealthyStaysHealthy) {
+    BrokerHealth h;
+    EXPECT_TRUE(h.isHealthy());
+    EXPECT_FALSE(h.isTerminal());
+    for (int i = 0; i < 10; i++) h.onCleanDwell();
+    EXPECT_EQ(h.fail_penalty, 0);
+    EXPECT_TRUE(h.isHealthy());
+}
+
+// A failure escalates the penalty and discards clean-streak progress.
+TEST(BrokerHealth, FailureEscalatesAndZeroesStreak) {
+    BrokerHealth h;
+    h.onFailure();
+    EXPECT_EQ(h.fail_penalty, 1);
+    EXPECT_EQ(h.clean_streak, 0);
+    h.onCleanDwell();
+    EXPECT_EQ(h.clean_streak, 1);   // progress toward the bar
+    h.onFailure();
+    EXPECT_EQ(h.fail_penalty, 2);
+    EXPECT_EQ(h.clean_streak, 0);   // failure wiped the progress
+}
+
+// THE CORE #739 PROPERTY: a single success does NOT clear the penalty. This is
+// what the old retry_count=0-on-connect did, and why a flaky broker never got
+// penalised.
+TEST(BrokerHealth, SingleSuccessDoesNotRehabilitate) {
+    BrokerHealth h;
+    h.onFailure(); h.onFailure(); h.onFailure();
+    EXPECT_EQ(h.fail_penalty, 3);
+    h.onCleanDwell();               // one good dwell
+    EXPECT_EQ(h.fail_penalty, 3) << "one success must NOT clear the penalty";
+    EXPECT_FALSE(h.isHealthy());
+}
+
+// A broker earns its way back with SUCCESS_BAR consecutive clean dwells.
+TEST(BrokerHealth, SuccessBarRehabilitates) {
+    BrokerHealth h;
+    h.onFailure(); h.onFailure();
+    EXPECT_EQ(h.fail_penalty, 2);
+    for (unsigned i = 0; i < OFFBAND_BROKER_SUCCESS_BAR; i++) {
+        EXPECT_FALSE(h.isHealthy()) << "must not rehabilitate before the bar";
+        h.onCleanDwell();
+    }
+    EXPECT_TRUE(h.isHealthy()) << "clears after the bar is met";
+    EXPECT_EQ(h.fail_penalty, 0);
+    EXPECT_EQ(h.clean_streak, 0);
+}
+
+// A failure part-way through the clean streak makes the broker start the bar over.
+TEST(BrokerHealth, FailureMidStreakRestartsTheBar) {
+    BrokerHealth h;
+    h.onFailure();
+    h.onCleanDwell();               // 1 of the bar
+    ASSERT_GE(OFFBAND_BROKER_SUCCESS_BAR, 2u);
+    h.onFailure();                  // back to square one, penalty up
+    EXPECT_EQ(h.clean_streak, 0);
+    EXPECT_EQ(h.fail_penalty, 2);
+    // now it must serve the FULL bar again
+    for (unsigned i = 0; i < OFFBAND_BROKER_SUCCESS_BAR - 1; i++) h.onCleanDwell();
+    EXPECT_FALSE(h.isHealthy());
+    h.onCleanDwell();
+    EXPECT_TRUE(h.isHealthy());
+}
+
+// A persistently-dead broker escalates to a terminal give-up.
+TEST(BrokerHealth, PersistentFailureBecomesTerminal) {
+    BrokerHealth h;
+    for (unsigned i = 0; i < OFFBAND_BROKER_TERMINAL_PENALTY; i++) {
+        EXPECT_FALSE(h.isTerminal());
+        h.onFailure();
+    }
+    EXPECT_TRUE(h.isTerminal()) << "gives up after the terminal threshold";
+}
+
+// The scenario that motivated the issue: a ~50% flaky broker that alternates
+// fail/clean never rehabilitates (the bar needs CONSECUTIVE cleans) and its
+// penalty ratchets toward terminal instead of oscillating at the floor.
+TEST(BrokerHealth, FlakyAlternatingNeverRehabilitatesAndEscalates) {
+    BrokerHealth h;
+    ASSERT_GE(OFFBAND_BROKER_SUCCESS_BAR, 2u);   // else a single clean would pass
+    uint16_t prev = 0;
+    for (int i = 0; i < 20; i++) {
+        h.onFailure();
+        h.onCleanDwell();            // one clean, not enough for the bar
+        EXPECT_FALSE(h.isHealthy()) << "alternating flaky must never look healthy";
+        EXPECT_GT(h.fail_penalty, prev) << "penalty must keep ratcheting up";
+        prev = h.fail_penalty;
+        if (h.isTerminal()) break;
+    }
+    EXPECT_TRUE(h.isTerminal()) << "a sustained-flaky broker eventually gives up";
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Closes #739. Refs #746 (auto-reconnect finding — addressed by the reaper, not the global disable; leaving its closure to owner judgment).

## The bug (#739)

The only backoff state was `retry_count`, reset to 0 on **any** successful connect. Fine for a *dead* broker, wrong for a *flaky* one: an intermittent broker connects just often enough to zero its penalty, so it oscillates at the 5s backoff floor forever and keeps claiming an equal rotation turn. Measured on `hv3-bench`: two ~50%-failing remote JWT brokers held **46% of a soak with no TLS broker up**.

## The change (3 commits)

1. **`BrokerHealth.h`** — dependency-free, host-testable policy object. `fail_penalty` is **sticky**: a single success does not clear it; only `OFFBAND_BROKER_SUCCESS_BAR` (3) consecutive clean full-dwells rehabilitate. Past `OFFBAND_BROKER_TERMINAL_PENALTY` (8) → terminal `Failed`.
2. **Lifecycle wiring** — `noteFailure()` at the three failure sites; backoff derives from `fail_penalty`; `onCleanDwell()` feeds rehab.
3. **Failed handling + reaper** — `onConnected()` ignores a late CONNECTED for a `Failed` broker (a racing esp-mqtt reconnect can't resurrect it); `tryConnect()` refuses to start `Failed`; the pool worker **reaps** (`releaseClient`) any `Failed` broker so its ~60KB TLS context is freed and it stops holding a client / a rotation turn.

## Why auto-reconnect stays ON (the reverted over-correction)

An earlier attempt on this branch globally set `disable_auto_reconnect`. A **~7h hardware soak** showed that terminally failed a *healthy* broker and collapsed rotation (`live=0/1` up to 96%). It was reverted; the pool's own reconnect isn't robust enough to be the sole driver yet. Only the `Failed` terminal state is reaped. **That catastrophic intermediate commit is collapsed out of this branch's history** — it does not land.

## Validation

- **`test_broker_health` 7/7** (native), incl. `FlakyAlternatingNeverRehabilitatesAndEscalates` reproducing the soak scenario.
- **Gemini 2.5-pro reviewed** — safe to merge; all 6 adversarial checks pass (healthy broker can't get stuck `Failed`; reaper/auto-reconnect race handled with no leak/corruption; `client_lock_` discipline maintained; `Failed` correctly leaves rotation; state machine correct). No bugs found.
- **~7h `hv3-bench` soak on this exact build**: `live=1/1` **99.3%** (2190/2205 samples), 329 clean rotate-outs, heap stable ~42K→~94K on rotate, **0 spurious terminal failures**. One lone transient TLS error exercised the penalty path correctly (+1 → Backoff, recovered — not terminal).

## Known scope

The **terminal-`Failed`-sticks** path (criterion 1) is covered by native tests + the reaper logic, but wasn't organically reached in the soak (no broker failed 8× — the config's brokers are reliable). Adjust-later is fine; the mechanism is unit-proven and Gemini-verified.

Agent: VioletBarn (session 82e07da7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)