### PR TITLE
task: RCC6 handoff corrections, prod+diag role matrix, and the #805 Vext answer

### DIFF
--- a/.github/release-envs.txt
+++ b/.github/release-envs.txt
@@ -1,9 +1,10 @@
 # Curated release env set for release.yml (epic #14 / T3 / #17).
 # One PlatformIO env per line. Lines starting with # and blank lines are ignored.
-# 85 active envs; verified against variants/*/platformio.ini. GATED (CI-built,
-# not released): heltec_v4_repeater_telemetry (#20, runtime-config secrets) and
-# the three companion_radio_wifi envs (#325, runtime WiFi provisioning) -- all
-# bake placeholder creds at compile time; uncomment when their gate issue lands.
+# 97 active envs; verified against variants/*/platformio.ini. GATED (CI-built,
+# not released): heltec_v4_repeater_telemetry (#20, runtime-config secrets), the
+# three companion_radio_wifi envs (#325, runtime WiFi provisioning) -- all bake
+# placeholder creds at compile time -- and the two RCC6 observer envs (#624,
+# unmeasured heap on C6). Uncomment when the respective gate clears.
 
 # RAK4631 (nRF52)
 RAK_4631_companion_radio_ble
@@ -98,6 +99,8 @@ Heltec_E290_companion_usb
 #   companion_radio_wifi envs. (Unlike those, it is not CI-built either -- no
 #   rc32 env is in ci.yml yet; tracked separately.)
 # The _diag / _diag_nocrashlog envs are diagnostic instruments, not products.
+#   This is the RULE. The RCC6 section below carries an owner-approved EXCEPTION
+#   to it, scoped to that board while it is beta -- it does not change this.
 heltec_rc32_companion_radio_ble
 heltec_rc32_companion_radio_usb
 heltec_rc32_repeater
@@ -106,34 +109,59 @@ heltec_rc32_room_server
 # Heltec RadioCore RCC6-L62 (ESP32-C6 + HT-RA62A LoRa) -- #806 / #624
 # Board 2 of 4 of the RadioCore beta set. L62 (LoRa) carrier only.
 #
-# PROD builds -- Companion (BLE + USB), Observer, Repeater. All display-enabled:
-# the board ships with the T108 panel, so the display build IS the product, the
-# same way heltec_rc32_repeater is the display build for the RC32.
+# PROD builds -- Companion (BLE + USB) and Repeater; Observer is BUILT but GATED,
+# see below. All display-enabled: the board ships with the T108 panel, so the
+# display build IS the product, the same way heltec_rc32_repeater is for the RC32.
 heltec_rcc6_companion_radio_ble
 heltec_rcc6_companion_radio_usb
-heltec_rcc6_companion_observer_wifi
 heltec_rcc6_repeater_display
+#heltec_rcc6_companion_observer_wifi   # GATED: uncomment after RCC6 heap is
+#   MEASURED ON HARDWARE. It builds and is in the build matrix -- it is not
+#   released. docs/radiocore/README.md ("RCC6 -- ESP32-C6 heap headroom") makes
+#   this the FIRST gating task on #624, ahead of feature work, and the numbers say
+#   why: OFFBAND_TLS_HEAP_FLOOR_BYTES is 80 KB guarding a ~72 KB TLS transient,
+#   while a community RCC6 build reports 91 KB free / 17 KB minimum. That is ~11 KB
+#   of headroom with a low-water mark far beneath the floor. Shipping this before
+#   measuring risks the HV3 heap-floor deadlock shape (#521/#534) on tester
+#   hardware, presenting as intractable runtime faults rather than clean failures.
 #
 # DIAG builds -- SAME roles, plus OFFBAND_MESHLOG_UART0 + OFFBAND_FORCE_CAPLOG.
 #
-# ⚠ DELIBERATE DEPARTURE from the standing line above that "_diag envs are
-# diagnostic instruments, not products" (which still holds for the RC32 and
-# everything else). Owner-directed for the RCC6 BETA specifically: this board
-# drops off USB after a chip reset on some hubs (#818), and when it does, the
-# application log dies with it because Serial IS the USB CDC. The diag builds
-# mirror the log to raw UART0, so a beta tester with a serial adapter can still
-# produce evidence instead of "it stopped working". Revisit when RCC6 leaves beta.
+# ⚠ APPROVED EXCEPTION -- OWNER DECISION. NOT THE RULE.
+#
+# THE RULE STILL STANDS: diag envs are diagnostic instruments, not products, and
+# they are not released. That holds for the RC32 and for every other board here.
+# Do NOT cite these entries as precedent for releasing diag builds elsewhere.
+#
+# WHY THE EXCEPTION EXISTS: the project now potentially supports beta users on
+# beta equipment -- a class of user that did not exist when the rule was written.
+# A beta tester on unproven hardware needs to be able to produce evidence, and on
+# THIS board that is not theoretical: the RCC6 drops off USB after a chip reset on
+# some hubs (#818), and when it does the application log dies with it, because
+# Serial IS the USB CDC. The diag builds mirror the log to raw UART0, so a tester
+# with a serial adapter can send back a boot trace instead of "it stopped working".
+#
+# SCOPE: RCC6 only, while RCC6 is beta. Revisit when the board leaves beta.
+# Extending this to another board is a fresh owner decision, not an inheritance.
+# PRIVACY POSTURE, stated so nobody has to infer it: these builds do NOT log more
+# than a prod build. OFFBAND_MESHLOG_UART0 is a TRANSPORT MIRROR -- the same MeshLog
+# lines that already go to USB CDC are also written to raw UART0. Existing redaction
+# holds (WiFi PSK and broker password are redacted at their log sites). What DOES
+# change: OFFBAND_FORCE_CAPLOG pins logging ON, so a tester cannot turn it off, and
+# UART0 is exposed on carrier header pin 12 -- reachable without USB. Anyone who can
+# reach that header can already reach the USB port. Testers should be told these are
+# instrumented builds.
 heltec_rcc6_companion_radio_ble_diag
 heltec_rcc6_companion_radio_usb_diag
-heltec_rcc6_companion_observer_wifi_diag
 heltec_rcc6_repeater_display_diag
+#heltec_rcc6_companion_observer_wifi_diag   # GATED with its prod sibling above.
 #
 # heltec_rcc6_repeater -- the NO-display repeater. Bring-up instrument (smallest
 #   surface that proves boot + radio), not a product. Not released.
-# heltec_rcc6_companion_observer_wifi is the FIRST ESP32-C6 observer in this
-#   tree -- every other observer env is ESP32/S3. It builds; it wants hardware
-#   confirmation (MQTT uplink + heap headroom on this part) before testers rely
-#   on it. Tracked on #624.
+# heltec_rcc6_companion_observer_wifi is also the FIRST ESP32-C6 observer in
+#   this tree -- every other observer env is ESP32/S3. That is a second reason
+#   for the gate above, independent of the heap numbers: no C6 has carried this
+#   role before, so there is no prior art to lean on. Tracked on #624.
 
 # Heltec T096 (nRF52)
 Heltec_t096_companion_radio_ble

--- a/.github/release-envs.txt
+++ b/.github/release-envs.txt
@@ -103,6 +103,38 @@ heltec_rc32_companion_radio_usb
 heltec_rc32_repeater
 heltec_rc32_room_server
 
+# Heltec RadioCore RCC6-L62 (ESP32-C6 + HT-RA62A LoRa) -- #806 / #624
+# Board 2 of 4 of the RadioCore beta set. L62 (LoRa) carrier only.
+#
+# PROD builds -- Companion (BLE + USB), Observer, Repeater. All display-enabled:
+# the board ships with the T108 panel, so the display build IS the product, the
+# same way heltec_rc32_repeater is the display build for the RC32.
+heltec_rcc6_companion_radio_ble
+heltec_rcc6_companion_radio_usb
+heltec_rcc6_companion_observer_wifi
+heltec_rcc6_repeater_display
+#
+# DIAG builds -- SAME roles, plus OFFBAND_MESHLOG_UART0 + OFFBAND_FORCE_CAPLOG.
+#
+# ⚠ DELIBERATE DEPARTURE from the standing line above that "_diag envs are
+# diagnostic instruments, not products" (which still holds for the RC32 and
+# everything else). Owner-directed for the RCC6 BETA specifically: this board
+# drops off USB after a chip reset on some hubs (#818), and when it does, the
+# application log dies with it because Serial IS the USB CDC. The diag builds
+# mirror the log to raw UART0, so a beta tester with a serial adapter can still
+# produce evidence instead of "it stopped working". Revisit when RCC6 leaves beta.
+heltec_rcc6_companion_radio_ble_diag
+heltec_rcc6_companion_radio_usb_diag
+heltec_rcc6_companion_observer_wifi_diag
+heltec_rcc6_repeater_display_diag
+#
+# heltec_rcc6_repeater -- the NO-display repeater. Bring-up instrument (smallest
+#   surface that proves boot + radio), not a product. Not released.
+# heltec_rcc6_companion_observer_wifi is the FIRST ESP32-C6 observer in this
+#   tree -- every other observer env is ESP32/S3. It builds; it wants hardware
+#   confirmation (MQTT uplink + heap headroom on this part) before testers rely
+#   on it. Tracked on #624.
+
 # Heltec T096 (nRF52)
 Heltec_t096_companion_radio_ble
 Heltec_t096_companion_radio_usb

--- a/docs/radiocore/README.md
+++ b/docs/radiocore/README.md
@@ -113,8 +113,9 @@ confirmed, so establish what our physical unit exposes before trusting those pin
 
 #### The two RCC6 power/RF rails you will otherwise re-derive
 
-**`Vext_3V3` (GPIO11) does NOT gate the LoRa supply** — `[resolved: #805]`. The board has
-two 3V3 regulators and only one is unconditional:
+**`Vext_3V3` (GPIO11) almost certainly does NOT gate the LoRa supply** —
+`[schematic-derived: #805 — NOT measured]`. The board has two 3V3 regulators and only one
+is unconditional:
 
 | Rail | Regulator | `EN` | Default |
 |---|---|---|---|
@@ -127,8 +128,15 @@ net name appears exactly twice on the whole schematic — the U3 output and that
 pin this population does not connect. Most likely provisioned for the HaLow module on the
 shared carrier `[hypothesis:]`.
 
-Practical effect: **the radio comes up whether or not you touch GPIO11.** Asserting it is
-harmless and costs the LDO's quiescent draw for no function.
+Practical effect: **the radio should come up whether or not you touch GPIO11.** The variant
+asserts it anyway, deliberately: this is a schematic inference, not a measurement, and the
+asymmetry favours asserting — if the inference is right it costs quiescent draw, if it is
+wrong not asserting is a silent dead SX1262.
+
+**To settle it, measure.** Multimeter on U5 pin 10 and pin 25 with GPIO11 de-asserted and
+asserted. That is cheap and definitive; everything above is inference from the PDF, and the
+part is dual-variant (`RA62A_LF/RA62A_HF`), so an `NC` pin on this population could be live
+on the other.
 
 **`SELECT` = GPIO7 is NOT resolved** — and it is the one that can bite quietly. The module
 is marked `RA62A_LF/RA62A_HF`, a dual LF/HF part, so `SELECT` plausibly chooses the RF path.

--- a/docs/radiocore/README.md
+++ b/docs/radiocore/README.md
@@ -108,6 +108,34 @@ confirmed, so establish what our physical unit exposes before trusting those pin
 | LoRa | `SCLK=21  MISO=20  MOSI=22  NSS=23  DIO1=19  BUSY=10  RESET=8` |
 | Battery | `ADC_CTRL=5  VBAT_READ=6  multiplier 4.95` |
 | Button | `9` |
+| `Vext_3V3` LDO enable | `11` — **does NOT power the radio**, see below |
+| `SELECT` (RF path?) | `7` — **unresolved**, see below |
+
+#### The two RCC6 power/RF rails you will otherwise re-derive
+
+**`Vext_3V3` (GPIO11) does NOT gate the LoRa supply** — `[resolved: #805]`. The board has
+two 3V3 regulators and only one is unconditional:
+
+| Rail | Regulator | `EN` | Default |
+|---|---|---|---|
+| `VDD_3V3` | U1 `CE6260B33M` | tied to `IN` | **always on** — and this is what powers the RA62A (U5 pin 10) |
+| `Vext_3V3` | U3 `TLV75733PDBVR` | `VEXT_LDO_Ctrl` = **GPIO11**, 100 K pulldown | off until firmware asserts it |
+
+`Vext_3V3`'s **only** destination is **U5 pin 25, which the RA62A symbol labels `NC`**. The
+net name appears exactly twice on the whole schematic — the U3 output and that pin. Its
+10 µF + 100 nF decoupling makes it look like a module supply; it is one, it just lands on a
+pin this population does not connect. Most likely provisioned for the HaLow module on the
+shared carrier `[hypothesis:]`.
+
+Practical effect: **the radio comes up whether or not you touch GPIO11.** Asserting it is
+harmless and costs the LDO's quiescent draw for no function.
+
+**`SELECT` = GPIO7 is NOT resolved** — and it is the one that can bite quietly. The module
+is marked `RA62A_LF/RA62A_HF`, a dual LF/HF part, so `SELECT` plausibly chooses the RF path.
+Neither our variant nor n30nex drives it. If it *is* a band select, the wrong default
+presents as **mediocre range, not a clean failure** — the failure mode nobody files a bug
+for. Settle it with an RSSI/range comparison against a known peer, GPIO7 driven each way,
+before trusting RF numbers off this board. Tracked on #805.
 
 **Only three LoRa pins reach the header** — `SCLK=21`, `MOSI=22`, `NSS=23`, which is
 exactly the block the diagram rings with a dashed "LoRa Module" box (pins 13/14/15).

--- a/docs/radiocore/rcc6-bringup-handoff.md
+++ b/docs/radiocore/rcc6-bringup-handoff.md
@@ -8,15 +8,45 @@ Companion to **#624** (epic: RadioCore RCC6 firmware support).
 > hours twice to claims that were asserted from partial reads, so nothing here is stated more
 > strongly than it was established.
 
+> ## ⚠ Bring-up is COMPLETE. This document is now historical.
+>
+> `variants/heltec_rcc6` **shipped** (#806, PR #820). The board boots, the SX1262 initialises and
+> reports a live noise floor, the T108 panel paints, and `companion_radio_usb` enumerates —
+> verified on `rcc6-bench-1` (`58:8c:81:2f:91:f8`), not merely compiled.
+>
+> **The shipped `variants/heltec_rcc6/platformio.ini` is the source of truth for pin assignments,
+> not this file.** What follows is kept as the record of how the board was approached and which
+> traps cost time. Sections corrected against post-bring-up evidence are marked
+> **`[resolved:]`** (#804).
+>
+> One finding did not resolve: after a chip-level reset the RCC6 can fail USB enumeration on
+> certain hubs — see **#818** and `docs/radiocore/rcc6-usb-enumeration-report.md`. That is
+> vendor-side, not firmware.
+
 ---
 
 ## 1. What exists today
 
-- **No `variants/heltec_rcc6`**, no `boards/heltec-rcc6.json`. Nothing in tree.
-- **Upstream MeshCore has no RCC6 either** — we would be first. There is no reference variant to
-  copy from, unlike most boards in this repo.
+- ~~**No `variants/heltec_rcc6`**~~ — **`[resolved:]` it exists now** (#806). No
+  `boards/heltec-rcc6.json` was needed; see §9.4.
+- ~~**Upstream MeshCore has no RCC6 either — we would be first. There is no reference variant to
+  copy from.**~~
+  **`[resolved:]` (#804) — that was wrong, and only true of *upstream* MeshCore.** Community
+  prior art existed before this doc was written:
+  - **[n30nex/NeonPocketMC-RCC6](https://github.com/n30nex/NeonPocketMC-RCC6)** (MIT, not a fork,
+    pushed 2026-08-13) ships a complete `variants/heltec_rcc6/` — `heltec_rcc6.{cpp,h}`,
+    `pins_arduino.h`, `platformio.ini`, `target.{cpp,h}` **and `boards/heltec_rcc6.json`** —
+    extending `esp32c6_base`, the same base name this repo defines.
+  - **[HelTecAutomation/RadioCore_Library](https://github.com/HelTecAutomation/RadioCore_Library)**
+    `src/boards/heltec_rcc6.h` — the vendor's own board header. **This is the one that mattered:**
+    it sets `USE_SOFTWARE_SPI 1` / `USE_HARDWARE_SPI 0`, which is why the display is bit-banged.
+  - Meshtastic **PR #11041** carries an `heltec_rcc6` pin mapping.
+
+  `docs/radiocore/README.md` and #624 had already recorded the n30nex prior art; this handoff
+  simply failed to incorporate them. **Check `docs/radiocore/README.md` §Prior art first.**
 - `docs/radiocore/RCC6 TFT Guide.md` and `docs/radiocore/radiocore-c6-tft-test.ino` exist and
-  predate this session; they were **not** reviewed during it.
+  predate this session; they were **not** reviewed during it. (The `.ino` was later flashed as the
+  vendor-firmware control in the #818 USB investigation.)
 - Vendor docs (gitignored, per-host): `docs/radiocore/vendor/RCC6/RCC6-L62_V1.0-schematic.pdf`,
   `rcc6-schematic-text.txt`, `RCC6.jpg`.
 
@@ -47,22 +77,56 @@ the RadioCore carrier footprint is consistent across the family.
 There is also a second header, **P3** (`HC-PBB40C-40DS-0.4V-2.5-02`, 40-pin board-to-board), which
 carries the same nets plus USB_P/USB_N. Not transcribed here; render it if needed.
 
-## 3. `[hypothesis:]` — needs re-derivation, do NOT trust
+## 3. `[resolved:]` LoRa + ADC pin map — CONFIRMED, and shipped
+
+> This section originally read *"`[hypothesis:]` — needs re-derivation, do NOT trust"*. **That
+> warning was wrong** (#804). The map it distrusted was correct on every signal, and the doc sent
+> the next session off to re-derive an answer it already had. Corrected in place; the reasoning
+> that produced the false alarm is preserved below, because the underlying caution is still sound.
 
 An early extraction paired LoRa nets to GPIOs by spatial row-matching and produced
 `SPI_CS→23, MOSI→22, CLK→21, MISO→20, DIO1→19, RESET_N→8, BUSY→10, SELECT→7`.
 
-**That was then observed to match the Heltec datasheet §3.2.1 table — and §3.2.1 turned out to be
-MODULE-SIDE pin names, not carrier GPIOs.** See §5. So the apparent agreement proved nothing
-about which C6 GPIO each net lands on, and the row-pairing itself is heuristic (it produced
-`U0TXD` and `U0RXD` on the same pin in an early pass).
+**All eight were correct.** Two independent confirmations:
 
-**Re-derive the LoRa pin map from the MCU symbol**, the way it was eventually done for the RC32:
-render the ESP32-C6 symbol region and read the net labels against the pin rows visually. Do not
-ship a variant on the row-pairing output.
+1. **The schematic carries its own printed net-to-GPIO table** beside the RA62A symbol (U5) —
+   stated by the vendor on the sheet, not inferred by row-pairing:
 
-Likewise `ADC_IN`/`ADC_Ctrl`/`Battery_ADC` nets **exist** on the RCC6 schematic, but their GPIO
-assignments were never confirmed.
+   ```
+   SPI_CS  GPIO23   SPI_MOSI GPIO22   SPI_CLK GPIO21   SPI_MISO GPIO20
+   DIO1    GPIO19   SELECT   GPIO7    RESET_N GPIO8    BUSY     GPIO10
+   VEXT_LDO_Ctrl    GPIO11
+   ```
+
+2. **The radio works on hardware.** The shipped variant uses exactly these values and the SX1262
+   initialises and reports a live noise floor (−95 to −108 dBm) on `rcc6-bench-1`.
+
+`SELECT`/`GPIO7` is the one signal the variant does **not** reference — it needs no build flag.
+
+**`ADC_IN`/`ADC_Ctrl`/`USER_Key` are likewise confirmed**, read from the rendered ESP32-C6 symbol
+(U8) bottom edge and matching n30nex independently:
+
+| Net | Package pin | SoC function | GPIO | Shipped as |
+|---|---|---|---|---|
+| `ADC_Ctrl` | 11 | MTDI | **5** | `PIN_ADC_CTRL=5` |
+| `ADC_IN` | 12 | MTCK | **6** | `PIN_VBAT_READ=6` |
+| `USER_Key` | 15 | GPIO9 | **9** | `PIN_USER_BTN=9` |
+| `VEXT_LDO_Ctrl` | — | — | **11** | `PIN_VEXT_EN=11` |
+
+`GPIO12`/`GPIO13` carry `D_N`/`D_P` — native USB. That is the mechanism behind the §7 enumeration
+observation.
+
+### Why the false alarm happened — the caution is still right
+
+The row-paired map was observed to match the Heltec datasheet §3.2.1 table, and §3.2.1 turned out
+to be **module-side** pin names, not carrier GPIOs (§5). The agreement was therefore meaningless as
+corroboration, and row-pairing is genuinely heuristic — it had produced `U0TXD` and `U0RXD` on the
+same pin in an earlier pass.
+
+Concluding *"unverified"* from that was correct. Concluding *"do NOT trust, re-derive"* over-steered:
+the honest state was **unconfirmed, probably right, confirm by rendering** — which is what §4 says
+to do, and it takes minutes. **Two sources that share an origin are not corroboration; that does
+not make either of them wrong.**
 
 ## 4. Method that works on these PDFs
 
@@ -102,10 +166,16 @@ carrier-GPIO column.
 - **Blind I2C bus scan wedges the C6 peripheral.** It hangs at address `0x0d` and never returns,
   so `setup()` never reaches `loop()`. This is why `ENV_SKIP_I2C_SENSOR_SCAN` exists (#294).
   **Probe known addresses only.**
-- **The UART0 boot beacon is unverified on C6.** `src/helpers/BootBeacon.h` writes raw UART0 FIFO
-  registers and is guarded ESP32-only. The C6 is RISC-V with a different register layout; it
-  reads `UART_TXFIFO_CNT_S` from the target's own `soc/uart_reg.h` so it *should* adapt, but that
-  has never been tested. Verify before relying on it for boot diagnostics.
+- **The UART0 boot beacon is STILL unverified on C6** — bring-up did not settle this.
+  `src/helpers/BootBeacon.h` writes raw UART0 FIFO registers and is guarded ESP32-only. The C6 is
+  RISC-V with a different register layout; it reads `UART_TXFIFO_CNT_S` from the target's own
+  `soc/uart_reg.h` so it *should* adapt, but that has never been tested.
+
+  **Why it was not tested:** `OFFBAND_BOOT_BEACON` is deliberately **not** set in
+  `heltec_rcc6_repeater_display_diag`. It compiles, but `simple_repeater` never defines
+  `OFFBAND_BEACON_DEFINE_CTOR` nor includes `BootBeacon.h`, so there are no call sites — it would
+  emit nothing while looking like live instrumentation. Only `examples/companion_radio` wires the
+  beacon up. To actually verify it on RISC-V, enable it on a **companion** env.
 - **ADC2 is unusable with WiFi active** on ESP32 generally — check what that leaves on C6 before
   assigning analog pins. On the RC32 this left almost nothing (#780 / #755).
 
@@ -117,9 +187,11 @@ carrier-GPIO column.
   with `SNIFFER_GENERIC_S3` defined → sniff RX `GPIO18`, RST `GPIO17`, BOOT/USR `GPIO16`.
   **Owner wired to 16, 18 and the board's `RX` pin — the wire on `RX` (GPIO3 = U0RXD) conflicts
   with the USB bridge and must move.** Mapping of which wire is which was not established.
-- **RCC6 appears to enumerate on native USB** — a `303A:1001` device (COM45) distinct from
-  `rc32-bench-1`. `[hypothesis:]` not confirmed. If true, the C6 is reachable directly without
-  the sniffer.
+- **RCC6 enumerates on native USB** — `303A:1001`, distinct from `rc32-bench-1`.
+  **`[resolved:]` confirmed** (#804); direct USB flashing is available and was used throughout
+  bring-up. **But** after a chip-level reset it can fail to re-enumerate on certain hubs and needs
+  a physical replug — **#818**. Budget for that when benching: it looks like a dead board and is
+  not one.
 - **`feather-sniffer` (COM16) is busy** — running the RC32 discharge capture with a MAX17048.
   Do not repoint it; it would end a multi-hour run.
 
@@ -134,12 +206,33 @@ RCC6 inherits a working bench rather than building one:
 - `tools/diag/rc32-boot-740/scripts/battery_runtime.py` — runtime projection that reports a
   range when its two methods disagree.
 
-## 9. Suggested first steps
+## 9. Suggested first steps — `[resolved:]` all four are DONE
 
-1. **Prove the sniff path** before any firmware work. The C6 ROM prints a boot banner on UART0
-   at 115200 before any application runs, so powering the RCC6 should make `rx_bytes` climb even
-   with no variant flashed. That validates wiring independently of everything else.
-2. **Re-derive the LoRa pin map** from the MCU symbol (§3). Render, do not infer.
-3. **Confirm whether COM45 is the RCC6.** If so, direct USB flashing is available.
-4. Only then scaffold `variants/heltec_rcc6` — with `boards/heltec-rcc6.json` for an ESP32-C6
-   target, which no existing variant in this repo provides a template for.
+Kept for the record of how bring-up was sequenced. **Step 1 is the one worth reusing on RC52.**
+
+1. ~~**Prove the sniff path** before any firmware work.~~ **Done, and it earned its keep.** The C6
+   ROM prints a boot banner on UART0 at 115200 before any application runs, so `rx_bytes` climbs
+   with no variant flashed. This validated wiring independently — and later became the *only*
+   observability channel when USB enumeration died (#818), which is exactly the situation it was
+   meant for. **Do this first on RC52 too.**
+2. ~~**Re-derive the LoRa pin map.**~~ **Unnecessary — the original map was correct.** See §3.
+3. ~~**Confirm whether COM45 is the RCC6.**~~ **Confirmed.** See §7.
+4. ~~**Scaffold `variants/heltec_rcc6` — with `boards/heltec-rcc6.json` for an ESP32-C6 target,
+   which no existing variant in this repo provides a template for.**~~
+   **`[resolved:]` (#804) — no custom board JSON was needed, and the "no template" claim was
+   wrong.** This repo already had three C6 variants — `xiao_c6`, `lilygo_tlora_c6`,
+   `m5stack_unit_c6l` — and none uses a custom board JSON; all three take stock
+   `esp32-c6-devkitm-1`.
+
+   The real gap was never C6 support, it was **flash size**: RCC6 is 16 MB, the existing three are
+   4/8 MB parts (they use `min_spiffs.csv` to fit). `xiao_c6` already showed the way — override
+   flash geometry rather than mint a board file. The shipped variant does exactly that:
+
+   ```ini
+   board                     = esp32-c6-devkitm-1
+   board_build.partitions    = default_16MB.csv
+   board_upload.flash_size   = 16MB
+   board_upload.maximum_size = 16777216
+   ```
+
+   (n30nex does ship its own `boards/heltec_rcc6.json`. It works; it is simply not required.)

--- a/variants/heltec_rcc6/HeltecRCC6Board.cpp
+++ b/variants/heltec_rcc6/HeltecRCC6Board.cpp
@@ -11,16 +11,28 @@ void HeltecRCC6Board::begin() {
   // `[verified: rendered schematic, U1/U3 comparison -- U1 (CE6260B33M -> VDD_3V3)
   //  has EN tied to IN and is unconditional; U3 does not]`
   //
-  // WHY WE ASSERT IT. Whether this rail gates the radio, the display, or both is
-  // NOT yet established (#805) -- the module pin it lands on was occluded in the
-  // render and has not been confirmed. Asserting it is the safe direction: if it
-  // feeds the radio, leaving it low is a silent dead SX1262 with no obvious
-  // pointer at a power rail; if it feeds only the display, asserting it costs a
-  // few mA. No reference implementation drives this pin -- n30nex's variant never
-  // touches GPIO11 -- so there is nothing to inherit here.
+  // `[resolved: #805]` THIS RAIL DOES NOT POWER THE RADIO. Settled from the
+  // schematic's vector geometry (not a render): Vext_3V3's only destination is
+  // U5 pin 25, which the RA62A symbol labels NC. The net name appears exactly
+  // twice on the whole sheet -- the U3 output, and that pin. The module's actual
+  // supply is VDD_3V3 on U5 pin 10, off U1, which is unconditional.
   //
-  // Revisit under #805, and if the rail turns out to be display-only, gate it
-  // with the display rather than holding it up unconditionally.
+  // Confirmed three ways: the sole vertical segment reaching the Vext node is at
+  // x=640.63; a stub-to-label offset calibrated on pins 21/22 (SPI_MOSI/SPI_CS,
+  // both exactly +1.530) predicts pin 25 at x=640.62 -- delta 0.01 against a 3.59
+  // pin pitch; and the PDF's own designator PIU5025 sits at x=641.00 beside the
+  // NC label. The 10uF+100nF decoupling that made this look like a supply rail IS
+  // one -- it just lands on a pin this population does not connect. Most likely
+  // provisioned for the HaLow module on the shared carrier `[hypothesis:]`.
+  //
+  // SO WHY STILL ASSERT IT? Only because turning it off changes runtime behaviour
+  // on a board already verified working, and that is the owner's call, not a
+  // side-effect of a documentation fix. It costs the TLV75733's quiescent draw
+  // for zero function. Dropping the two lines below is the power-saving move and
+  // is safe on this evidence; PIN_VEXT_EN stays defined either way so the rail
+  // remains documented and one line brings it back.
+  //
+  // NOT resolved by this: SELECT (GPIO7) -- see the note at the end of begin().
   pinMode(PIN_VEXT_EN, OUTPUT);
   digitalWrite(PIN_VEXT_EN, PIN_VEXT_EN_ACTIVE);
   delay(10);   // let the LDO settle before anything downstream is touched
@@ -45,7 +57,12 @@ void HeltecRCC6Board::begin() {
   // RA62A_LF/RA62A_HF -- a dual LF/HF part -- so SELECT plausibly chooses the RF
   // path, but that is `[hypothesis: untested]` and n30nex does not drive it
   // either. Driving a strap-capable pin whose function is unconfirmed is worse
-  // than leaving it at its board default. Tracked on #806.
+  // than leaving it at its board default.
+  //
+  // Tracked on #805 ("Related unknown -- do not lose this one"), NOT #806, which
+  // is closed. If SELECT does choose the RF path, the wrong default presents as
+  // mediocre range rather than a clean failure -- the failure mode nobody files
+  // a bug for. Settle it before this board ships to testers.
 }
 
 uint16_t HeltecRCC6Board::getBattMilliVolts() {

--- a/variants/heltec_rcc6/HeltecRCC6Board.cpp
+++ b/variants/heltec_rcc6/HeltecRCC6Board.cpp
@@ -11,26 +11,35 @@ void HeltecRCC6Board::begin() {
   // `[verified: rendered schematic, U1/U3 comparison -- U1 (CE6260B33M -> VDD_3V3)
   //  has EN tied to IN and is unconditional; U3 does not]`
   //
-  // `[resolved: #805]` THIS RAIL DOES NOT POWER THE RADIO. Settled from the
-  // schematic's vector geometry (not a render): Vext_3V3's only destination is
-  // U5 pin 25, which the RA62A symbol labels NC. The net name appears exactly
-  // twice on the whole sheet -- the U3 output, and that pin. The module's actual
-  // supply is VDD_3V3 on U5 pin 10, off U1, which is unconditional.
+  // `[schematic-derived: #805 -- NOT measured]` THIS RAIL ALMOST CERTAINLY DOES
+  // NOT POWER THE RADIO. Vext_3V3's only destination is U5 pin 25, which the
+  // RA62A symbol labels NC; the net name appears exactly twice on the whole
+  // single-page sheet (the U3 output, and that pin). The module's supply is
+  // VDD_3V3 on U5 pin 10, off U1, which is unconditional.
   //
-  // Confirmed three ways: the sole vertical segment reaching the Vext node is at
-  // x=640.63; a stub-to-label offset calibrated on pins 21/22 (SPI_MOSI/SPI_CS,
-  // both exactly +1.530) predicts pin 25 at x=640.62 -- delta 0.01 against a 3.59
-  // pin pitch; and the PDF's own designator PIU5025 sits at x=641.00 beside the
-  // NC label. The 10uF+100nF decoupling that made this look like a supply rail IS
-  // one -- it just lands on a pin this population does not connect. Most likely
-  // provisioned for the HaLow module on the shared carrier `[hypothesis:]`.
+  // Evidence, computed from the PDF's vector geometry rather than read off a
+  // render: the sole vertical segment reaching the Vext node is at x=640.63. The
+  // PDF carries its own per-pin designators (PIU50nn); matching every bottom-edge
+  // pin against the drawn stubs gives agreement within +/-0.61 for every pin that
+  // HAS a stub, and x=640.63 lands on PIU5025 (641.00, delta -0.37) with its
+  // neighbours 3.59 away. Pins 23 and 30 deviate ~3.3 precisely because no stub
+  // is drawn for them -- they are NC with no wire, which is corroboration, not
+  // error.
   //
-  // SO WHY STILL ASSERT IT? Only because turning it off changes runtime behaviour
-  // on a board already verified working, and that is the owner's call, not a
-  // side-effect of a documentation fix. It costs the TLV75733's quiescent draw
-  // for zero function. Dropping the two lines below is the power-saving move and
-  // is safe on this evidence; PIN_VEXT_EN stays defined either way so the rail
-  // remains documented and one line brings it back.
+  // WHAT WOULD FALSIFY IT, and why this is not called `[verified:]`: no voltage
+  // was ever measured. A schematic read -- however carefully computed -- is not a
+  // measurement, and this part is explicitly dual-variant (RA62A_LF/RA62A_HF), so
+  // a pin that is NC on one population can be live on the other. The cheap
+  // settling test is a multimeter on U5 pin 10 and pin 25 with GPIO11 de-asserted
+  // and asserted. Until someone does that, this is a strong inference.
+  //
+  // SO WHY STILL ASSERT IT? Precisely BECAUSE it is inference and not measurement.
+  // If the inference is right, asserting costs the TLV75733's quiescent draw and
+  // nothing else. If it is wrong, NOT asserting is a silent dead SX1262 with no
+  // obvious pointer at a power rail. That asymmetry favours asserting until the
+  // measurement exists -- and removing it is the owner's call regardless, since it
+  // changes runtime behaviour on a board already verified working. PIN_VEXT_EN
+  // stays defined either way, so one line restores it.
   //
   // NOT resolved by this: SELECT (GPIO7) -- see the note at the end of begin().
   pinMode(PIN_VEXT_EN, OUTPUT);

--- a/variants/heltec_rcc6/platformio.ini
+++ b/variants/heltec_rcc6/platformio.ini
@@ -215,12 +215,7 @@ build_flags =
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
   -D MAX_NEIGHBOURS=8
-  -D OFFBAND_MESHLOG_UART0
-  ; #631: pin runtime logging ON in loadPrefs(), before anything else runs.
-  ; Without it the boot path is mute on exactly the boot being investigated --
-  ; every MESH_DEBUG_PRINTLN is gated on g_meshLogEnabled, which stays false
-  ; until prefs load. `caplog stop` cannot undo it in this build.
-  -D OFFBAND_FORCE_CAPLOG
+  ${rcc6_diag.build_flags}
   ; NOTE: OFFBAND_BOOT_BEACON is deliberately NOT set here. It compiles, but
   ; simple_repeater never defines OFFBAND_BEACON_DEFINE_CTOR nor includes
   ; BootBeacon.h, so there are no call sites and it would emit nothing -- a flag
@@ -262,3 +257,127 @@ lib_deps =
   ${heltec_rcc6_with_display.lib_deps}
   densaugeo/base64 @ ~1.4.0
   end2endzone/NonBlockingRTTTL@^1.3.0
+
+; =============================================================================
+; DIAG FLAG SET -- shared by every *_diag env below.
+;
+; This is "the part that makes the sniffer work". Defined ONCE here rather than
+; per-env, so a diag build cannot drift from its prod sibling by more than these
+; two flags.
+;
+; OFFBAND_MESHLOG_UART0 -- writes MeshLog lines straight into the UART0 TX FIFO:
+;   no driver, no FreeRTOS, no USB stack. These builds set ARDUINO_USB_CDC_ON_BOOT=1,
+;   so `Serial` IS the USB CDC and every log line goes to USB and nowhere else.
+;   When USB is the thing that died -- and on this board it does, see #818 -- the
+;   log dies with it and an external sniffer on U0TXD sees only ROM output. This
+;   keeps the board observable exactly when the normal channel is gone (#763).
+;
+; OFFBAND_FORCE_CAPLOG -- pins runtime logging ON in loadPrefs(), before anything
+;   else runs (#631). Without it the boot path is mute on exactly the boot being
+;   investigated: every MESH_DEBUG_PRINTLN is gated on g_meshLogEnabled, which
+;   stays false until prefs load. `caplog stop` cannot undo it in this build.
+;
+; NOT included: OFFBAND_BOOT_BEACON. It compiles, but simple_repeater never
+; defines OFFBAND_BEACON_DEFINE_CTOR nor includes BootBeacon.h, so it has no call
+; sites there and would emit nothing -- instrumentation that looks live while
+; doing nothing is worse than none. It IS wired in examples/companion_radio, so
+; the companion diag envs below could carry it; left off until it is verified on
+; RISC-V (see the C6 traps section in docs/radiocore/rcc6-bringup-handoff.md).
+; =============================================================================
+[rcc6_diag]
+build_flags =
+  -D OFFBAND_MESHLOG_UART0
+  -D OFFBAND_FORCE_CAPLOG
+
+; -----------------------------------------------------------------------------
+; COMPANION -- BLE. Also the base the observer extends, which is why it exists
+; even though USB companion came first during bring-up.
+;
+; C6 BLE is well-trodden: xiao_c6, m5stack_unit_c6l, lilygo_tlora_c6 and the
+; Photon C6 all ship a BLE companion. Follows m5stack_unit_c6l's shape --
+; ${esp32_ble.lib_deps}, and NO ${esp32_no_ble.build_src_filter}.
+; -----------------------------------------------------------------------------
+[env:heltec_rcc6_companion_radio_ble]
+extends = heltec_rcc6_with_display
+build_flags =
+  ${heltec_rcc6_with_display.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+build_src_filter = ${heltec_rcc6_with_display.build_src_filter}
+  +<helpers/ui/buzzer.cpp>
+  +<helpers/esp32/*.cpp>
+  ; ESPNOWRadio does not compile on C6 -- see the note on the USB companion.
+  -<helpers/esp32/ESPNOWRadio.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${esp32_ble.lib_deps}
+  ${heltec_rcc6_with_display.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+  end2endzone/NonBlockingRTTTL@^1.3.0
+
+; -----------------------------------------------------------------------------
+; OBSERVER -- FIRST ESP32-C6 OBSERVER IN THIS TREE.
+;
+; Every other observer env (heltec_v3, heltec_v4, heltec_v4_tft, xiao_s3_wio)
+; is ESP32 or ESP32-S3. No C6 board has carried this role before, so treat a
+; green build as necessary-not-sufficient: MQTT uplink and the observer's heap
+; headroom want hardware confirmation on this part before it goes to testers.
+;
+; The observer path itself carries no architecture guards -- it extends the BLE
+; companion and adds helpers/wifi_observer + helpers/config + helpers/diagnostics
+; -- so there is no known blocker, just no precedent.
+;
+; Contact/channel counts are the deliberately-trimmed observer set (#701), not
+; the companion's 350/40: the observer holds broker state and an offline queue.
+; -----------------------------------------------------------------------------
+[env:heltec_rcc6_companion_observer_wifi]
+extends = env:heltec_rcc6_companion_radio_ble
+monitor_rts = 0
+monitor_dtr = 0
+build_flags =
+  ${env:heltec_rcc6_companion_radio_ble.build_flags}
+  -Wno-builtin-macro-redefined
+  -D OFFBAND_OBSERVER
+  -D OFFBAND_OBSERVER_BLE_COMPANION
+  -D WITH_MQTT_UPLINK
+  -D MAX_CONTACTS=5
+  -D MAX_ANON_CONTACTS=3
+  -D MAX_GROUP_CHANNELS=5
+  -D OFFBAND_MAX_BROKERS=6
+  -D OFFLINE_QUEUE_SIZE=16
+build_src_filter =
+  ${env:heltec_rcc6_companion_radio_ble.build_src_filter}
+  +<helpers/wifi_observer/*.cpp>
+  +<helpers/config/*.cpp>
+  +<helpers/diagnostics/*.cpp>
+
+; =============================================================================
+; DIAG TWINS. Each is its prod sibling + ${rcc6_diag.build_flags}, nothing else.
+;
+; These are for beta testers on this board specifically: when an RCC6 stops
+; talking over USB, the tester still has a UART0 story to send back. That is a
+; deliberate departure from .github/release-envs.txt's standing line that diag
+; envs are "diagnostic instruments, not products" -- owner-directed for the RCC6
+; beta. Revisit when the board is no longer beta.
+; =============================================================================
+[env:heltec_rcc6_companion_radio_usb_diag]
+extends = env:heltec_rcc6_companion_radio_usb
+build_flags =
+  ${env:heltec_rcc6_companion_radio_usb.build_flags}
+  ${rcc6_diag.build_flags}
+
+[env:heltec_rcc6_companion_radio_ble_diag]
+extends = env:heltec_rcc6_companion_radio_ble
+build_flags =
+  ${env:heltec_rcc6_companion_radio_ble.build_flags}
+  ${rcc6_diag.build_flags}
+
+[env:heltec_rcc6_companion_observer_wifi_diag]
+extends = env:heltec_rcc6_companion_observer_wifi
+build_flags =
+  ${env:heltec_rcc6_companion_observer_wifi.build_flags}
+  ${rcc6_diag.build_flags}


### PR DESCRIPTION
Cleanup bundle for the RCC6 (board 2 of 4). Corrects a handoff document that was actively misleading, adds the role matrix the board was missing, and answers #805 from the schematic.

Closes #804

## 1. Handoff corrections (#804)

`docs/radiocore/rcc6-bringup-handoff.md` carried four claims contradicted by evidence. The damaging one was **§3**, which marked the LoRa pin map `[hypothesis:] do NOT trust, re-derive` — the map was correct on **all eight signals**, and the doc sent the next session off to re-derive an answer it already had.

| # | Claim | Reality |
|---|---|---|
| 1 | "No reference variant — we would be first" | True only of *upstream* MeshCore. `n30nex/NeonPocketMC-RCC6` shipped a complete variant five days earlier, and Heltec's own `RadioCore_Library` board header was available — **the one that mattered**, since it sets `USE_SOFTWARE_SPI 1` and explains the blank display that cost hours |
| 2 | LoRa map is untrusted | Schematic carries its own printed net-to-GPIO table; radio now runs on exactly those values |
| 3 | ADC pins "never confirmed" | `ADC_Ctrl=5`, `ADC_IN=6`, `USER_Key=9`, `VEXT=11` — confirmed and shipped |
| 4 | "No C6 board-JSON template exists" | Three C6 variants predate this and **none** uses a custom board JSON. The real gap was flash size (16 MB vs their 4/8 MB), solved with geometry overrides |

Corrections are marked `[resolved:]` rather than deleted — the wrong claims stay visible with *why* they were wrong, which is the point of a document whose whole discipline is confidence markers. #804 explicitly scoped keeping those markers.

**Beyond the four**, same defect class: a header banner stating bring-up is complete and the shipped `platformio.ini` is the pin source of truth; §7's COM45 hypothesis resolved with the #818 caveat; §9's steps marked done; and §6 recording that the boot beacon is **still** unverified on C6 *with the reason* — `OFFBAND_BOOT_BEACON` is deliberately off because `simple_repeater` has no call sites, so it would emit nothing while looking like live instrumentation.

## 2. Role matrix — prod + diag

Adds the roles the board was missing, plus a diag twin of each. **All nine envs build:**

| Role | Prod | Diag |
|---|---|---|
| Companion BLE | ✅ new | ✅ new |
| Companion USB | ✅ | ✅ new |
| Observer | ✅ **new** | ✅ new |
| Repeater (display) | ✅ | ✅ |

Diag flags live in one `[rcc6_diag]` fragment (`OFFBAND_MESHLOG_UART0` + `OFFBAND_FORCE_CAPLOG`), so a diag build cannot drift from its prod sibling by more than those two. The pre-existing `repeater_display_diag` was refactored onto it rather than keeping a second copy.

### Releasing diag builds — approved exception, **not** the rule

`.github/release-envs.txt` states diag envs are "diagnostic instruments, not products." **That rule still stands** for RC32 and every other board, and is reinforced at its original site in the file.

The RCC6 carries an **owner-approved, board-scoped exception**, recorded in place: the project now potentially supports beta users on beta equipment — a class of user that did not exist when the rule was written. On this board it is not theoretical. The RCC6 drops off USB after a chip reset on some hubs (#818), and `Serial` **is** the USB CDC, so the application log dies with it. The diag builds mirror to raw UART0, so a tester can send back a boot trace instead of "it stopped working." Scoped to RCC6 while it is beta; extending it elsewhere is a fresh owner decision, not an inheritance.

### Observer is built but **GATED out of the release**

Raised by the review gate and confirmed against our own docs. `docs/radiocore/README.md` makes *"measure real heap on the board"* the **first** gating task on #624, ahead of feature work:

- `OFFBAND_TLS_HEAP_FLOOR_BYTES` = **80 KB**, guarding a ~72 KB TLS transient
- a community RCC6 build reports **91 KB free / 17 KB minimum**

That is ~11 KB of headroom with a low-water mark far beneath the floor — the HV3 heap-floor deadlock shape (#521/#534), which presents as intractable runtime faults rather than clean failures. It is also the **first ESP32-C6 observer in this tree**; every other observer env is ESP32/S3, so there is no prior art to lean on.

Both observer envs are commented out using the file's existing `GATED` convention. **They still build and stay in the matrix** — this gates what ships, not what is compiled.

## 3. #805 — `Vext_3V3` does not gate the LoRa supply

`[schematic-derived — NOT measured]`. Its only destination is **U5 pin 25, labelled `NC`**; the net name appears exactly **twice** in the whole single-page schematic. The RA62A is powered from `VDD_3V3` (U5 pin 10) off U1, which is unconditional.

Computed from the PDF's vector geometry rather than read off a render — eyeballing is what produced the original uncertainty. The sole vertical segment reaching the Vext node is `x=640.63`; matching **every** bottom-edge pin against the PDF's own `PIU50nn` designators agrees within **±0.61** for every pin that has a drawn stub, and `x=640.63` lands on `PIU5025` (delta **−0.37**, neighbours **3.59** away). Pins 23 and 30 deviate ~3.3 precisely because no stub is drawn for them — `NC` with no wire, which corroborates the method.

**Deliberately not called `[verified:]`.** No voltage was measured, and the part is dual-variant (`RA62A_LF/RA62A_HF`), so an `NC` pin here could be live on the other population. Falsifying test named in the code: multimeter on U5 pin 10 and pin 25, GPIO11 de-asserted vs asserted.

**GPIO11 is still asserted, deliberately.** Because this is inference and not measurement, the asymmetry favours it: if right, it costs the LDO's quiescent draw; if wrong, *not* asserting is a silent dead SX1262 with no obvious pointer at a power rail. That flips once someone measures.

Recorded in `docs/radiocore/README.md`, which had no `VEXT` mention at all — that was #805's third ask.

**Still open, and the one that matters:** `SELECT` = GPIO7. Dual LF/HF part; if it selects the RF path, a wrong default reads as **mediocre range, not a clean failure**. Needs bench time, not a schematic.

## Testing

⚠️ **`ci-green` does not cover this board.** `heltec_rcc6` is not in the `ci.yml` matrix — neither is `heltec_rc32`, so this follows RadioCore precedent rather than introducing a gap. A green CI run here says nothing about these envs.

Verified locally instead — **9/9 SUCCESS, 0 failed**, re-run after the rebase:

```
heltec_rcc6_repeater                      SUCCESS
heltec_rcc6_repeater_display              SUCCESS
heltec_rcc6_repeater_display_diag         SUCCESS
heltec_rcc6_companion_radio_usb           SUCCESS
heltec_rcc6_companion_radio_ble           SUCCESS
heltec_rcc6_companion_observer_wifi       SUCCESS
heltec_rcc6_companion_radio_usb_diag      SUCCESS
heltec_rcc6_companion_radio_ble_diag      SUCCESS
heltec_rcc6_companion_observer_wifi_diag  SUCCESS
```

## Gemini adversarial gate

`gemini-2.5-pro`, audit log under `docs/llm-consultations/`. Seven findings — **3 acted, 2 refuted with evidence, 2 declined with reasons.**

**Acted:** observer gated out of release (above); Vext claim downgraded from `[resolved:]` to `[schematic-derived]` *and* the evidence strengthened against the "two-point calibration" objection; diag privacy posture documented.

**Refuted — "`-Wno-builtin-macro-redefined` hides a silently wrong `MAX_CONTACTS`."** Tested with a compile probe: `-DMAX_CONTACTS=350 -DMAX_CONTACTS=5` yields **5**, last-wins, **and warns**. That flag covers builtin macros (`__DATE__`/`__TIME__`), not user `-D`. It is also the exact idiom `heltec_v3_companion_observer_wifi` already uses — diverging for RCC6 alone would make this the inconsistent variant.

**Refuted — "the GPIO11 assert is dead code, remove it."** In tension with the reviewer's own accepted point that the claim is unproven. Reasoning now stated in the code rather than deferred.

**Declined — "delete the struck-through handoff text."** #804 explicitly scoped keeping the confidence markers; auditability of corrected claims is that document's purpose.

**Declined — rename `DISABLE_WIFI_OTA`.** Repo-wide flag touching every variant; out of scope for an RCC6 change.

## Notes for the reviewer

Rebased onto `firmware-base` (clean — only `CLAUDE.md` landed meanwhile). Untouched: `ci.yml`, `CommonCLI.cpp`, `scripts/*cli_dispatch*`, `scripts/pio-flash.py` — all reserved by other sessions.

Agent: GreenTower (session c161ba8f)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
