### PR TITLE
feat(#884): enable OFFBAND_POWER_TELEMETRY on the RCC6 BLE diag env

### DIFF
--- a/variants/heltec_rcc6/platformio.ini
+++ b/variants/heltec_rcc6/platformio.ini
@@ -424,6 +424,25 @@ extends = env:heltec_rcc6_companion_radio_ble
 build_flags =
   ${env:heltec_rcc6_companion_radio_ble.build_flags}
   ${rcc6_diag.build_flags}
+  ; Battery telemetry: emits "[pwr] mv=<n> up=<n>s" every 30 s from
+  ; board.getBattMilliVolts(). Diag env ONLY, mirroring heltec_rc32 -- that
+  ; variant's note applies verbatim: it is noise when the question is "why will
+  ; it not boot", and a tester has no battery instrumentation rig.
+  ;
+  ; WHY IT IS REQUIRED FOR A DISCHARGE RUN. #833 established two rules this
+  ; satisfies: (1) "Runtime = last [pwr] timestamp - first on-battery [pwr]
+  ; timestamp" -- measured from BOARD telemetry, not the external gauge; and
+  ; (2) "Both instruments must agree. Divergence beyond ~30 mV means something
+  ; is wrong with the measurement, not the battery." With only the Feather's
+  ; MAX17048 there is no second instrument to disagree with.
+  ;
+  ; SECOND REASON, specific to this board: the RCC6 reports through its divider
+  ; using ADC_MULTIPLIER=4.9, which #835 DERIVED from the schematic and never
+  ; measured. Logging [pwr] beside [gauge] compares divider-scaled against true
+  ; cell voltage across a full discharge, which is the cheapest available check
+  ; on that constant -- #835 left tolerance (~4.83-4.97 at 1% parts) and ADC
+  ; source impedance explicitly open.
+  -D OFFBAND_POWER_TELEMETRY
 
 [env:heltec_rcc6_companion_observer_wifi_diag]
 extends = env:heltec_rcc6_companion_observer_wifi


### PR DESCRIPTION
An RCC6 discharge run had **one instrument where #833 had two**. This restores the second.

Closes #884

## The gap

`OFFBAND_POWER_TELEMETRY` is enabled in exactly one env in the tree — `heltec_rc32_companion_radio_ble_diag`, the env #833 used. `[verified: variants/heltec_rc32/platformio.ini:539]` It emits `[pwr] mv=<n> up=<n>s` every 30 s from `board.getBattMilliVolts()`. `[verified: examples/companion_radio/main.cpp:589-593]`

The RCC6 defined it nowhere, so the burn image reported only the Feather's external MAX17048.

That breaks two things #833 established:

- **Its runtime definition** — *"Runtime = last `[pwr]` timestamp − first on-battery `[pwr]` timestamp."* Measured from **board** telemetry, not the external gauge.
- **Its validity rule** — *"Both instruments must agree. Divergence beyond ~30 mV means something is wrong with the measurement, not the battery."* A single instrument cannot disagree with anything.

## Second reason, specific to this board

The RCC6 reports through its divider using `ADC_MULTIPLIER=4.9` — **derived from the schematic in #835 and never measured.** Logging `[pwr]` beside `[gauge]` compares a divider-scaled reading against true cell voltage across a full discharge, which is the cheapest available check on that constant.

#835 left both resistor tolerance (~4.83–4.97 at 1% parts) and ADC source impedance (~79.6 kΩ against the <10 kΩ recommended for the SAR ADC) explicitly open. Without this flag the run produced no evidence on either.

## Already producing that evidence

Verified on the wire after flashing, both instruments live:

```
[pwr]   mv=4145 up=1592s          <- board, through the divider
[gauge] mv=4177 charge=98.7%      <- Feather MAX17048, true cell
                                     divergence 32 mV, board reads LOW
```

**32 mV, board low** — right at #833's threshold and in the direction #835 predicted, since a high source impedance biases the ADC low and no multiplier corrects a sampling shortfall. Whether that offset stays constant or scales with voltage is exactly what the run will now show.

## Scope

Diag env only, mirroring RC32. That variant's omission note applies verbatim and is why it stays out of tester-facing builds: *"It emits a battery line every 30 s, which is noise when the question is 'why will it not boot', and the tester has no battery instrumentation rig."* `[verified: variants/heltec_rc32/platformio.ini:584-586]`

No prod env changes.

## Testing

Env builds **SUCCESS**. Flashed to `rcc6-bench-1`; both telemetry streams confirmed on the external UART0 sniffer, quoted above. Rebase-clean (0 behind).

Agent: GreenTower (session c161ba8f)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
