### PR TITLE
bug: un-gate the RCC6 observer envs — the gate in #828 was a false analysis

### DIFF
--- a/.github/release-envs.txt
+++ b/.github/release-envs.txt
@@ -1,10 +1,9 @@
 # Curated release env set for release.yml (epic #14 / T3 / #17).
 # One PlatformIO env per line. Lines starting with # and blank lines are ignored.
-# 97 active envs; verified against variants/*/platformio.ini. GATED (CI-built,
+# 99 active envs; verified against variants/*/platformio.ini. GATED (CI-built,
 # not released): heltec_v4_repeater_telemetry (#20, runtime-config secrets), the
 # three companion_radio_wifi envs (#325, runtime WiFi provisioning) -- all bake
-# placeholder creds at compile time -- and the two RCC6 observer envs (#624,
-# unmeasured heap on C6). Uncomment when the respective gate clears.
+# placeholder creds at compile time. Uncomment when their gate issue lands.
 
 # RAK4631 (nRF52)
 RAK_4631_companion_radio_ble
@@ -109,21 +108,20 @@ heltec_rc32_room_server
 # Heltec RadioCore RCC6-L62 (ESP32-C6 + HT-RA62A LoRa) -- #806 / #624
 # Board 2 of 4 of the RadioCore beta set. L62 (LoRa) carrier only.
 #
-# PROD builds -- Companion (BLE + USB) and Repeater; Observer is BUILT but GATED,
-# see below. All display-enabled: the board ships with the T108 panel, so the
-# display build IS the product, the same way heltec_rc32_repeater is for the RC32.
+# PROD builds -- Companion (BLE + USB), Observer, Repeater. All display-enabled:
+# the board ships with the T108 panel, so the display build IS the product, the
+# same way heltec_rc32_repeater is for the RC32.
+#
+# OBSERVER IS VERIFIED ON HARDWARE (#830). Owner-configured with four brokers on
+# rcc6-bench-1: WiFi + MQTT + radio up, stable, brokers rotating normally. One
+# live TLS context at a time -- which is OFFBAND_MAX_LIVE_TLS=1, the GLOBAL default
+# on every PSRAM-less board, not a C6 limit; HV3 holds exactly one too. Heap
+# recovers to ~86 KB between brokers, above the 80 KB handshake floor, which is
+# the #175 rotation scheduler working as designed.
 heltec_rcc6_companion_radio_ble
 heltec_rcc6_companion_radio_usb
+heltec_rcc6_companion_observer_wifi
 heltec_rcc6_repeater_display
-#heltec_rcc6_companion_observer_wifi   # GATED: uncomment after RCC6 heap is
-#   MEASURED ON HARDWARE. It builds and is in the build matrix -- it is not
-#   released. docs/radiocore/README.md ("RCC6 -- ESP32-C6 heap headroom") makes
-#   this the FIRST gating task on #624, ahead of feature work, and the numbers say
-#   why: OFFBAND_TLS_HEAP_FLOOR_BYTES is 80 KB guarding a ~72 KB TLS transient,
-#   while a community RCC6 build reports 91 KB free / 17 KB minimum. That is ~11 KB
-#   of headroom with a low-water mark far beneath the floor. Shipping this before
-#   measuring risks the HV3 heap-floor deadlock shape (#521/#534) on tester
-#   hardware, presenting as intractable runtime faults rather than clean failures.
 #
 # DIAG builds -- SAME roles, plus OFFBAND_MESHLOG_UART0 + OFFBAND_FORCE_CAPLOG.
 #
@@ -153,15 +151,14 @@ heltec_rcc6_repeater_display
 # instrumented builds.
 heltec_rcc6_companion_radio_ble_diag
 heltec_rcc6_companion_radio_usb_diag
+heltec_rcc6_companion_observer_wifi_diag
 heltec_rcc6_repeater_display_diag
-#heltec_rcc6_companion_observer_wifi_diag   # GATED with its prod sibling above.
 #
 # heltec_rcc6_repeater -- the NO-display repeater. Bring-up instrument (smallest
 #   surface that proves boot + radio), not a product. Not released.
-# heltec_rcc6_companion_observer_wifi is also the FIRST ESP32-C6 observer in
-#   this tree -- every other observer env is ESP32/S3. That is a second reason
-#   for the gate above, independent of the heap numbers: no C6 has carried this
-#   role before, so there is no prior art to lean on. Tracked on #624.
+# heltec_rcc6_companion_observer_wifi is the FIRST ESP32-C6 observer in this tree
+#   -- every other observer env is ESP32/S3. Recorded as a fact worth knowing, not
+#   as a caveat: it is verified running on hardware (#830).
 
 # Heltec T096 (nRF52)
 Heltec_t096_companion_radio_ble

--- a/docs/radiocore/README.md
+++ b/docs/radiocore/README.md
@@ -177,22 +177,44 @@ before USB init — at full charge, presenting as a completely dead board. See #
 board. Never copy it from a sibling variant.** `[verified: RC52 pinout diagram shows the
 gate; the #602 failure mode is documented in HARDWARE.local.md]`
 
-### RCC6 — ESP32-C6 heap headroom
+### RCC6 — ESP32-C6 heap, MEASURED
 
-The C6 has materially less usable SRAM than the S3, and Offband's WiFi/TLS observer path
-has a hard heap floor: `OFFBAND_TLS_HEAP_FLOOR_BYTES` = **80 KB**, guarding a ~72 KB TLS
-handshake transient. `[verified: src/helpers/wifi_observer/WifiObserverConfig.h:85]`
+**The observer runs on the RCC6.** `[verified: rcc6-bench-1, owner-configured with four
+brokers, 354 s continuous — WiFi + MQTT + radio up, brokers rotating normally]` This
+supersedes the earlier "measure before designing any WiFi/Observer work" gating note; the
+measurement is done and it did not block.
 
-A community RCC6 repeater dashboard reports **free heap 91 KB, minimum 17 KB** — i.e. a
-working C6 build sits only ~11 KB above that floor, with a low-water mark far beneath it.
-`[hypothesis: untested — that figure is from a third-party build, not ours]`
+**Read the two numbers correctly — this is where a prior analysis went wrong (#830):**
 
-If it holds on our hardware, an Offband TLS observer on RCC6 would land in the same shape
-as the HV3 heap-floor deadlock (#521, fixed by #534 lazy client allocation). **Measure
-real heap on the board before designing any WiFi/Observer work for it** — that is the
-first gating task on #624, ahead of feature work. A web UI, TLS broker, or high contact
-count on this module can exhaust memory in ways that present as intractable runtime
-faults rather than clean failures.
+- **`OFFBAND_MAX_LIVE_TLS` = 1 is the GLOBAL default**, not a C6 limit. Each live wss
+  broker holds a ~60 KB mbedTLS context, so *every* PSRAM-less board holds exactly one;
+  HV3 included. Seeing `live=1/1` on RCC6 is the designed cap, not a symptom. The #175
+  rotation scheduler exists precisely to cycle more brokers through that 1-wide budget.
+- **`OFFBAND_TLS_HEAP_FLOOR_BYTES` = 80 KB gates *starting* a handshake — it is not a
+  required running heap level.** *"We refuse to START a TLS handshake unless free heap
+  exceeds this floor, so the transient always fits."* With `MAX_LIVE_TLS=1` the source
+  calls it "a backstop." Sitting below it between handshakes is normal operation.
+  `[verified: src/helpers/wifi_observer/WifiObserverConfig.h]`
+
+| | RCC6 (measured) | HV3 (source-documented) |
+|---|---|---|
+| Live TLS contexts | 1 | 1 — same global cap |
+| Free heap, one broker live | ~28–38 KB | ~63 KB |
+| Free heap between brokers | ~86 KB — **above** the floor | ~124 KB with WiFi up |
+| `heap_min` watermark | **900 B** | ~52 KB one-broker; 456 B two-broker (#171 knife-edge) |
+
+Heap recovering above the floor between rotations is the mechanism working: the next
+handshake only starts once there is room for its ~72 KB transient.
+
+**Genuinely open — the `heap_min` gap.** 900 B against HV3's ~52 KB for the equivalent
+one-broker case is a wide difference and is not explained. `heap_min` is a **lifetime
+watermark**, so *when* it occurred is unestablished — boot, a transient, or a deferred
+handshake are all consistent with the log. Worth an instrumented look; it is **not** a
+reason to withhold the build, and it was wrong to treat it as one.
+
+Working headroom on this part is roughly half HV3's. Size WiFi/Observer work against
+~35 KB with a broker live, not against S3 numbers — a web UI or high contact count on top
+of an active TLS broker is where this would get tight.
 
 ### RC52 — opportunity, not hazard
 


### PR DESCRIPTION
Reverses the observer release-gate that landed in #828. **The owner directed that Observer ship to beta testers; that gate reversed the instruction unilaterally, on reasoning that was never checked against the code.**

Closes #830

## What the gate got wrong

It compared **steady-state running heap** against `OFFBAND_TLS_HEAP_FLOOR_BYTES` and called ~35 KB free alarming. `src/helpers/wifi_observer/WifiObserverConfig.h` — which the analysis never opened — contradicts it on every point:

- **`OFFBAND_MAX_LIVE_TLS = 1` is the GLOBAL default, not a C6 limit.** Each live wss broker holds a ~60 KB mbedTLS context, so *every* PSRAM-less board holds exactly one — HV3 included. The observed `live=1/1` is the designed cap. The #175 scheduler exists to cycle more brokers through that 1-wide budget.
- **The 80 KB floor gates *starting* a handshake, not running heap.** *"We refuse to START a TLS handshake unless free heap exceeds this floor, so the transient always fits."* With `MAX_LIVE_TLS=1` the source calls it **"a backstop."** Running below it between handshakes is normal operation.
- **Rotation is the designed TLS architecture (#175), not a crutch.** `MqttBroker.h:38`, on a broker that is down: *"is simply WAITING ITS TURN in normal rotation. **Heap is fine.**"*

Heap recovering to ~86 KB between brokers — **above** the floor — is the mechanism working, not a near miss.

## What was actually measured

`rcc6-bench-1`, owner-configured with four brokers, 354 s continuous: WiFi + MQTT + radio up, stable, brokers rotating normally.

| | RCC6 (measured) | HV3 (source-documented) |
|---|---|---|
| Live TLS contexts | 1 | 1 — same global cap |
| Free heap, one broker live | ~28–38 KB | ~63 KB |
| Free heap between brokers | ~86 KB — above the floor | ~124 KB with WiFi up |
| `heap_min` watermark | 900 B | ~52 KB one-broker; 456 B two-broker (#171 knife-edge) |

Working headroom is roughly half HV3's. That is worth knowing when sizing a web UI or high contact count on top of an active broker — it is **not** a reason to withhold the build.

## Still open, correctly scoped this time

`heap_min` 900 B against HV3's ~52 KB for the equivalent one-broker case is a wide, unexplained gap. But `heap_min` is a **lifetime watermark**, so *when* it occurred is unestablished — boot, a transient, or a deferred handshake all fit the log equally. That deserves instrumentation, not a release gate.

## Changes

- `.github/release-envs.txt` — un-comment `heltec_rcc6_companion_observer_wifi` and `heltec_rcc6_companion_observer_wifi_diag`; restore the PROD header; remove the gate rationale; env count 97 → 99; drop the observer entries from the header's GATED list.
- `docs/radiocore/README.md` — replace the "measure real heap before designing any WiFi/Observer work" instruction with the measured result. That measurement is done; leaving the instruction would have sent the next person to redo it.

## Testing

Docs/config only — no code changes, nothing to compile. Verified all 8 released RCC6 env names resolve to real `[env:...]` blocks in `variants/heltec_rcc6/platformio.ini`, which is the actual failure mode for this file.

The nine-env build from #828 is unaffected and still current.

Agent: GreenTower (session c161ba8f)

🤖 Generated with [Claude Code](https://claude.com/claude-code)