### PR TITLE
fix(#779): zero the reply buffer before dispatch — stop transmitting stack bytes

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -736,9 +736,12 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
       uint8_t temp[166];
       char *command = (char *)&data[5];
       char *reply = (char *)&temp[5];
-      if (is_retry) {
-        *reply = 0;
-      } else {
+      // #765: zero BEFORE dispatch, not only on the retry path. `temp` is
+      // uninitialised stack, so a handler that writes nothing would otherwise
+      // leave the strlen() below reading -- and transmitting -- whatever was
+      // already there.
+      *reply = 0;
+      if (!is_retry) {
         handleCommand(sender_timestamp, command, reply);
       }
       int text_len = strlen(reply);

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -463,12 +463,14 @@ void MyMesh::onPeerDataRecv(mesh::Packet *packet, uint8_t type, int sender_idx, 
                           PUB_KEY_SIZE);
 
       uint8_t temp[166];
+      // #765: `temp` is uninitialised stack. Every branch below except the admin
+      // dispatch already zeroed it, so the one path that calls handleCommand was
+      // the one path that could transmit stack bytes. Zero it up front instead.
+      temp[5] = 0; // no reply
       bool send_ack;
       if (flags == TXT_TYPE_CLI_DATA) {
         if (client->isAdmin()) {
-          if (is_retry) {
-            temp[5] = 0; // no reply
-          } else {
+          if (!is_retry) {
             handleCommand(sender_timestamp, (char *)&data[5], (char *)&temp[5]);
             temp[4] = (TXT_TYPE_CLI_DATA << 2); // attempt and flags,  (NOTE: legacy was: TXT_TYPE_PLAIN)
           }

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -586,6 +586,7 @@ void SensorMesh::onPeerDataRecv(mesh::Packet* packet, uint8_t type, int sender_i
         uint8_t temp[166];
         char *command = (char *) &data[5];
         char *reply = (char *) &temp[5];
+        *reply = 0;   // #765: uninitialised stack otherwise; the strlen() below would transmit it
         handleCommand(sender_timestamp, command, reply);
 
         int text_len = strlen(reply);

--- a/examples/simple_sensor/main.cpp
+++ b/examples/simple_sensor/main.cpp
@@ -162,6 +162,7 @@ void loop() {
   if (len > 0 && command[len - 1] == '\r') {  // received complete line
     command[len - 1] = 0;  // replace newline with C string null terminator
     char reply[160];
+    reply[0] = 0;   // #765: the `if (reply[0])` guard below reads this either way
     the_mesh.handleCommand(0, command, reply);  // NOTE: there is no sender_timestamp via serial!
     if (reply[0]) {
       Serial.print("  -> "); Serial.println(reply);


### PR DESCRIPTION
Closes #779. Fixes the code half of #765. Under epic #774.

**#778 fixed the three keys that triggered the bug. This fixes the mechanism**, so a handler that writes nothing can never again put stack bytes on the air.

## The defect

```c
uint8_t temp[166];                 // uninitialised stack
char *reply = (char *)&temp[5];
if (is_retry) { *reply = 0; }      // zeroed ONLY on the retry path
else { handleCommand(sender_timestamp, command, reply); }
int text_len = strlen(reply);      // over uninitialised memory
if (text_len > 0) { ...transmit... }
```

A handler that returns without writing causes `strlen()` to read uninitialised stack, and the result is transmitted to the requesting peer. That is the mojibake a user saw in the client app after upgrading from stock MeshCore 1.15.0.

**It was invisible on serial** — those callers zero their buffer and suppress empty replies. Only the radio transport showed it: the transport hardest to observe, and the one real users are on.

## Four call sites, one invariant

The reply buffer is empty **before** dispatch, not per-branch.

| File | Transport | Was |
|---|---|---|
| `simple_repeater/MyMesh.cpp` | over-the-air | zeroed only on `is_retry` |
| `simple_room_server/MyMesh.cpp` | over-the-air | zeroed on every branch **except** the admin dispatch — the one path that actually reached `handleCommand` |
| `simple_sensor/SensorMesh.cpp` | over-the-air | never zeroed on any path |
| `simple_sensor/main.cpp` | **serial** | missing `reply[0] = 0` |

`simple_sensor` was the only role missing it on **both** transports, so it had no safe transport to fall back on.

## Verification

**All 15 `handleCommand` call sites audited**, not only the four changed. Twelve own a reply buffer and now zero it before dispatch. Three own no buffer and are correctly untouched:

- `simple_repeater/main.cpp:762` — zeroes with `reply[0] = '\0'`
- `simple_secure_chat/main.cpp:546` — single-argument signature, no reply parameter
- `simple_sensor/SensorMesh.cpp:450` — forwards a buffer its caller owns

**The `temp[4]` adjacency.** In `simple_room_server` the flags byte `temp[4]` sits directly below the reply buffer at `temp[5]`. It is written *after* `handleCommand` returns, so hoisting the zeroing cannot disturb it. Called out because it is the one place where moving an assignment earlier could plausibly have broken something.

**Builds 5/5:** `Heltec_ct62_sensor`, `Heltec_WSL3_sensor`, `heltec_v4_repeater_telemetry`, `heltec_v4_room_server`, `RAK_4631_repeater`.

**Adversarial review.** Gemini was given SAFELANE, CLAUDE-BASE, the diff and the call-site context with no question list. Verdict: recommend merge, no findings. It independently confirmed the `temp[4]`/`temp[5]` ordering and judged the caller-side fix the right layer — a handful of transport call sites versus every present and future command handler.

It noted it could not audit the whole tree for other call sites. That audit is the 15-site check above.

## Not closed here

**#765 stays open.** This is its code fix; the bug closes on the owner's call after #777, the epic integration test that exercises the surface over **both** transports.

## Note for reviewers touching `examples/`

BrightCat has claimed #822 (splash consolidation), which touches every role's `UITask`. The only overlap is `simple_sensor/main.cpp`, and this change is one line inside the serial command handler — nowhere near UI setup. Flagged so a textual conflict is expected rather than surprising.

---
Agent: **FoggyCanyon** (Agent Mail `app-c-dev-crosswire`, session `2d2b37f1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
