### PR TITLE
bug: RC32 serial-monitor attach resets the board — monitor_rts/monitor_dtr never set (#700)

### DIFF
--- a/variants/heltec_rc32/platformio.ini
+++ b/variants/heltec_rc32/platformio.ini
@@ -2,6 +2,18 @@
 extends = esp32_base
 board = heltec-rc32
 board_build.partitions = default_16MB.csv
+; #700: RC32 is a native-USB ESP32-S3 (USB-Serial/JTAG). Opening the serial port
+; with default DTR/RTS handling RESETS the chip, so a monitor attach captures a
+; boot it caused itself -- which polluted the #699 bring-up evidence.
+;
+; Set board-wide rather than per-env (heltec_v3 / heltec_v4 / xiao_s3_wio set
+; these only on their observer envs): the reset-on-open behaviour is a property
+; of this board's USB, not of a role, so every rc32 env is affected.
+;
+; NOTE: this governs `pio device monitor` only. It does NOT change how a client
+; application drives DTR/RTS on this port.
+monitor_rts = 0
+monitor_dtr = 0
 build_flags =
   ${esp32_base.build_flags}
   ${sensor_base.build_flags}


### PR DESCRIPTION
Closes #700.

Config only -- twelve lines in `variants/heltec_rc32/platformio.ini`, no source
change, no behaviour change to any shipped firmware image.

## The bug

The RC32 is a native-USB ESP32-S3 (USB-Serial/JTAG). **Opening its serial port
with default DTR/RTS handling resets the chip.** So attaching a serial monitor
does not observe a boot -- it *causes* one, and then reports the boot it caused.

Every `heltec_rc32` env was missing `monitor_rts` / `monitor_dtr`. Count on
`firmware-base` before this PR:

```
$ git show origin/firmware-base:variants/heltec_rc32/platformio.ini | grep -c 'monitor_rts'
0
```

## Why board-wide rather than per-env

`heltec_v3`, `heltec_v4` and `xiao_s3_wio` set these only on their observer envs.
That is the wrong shape here: **reset-on-open is a property of this board's USB,
not of a role.** Every rc32 env is affected, so it belongs on the board block.

## What it cost

This is the mechanism behind a recurring class of wrong conclusion on this bench:

- It polluted the #699 bring-up evidence -- captures came from monitor-induced boots
- It is why external UART sniffing on header pin 12 was needed to see a #702
  failure at all: every log taken over USB came from a boot that had already
  succeeded

## Scope

These two keys affect the **host-side serial monitor only.** They are not compiled
into firmware and do not change how a client application drives DTR/RTS on this
port. No shipped image changes.

## Provenance

Committed as `fdf592ec` on 2026-08-14 and then **never pushed** -- it sat in a
local worktree for six days while the behaviour it fixes kept costing bench time.
Cherry-picked unchanged onto `epic/886-rc32-bench-bringup` at current base as
`0fac6d8b`; the diff is byte-identical to the original.

## Verification

Config-only, so the meaningful check is that the keys are present and every env
still resolves -- `config-lint` enforces the latter, and the rc32 envs join the
build matrix when #877 lands.
