### PR TITLE
feat(#878): AUTO_SHUTDOWN_MILLIVOLTS=3400 on the RCC6 BLE companion envs

### DIFF
--- a/variants/heltec_rcc6/platformio.ini
+++ b/variants/heltec_rcc6/platformio.ini
@@ -346,6 +346,15 @@ build_flags =
   -D MAX_GROUP_CHANNELS=40
   -D BLE_PIN_CODE=123456
   -D OFFLINE_QUEUE_SIZE=256
+  ; Battery cutoff. Scoped to the BLE companion envs ONLY, mirroring heltec_rc32
+  ; -- repeater / room_server / USB-companion are mains, solar or USB powered and
+  ; deliberately do not carry it there either.
+  ;
+  ; 3400 is not arbitrary: #833 measured RC32 runtime as 21h35m TO AUTO-SHUTDOWN
+  ; at this exact value. A runtime figure is a time-to-a-specific-voltage, so an
+  ; RCC6 run on a different cutoff is not comparable to it no matter how well the
+  ; role and cell match. Same number here is what makes the boards comparable.
+  -D AUTO_SHUTDOWN_MILLIVOLTS=3400
 build_src_filter = ${heltec_rcc6_with_display.build_src_filter}
   +<helpers/ui/buzzer.cpp>
   +<helpers/esp32/*.cpp>


### PR DESCRIPTION
The RCC6 defined no battery cutoff, and there is no shared default — only `heltec_rc32` set one. `[verified: grep across variants/ and platformio.ini]`

Closes #878

## Why this is needed now

#833 measured RC32 runtime as **21 h 35 m to auto-shutdown**, terminating at `AUTO_SHUTDOWN_MILLIVOLTS=3400`. An RCC6 discharge run is starting on the **same 2500 mAh cell** for a direct board-to-board comparison.

A runtime figure is a *time-to-a-specific-voltage*. Without the same cutoff the two numbers measure different things no matter how well role and cell match — and the comparison is the entire point of the run.

## Scope mirrors RC32 exactly

| RC32 | RCC6 |
|---|---|
| `heltec_rc32_companion_radio_ble` | ✅ `heltec_rcc6_companion_radio_ble` |
| `heltec_rc32_companion_radio_ble_diag` | ✅ `heltec_rcc6_companion_radio_ble_diag` (inherits) |
| `heltec_rc32_without_display_companion_radio_ble` | *(no RCC6 equivalent)* |

RC32 deliberately does **not** set it on repeater, room_server or USB-companion envs — those are mains, solar or USB powered. Same reasoning applies, so this is scoped to the two BLE envs and nothing else.

The `_diag` env inherits it by extending the prod env and re-referencing its `build_flags`; confirmed by reading the env rather than assuming inheritance.

## Why the scoping matters more than it looks

`AUTO_SHUTDOWN` resolves to `powerOff()` → `enterDeepSleep(0)` — *"Do not wakeup"*, with all wake sources cleared. `[verified: src/helpers/ESP32Board.cpp:686-726]` That is **terminal**: recovery needs a hardware reset or power cycle.

Correct for a handheld companion. **Wrong for an unattended solar node**, which is exactly why RC32 omits it from repeater roles and why this PR does too.

That asymmetry — recover-capable gate at boot (`SafeBoot`), terminal-only shutdown at runtime — is a real gap, and is now tracked separately as **#882**. It is out of scope here.

## Testing

Both envs build **SUCCESS**. Flashed to `rcc6-bench-1` and verified on the external UART0 sniffer: boots clean, radio live at `noise_floor = -109/-110`.

Constant confirmed to have a live call site rather than just reaching the compiler — the shutdown block sits inside `#ifdef AUTO_SHUTDOWN_MILLIVOLTS` at `examples/companion_radio/ui-new/UITask.cpp:960`, so an undefined macro compiles the path out entirely.

## Known uncontrolled difference, for whoever reports the comparison

The RCC6 **bit-bangs its panel over software SPI** because no SPI peripheral is free (#806), where RC32 uses hardware SPI. That CPU cost is arguably part of what the comparison measures rather than a confound — but it must be stated alongside the result.

Agent: GreenTower (session c161ba8f)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
