### PR TITLE
bug: RCC6 ADC_MULTIPLIER 4.95 -> 4.90 — battery read ~1% high on an invented constant

### DIFF
--- a/variants/heltec_rcc6/platformio.ini
+++ b/variants/heltec_rcc6/platformio.ini
@@ -50,10 +50,50 @@ build_flags =
 ; --- Battery (enable-gated divider) -------------------------------------------
 ; ADC_Ctrl=GPIO5 gates the divider feeding ADC_IN=GPIO6. Polarity is from THIS
 ; board's schematic -- never inherit it from a sibling variant (#602).
+;
+; ENABLE PATH `[verified: RCC6-L62_V1.0-schematic.pdf, Battery_ADC block]`:
+;   ADC_Ctrl -> R34 1K -> Q3 (S8050T, NPN) base; R35 100K pulldown holds it low.
+;   Q3 collector -> R32 10K to VBAT, and -> R33 1K -> gate of Q2.
+;   Q2 is P-CHANNEL (DMG1013T) with source on VBAT, so pulling its gate LOW turns
+;   it ON. Hence ADC_CTRL_ENABLED=HIGH. R35 means the divider is OFF at reset --
+;   no idle drain on a battery node.
   -D PIN_ADC_CTRL=5
   -D ADC_CTRL_ENABLED=HIGH
   -D PIN_VBAT_READ=6
-  -D ADC_MULTIPLIER=4.95f
+;
+; MULTIPLIER = THE NOMINAL DIVIDER RATIO (#835). Same schematic block:
+;   VBAT -> Q2 -> R36 390K -> [ADC_IN tap] -> R38 100K -> GND
+;   (R36 + R38) / R38 = (390K + 100K) / 100K = 4.90
+;
+; Q2's R_ds(on) is in series with R36 and is ignored deliberately: the DMG1013T
+; is ~120 mOhm against 390 kOhm, which moves the ratio in the sixth significant
+; figure. Range check for the ADC_2_5db attenuation used in getBattMilliVolts()
+; (usable to ~1.1 V): 4.2 V / 4.9 = ~857 mV, 3.0 V / 4.9 = ~612 mV -- the whole
+; discharge sits inside range, and a 4.35 V charger top-off (~888 mV) still does.
+;
+; This read 4.95f until #835 -- a value with NO source: not this schematic, not
+; heltec_rc32 (4.9), not xiao_c6 or m5stack_unit_c6l (neither defines one), and
+; NOT an empirical calibration -- it entered in the scaffold commit (0aedf199)
+; when the board had never been battery-powered. It was invented, and biased
+; every sample ~1% high (~+43 mV at 4.2 V).
+;
+; THIS IS THE NOMINAL VALUE, NOT A CALIBRATED ONE, and it is not the dominant
+; error term. Two larger ones are known and NOT addressed here:
+;   1. Resistor tolerance. At 1% parts the true ratio is ~4.83-4.97 -- wider
+;      than the correction this constant just made. Per-board calibration via
+;      setAdcMultiplier() is legitimate and expected; this is only the default.
+;   2. Source impedance. The divider's Thevenin impedance is ~79.6 kOhm, well
+;      above the <10 kOhm Espressif recommends for the SAR ADC. If the sample
+;      -and-hold cannot fully charge in the acquisition window, readings run
+;      systematically LOW regardless of this constant, and averaging 8 samples
+;      does not correct it (that reduces random noise, not a systematic offset).
+;      This is the VENDOR's divider -- heltec_rc32 shares the topology -- so it
+;      is a board characteristic, not something introduced here. UNMEASURED.
+;
+; So: change this if the DIVIDER changes. Calibrating per board against a known
+; voltage is fine and is the right way to beat tolerance -- just do it at
+; runtime, and do not silently retune this default to make one board look right.
+  -D ADC_MULTIPLIER=4.9f
 ; --- Vext_3V3 rail ------------------------------------------------------------
 ; U3 (TLV75733PDBVR), EN driven by GPIO11 through a 100K pulldown -> defaults OFF.
 ; What it supplies is not yet confirmed (#805). Asserted at begin() as the safe


### PR DESCRIPTION
Battery voltage on the RCC6 read **~1% high** — about **+43 mV at 4.2 V**. Caught while validating the telemetry path ahead of a discharge run on `rcc6-bench-1`, i.e. **before** it silently biased hours of curve data.

Closes #835

## Derivation

From the `Battery_ADC` block of `RCC6-L62_V1.0-schematic.pdf`, confirmed two ways — the rendered symbol, then text-layer extraction using the PDF's own `PIR36xx`/`PIR38xx` pin designators:

```
VBAT -> Q2 (DMG1013T, P-ch) -> R36 390K -> [ADC_IN tap] -> R38 100K -> GND

(R36 + R38) / R38 = (390K + 100K) / 100K = 4.90
```

**The old 4.95 had no source.** Not this schematic, not `heltec_rc32` (which uses 4.9), not `xiao_c6` or `m5stack_unit_c6l` (neither defines one) — and **not an empirical calibration**: `git log -S` shows it entered in the scaffold commit `0aedf199`, when the board had never been battery-powered. It was invented.

## The enable path was re-verified and is unchanged

`ADC_Ctrl` → R34 1K → Q3 (S8050T, NPN); Q3 collector → R33 1K → gate of Q2, which is **P-channel** with source on VBAT, so gate-low turns it **on**. `ADC_CTRL_ENABLED=HIGH` is correct. R35 100K pulldown leaves the divider **off at reset** — no idle drain on a battery node. Only the constant changed.

## What this fix is NOT

Recorded in the file itself, after adversarial review. This is the **nominal** ratio and **not the dominant error term**:

- **Resistor tolerance.** At 1% parts the true ratio spans **~4.83–4.97** — wider than the correction just made. Per-board calibration via `setAdcMultiplier()` is legitimate and expected; this is only the default.
- **Source impedance.** The divider's Thevenin impedance is **~79.6 kΩ**, against the **<10 kΩ** Espressif recommends for the SAR ADC. If the sample-and-hold cannot charge within the acquisition window, readings run systematically **low** regardless of this constant, and averaging 8 samples does not correct a systematic offset. This is the **vendor's** divider and `heltec_rc32` shares the topology — a board characteristic, not introduced here. **Unmeasured.**

An earlier draft of the comment claimed this constant *"IS the accuracy story"* and instructed readers not to tune it. Both were wrong and are corrected in this PR: it is one term among larger ones, and runtime calibration is the right way to beat tolerance.

Also now documented: Q2's `R_ds(on)` deliberately ignored (~120 mΩ against 390 kΩ — sixth significant figure), and the `ADC_2_5db` range check — 857 mV at 4.2 V, 612 mV at 3.0 V, 888 mV at a 4.35 V top-off, all inside the ~1.1 V usable range.

## Testing

4 affected envs build **SUCCESS**, 0 failed: `companion_observer_wifi`, `companion_radio_ble`, `companion_radio_usb`, `repeater_display`.

**Verified at artifact level rather than by build timing** — `platformio.ini` was edited mid-build, so the log alone would not settle it:

```
firmware.bin (observer):  4.9f  bytes cd cc 9c 40  -> 1 occurrence
                          4.95f bytes 66 66 9e 40  -> 0 occurrences
```

## Gemini adversarial gate

`gemini-2.5-pro`, audit log under `docs/llm-consultations/`. 5 findings — 1 refuted, 4 accepted and documented in place.

**Refuted:** *"4.95 may have been a deliberate fudge factor compensating for ADC loading."* Git history shows no calibration ever existed — it predates any battery-powered operation of this board.

**Accepted:** source impedance dominates; tolerance exceeds the correction; `R_ds(on)` omitted from the derivation; attenuation range unstated. All four are now written into the file, including the two that contradict my original wording.

Agent: GreenTower (session c161ba8f)

🤖 Generated with [Claude Code](https://claude.com/claude-code)