### PR TITLE
fix(#849): redact secret CLI replies in pio-flash send, at the source

### DIFF
--- a/scripts/log_redact.py
+++ b/scripts/log_redact.py
@@ -76,6 +76,13 @@ def redact_positions(line: str) -> str:
 
 _SECRET_WORDS = (r"password|passwd|pwd|psk|secret|token|apikey|api_key|bearer|pass")
 
+# Named so a caller that already KNOWS which command it issued can opt out of
+# just this one rule (#849). `pio-flash send` has to keep printing
+# `> 910.525,62.5,7,5` verbatim for ordinary keys while still redacting
+# `get prv.key`; a blanket net cannot do both. The length is carried so a
+# sweep can assert that a secret key ANSWERED without recording what it said.
+_CLI_REPLY_RE = re.compile(r"(^\s*>\s*)([^\r\n]+)")
+
 _REDACTIONS = [
     # WiFi SSID, in the shapes the firmware actually prints.
     (re.compile(r"(SSID\s*=\s*)([^;\r\n]+)", re.IGNORECASE), r"\1<redacted:ssid>"),
@@ -108,14 +115,24 @@ _REDACTIONS = [
     # must allow leading whitespace; the original `^>` missed it and leaked a real
     # SSID on the bench. Runtime log lines are "[ms] LEVEL: ..." or "[Tag] ...",
     # never a leading ">", so this does not over-redact a caplog.
-    (re.compile(r"(^\s*>\s*)([^\r\n]+)"), r"\1<redacted:cli-reply>"),
+    (_CLI_REPLY_RE,
+     lambda m: m.group(1) + "<redacted:cli-reply:" + str(len(m.group(2))) + ">"),
 ]
 
 
-def redact_line(line: str) -> str:
+def redact_line(line: str, cli_reply_net: bool = True) -> str:
     """Apply every rule to one line. Position classification runs last so a
-    coordinate inside an otherwise-redacted line is still handled."""
+    coordinate inside an otherwise-redacted line is still handled.
+
+    `cli_reply_net` defaults True, so every existing caller is unchanged.
+    Pass False ONLY when you already know which command produced this line
+    and know it is not secret-bearing (see `pio-flash send`, #849). Turning
+    it off blindly reopens #382, where a real SSID reached chat as `  > ...`
+    with no label for any other rule to match on.
+    """
     for pattern, repl in _REDACTIONS:
+        if not cli_reply_net and pattern is _CLI_REPLY_RE:
+            continue
         line = pattern.sub(repl, line)
     return redact_positions(line)
 

--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -43,6 +43,13 @@ import sys
 import tempfile
 import time
 from pathlib import Path
+
+# #849: `send` streams the device's reply straight to stdout, and three CLI keys
+# return secrets. The patterns live in scripts/log_redact.py and are shared with
+# _cap_serial.py and companion_harness.py -- a second copy is a copy that drifts,
+# and the copy that drifts is the one that leaks (#667).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from log_redact import redact_line  # noqa: E402
 from typing import Any, Optional
 
 try:
@@ -1442,6 +1449,93 @@ def cmd_confirm(args, registry):
     return rc
 
 
+# ---------------------------------------------------------------------------
+# #849: secret-bearing CLI replies
+#
+# `get prv.key` returns the node's private key, and is serial-only by design
+# (CommonCLI gates it on sender_timestamp == 0) -- which is exactly the path
+# this tool uses. `get guest.password` and `get bridge.secret` are the same
+# problem. Anything reading this tool's stdout (an agent, a log, a session
+# transcript) receives the value, and scrubbing it afterwards is too late.
+#
+# A deny-list that refuses to SEND these was considered and rejected: it keeps
+# them out of logs by never testing them, leaving three keys permanently
+# unverified. That is precisely how #764's three keys went ten months returning
+# empty replies. So we send everything and redact the reply instead.
+# ---------------------------------------------------------------------------
+
+_SECRET_CLI_KEYS = frozenset({
+    "prv.key",         # node private key
+    "guest.password",
+    "bridge.secret",
+    "password",        # `set password <v>`; CommonCLI echoes it back
+})
+
+
+def _is_secret_command(cmd: str) -> bool:
+    """True when this command's reply may carry a secret.
+
+    Matches the KEY exactly after the verb -- never by prefix. Prefix matching
+    is the defect class this repo just removed from the firmware CLI (#764);
+    reintroducing it here would mean `get prv.keyfoo` silently classified as
+    secret, or worse, a real secret key missed by a near-match.
+    """
+    tokens = (cmd or "").split()
+    if len(tokens) < 2:
+        return False
+    verb = tokens[0].lower()
+    if verb not in ("get", "set"):
+        return False
+    return tokens[1].lower() in _SECRET_CLI_KEYS
+
+
+class _ReplyRedactor:
+    """Buffers serial bytes to line boundaries, then redacts before printing.
+
+    Serial arrives in arbitrary reads, so a secret can straddle two of them.
+    Redacting each chunk as it lands would miss `  > hun` + `ter2\r\n`
+    entirely, which is the whole failure this class exists to prevent.
+
+    `secret=False` still applies every other rule (SSID, password:, JWT, email,
+    GPS) but skips the label-less `> value` net, so an ordinary reply such as
+    `> 910.525,62.5,7,5` survives byte-for-byte. Without that, every existing
+    use of this tool regresses and the CLI sweep (#852) can assert nothing.
+    """
+
+    def __init__(self, secret: bool):
+        self._secret = bool(secret)
+        self._buf = ""
+
+    def _scrub(self, text: str) -> str:
+        if not text:
+            return text
+        # Keep the line ending exactly as it arrived; the rules operate on the
+        # content, and the caller's byte stream should not be reshaped.
+        stripped = text.rstrip("\r\n")
+        ending = text[len(stripped):]
+        return redact_line(stripped, cli_reply_net=self._secret) + ending
+
+    def feed(self, data: bytes) -> str:
+        """Absorb a raw chunk; return only whole redacted lines."""
+        self._buf += data.decode("utf-8", errors="replace")
+        out = []
+        while True:
+            nl = self._buf.find("\n")
+            if nl < 0:
+                break
+            line, self._buf = self._buf[:nl + 1], self._buf[nl + 1:]
+            out.append(self._scrub(line))
+        return "".join(out)
+
+    def flush(self) -> str:
+        """Redact and return whatever is left, including a line with no newline.
+
+        A reply that never terminates its line must not escape unredacted.
+        """
+        rest, self._buf = self._buf, ""
+        return self._scrub(rest)
+
+
 def cmd_send(args, registry):
     """
     Tier B: open serial, write command + CR, read response for N seconds.
@@ -1486,17 +1580,22 @@ def cmd_send(args, registry):
 
             deadline = time.time() + args.read_time
             captured = bytearray()
+            # #849: never write raw device bytes to stdout. Buffer to line
+            # boundaries and redact first -- a secret can straddle two reads.
+            redactor = _ReplyRedactor(secret=_is_secret_command(args.command))
             while time.time() < deadline:
                 data = s.read(1024)
                 if data:
                     captured.extend(data)
-                    try:
-                        sys.stdout.buffer.write(data)
-                        sys.stdout.buffer.flush()
-                    except Exception:
-                        # If stdout.buffer not available, fall back to text print
-                        sys.stdout.write(data.decode("utf-8", errors="replace"))
+                    text = redactor.feed(data)
+                    if text:
+                        sys.stdout.write(text)
                         sys.stdout.flush()
+
+            tail = redactor.flush()
+            if tail:
+                sys.stdout.write(tail)
+                sys.stdout.flush()
 
             if captured and not bytes(captured).endswith(b"\n"):
                 print()

--- a/scripts/test_pio_flash_send_redaction.py
+++ b/scripts/test_pio_flash_send_redaction.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Tests for secret redaction on the `pio-flash send` output path (#849).
+
+Pure. No serial port, no device, no flashing.
+
+Why this exists: `cmd_send` streamed raw serial bytes straight to stdout. Three
+CLI keys return secrets -- `get prv.key` (the node private key, and serial-only
+by design, which is exactly the path this tool uses), `get guest.password`, and
+`get bridge.secret`. Anything reading that stdout -- an agent, a log, a session
+transcript -- received the value, and scrubbing afterwards is too late.
+
+The two hard constraints pulled in opposite directions and both are pinned here:
+
+  1. Secret-bearing replies MUST NOT reach stdout in the clear.
+  2. Ordinary replies MUST pass through byte-for-byte. `get radio` has to keep
+     printing `> 910.525,62.5,7,5` or every existing use of this tool regresses
+     and the CLI sweep it was built for cannot assert on anything.
+
+A blanket redact satisfies (1) and destroys (2). Hence command-aware redaction.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import importlib.util
+_spec = importlib.util.spec_from_file_location(
+    "pio_flash", os.path.join(os.path.dirname(os.path.abspath(__file__)), "pio-flash.py"))
+pio_flash = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pio_flash)
+
+
+# ------------------------------------------------- which commands are secret ---
+
+def test_known_secret_keys_are_recognised():
+    for cmd in ("get prv.key", "get guest.password", "get bridge.secret"):
+        assert pio_flash._is_secret_command(cmd), cmd
+
+
+def test_ordinary_keys_are_not_secret():
+    for cmd in ("get radio", "get name", "get cad", "get freq", "advert"):
+        assert not pio_flash._is_secret_command(cmd), cmd
+
+
+def test_secret_detection_tolerates_whitespace_and_case():
+    assert pio_flash._is_secret_command("  GET PRV.KEY  ")
+    assert pio_flash._is_secret_command("get   prv.key")
+
+
+def test_set_password_is_secret_too():
+    """`set password hunter2` puts the secret in the COMMAND, and CommonCLI
+    echoes it back in the reply. Both directions have to be covered."""
+    assert pio_flash._is_secret_command("set password hunter2")
+    assert pio_flash._is_secret_command("set guest.password hunter2")
+
+
+def test_a_key_that_merely_starts_with_a_secret_name_is_not_secret():
+    """Prefix-matching is the exact defect class this repo just spent a session
+    removing from the firmware. Do not reintroduce it in the tooling."""
+    assert not pio_flash._is_secret_command("get prv.keyfoo")
+
+
+# ----------------------------------------------------- streaming redaction ---
+
+def _drain(redactor, chunks):
+    return "".join(redactor.feed(c) for c in chunks) + redactor.flush()
+
+
+def test_ordinary_reply_passes_through_unchanged():
+    r = pio_flash._ReplyRedactor(secret=False)
+    assert _drain(r, [b"get radio\r\n  > 910.525,62.5,7,5\r\n"]) == \
+        "get radio\r\n  > 910.525,62.5,7,5\r\n"
+
+
+def test_secret_reply_is_redacted():
+    r = pio_flash._ReplyRedactor(secret=True)
+    out = _drain(r, [b"get guest.password\r\n  > hunter2\r\n"])
+    assert "hunter2" not in out, out
+    assert "redacted" in out, out
+
+
+def test_secret_split_across_chunks_is_still_redacted():
+    """The real failure mode: serial arrives in arbitrary 1024-byte reads, so a
+    secret can straddle two of them. Redacting per-chunk misses it entirely."""
+    r = pio_flash._ReplyRedactor(secret=True)
+    out = _drain(r, [b"  > hun", b"ter2\r\n"])
+    assert "hunter2" not in out, out
+    assert "redacted" in out, out
+
+
+def test_length_is_preserved_so_shape_assertions_still_work():
+    """The sweep (#852) asserts a secret key ANSWERED, without recording what it
+    said. That needs the length to survive redaction."""
+    r = pio_flash._ReplyRedactor(secret=True)
+    out = _drain(r, [b"  > abcdefghij\r\n"])
+    assert "abcdefghij" not in out, out
+    assert "10" in out, f"redacted marker should carry the length: {out}"
+
+
+def test_trailing_partial_line_is_flushed_through_redaction():
+    """A reply with no trailing newline must not escape unredacted at flush."""
+    r = pio_flash._ReplyRedactor(secret=True)
+    out = _drain(r, [b"  > hunter2"])
+    assert "hunter2" not in out, out
+
+
+def test_nothing_is_lost_for_ordinary_output_without_trailing_newline():
+    r = pio_flash._ReplyRedactor(secret=False)
+    assert _drain(r, [b"  > 910.525"]) == "  > 910.525"
+
+
+def test_undecodable_bytes_do_not_crash_or_vanish():
+    """A garbled reply is itself diagnostic -- exactly the #765 symptom. It must
+    survive rather than be swallowed."""
+    r = pio_flash._ReplyRedactor(secret=False)
+    out = _drain(r, [b"  > \xff\xfe junk\r\n"])
+    assert "junk" in out, out
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"FAIL {name}: {e}")
+            except Exception as e:
+                failures += 1
+                print(f"ERROR {name}: {type(e).__name__}: {e}")
+    print(f"\n{failures} failure(s)")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
Closes #849. Under epic #736. First of the four tasks the CLI sweep (#852) needs.

## The leak

`pio-flash send` streamed the device's reply straight to stdout. Three CLI keys return secrets:

| Key | Returns |
|---|---|
| `get prv.key` | the node's private key — **serial-only by design** (`sender_timestamp == 0`), which is exactly the path this tool uses |
| `get guest.password` | a password |
| `get bridge.secret` | a shared secret |

Anything reading that stdout — an agent, a log, a session transcript — got the value. Scrubbing afterwards is too late. This is #382 in a second tool: a real SSID once reached chat as `  > <value>`, with no label for any pattern to match on.

## Two constraints that pull against each other

1. A secret reply must not reach stdout in the clear.
2. An ordinary reply must pass through **byte-for-byte** — `get radio` has to keep printing `> 910.525,62.5,7,5`, or every existing use of this tool regresses and #852 can assert nothing.

`log_redact`'s last-resort net redacts *any* `> value` line. It satisfies (1) and destroys (2). So the net became opt-out, and `send` — which already knows the command it issued — decides per command.

## Changes

**`log_redact.py`** — `redact_line` gains `cli_reply_net: bool = True`. Defaulting True means `_cap_serial.py` and `companion_harness.py` are untouched; they keep the blanket net, which is correct for capture paths that *don't* know the command. The marker now carries the redacted length — `<redacted:cli-reply:7>` — so #852 can assert a secret key **answered** without recording what it said.

**`pio-flash.py`** — `_is_secret_command()` matches the key **exactly after the verb, never by prefix**. Prefix matching is the defect class this repo just finished removing from the firmware CLI (#764); reintroducing it here would classify `get prv.keyfoo` as secret and, worse, could miss a real secret key on a near-match.

`_ReplyRedactor` buffers to line boundaries before redacting. **This is the part the issue didn't anticipate:** serial arrives in arbitrary reads, so a secret can straddle two of them — redacting each chunk as it lands misses `  > hun` + `ter2\r\n` entirely. The flush path covers a reply that never terminates its line.

## The rejected alternative

A deny-list refusing to *send* those three keys. The owner rejected it: it keeps secrets out of logs by never testing them, leaving three keys permanently unverified — which is exactly how #764's three keys spent ten months returning empty replies.

## Verification

**12 tests written first**, all failing on missing attributes, all passing now. The ones that matter:

- a secret split across chunk boundaries
- a trailing partial line with no newline
- length preserved through redaction
- **byte-identical passthrough** for ordinary replies
- `get prv.keyfoo` correctly *not* classified as secret

`test_log_redact.py` and `test_observer_log_redaction.py` still pass — neither other caller regressed.

**Gemini adversarial review** — SAFELANE, CLAUDE-BASE and the full diff, no question list supplied. No findings; it independently confirmed the chunk-boundary handling, the default-True safety for shared callers, and that the marker change is additive.

## What is NOT verified

**Hardware.** The end-to-end proof is `get prv.key` returning a redacted marker and `get radio` unchanged on a live board. Offered, not yet run.

**CI does not gate any of this.** There are zero references to `test_pio_flash` in `ci.yml` — four existing suites, none run, which is how the red test in #861 sat on `firmware-base` for three weeks. This PR adds a fifth ungated suite. Tracked as #862; deliberately not fixed here.

---
Agent: **FoggyCanyon** (Agent Mail `app-c-dev-crosswire`, session `2d2b37f1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
