### PR TITLE
epic(#892): CLI verification toolchain — sweep the whole surface, on hardware

### DIFF
--- a/scripts/cli_sweep.py
+++ b/scripts/cli_sweep.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Sweep the firmware's CLI surface and assert every key still answers (#852).
+
+WHY THIS EXISTS
+
+`get radio`, `get agc.reset.interval` and `get pwrmgt.bootmv` returned an empty
+reply for ten months (#764). Nothing caught it: the code compiles, no compiler
+calls it dead, and the serial console hides it because that caller zeroes its
+buffer and suppresses empty replies. Only the radio transport showed it -- as
+uninitialised stack (#765).
+
+The static guard from #775 now catches the STRUCTURAL form of that defect on
+every PR. It cannot catch a key that compiles fine and misbehaves at runtime:
+a handler that returns early on device state, one whose reply depends on
+hardware that is absent, or one that is simply slow. This is the runtime half.
+
+HOW IT RUNS, AND WHY IT IS SPLIT
+
+    enumerate-keys  ->  commands file  ->  [operator runs pio-flash]  ->  analyse
+
+The sweep does NOT invoke `pio-flash` itself. The flash discipline is one human
+approval per RUN of that tool, and a wrapper that shells out to it hides the run
+behind another layer. The operator issues the run and sees it happen.
+
+    python scripts/cli_sweep.py emit --out cmds.txt
+    python scripts/pio-flash.py send-batch <device> --commands-file cmds.txt \\
+        --json-out sweep.json
+    python scripts/cli_sweep.py analyse --json sweep.json
+
+THE KEY LIST COMES FROM SOURCE, EVERY RUN
+
+Hand-listing is precisely how three keys hid for ten months while everyone
+assumed the surface was covered. If a key exists in the dispatch chain, it gets
+swept -- including the serial-only ones, and including the secret-bearing ones,
+whose replies are redacted at source by #849 with length preserved so the shape
+assertion still holds.
+
+A deny-list that skipped the secret keys was proposed and rejected by the owner:
+it keeps secrets out of logs by never testing them, which leaves three keys
+permanently unverified. That is the failure this whole exercise exists to close.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Matches a key literal in a dispatch arm, whichever matcher is used. `memcmp`
+# arms are included deliberately: #299's conversion left some behind, and those
+# are exactly the ones that go stale unnoticed.
+_KEY = re.compile(
+    r'\b(?:isKey|memcmp)\s*\(\s*config\s*,\s*"((?:[^"\\]|\\.)+)"'
+)
+
+class NoKeysFound(Exception):
+    """Enumeration produced nothing. That is a failure, not an empty surface."""
+
+
+DEFAULT_SOURCE = "src/helpers/CommonCLI.cpp"
+
+# A reply slower than this is surfaced. Not a failure -- a question worth
+# asking, and the thread #893 is pulling on.
+DEFAULT_SLOW_S = 1.0
+
+_PRINTABLE_OK = set("\r\n\t")
+
+
+def _fn_body(src: str, name: str) -> str:
+    """Brace-matched body of one CommonCLI method, or "" if absent."""
+    i = src.find(f"void CommonCLI::{name}")
+    if i < 0:
+        return ""
+    b = src.find("{", i)
+    if b < 0:
+        return ""
+    depth = 0
+    for j in range(b, len(src)):
+        if src[j] == "{":
+            depth += 1
+        elif src[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[b:j + 1]
+    # Unbalanced braces. Returning the tail would sweep in every `isKey` call
+    # from every function that follows -- inventing keys that are not CLI keys
+    # at all. Fail closed: no body, no keys, and the caller's require_keys
+    # check turns that into a loud error rather than an empty sweep.
+    return ""
+
+
+def enumerate_keys(source: str, require_keys: bool = False):
+    """(get_keys, set_keys) read from the dispatch chains, sorted and unique.
+
+    A `set` matcher usually carries a trailing space (`"freq "`), because the
+    value follows the key. That is stripped -- the key is `freq`.
+    """
+    gets = {k.strip() for k in _KEY.findall(_fn_body(source, "handleGetCmd"))}
+    sets = {k.strip() for k in _KEY.findall(_fn_body(source, "handleSetCmd"))}
+    # The terminal `else` formats "??: %s"; it is a fallback, not a key.
+    drop = lambda s: {k for k in s if k and "?" not in k and "%" not in k}
+    g, st = sorted(drop(gets)), sorted(drop(sets))
+    if require_keys and not g:
+        # A renamed method or a moved dispatch chain yields nothing here. Writing
+        # an empty command list would report a clean sweep having tested nothing
+        # -- the silent no-op this whole effort exists to eliminate.
+        raise NoKeysFound(
+            "no `get` keys found -- the dispatch chain moved, was renamed, or "
+            "the matchers changed. Refusing to emit an empty sweep."
+        )
+    return g, st
+
+
+def build_commands(keys, verb: str = "get"):
+    return [f"{verb} {k}" for k in keys]
+
+
+def build_probes(keys, verb: str = "get"):
+    """One junk-suffix probe per prefix ROOT, not per key.
+
+    A probe exists to prove an arm is not prefix-matching. `radio`,
+    `radio.rxgain` and `radio.fem.rxgain` share a root, so probing all three
+    exercises the same arm three times -- and on a 47-key surface that doubles
+    the run for no extra coverage.
+    """
+    roots = []
+    for k in keys:
+        r = k.split(".")[0]
+        if r not in roots:
+            roots.append(r)
+    return [f"{verb} {r}X" for r in roots]
+
+
+def analyse(rows, slow_s: float = DEFAULT_SLOW_S):
+    """Findings from a `send-batch --json-out` result set.
+
+    Each row is judged against what its command SHOULD do. A row marked
+    `probe: true` is a junk-suffix key that is expected to reach the `??:`
+    fallback -- for those, the expectation is inverted.
+    """
+    out = []
+
+    def add(r, kind, detail):
+        out.append({"command": r.get("command"), "kind": kind, "detail": detail})
+
+    for r in rows:
+        cmd = r.get("command", "")
+        reply = (r.get("reply") or "").strip()
+        probe = bool(r.get("probe"))
+
+        if r.get("skipped"):
+            continue
+        if "error" in r:
+            add(r, "transport-error", r["error"])
+            continue
+
+        # "never answered" and "answered with nothing" are DIFFERENT failures.
+        # The first is the latency/loss symptom; the second is #764's shape.
+        if not r.get("answered"):
+            add(r, "no-reply", f"no bytes within the read window "
+                               f"({r.get('elapsed_s')}s)")
+            continue
+        if r.get("empty_reply") or not reply:
+            add(r, "empty-reply", "matched the key and wrote nothing")
+            continue
+
+        is_fallback = reply.startswith("??:")
+        if probe:
+            # A junk suffix MUST fall through. A real value back means the arm
+            # is still prefix-matching -- #764's `cad` / `extra.sf` half.
+            if not is_fallback:
+                add(r, "prefix-match",
+                    f"junk suffix answered with a real value: {reply[:40]!r}")
+        elif is_fallback:
+            # Checked BEFORE the redaction branch below, so a fallback that
+            # somehow carried a redaction marker is still reported rather than
+            # reading as a healthy answer.
+            # A key read from the source came back unknown: the dispatch does
+            # not do what the source says. That is #657's shape.
+            add(r, "unknown-key", f"enumerated from source but dispatch says {reply[:40]!r}")
+
+        # Redaction markers are a healthy answer, not garbage.
+        if "<redacted:" not in reply:
+            bad = [c for c in reply if not c.isprintable() and c not in _PRINTABLE_OK]
+            if bad:
+                add(r, "non-printable",
+                    f"{len(bad)} non-printable byte(s) in the reply")
+
+        el = r.get("elapsed_s")
+        if el is not None and el > slow_s:
+            add(r, "slow", f"{el}s (threshold {slow_s}s)")
+
+    return out
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    e = sub.add_parser("emit", help="write the command list, read from source")
+    e.add_argument("--source", default=DEFAULT_SOURCE)
+    e.add_argument("--out", required=True)
+    e.add_argument("--probes", action="store_true",
+                   help="append junk-suffix probes (get radioX, ...) that MUST "
+                        "reach the ??: fallback")
+
+    a = sub.add_parser("analyse", help="assert on a send-batch --json-out result")
+    a.add_argument("--json", required=True)
+    a.add_argument("--slow-s", type=float, default=DEFAULT_SLOW_S)
+
+    args = ap.parse_args(argv)
+    root = Path(__file__).resolve().parent.parent
+
+    if args.cmd == "emit":
+        src = (root / args.source).read_text(encoding="utf-8", errors="replace")
+        gets, sets = enumerate_keys(src, require_keys=True)
+        cmds = build_commands(gets)
+        if args.probes:
+            cmds.extend(build_probes(gets))
+        Path(args.out).write_text("\n".join(cmds) + "\n", encoding="utf-8")
+        print(f"{len(gets)} get key(s), {len(sets)} set key(s) read from {args.source}")
+        print(f"wrote {len(cmds)} command(s) to {args.out}")
+        print("set keys are NOT swept: they mutate config, and batch is read-only "
+              "by construction. Interrogate them individually with `send`.")
+        return 0
+
+    rows = json.loads(Path(args.json).read_text(encoding="utf-8"))
+    findings = analyse(rows, slow_s=args.slow_s)
+    if not findings:
+        print(f"cli_sweep: {len(rows)} command(s), no findings")
+        return 0
+    for f in findings:
+        print(f"{f['command']}: {f['kind']}: {f['detail']}")
+    kinds = {}
+    for f in findings:
+        kinds[f["kind"]] = kinds.get(f["kind"], 0) + 1
+    print("\n" + ", ".join(f"{v} {k}" for k, v in sorted(kinds.items())))
+    print(f"{len(findings)} finding(s) across {len(rows)} command(s). See #852.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/cli_sweep.py
+++ b/scripts/cli_sweep.py
@@ -66,6 +66,10 @@ DEFAULT_SLOW_S = 1.0
 
 _PRINTABLE_OK = set("\r\n\t")
 
+# An ESP-IDF / Arduino log line: `[123456][E][File.cpp:483] ...`. Its presence
+# inside a CLI reply proves two writers shared the UART during that reply.
+_LOG_LINE = re.compile(r"\[\d+\]\[[EWIDV]\]\[[^\]]+\]")
+
 
 def _fn_body(src: str, name: str) -> str:
     """Brace-matched body of one CommonCLI method, or "" if absent."""
@@ -144,6 +148,18 @@ def analyse(rows, slow_s: float = DEFAULT_SLOW_S):
     def add(r, kind, detail):
         out.append({"command": r.get("command"), "kind": kind, "detail": detail})
 
+    # A reply carrying an ESP-IDF log line is a reply the device interleaved
+    # other output into. That makes every timing in the run unusable, so detect
+    # it ONCE up front rather than reporting 60-odd bogus "slow" findings.
+    # Threshold, not presence. ONE reply carrying a log line is a legitimate
+    # answer -- `get last_error` can return a stored log line verbatim, and
+    # voiding a whole run's timings on that would suppress real slow findings.
+    # Interleaving from a chattering device is SYSTEMIC and shows up across many
+    # replies (79/79 on ST-P), never in exactly one.
+    noisy = sum(1 for r in rows if _LOG_LINE.search(r.get("reply") or ""))
+    if noisy < 2:
+        noisy = 0
+
     for r in rows:
         cmd = r.get("command", "")
         reply = (r.get("reply") or "").strip()
@@ -187,10 +203,28 @@ def analyse(rows, slow_s: float = DEFAULT_SLOW_S):
                 add(r, "non-printable",
                     f"{len(bad)} non-printable byte(s) in the reply")
 
-        el = r.get("elapsed_s")
-        if el is not None and el > slow_s:
+        el = r.get("round_trip_s")
+        if el is not None and el > slow_s and not noisy:
             add(r, "slow", f"{el}s (threshold {slow_s}s)")
 
+    if noisy:
+        # Timing is meaningless when the device chatters: the read loop's
+        # last-byte marker advances on ANY input, so an unrelated log line is
+        # charged to whatever command was in flight. On ST-P this produced a
+        # 0.17-17.2s spread that had nothing to do with command latency, while
+        # the true serial round trip on a quiet board is ~0.2s.
+        #
+        # Reported as ONE finding rather than suppressed silently: a run whose
+        # timings are void must say so, or the next reader treats the numbers as
+        # measurements. Shape assertions above are unaffected -- they do not
+        # depend on timing.
+        out.append({
+            "command": "(run)", "kind": "timings-void",
+            "detail": f"{noisy} of {len(rows)} replies carry interleaved async "
+                      f"log output; every timing in this run is contaminated and "
+                      f"slow-detection is disabled. Fix the chatter (see #899) "
+                      f"and re-run before drawing any latency conclusion.",
+        })
     return out
 
 

--- a/scripts/log_redact.py
+++ b/scripts/log_redact.py
@@ -83,6 +83,27 @@ _SECRET_WORDS = (r"password|passwd|pwd|psk|secret|token|apikey|api_key|bearer|pa
 # sweep can assert that a secret key ANSWERED without recording what it said.
 _CLI_REPLY_RE = re.compile(r"(^\s*>\s*)([^\r\n]+)")
 
+# The rule above assumes a CLI reply BEGINS its line. That assumption was broken
+# by the firmware, not by this file. Unsynchronized UART writers splice log
+# output in front of a reply, and a real ST-P capture contained:
+#
+#   [247008][E][Preferences.cpp:483] getString(): nvs_get_str  -> > <private key>
+#
+# `^\s*>` never matched, and a node private key was written to a capture file in
+# full. The control was not wrong when written -- its PRECONDITION stopped
+# holding. Every fixture fed it clean, line-anchored input, so no test failed.
+#
+# For a reply already classified as secret, position must not decide whether the
+# secret is protected. These are unanchored and deliberately greedy: on a
+# known-secret reply, over-redacting costs a re-read; under-redacting leaks a key.
+_SECRET_ANYWHERE_RES = (
+    # `> value` anywhere on the line, however much junk precedes it.
+    re.compile(r"(>[ \t]*)([^\r\n]+)"),
+    # Belt and braces: a long opaque token with no `>` marker at all, because a
+    # splice can land mid-value and destroy the marker itself.
+    re.compile(r"([0-9A-Fa-f]{16,}|[A-Za-z0-9+/=_-]{24,})"),
+)
+
 _REDACTIONS = [
     # WiFi SSID, in the shapes the firmware actually prints.
     (re.compile(r"(SSID\s*=\s*)([^;\r\n]+)", re.IGNORECASE), r"\1<redacted:ssid>"),
@@ -120,7 +141,8 @@ _REDACTIONS = [
 ]
 
 
-def redact_line(line: str, cli_reply_net: bool = True) -> str:
+def redact_line(line: str, cli_reply_net: bool = True,
+                secret: bool = False) -> str:
     """Apply every rule to one line. Position classification runs last so a
     coordinate inside an otherwise-redacted line is still handled.
 
@@ -134,6 +156,22 @@ def redact_line(line: str, cli_reply_net: bool = True) -> str:
         if not cli_reply_net and pattern is _CLI_REPLY_RE:
             continue
         line = pattern.sub(repl, line)
+    if secret:
+        # Applied LAST and unanchored, so it also catches a value the positional
+        # rules skipped because a log splice moved it off column 0.
+        #
+        # MUST be idempotent: the anchored rule above may already have replaced
+        # the value with a marker, and re-redacting that marker would overwrite
+        # the real length with the marker's own length -- destroying the one
+        # property the sweep relies on to assert a secret key ANSWERED.
+        def _once(m):
+            val = m.group(m.lastindex)
+            if "<redacted:" in val:
+                return m.group(0)
+            return "<redacted:cli-reply:%d>" % len(val.strip())
+
+        for pat in _SECRET_ANYWHERE_RES:
+            line = pat.sub(_once, line)
     return redact_positions(line)
 
 

--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -1536,6 +1536,141 @@ class _ReplyRedactor:
         return self._scrub(rest)
 
 
+# ---------------------------------------------------------------------------
+# #850: batch mode
+#
+# `send` is one command per run, and the flash discipline is one human approval
+# per RUN of this tool. Sweeping the CLI surface is 47 `get` keys (#852), so at
+# one approval each it costs 47 approvals and therefore never gets run. The
+# tool's granularity is what makes the work impossible, not the work itself.
+#
+# Batch is READ-ONLY BY CONSTRUCTION. The approval model exists because a
+# wrong-device flash happened (#500); a batch that could carry `set` would let
+# forty state changes ride in on one approval. Only `get` is accepted, and the
+# whole run is refused up front -- never halfway through, because a partially
+# executed batch is the worst outcome: some state changed and the operator
+# approved none of it.
+# ---------------------------------------------------------------------------
+
+
+_BATCH_ABORT_AFTER = 3  # consecutive transport failures before giving up
+
+
+class BatchRefused(Exception):
+    """A batch contained something that is not a read-only interrogation."""
+
+
+def _is_read_only_command(cmd: str) -> bool:
+    """Only `get <key>` interrogations. Deliberately narrow.
+
+    Not an allowlist of 'probably safe' verbs -- `advert` transmits, `reboot`
+    and `erase` change device state, `set` writes config. Any of those belongs
+    in a single `send` under its own approval, where a human sees it.
+
+    ASSUMPTION THIS GATE RESTS ON, stated because it is a property of the
+    firmware and not of this tool: `get` is side-effect-free. Verified against
+    CommonCLI::handleGetCmd -- its body contains no assignment to _prefs, no
+    save, no reboot/advert/erase, and every _board / _callbacks call it makes
+    is a getter. If a future `get` handler mutates state, this gate silently
+    stops being a gate. A firmware-side check belongs with the CLI dispatch
+    guard (#775), not here.
+    """
+    tokens = (cmd or "").split()
+    return len(tokens) >= 2 and tokens[0].lower() == "get"
+
+
+def _read_until_idle(read_fn, idle_s: float, max_s: float,
+                     now_fn=time.time, sleep_fn=time.sleep) -> bytes:
+    """Read until the device goes quiet, bounded by `max_s`.
+
+    A fixed read window is wrong in both directions: it truncates a reply that
+    arrives slowly (reporting it as absent, which is the exact signal #851 is
+    trying to measure) and it burns the whole window on a reply that arrived in
+    milliseconds -- 47 keys at 2s each is 94 seconds of deliberate waiting.
+
+    Waits for the FIRST byte for up to `max_s`, then returns once `idle_s`
+    passes with nothing new. `max_s` still bounds a device that chatters
+    forever, and whatever arrived is returned rather than discarded.
+    """
+    buf = bytearray()
+    start = now_fn()
+    last = start
+    while True:
+        if now_fn() - start >= max_s:
+            break
+        chunk = read_fn()
+        if chunk:
+            buf.extend(chunk)
+            last = now_fn()
+        elif buf and (now_fn() - last) >= idle_s:
+            break
+    return bytes(buf)
+
+
+def _run_batch(commands, send_fn, read_time: float = 5.0):
+    """Send each command through `send_fn`, redact per command, collect results.
+
+    `send_fn(cmd) -> bytes` is injected so the sequencing, classification and
+    fail-soft behaviour are testable without a serial port.
+
+    Returns one row per command, in order:
+        {command, reply, answered, [error]}
+
+    `answered` distinguishes the two failures that matter and must never be
+    conflated: a reply that is EMPTY is the #764 shape (the handler matched and
+    wrote nothing), while a command that never came back at all is the
+    latency/loss symptom #851 measures. Recording both as "no reply" would
+    destroy the diagnosis the sweep exists to make.
+    """
+    refused = [c for c in commands if not _is_read_only_command(c)]
+    if refused:
+        raise BatchRefused(
+            "batch accepts read-only `get` interrogations only; refusing the "
+            "whole run because of: " + ", ".join(repr(c) for c in refused) +
+            ". Issue state-changing commands one at a time with `send`, so each "
+            "gets its own approval."
+        )
+
+    rows = []
+    consecutive_failures = 0
+    aborted = False
+    for cmd in commands:
+        row = {"command": cmd, "reply": "", "answered": False, "empty_reply": False}
+
+        if aborted:
+            # The port is gone. Retrying 40 more times produces 40 identical
+            # exceptions after a long wait and tells nobody anything new.
+            row["skipped"] = True
+            rows.append(row)
+            continue
+
+        try:
+            raw = send_fn(cmd)
+        except Exception as e:
+            row["error"] = f"{type(e).__name__}: {e}"
+            consecutive_failures += 1
+            if consecutive_failures >= _BATCH_ABORT_AFTER:
+                aborted = True
+                row["aborted_here"] = True
+            rows.append(row)
+            continue
+
+        consecutive_failures = 0
+        raw = raw or b""
+        redactor = _ReplyRedactor(secret=_is_secret_command(cmd))
+        text = redactor.feed(raw) + redactor.flush()
+        row["reply"] = text
+        # `answered` is a TRANSPORT question: did the device respond at all?
+        # Whether the response had content is a separate, and different,
+        # finding -- a reply of "\r\n" is answered-but-empty, which is #764's
+        # shape. Collapsing the two turns a valid quiet reply into a phantom
+        # failure, and hides the defect the sweep exists to catch.
+        row["answered"] = len(raw) > 0
+        row["empty_reply"] = row["answered"] and not text.strip()
+        rows.append(row)
+    return rows
+
+
 def cmd_send(args, registry):
     """
     Tier B: open serial, write command + CR, read response for N seconds.
@@ -1614,6 +1749,76 @@ def cmd_send(args, registry):
         "exit_code": 0,
     })
     return 0
+
+
+def cmd_send_batch(args, registry):
+    """Tier B: one open port, N read-only commands, one approval."""
+    port, _ = resolve_device(args.device, registry)
+    if port.get("bridge_provisional"):
+        refuse(
+            f"'{args.device}' resolved only provisionally (bridge-class; identity "
+            "unverifiable without a chip reset). Refusing to send to a possibly-"
+            "wrong board (#468)."
+        )
+
+    try:
+        commands = [
+            l.strip() for l in Path(args.commands_file).read_text(encoding="utf-8").splitlines()
+            if l.strip() and not l.strip().startswith("#")
+        ]
+    except OSError as e:
+        refuse(f"cannot read --commands-file: {e}")
+    if not commands:
+        refuse(f"no commands in {args.commands_file}")
+
+    try:
+        import serial
+    except ImportError:
+        refuse("pyserial not available; pip install pyserial")
+
+    out(f"Batch to {args.device} on {port['com']}: {len(commands)} command(s), "
+        f"{args.read_time}s each")
+
+    try:
+        # timeout well under idle_time so an idle gap is noticed promptly
+        with serial.Serial(port["com"], baudrate=args.baud, timeout=0.05) as sp:
+            time.sleep(0.2)
+            try:
+                sp.reset_input_buffer()
+            except Exception:
+                pass
+
+            def send_one(cmd: str) -> bytes:
+                try:
+                    sp.reset_input_buffer()
+                except Exception:
+                    pass
+                sp.write((cmd + "\r").encode("utf-8"))
+                sp.flush()
+                return _read_until_idle(lambda: sp.read(1024),
+                                        idle_s=args.idle_time,
+                                        max_s=args.read_time)
+
+            rows = _run_batch(commands, send_one, read_time=args.read_time)
+    except BatchRefused as e:
+        refuse(str(e))
+    except Exception as e:
+        refuse(f"serial batch failed on {port['com']}: {e}")
+
+    answered = sum(1 for r in rows if r["answered"])
+    empty = sum(1 for r in rows if r.get("empty_reply"))
+    skipped = sum(1 for r in rows if r.get("skipped"))
+    for r in rows:
+        status = "ok " if r["answered"] else "MISS"
+        first = (r["reply"].strip().splitlines() or [""])[0]
+        out(f"  [{status}] {r['command']}: {first}")
+    out(f"{answered}/{len(rows)} answered"
+        + (f", {empty} answered-but-EMPTY" if empty else "")
+        + (f", {skipped} skipped after transport failure" if skipped else ""))
+
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(rows, indent=2), encoding="utf-8")
+        out(f"wrote {args.json_out}")
 
 
 def cmd_monitor(args, registry):
@@ -2375,6 +2580,18 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("--read-time", type=float, default=5.0,
                    help="seconds to read response after sending (default 5)")
 
+    s = sub.add_parser("send-batch",
+                       help="send N read-only `get` commands over one open port (Tier B)")
+    s.add_argument("device")
+    s.add_argument("--commands-file", required=True,
+                   help="one command per line; blank lines and # comments ignored")
+    s.add_argument("--baud", type=int, default=115200)
+    s.add_argument("--read-time", type=float, default=3.0,
+                   help="hard cap on the read for each command (default 3)")
+    s.add_argument("--idle-time", type=float, default=0.25,
+                   help="return once the device has been quiet this long (default 0.25)")
+    s.add_argument("--json-out", help="write structured per-command results here")
+
     s = sub.add_parser("info", help="meshtastic --info (Tier B)")
     s.add_argument("device")
     s.add_argument("--known-port", default=None, metavar="COMx",
@@ -2438,6 +2655,7 @@ def main() -> int:
         "confirm": cmd_confirm,
         "monitor": cmd_monitor,
         "send": cmd_send,
+        "send-batch": cmd_send_batch,
         "info": cmd_info,
         "read-mac": cmd_read_mac,
         "backup": cmd_backup,

--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -1513,7 +1513,13 @@ class _ReplyRedactor:
         # content, and the caller's byte stream should not be reshaped.
         stripped = text.rstrip("\r\n")
         ending = text[len(stripped):]
-        return redact_line(stripped, cli_reply_net=self._secret) + ending
+        # `secret=` is what survives a log splice. `cli_reply_net` alone relies
+        # on the reply starting its line, and the firmware's unsynchronized UART
+        # writers break that -- which is how a node private key reached a capture
+        # file in full. Both are passed: the anchored net for the clean case, the
+        # unanchored sweep for the spliced one.
+        return redact_line(stripped, cli_reply_net=self._secret,
+                           secret=self._secret) + ending
 
     def feed(self, data: bytes) -> str:
         """Absorb a raw chunk; return only whole redacted lines."""
@@ -1608,6 +1614,62 @@ class TransportReply(NamedTuple):
     data: bytes
     first_byte_s: float = None
     last_byte_s: float = None
+
+
+# How long to let a freshly-opened port settle before the first command.
+#
+# Opening a serial port asserts DTR/RTS, which RESETS an ESP32. The old 0.2s
+# settle was tuned on an nRF52 (T096), whose USB-CDC does not reboot on open --
+# so it was never wrong until an ESP32 was on the wire. On ESP32 the first
+# commands land mid-boot and come back empty or garbled, which is exactly the
+# #764 signature the sweep exists to detect. False findings that look like the
+# real defect are worse than no findings at all.
+#
+# Suppressing DTR instead was considered and REJECTED: Arduino's ESP32 USB-CDC
+# gates transmission on DTR, so a device opened with DTR deasserted may never
+# reply. Taking the reset and waiting it out works on every board.
+SETTLE_QUIET_S = 0.6      # boot chatter must stop for this long
+SETTLE_GRACE_S = 1.0      # silent board: assume already up after this
+SETTLE_MAX_S = 12.0       # hard bound on a slow or chattering boot
+
+
+def _await_device_ready(read_fn, quiet_s: float = SETTLE_QUIET_S,
+                        grace_s: float = SETTLE_GRACE_S,
+                        max_s: float = SETTLE_MAX_S,
+                        now_fn=time.time, sleep_fn=time.sleep) -> bytes:
+    """Wait until a just-opened port is quiet, and return whatever it said.
+
+    Deliberately NOT _read_until_idle: that one waits for a first byte for the
+    whole window, so a board that never chatters would burn max_s every run.
+    Two exits instead --
+
+      * data arrived (a boot banner) -> wait for `quiet_s` of silence
+      * nothing at all by `grace_s`  -> the board was already up, proceed
+
+    The drained bytes are returned rather than dropped so a caller can log the
+    boot banner; discarding it would throw away the evidence that a reset
+    happened at all.
+    """
+    buf = bytearray()
+    start = now_fn()
+    last = start
+    while True:
+        now = now_fn()
+        if now - start >= max_s:
+            break
+        chunk = read_fn()
+        if chunk:
+            buf.extend(chunk)
+            last = now_fn()
+        elif buf:
+            if now - last >= quiet_s:
+                break
+            sleep_fn(0.01)
+        else:
+            if now - start >= grace_s:
+                break
+            sleep_fn(0.01)
+    return bytes(buf)
 
 
 def _read_until_idle(read_fn, idle_s: float, max_s: float,
@@ -1936,7 +1998,12 @@ def cmd_send_batch(args, registry):
         # FIRST_BYTE_GRANULARITY_NOTE) -- at 0.05 that error could exceed
         # the latency being measured
         with serial.Serial(port["com"], baudrate=args.baud, timeout=0.01) as sp:
-            time.sleep(0.2)
+            # Not a fixed sleep: an ESP32 reboots when this port opens, and a
+            # repeater's boot is seconds, not milliseconds. Wait for quiet.
+            banner = _await_device_ready(lambda: sp.read(1024))
+            if banner:
+                out(f"device chattered {len(banner)} byte(s) on open "
+                    f"(reset on port open); waited for quiet before command 1")
             try:
                 sp.reset_input_buffer()
             except Exception:

--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -1607,6 +1607,7 @@ class TransportReply(NamedTuple):
     """
     data: bytes
     first_byte_s: float = None
+    last_byte_s: float = None
 
 
 def _read_until_idle(read_fn, idle_s: float, max_s: float,
@@ -1628,6 +1629,7 @@ def _read_until_idle(read_fn, idle_s: float, max_s: float,
     start = now_fn()
     last = start
     first_byte_at = None
+    last_byte_at = None
     while True:
         if now_fn() - start >= max_s:
             break
@@ -1640,6 +1642,7 @@ def _read_until_idle(read_fn, idle_s: float, max_s: float,
             # must keep doing so.
             if on_chunk is not None:
                 on_chunk(chunk)
+            last_byte_at = now_fn()
             if first_byte_at is None:
                 # #851: time-to-first-byte separates "slow to START answering"
                 # from "answered at length". They have different causes and the
@@ -1657,6 +1660,14 @@ def _read_until_idle(read_fn, idle_s: float, max_s: float,
         base = start if origin is None else origin
         stats["first_byte_s"] = (None if first_byte_at is None
                                  else round(first_byte_at - base, 4))
+        # The TRUE round trip: origin to the last byte received. Wall time from
+        # here also contains the idle wait -- which is this tool's own timeout,
+        # not the device's latency. Charging the device for it inflated every
+        # measurement by idle_s, and by a DIFFERENT amount whenever --idle-time
+        # changed, making two runs incomparable. Found on hardware (T096):
+        # elapsed 1.2188 vs first byte 0.2136, a gap of exactly the 1.0s idle.
+        stats["last_byte_s"] = (None if last_byte_at is None
+                                else round(last_byte_at - base, 4))
     return bytes(buf)
 
 
@@ -1679,7 +1690,8 @@ def _timed_send(cmd: str, send_fn, now_fn=time.time) -> dict:
     shape, which is a handler matching a key and writing nothing.
     """
     row = {"command": cmd, "reply": "", "answered": False, "empty_reply": False,
-           "elapsed_s": None, "first_byte_s": None, "reply_bytes": 0}
+           "elapsed_s": None, "round_trip_s": None, "first_byte_s": None,
+           "reply_bytes": 0}
 
     started = now_fn()
     try:
@@ -1694,7 +1706,11 @@ def _timed_send(cmd: str, send_fn, now_fn=time.time) -> dict:
     # Timing arrives ONLY via the explicit TransportReply type. Accepting any
     # 2-tuple would silently record an unrelated second element as a latency.
     if isinstance(result, TransportReply):
-        raw, row["first_byte_s"] = result.data, result.first_byte_s
+        raw = result.data
+        row["first_byte_s"] = result.first_byte_s
+        # round_trip_s is what a consumer should compare across runs;
+        # elapsed_s is wall time and includes this tool's idle wait.
+        row["round_trip_s"] = result.last_byte_s
     elif isinstance(result, (bytes, bytearray)):
         raw = result
     elif isinstance(result, tuple) and result and isinstance(result[0], (bytes, bytearray)):
@@ -1841,7 +1857,9 @@ def cmd_send(args, registry):
                                         max_s=args.read_time,
                                         stats=st, origin=origin,
                                         on_chunk=_emit)
-                return TransportReply(data=data, first_byte_s=st.get("first_byte_s"))
+                return TransportReply(data=data,
+                                      first_byte_s=st.get("first_byte_s"),
+                                      last_byte_s=st.get("last_byte_s"))
 
             row = _timed_send(args.command, transport)
 
@@ -1856,7 +1874,12 @@ def cmd_send(args, registry):
                 "answered but EMPTY" if row["empty_reply"] else "ok")
             fb = "" if row["first_byte_s"] is None else \
                  f", first byte {row['first_byte_s']:.3f}s"
-            out(f"[{status}] {row['elapsed_s']:.3f}s{fb}, {row['reply_bytes']} bytes")
+            rt = ("?" if row["round_trip_s"] is None
+                  else f"{row['round_trip_s']:.3f}s")
+            # Lead with the round trip. elapsed_s is shown for completeness but
+            # carries this tool's idle wait and must not be compared across runs.
+            out(f"[{status}] round-trip {rt}{fb}, {row['reply_bytes']} bytes "
+                f"(wall {row['elapsed_s']:.3f}s incl. {args.idle_time}s idle)")
             if "error" in row:
                 out(f"  error: {row['error']}")
             if args.json_out:
@@ -1932,7 +1955,9 @@ def cmd_send_batch(args, registry):
                                         idle_s=args.idle_time,
                                         max_s=args.read_time,
                                         stats=st, origin=origin)
-                return TransportReply(data=data, first_byte_s=st.get("first_byte_s"))
+                return TransportReply(data=data,
+                                      first_byte_s=st.get("first_byte_s"),
+                                      last_byte_s=st.get("last_byte_s"))
 
             rows = _run_batch(commands, send_one, read_time=args.read_time)
     except BatchRefused as e:
@@ -1946,13 +1971,13 @@ def cmd_send_batch(args, registry):
     for r in rows:
         status = "ok " if r["answered"] else "MISS"
         first = (r["reply"].strip().splitlines() or [""])[0]
-        t = "" if r.get("elapsed_s") is None else f" {r['elapsed_s']:.2f}s"
+        t = "" if r.get("round_trip_s") is None else f" {r['round_trip_s']:.2f}s"
         fb = "" if r.get("first_byte_s") is None else f" (first byte {r['first_byte_s']:.2f}s)"
         out(f"  [{status}]{t}{fb} {r['command']}: {first}")
-    timed = [r["elapsed_s"] for r in rows if r.get("elapsed_s") is not None]
+    timed = [r["round_trip_s"] for r in rows if r.get("round_trip_s") is not None]
     if timed:
-        slowest = max(rows, key=lambda r: r.get("elapsed_s") or -1)
-        out(f"slowest: {slowest['command']} at {slowest['elapsed_s']:.2f}s; "
+        slowest = max(rows, key=lambda r: r.get("round_trip_s") or -1)
+        out(f"slowest: {slowest['command']} at {slowest['round_trip_s']:.2f}s; "
             f"median {sorted(timed)[len(timed)//2]:.2f}s")
     out(f"{answered}/{len(rows)} answered"
         + (f", {empty} answered-but-EMPTY" if empty else "")

--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -1518,8 +1518,33 @@ class _ReplyRedactor:
         # writers break that -- which is how a node private key reached a capture
         # file in full. Both are passed: the anchored net for the clean case, the
         # unanchored sweep for the spliced one.
-        return redact_line(stripped, cli_reply_net=self._secret,
-                           secret=self._secret) + ending
+        red = redact_line(stripped, cli_reply_net=self._secret,
+                          secret=self._secret)
+        # `red == stripped` means NO rule fired, i.e. nothing was located. Do
+        # NOT test for the literal "<redacted:" here: that string can arrive
+        # FROM THE DEVICE, and a reply like `> hunter2 <redacted:x>` would then
+        # suppress the fail-closed branch and leak. Whether we redacted is our
+        # own fact -- read it from our own output, never from device text.
+        if self._secret and stripped.strip() and red == stripped:
+            # FAIL CLOSED. Every locating rule above needs SOMETHING to match
+            # on -- a `>` marker, or a value long enough to look opaque. A log
+            # splice can destroy the marker while leaving a SHORT secret behind:
+            #
+            #   [D][main.cpp:123] Loop hunter2
+            #
+            # No `>`, only 7 characters, no keyword. Nothing matches, and the
+            # secret is written out verbatim. Found by adversarial review.
+            #
+            # On a command already classified secret we do not need to find the
+            # value -- we can refuse to emit the line at all. `??:` is the one
+            # exception: the unknown-key fallback echoes the KEY, never a value,
+            # and the sweep needs it visible to report a broken key (#852).
+            # STARTSWITH, not "contains". A genuine fallback IS the whole reply
+            # (`??: some.key`). Accepting it anywhere on the line lets
+            # `... ??: prv.key > <the actual key>` bypass the guard.
+            if not stripped.strip().startswith("??:"):
+                red = "<redacted:cli-reply:%d>" % len(stripped.strip())
+        return red + ending
 
     def feed(self, data: bytes) -> str:
         """Absorb a raw chunk; return only whole redacted lines."""
@@ -1629,7 +1654,15 @@ class TransportReply(NamedTuple):
 # gates transmission on DTR, so a device opened with DTR deasserted may never
 # reply. Taking the reset and waiting it out works on every board.
 SETTLE_QUIET_S = 0.6      # boot chatter must stop for this long
-SETTLE_GRACE_S = 1.0      # silent board: assume already up after this
+SETTLE_GRACE_S = 3.0      # silent board: assume already up after this
+# 3.0s, not 1.0s. Silence is AMBIGUOUS: an already-booted board and a board
+# in a silent boot stage look identical. At 1.0s an ESP32 whose banner had
+# not started yet would be declared ready, and command 1 would collide with
+# the banner -- returning empty, which is indistinguishable from the #764
+# defect the sweep hunts. Found by adversarial review, not by a test.
+# RESIDUAL RISK: a boot stage silent for >3.0s still defeats this. The
+# complete fix is an ACTIVE probe (poke, require an answer) rather than a
+# timeout; tracked separately rather than bolted on here.
 SETTLE_MAX_S = 12.0       # hard bound on a slow or chattering boot
 
 
@@ -1722,7 +1755,15 @@ def _read_until_idle(read_fn, idle_s: float, max_s: float,
         base = start if origin is None else origin
         stats["first_byte_s"] = (None if first_byte_at is None
                                  else round(first_byte_at - base, 4))
-        # The TRUE round trip: origin to the last byte received. Wall time from
+        # Origin to the last byte received.
+        #
+        # NOT the true round trip when the device chatters asynchronously:
+        # last_byte_at advances on ANY input, so an unrelated log line
+        # arriving after the reply is charged to the command. Measured on
+        # ST-P at 29.3 log lines/sec (#899), this inflated readings across
+        # a 0.17-17.2s spread that had nothing to do with command latency.
+        # Trustworthy only on a QUIET device. Consumers must treat a noisy
+        # capture's timings as void -- see cli_sweep's chatter guard. Wall time from
         # here also contains the idle wait -- which is this tool's own timeout,
         # not the device's latency. Charging the device for it inflated every
         # measurement by idle_s, and by a DIFFERENT amount whenever --idle-time
@@ -1794,6 +1835,12 @@ def _timed_send(cmd: str, send_fn, now_fn=time.time) -> dict:
     row["answered"] = len(raw) > 0
     row["empty_reply"] = row["answered"] and not text.strip()
     return row
+
+
+# A commands file is hand-written or emitted by cli_sweep; the real surface is
+# ~79 commands. Anything past this is a mistake (wrong file, generated garbage)
+# and reading it whole would exhaust memory before a single command is sent.
+MAX_BATCH_COMMANDS = 5000
 
 
 def _run_batch(commands, send_fn, read_time: float = 5.0, now_fn=time.time):
@@ -1975,14 +2022,28 @@ def cmd_send_batch(args, registry):
         )
 
     try:
+        # Size-checked BEFORE the read: read_text() on a wrong path (a firmware
+        # image, a core dump) would exhaust memory before a single command runs.
+        cf = Path(args.commands_file)
+        # is_file() first: a FIFO or character device reports st_size == 0, so
+        # the size cap below would pass it and read_text() would then read
+        # unbounded. A command list is always a regular file.
+        if not cf.is_file():
+            refuse(f"--commands-file is not a regular file: {args.commands_file}")
+        size = cf.stat().st_size
+        if size > MAX_BATCH_COMMANDS * 256:
+            refuse(f"--commands-file is {size} bytes; a command list for a "
+                   f"~79-command surface is not this large. Wrong file?")
         commands = [
-            l.strip() for l in Path(args.commands_file).read_text(encoding="utf-8").splitlines()
+            l.strip() for l in cf.read_text(encoding="utf-8").splitlines()
             if l.strip() and not l.strip().startswith("#")
         ]
     except OSError as e:
         refuse(f"cannot read --commands-file: {e}")
     if not commands:
         refuse(f"no commands in {args.commands_file}")
+    if len(commands) > MAX_BATCH_COMMANDS:
+        refuse(f"{len(commands)} commands exceeds the {MAX_BATCH_COMMANDS} cap")
 
     try:
         import serial

--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -50,7 +50,7 @@ from pathlib import Path
 # and the copy that drifts is the one that leaks (#667).
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from log_redact import redact_line  # noqa: E402
-from typing import Any, Optional
+from typing import Any, NamedTuple, Optional
 
 try:
     import yaml
@@ -1579,8 +1579,29 @@ def _is_read_only_command(cmd: str) -> bool:
     return len(tokens) >= 2 and tokens[0].lower() == "get"
 
 
+FIRST_BYTE_GRANULARITY_NOTE = (
+    "first_byte_s granularity is bounded by the serial read timeout: the loop "
+    "can only notice data when a blocking read returns, so the value carries an "
+    "error of up to one timeout period. Treat it as a coarse signal for 'slow to "
+    "start answering', not as a precise latency."
+)
+
+
+class TransportReply(NamedTuple):
+    """What a batch transport returns when it can report timing.
+
+    An explicit type rather than a bare tuple: `isinstance(result, tuple)` would
+    silently unpack ANY 2-tuple as timing data, so a transport returning
+    (data, status) for some unrelated reason would have its status recorded as a
+    latency. A transport that cannot report timing still returns plain bytes.
+    """
+    data: bytes
+    first_byte_s: float = None
+
+
 def _read_until_idle(read_fn, idle_s: float, max_s: float,
-                     now_fn=time.time, sleep_fn=time.sleep) -> bytes:
+                     now_fn=time.time, sleep_fn=time.sleep,
+                     stats: dict = None, origin: float = None) -> bytes:
     """Read until the device goes quiet, bounded by `max_s`.
 
     A fixed read window is wrong in both directions: it truncates a reply that
@@ -1595,26 +1616,45 @@ def _read_until_idle(read_fn, idle_s: float, max_s: float,
     buf = bytearray()
     start = now_fn()
     last = start
+    first_byte_at = None
     while True:
         if now_fn() - start >= max_s:
             break
         chunk = read_fn()
         if chunk:
+            if first_byte_at is None:
+                # #851: time-to-first-byte separates "slow to START answering"
+                # from "answered at length". They have different causes and the
+                # total duration alone cannot tell them apart.
+                first_byte_at = now_fn()
             buf.extend(chunk)
             last = now_fn()
         elif buf and (now_fn() - last) >= idle_s:
             break
+    if stats is not None:
+        # Anchor to `origin` -- the moment the command was WRITTEN -- not to when
+        # this read loop happened to start. Measuring from here would exclude the
+        # write and flush, leaving first_byte_s and the caller's elapsed_s with
+        # different zero points and therefore uncorrelatable (#851 review).
+        base = start if origin is None else origin
+        stats["first_byte_s"] = (None if first_byte_at is None
+                                 else round(first_byte_at - base, 4))
     return bytes(buf)
 
 
-def _run_batch(commands, send_fn, read_time: float = 5.0):
+def _run_batch(commands, send_fn, read_time: float = 5.0, now_fn=time.time):
     """Send each command through `send_fn`, redact per command, collect results.
 
     `send_fn(cmd) -> bytes` is injected so the sequencing, classification and
     fail-soft behaviour are testable without a serial port.
 
     Returns one row per command, in order:
-        {command, reply, answered, [error]}
+        {command, reply, answered, empty_reply, elapsed_s, first_byte_s,
+         reply_bytes, [error], [skipped]}
+
+    `send_fn` may return plain bytes, or `(bytes, first_byte_s)` when the
+    transport can report time-to-first-byte. Both shapes are accepted so the
+    injected test transports stay trivial.
 
     `answered` distinguishes the two failures that matter and must never be
     conflated: a reply that is EMPTY is the #764 shape (the handler matched and
@@ -1635,18 +1675,23 @@ def _run_batch(commands, send_fn, read_time: float = 5.0):
     consecutive_failures = 0
     aborted = False
     for cmd in commands:
-        row = {"command": cmd, "reply": "", "answered": False, "empty_reply": False}
+        row = {"command": cmd, "reply": "", "answered": False, "empty_reply": False,
+               "elapsed_s": None, "first_byte_s": None, "reply_bytes": 0}
 
         if aborted:
             # The port is gone. Retrying 40 more times produces 40 identical
             # exceptions after a long wait and tells nobody anything new.
+            # elapsed_s stays None: this command was never attempted, and a
+            # zero would read as "answered instantly" in any summary.
             row["skipped"] = True
             rows.append(row)
             continue
 
+        started = now_fn()
         try:
-            raw = send_fn(cmd)
+            result = send_fn(cmd)
         except Exception as e:
+            row["elapsed_s"] = round(now_fn() - started, 4)
             row["error"] = f"{type(e).__name__}: {e}"
             consecutive_failures += 1
             if consecutive_failures >= _BATCH_ABORT_AFTER:
@@ -1656,7 +1701,18 @@ def _run_batch(commands, send_fn, read_time: float = 5.0):
             continue
 
         consecutive_failures = 0
+        row["elapsed_s"] = round(now_fn() - started, 4)
+        # A transport may report time-to-first-byte alongside the data, but ONLY
+        # via the explicit TransportReply type. Accepting any 2-tuple would
+        # silently record an unrelated second element as a latency.
+        if isinstance(result, TransportReply):
+            raw, row["first_byte_s"] = result.data, result.first_byte_s
+        elif isinstance(result, (bytes, bytearray)):
+            raw = result
+        else:
+            raw = result[0] if isinstance(result, tuple) and result else result
         raw = raw or b""
+        row["reply_bytes"] = len(raw)
         redactor = _ReplyRedactor(secret=_is_secret_command(cmd))
         text = redactor.feed(raw) + redactor.flush()
         row["reply"] = text
@@ -1780,24 +1836,31 @@ def cmd_send_batch(args, registry):
         f"{args.read_time}s each")
 
     try:
-        # timeout well under idle_time so an idle gap is noticed promptly
-        with serial.Serial(port["com"], baudrate=args.baud, timeout=0.05) as sp:
+        # timeout well under idle_time so an idle gap is noticed promptly, and
+        # small because it bounds the first_byte_s error (see
+        # FIRST_BYTE_GRANULARITY_NOTE) -- at 0.05 that error could exceed
+        # the latency being measured
+        with serial.Serial(port["com"], baudrate=args.baud, timeout=0.01) as sp:
             time.sleep(0.2)
             try:
                 sp.reset_input_buffer()
             except Exception:
                 pass
 
-            def send_one(cmd: str) -> bytes:
+            def send_one(cmd: str) -> TransportReply:
                 try:
                     sp.reset_input_buffer()
                 except Exception:
                     pass
+                origin = time.time()          # the command starts HERE
                 sp.write((cmd + "\r").encode("utf-8"))
                 sp.flush()
-                return _read_until_idle(lambda: sp.read(1024),
+                st = {}
+                data = _read_until_idle(lambda: sp.read(1024),
                                         idle_s=args.idle_time,
-                                        max_s=args.read_time)
+                                        max_s=args.read_time,
+                                        stats=st, origin=origin)
+                return TransportReply(data=data, first_byte_s=st.get("first_byte_s"))
 
             rows = _run_batch(commands, send_one, read_time=args.read_time)
     except BatchRefused as e:
@@ -1811,7 +1874,14 @@ def cmd_send_batch(args, registry):
     for r in rows:
         status = "ok " if r["answered"] else "MISS"
         first = (r["reply"].strip().splitlines() or [""])[0]
-        out(f"  [{status}] {r['command']}: {first}")
+        t = "" if r.get("elapsed_s") is None else f" {r['elapsed_s']:.2f}s"
+        fb = "" if r.get("first_byte_s") is None else f" (first byte {r['first_byte_s']:.2f}s)"
+        out(f"  [{status}]{t}{fb} {r['command']}: {first}")
+    timed = [r["elapsed_s"] for r in rows if r.get("elapsed_s") is not None]
+    if timed:
+        slowest = max(rows, key=lambda r: r.get("elapsed_s") or -1)
+        out(f"slowest: {slowest['command']} at {slowest['elapsed_s']:.2f}s; "
+            f"median {sorted(timed)[len(timed)//2]:.2f}s")
     out(f"{answered}/{len(rows)} answered"
         + (f", {empty} answered-but-EMPTY" if empty else "")
         + (f", {skipped} skipped after transport failure" if skipped else ""))

--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -1579,6 +1579,16 @@ def _is_read_only_command(cmd: str) -> bool:
     return len(tokens) >= 2 and tokens[0].lower() == "get"
 
 
+# Idle gap before a read is considered finished.
+#
+# Batch only issues `get` keys, which answer in one shot, so a tight gap is safe
+# and keeps a 47-key sweep quick. Single `send` reaches commands that may print
+# in STAGES with real pauses between them ("Formatting... done"), and an
+# aggressive gap would truncate those mid-reply -- so its default is looser.
+# Raise it with --idle-time when a command is known to pause.
+BATCH_IDLE_DEFAULT = 0.25
+SEND_IDLE_DEFAULT = 1.0
+
 FIRST_BYTE_GRANULARITY_NOTE = (
     "first_byte_s granularity is bounded by the serial read timeout: the loop "
     "can only notice data when a blocking read returns, so the value carries an "
@@ -1601,7 +1611,8 @@ class TransportReply(NamedTuple):
 
 def _read_until_idle(read_fn, idle_s: float, max_s: float,
                      now_fn=time.time, sleep_fn=time.sleep,
-                     stats: dict = None, origin: float = None) -> bytes:
+                     stats: dict = None, origin: float = None,
+                     on_chunk=None) -> bytes:
     """Read until the device goes quiet, bounded by `max_s`.
 
     A fixed read window is wrong in both directions: it truncates a reply that
@@ -1622,6 +1633,13 @@ def _read_until_idle(read_fn, idle_s: float, max_s: float,
             break
         chunk = read_fn()
         if chunk:
+            # #896: hand each chunk to the caller AS IT ARRIVES. Buffering the
+            # whole reply until idle means a slow multi-line response shows
+            # nothing for seconds and then dumps -- the user loses any sign the
+            # command is still working. `send` streamed before this refactor and
+            # must keep doing so.
+            if on_chunk is not None:
+                on_chunk(chunk)
             if first_byte_at is None:
                 # #851: time-to-first-byte separates "slow to START answering"
                 # from "answered at length". They have different causes and the
@@ -1640,6 +1658,64 @@ def _read_until_idle(read_fn, idle_s: float, max_s: float,
         stats["first_byte_s"] = (None if first_byte_at is None
                                  else round(first_byte_at - base, 4))
     return bytes(buf)
+
+
+def _timed_send(cmd: str, send_fn, now_fn=time.time) -> dict:
+    """Execute ONE command through `send_fn`, time it, redact it, classify it.
+
+    Shared by `send` (#896) and `send-batch` (#850/#851) so there is exactly one
+    timing implementation. Two copies drift, and the copy that drifts is the one
+    that lies about the number you are trying to measure.
+
+    `send_fn(cmd)` returns raw bytes, or a TransportReply when the transport can
+    also report time-to-first-byte.
+
+    Returns {command, reply, answered, empty_reply, elapsed_s, first_byte_s,
+             reply_bytes, [error]}.
+
+    `answered` is a TRANSPORT question -- did the device respond at all -- and
+    `empty_reply` carries the answered-but-blank case separately. Collapsing
+    them turns a valid quiet reply into a phantom failure and hides #764's
+    shape, which is a handler matching a key and writing nothing.
+    """
+    row = {"command": cmd, "reply": "", "answered": False, "empty_reply": False,
+           "elapsed_s": None, "first_byte_s": None, "reply_bytes": 0}
+
+    started = now_fn()
+    try:
+        result = send_fn(cmd)
+    except Exception as e:
+        row["elapsed_s"] = round(now_fn() - started, 4)
+        row["error"] = f"{type(e).__name__}: {e}"
+        return row
+
+    row["elapsed_s"] = round(now_fn() - started, 4)
+
+    # Timing arrives ONLY via the explicit TransportReply type. Accepting any
+    # 2-tuple would silently record an unrelated second element as a latency.
+    if isinstance(result, TransportReply):
+        raw, row["first_byte_s"] = result.data, result.first_byte_s
+    elif isinstance(result, (bytes, bytearray)):
+        raw = result
+    elif isinstance(result, tuple) and result and isinstance(result[0], (bytes, bytearray)):
+        raw = result[0]
+    else:
+        # This path is shared by `send` and `send-batch`, so a bad transport
+        # would crash both. A str used to reach the redactor and raise
+        # TypeError from inside the timing code, which is the worst place to
+        # discover it.
+        row["error"] = (f"transport returned {type(result).__name__}, expected "
+                        f"bytes or TransportReply")
+        return row
+
+    raw = raw or b""
+    row["reply_bytes"] = len(raw)
+    redactor = _ReplyRedactor(secret=_is_secret_command(cmd))
+    text = redactor.feed(raw) + redactor.flush()
+    row["reply"] = text
+    row["answered"] = len(raw) > 0
+    row["empty_reply"] = row["answered"] and not text.strip()
+    return row
 
 
 def _run_batch(commands, send_fn, read_time: float = 5.0, now_fn=time.time):
@@ -1675,10 +1751,10 @@ def _run_batch(commands, send_fn, read_time: float = 5.0, now_fn=time.time):
     consecutive_failures = 0
     aborted = False
     for cmd in commands:
-        row = {"command": cmd, "reply": "", "answered": False, "empty_reply": False,
-               "elapsed_s": None, "first_byte_s": None, "reply_bytes": 0}
-
         if aborted:
+            row = {"command": cmd, "reply": "", "answered": False,
+                   "empty_reply": False, "elapsed_s": None,
+                   "first_byte_s": None, "reply_bytes": 0}
             # The port is gone. Retrying 40 more times produces 40 identical
             # exceptions after a long wait and tells nobody anything new.
             # elapsed_s stays None: this command was never attempted, and a
@@ -1687,42 +1763,16 @@ def _run_batch(commands, send_fn, read_time: float = 5.0, now_fn=time.time):
             rows.append(row)
             continue
 
-        started = now_fn()
-        try:
-            result = send_fn(cmd)
-        except Exception as e:
-            row["elapsed_s"] = round(now_fn() - started, 4)
-            row["error"] = f"{type(e).__name__}: {e}"
+        row = _timed_send(cmd, send_fn, now_fn=now_fn)
+
+        if "error" in row:
             consecutive_failures += 1
             if consecutive_failures >= _BATCH_ABORT_AFTER:
                 aborted = True
                 row["aborted_here"] = True
-            rows.append(row)
-            continue
-
-        consecutive_failures = 0
-        row["elapsed_s"] = round(now_fn() - started, 4)
-        # A transport may report time-to-first-byte alongside the data, but ONLY
-        # via the explicit TransportReply type. Accepting any 2-tuple would
-        # silently record an unrelated second element as a latency.
-        if isinstance(result, TransportReply):
-            raw, row["first_byte_s"] = result.data, result.first_byte_s
-        elif isinstance(result, (bytes, bytearray)):
-            raw = result
         else:
-            raw = result[0] if isinstance(result, tuple) and result else result
-        raw = raw or b""
-        row["reply_bytes"] = len(raw)
-        redactor = _ReplyRedactor(secret=_is_secret_command(cmd))
-        text = redactor.feed(raw) + redactor.flush()
-        row["reply"] = text
-        # `answered` is a TRANSPORT question: did the device respond at all?
-        # Whether the response had content is a separate, and different,
-        # finding -- a reply of "\r\n" is answered-but-empty, which is #764's
-        # shape. Collapsing the two turns a valid quiet reply into a phantom
-        # failure, and hides the defect the sweep exists to catch.
-        row["answered"] = len(raw) > 0
-        row["empty_reply"] = row["answered"] and not text.strip()
+            consecutive_failures = 0
+
         rows.append(row)
     return rows
 
@@ -1766,30 +1816,52 @@ def cmd_send(args, registry):
             except Exception:
                 pass
 
-            s.write((args.command + "\r").encode("utf-8"))
-            s.flush()
+            # #896: one timing path, shared with send-batch. Reads until the
+            # device goes idle rather than burning a fixed window -- a fast
+            # command must report milliseconds, not the read timeout.
+            # Streams redacted output live, exactly as this subcommand did
+            # before timing was added. The redactor here works from the raw
+            # chunks; _timed_send redacts the same raw bytes independently for
+            # the recorded row, so nothing is redacted twice.
+            live = _ReplyRedactor(secret=_is_secret_command(args.command))
 
-            deadline = time.time() + args.read_time
-            captured = bytearray()
-            # #849: never write raw device bytes to stdout. Buffer to line
-            # boundaries and redact first -- a secret can straddle two reads.
-            redactor = _ReplyRedactor(secret=_is_secret_command(args.command))
-            while time.time() < deadline:
-                data = s.read(1024)
-                if data:
-                    captured.extend(data)
-                    text = redactor.feed(data)
-                    if text:
-                        sys.stdout.write(text)
-                        sys.stdout.flush()
+            def _emit(chunk: bytes) -> None:
+                text = live.feed(chunk)
+                if text:
+                    sys.stdout.write(text)
+                    sys.stdout.flush()
 
-            tail = redactor.flush()
+            def transport(cmd: str) -> TransportReply:
+                origin = time.time()          # the command starts HERE
+                s.write((cmd + "\r").encode("utf-8"))
+                s.flush()
+                st = {}
+                data = _read_until_idle(lambda: s.read(1024),
+                                        idle_s=args.idle_time,
+                                        max_s=args.read_time,
+                                        stats=st, origin=origin,
+                                        on_chunk=_emit)
+                return TransportReply(data=data, first_byte_s=st.get("first_byte_s"))
+
+            row = _timed_send(args.command, transport)
+
+            tail = live.flush()
             if tail:
                 sys.stdout.write(tail)
-                sys.stdout.flush()
-
-            if captured and not bytes(captured).endswith(b"\n"):
+            if row["reply"] and not row["reply"].endswith("\n"):
                 print()
+            sys.stdout.flush()
+
+            status = "no reply" if not row["answered"] else (
+                "answered but EMPTY" if row["empty_reply"] else "ok")
+            fb = "" if row["first_byte_s"] is None else \
+                 f", first byte {row['first_byte_s']:.3f}s"
+            out(f"[{status}] {row['elapsed_s']:.3f}s{fb}, {row['reply_bytes']} bytes")
+            if "error" in row:
+                out(f"  error: {row['error']}")
+            if args.json_out:
+                Path(args.json_out).write_text(json.dumps(row, indent=2), encoding="utf-8")
+                out(f"wrote {args.json_out}")
     except Exception as e:
         refuse(f"serial send failed on {port['com']}: {e}")
 
@@ -2648,7 +2720,12 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("command", help="text command to send (CR is auto-appended)")
     s.add_argument("--baud", type=int, default=115200)
     s.add_argument("--read-time", type=float, default=5.0,
-                   help="seconds to read response after sending (default 5)")
+                   help="hard cap on the read (default 5)")
+    s.add_argument("--idle-time", type=float, default=SEND_IDLE_DEFAULT,
+                   help=f"return once the device has been quiet this long "
+                        f"(default {SEND_IDLE_DEFAULT}; raise it for a command "
+                        f"that prints in stages)")
+    s.add_argument("--json-out", help="write the timed result here")
 
     s = sub.add_parser("send-batch",
                        help="send N read-only `get` commands over one open port (Tier B)")
@@ -2658,8 +2735,9 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("--baud", type=int, default=115200)
     s.add_argument("--read-time", type=float, default=3.0,
                    help="hard cap on the read for each command (default 3)")
-    s.add_argument("--idle-time", type=float, default=0.25,
-                   help="return once the device has been quiet this long (default 0.25)")
+    s.add_argument("--idle-time", type=float, default=BATCH_IDLE_DEFAULT,
+                   help=f"return once the device has been quiet this long "
+                        f"(default {BATCH_IDLE_DEFAULT})")
     s.add_argument("--json-out", help="write structured per-command results here")
 
     s = sub.add_parser("info", help="meshtastic --info (Tier B)")

--- a/scripts/test_cli_sweep.py
+++ b/scripts/test_cli_sweep.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Tests for the CLI surface sweep (#852).
+
+Pure. No serial port, no device, no `pio-flash` invocation.
+
+The sweep is split into two testable halves with the human-approved
+`pio-flash send-batch` run in between:
+
+    enumerate_keys(source)  ->  commands file  ->  [operator runs pio-flash]
+                                                   ->  analyse(rows)  ->  findings
+
+That split is deliberate. The sweep does NOT invoke `pio-flash` itself: the
+flash discipline is one human approval per RUN of that tool, and a wrapper that
+shells out to it hides the run behind another layer. The operator issues the
+run and sees it.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import cli_sweep
+
+
+# ------------------------------------------------- enumeration, from source ---
+# Hand-listing is exactly how `radio`, `agc.reset.interval` and `pwrmgt.bootmv`
+# spent ten months returning empty replies while everyone assumed the surface
+# was covered. The key list must come from the source every run.
+
+SAMPLE = '''
+void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* reply) {
+  const char* config = &command[4];
+  if (isKey(config, "dutycycle")) {
+    sprintf(reply, "> %d", dc);
+  } else if (isKey(config, "radio")) {
+    sprintf(reply, "> %s", freq);
+  } else if (memcmp(config, "extra.sf", 8) == 0) {
+    sprintf(reply, "> %d", sf);
+  } else if (sender_timestamp == 0 && isKey(config, "prv.key")) {
+    sprintf(reply, "> %s", key);
+  } else {
+    sprintf(reply, "??: %s", config);
+  }
+}
+
+void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* reply) {
+  const char* config = &command[4];
+  if (memcmp(config, "freq ", 5) == 0) {
+    strcpy(reply, "ok");
+  } else if (isKey(config, "name")) {
+    strcpy(reply, "ok");
+  }
+}
+'''
+
+
+def test_get_keys_are_found_regardless_of_matcher():
+    gets, _ = cli_sweep.enumerate_keys(SAMPLE)
+    assert "dutycycle" in gets
+    assert "radio" in gets
+    assert "extra.sf" in gets, "memcmp arms must be enumerated too, not just isKey"
+
+
+def test_set_keys_are_separated_from_get_keys():
+    gets, sets = cli_sweep.enumerate_keys(SAMPLE)
+    assert "name" in sets
+    assert "freq" in sets, "trailing space in the matcher must be stripped"
+    assert "name" not in gets
+
+
+def test_serial_only_keys_are_still_enumerated():
+    """`get prv.key` is gated on sender_timestamp == 0, which is the serial
+    path -- exactly the path this sweep uses. It must not be skipped."""
+    gets, _ = cli_sweep.enumerate_keys(SAMPLE)
+    assert "prv.key" in gets
+
+
+def test_the_fallback_marker_is_not_mistaken_for_a_key():
+    gets, _ = cli_sweep.enumerate_keys(SAMPLE)
+    assert not any("??" in k for k in gets), gets
+
+
+def test_commands_are_emitted_one_per_line_with_the_get_verb():
+    cmds = cli_sweep.build_commands(["radio", "name"])
+    assert cmds == ["get radio", "get name"], cmds
+
+
+# --------------------------------------------------------------- analysis ---
+
+def row(cmd, reply="> x", answered=True, empty=False, elapsed=0.05, **kw):
+    r = {"command": cmd, "reply": reply, "answered": answered,
+         "empty_reply": empty, "elapsed_s": elapsed, "first_byte_s": None,
+         "reply_bytes": len(reply)}
+    r.update(kw)
+    return r
+
+
+def test_a_healthy_reply_produces_no_finding():
+    f = cli_sweep.analyse([row("get radio", "> 910.525,62.5,7,5")])
+    assert f == [], f
+
+
+def test_an_empty_reply_is_the_headline_finding():
+    """#764's exact shape: the handler matched the key and wrote nothing."""
+    f = cli_sweep.analyse([row("get radio", reply="", answered=True, empty=True)])
+    assert len(f) == 1 and f[0]["kind"] == "empty-reply", f
+
+
+def test_a_timeout_is_reported_separately_from_an_empty_reply():
+    """Different failures. One is a broken handler, the other is a device that
+    never answered -- conflating them destroys the diagnosis."""
+    f = cli_sweep.analyse([row("get radio", reply="", answered=False, elapsed=3.0)])
+    assert len(f) == 1 and f[0]["kind"] == "no-reply", f
+
+
+def test_an_unknown_key_fallback_is_a_finding_for_a_REAL_key():
+    """A key enumerated from source that comes back `??:` means the dispatch
+    does not match what the source says -- which is #657's shape."""
+    f = cli_sweep.analyse([row("get radio", reply="??: radio")])
+    assert len(f) == 1 and f[0]["kind"] == "unknown-key", f
+
+
+def test_a_junk_suffix_probe_EXPECTS_the_fallback():
+    """`get radioX` must reach `??:`. Getting a real value back is the
+    prefix-match defect (#764's `cad`/`extra.sf` half), so the expectation is
+    inverted for probes."""
+    ok = cli_sweep.analyse([row("get radioX", reply="??: radioX", probe=True)])
+    assert ok == [], ok
+    bad = cli_sweep.analyse([row("get cadfoo", reply="> off", probe=True)])
+    assert len(bad) == 1 and bad[0]["kind"] == "prefix-match", bad
+
+
+def test_non_printable_bytes_in_a_reply_are_a_finding():
+    """The reported symptom was mojibake -- uninitialised stack on the wire."""
+    f = cli_sweep.analyse([row("get radio", reply="> \x01\x02")])
+    assert len(f) == 1 and f[0]["kind"] == "non-printable", f
+
+
+def test_a_redacted_secret_reply_is_healthy_not_a_finding():
+    """Redaction must not read as a defect. #849 redacts at source, so the
+    sweep sees the marker and has to treat it as a normal answer."""
+    f = cli_sweep.analyse([row("get prv.key", reply="> <redacted:cli-reply:64>")])
+    assert f == [], f
+
+
+def test_a_slow_key_is_surfaced_with_its_time():
+    f = cli_sweep.analyse([row("get radio", elapsed=4.5)], slow_s=1.0)
+    assert len(f) == 1 and f[0]["kind"] == "slow", f
+    assert "4.5" in str(f[0]["detail"]), f
+
+
+def test_every_finding_names_its_command():
+    f = cli_sweep.analyse([row("get agc.reset.interval", reply="", empty=True)])
+    assert f[0]["command"] == "get agc.reset.interval", f
+
+
+# ===========================================================================
+# Gemini review follow-ups (#852)
+# ===========================================================================
+
+def test_unbalanced_braces_fail_closed_not_open():
+    """If brace matching runs off the end of the file, returning the tail would
+    make the sweep enumerate keys from unrelated functions -- inventing keys.
+    Fail closed instead."""
+    broken = '''
+void CommonCLI::handleGetCmd(uint32_t t, char* command, char* reply) {
+  if (isKey(config, "radio")) { sprintf(reply, "x");
+// missing closing brace
+
+void SomethingElse::other() {
+  if (isKey(config, "not_a_cli_key")) { }
+}
+'''
+    gets, _ = cli_sweep.enumerate_keys(broken)
+    assert "not_a_cli_key" not in gets, gets
+
+
+def test_zero_keys_is_an_error_not_an_empty_sweep():
+    """A renamed function or a moved dispatch chain would yield no keys. Emitting
+    an empty command list would report a clean sweep having tested nothing --
+    the exact silent no-op this whole effort exists to eliminate."""
+    try:
+        cli_sweep.enumerate_keys("void Unrelated::thing() { }", require_keys=True)
+    except cli_sweep.NoKeysFound:
+        pass
+    else:
+        assert False, "expected NoKeysFound"
+
+
+def test_probes_are_deduplicated_by_root():
+    """One probe per prefix root, not one per key. 47 keys would otherwise
+    double the run to 94 commands for no extra coverage: `radio` and
+    `radio.rxgain` share a root, so probing both tests the same arm twice."""
+    probes = cli_sweep.build_probes(["radio", "radio.rxgain", "radio.fem.rxgain", "cad"])
+    roots = {p.split()[1].rstrip("X").split(".")[0] for p in probes}
+    assert roots == {"radio", "cad"}, probes
+    assert len(probes) == 2, probes
+
+
+def test_a_fallback_reply_is_not_redacted_so_unknown_key_stays_visible():
+    """Guards a real coupling. If a `??:` reply were ever redacted, an
+    unknown-key failure would read as a healthy answer and the sweep would
+    report a broken key as working. Verified against the shared redactor rather
+    than assumed."""
+    import log_redact
+    for s in ("??: prv.key", "??: guest.password", "??: bridge.secret"):
+        assert log_redact.redact_line(s) == s, (s, log_redact.redact_line(s))
+
+
+def test_a_redacted_fallback_would_still_be_caught_if_it_ever_happened():
+    """Belt and braces for the above: even if redaction one day swallowed a
+    fallback, the analyser should not silently pass it."""
+    f = cli_sweep.analyse([{
+        "command": "get prv.key", "reply": "??: <redacted:cli-reply:8>",
+        "answered": True, "empty_reply": False, "elapsed_s": 0.05, "reply_bytes": 26,
+    }])
+    assert any(x["kind"] == "unknown-key" for x in f), f
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"FAIL {name}: {e}")
+            except Exception as e:
+                failures += 1
+                print(f"ERROR {name}: {type(e).__name__}: {e}")
+    print(f"\n{failures} failure(s)")
+    sys.exit(1 if failures else 0)

--- a/scripts/test_cli_sweep.py
+++ b/scripts/test_cli_sweep.py
@@ -87,9 +87,12 @@ def test_commands_are_emitted_one_per_line_with_the_get_verb():
 # --------------------------------------------------------------- analysis ---
 
 def row(cmd, reply="> x", answered=True, empty=False, elapsed=0.05, **kw):
+    # round_trip_s mirrors elapsed_s here because a real row carries BOTH, and
+    # slow-detection reads round_trip_s -- elapsed_s includes the tool's own
+    # idle wait (#896) and would flag every command on a loose --idle-time.
     r = {"command": cmd, "reply": reply, "answered": answered,
-         "empty_reply": empty, "elapsed_s": elapsed, "first_byte_s": None,
-         "reply_bytes": len(reply)}
+         "empty_reply": empty, "elapsed_s": elapsed, "round_trip_s": elapsed,
+         "first_byte_s": None, "reply_bytes": len(reply)}
     r.update(kw)
     return r
 
@@ -214,6 +217,45 @@ def test_a_redacted_fallback_would_still_be_caught_if_it_ever_happened():
         "answered": True, "empty_reply": False, "elapsed_s": 0.05, "reply_bytes": 26,
     }])
     assert any(x["kind"] == "unknown-key" for x in f), f
+
+
+
+def test_a_noisy_capture_voids_its_own_timings_loudly():
+    """Adversarial review, HIGH: last-byte advances on ANY input, so an
+    unrelated log line is charged to whatever command was in flight. On ST-P
+    that produced a 0.17-17.2s spread unrelated to command latency. A run whose
+    timings are void must SAY so, not suppress silently."""
+    # TWO rows, not one: interleaving from a chattering device is systemic
+    # (79/79 on ST-P). A single log-carrying reply is a legitimate answer and
+    # must not void a run -- see the companion test below.
+    noisy = [row("get radio", reply="[472110][E][Pref.cpp:483] x  -> > 0.5",
+                 elapsed=9.0),
+             row("get tx", reply="[472118][E][Pref.cpp:483] y  -> > 22",
+                 elapsed=7.0)]
+    f = cli_sweep.analyse(noisy, slow_s=1.0)
+    kinds = {x["kind"] for x in f}
+    assert "timings-void" in kinds, f
+    assert "slow" not in kinds, "slow-detection must be disabled on a noisy run"
+
+
+def test_a_quiet_capture_still_reports_slow_commands():
+    """The guard must not disable slow-detection on a clean run."""
+    r = row("get radio", reply="> 910.525", elapsed=4.5)
+    r["round_trip_s"] = 4.5
+    f = cli_sweep.analyse([r], slow_s=1.0)
+    assert {x["kind"] for x in f} == {"slow"}, f
+
+
+
+def test_ONE_reply_containing_a_log_line_does_not_void_the_run():
+    """MEDIUM, second-pass review. `get last_error` can legitimately return a
+    stored log line. Voiding a whole run's timings on a single such reply would
+    suppress real slow findings. Interleaving is SYSTEMIC, never exactly one."""
+    r = row("get last_error", reply="> [12345][E][radio.cpp:55] TX failed", elapsed=4.5)
+    f = cli_sweep.analyse([r], slow_s=1.0)
+    kinds = {x["kind"] for x in f}
+    assert "timings-void" not in kinds, f
+    assert "slow" in kinds, "a real slow finding was suppressed"
 
 
 if __name__ == "__main__":

--- a/scripts/test_pio_flash_batch_latency.py
+++ b/scripts/test_pio_flash_batch_latency.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Tests for per-command latency capture in batch runs (#851).
+
+Pure. No serial port, no device. Timing is driven by an injected clock so the
+assertions are exact rather than flaky.
+
+WHY THIS EXISTS, in the owner's words: CLI responses over the client path are
+slow to return, sometimes never return, and handling is spotty. Client-side work
+has been done and the owner is not convinced it is client-side only.
+
+Nobody can currently answer that, because nothing measures it. A serial baseline
+settles it: if the firmware answers every key promptly over the console while the
+over-the-air path is slow or lossy, the fault is in the transport or the client.
+If serial is also slow on particular keys, it is ours.
+"""
+import os
+import sys
+import importlib.util
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "pio_flash", os.path.join(os.path.dirname(os.path.abspath(__file__)), "pio-flash.py"))
+pio_flash = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pio_flash)
+
+
+class Clock:
+    def __init__(self): self.t = 0.0
+    def __call__(self): return self.t
+    def advance(self, d): self.t += d
+
+
+# ------------------------------------------------------------- basic timing ---
+
+def test_every_command_records_elapsed_time():
+    clock = Clock()
+    def transport(cmd):
+        clock.advance(0.4 if cmd == "get slow" else 0.05)
+        return b"> ok\r\n"
+    rows = pio_flash._run_batch(["get fast", "get slow"], transport,
+                                read_time=3, now_fn=clock)
+    assert rows[0]["elapsed_s"] == 0.05, rows[0]
+    assert rows[1]["elapsed_s"] == 0.4, rows[1]
+
+
+def test_a_slow_key_is_distinguishable_from_a_fast_one():
+    """The entire point: which key is slow, not just that something is."""
+    clock = Clock()
+    def transport(cmd):
+        clock.advance({"get a": 0.02, "get b": 1.5, "get c": 0.03}[cmd])
+        return b"> ok\r\n"
+    rows = pio_flash._run_batch(["get a", "get b", "get c"], transport,
+                                read_time=3, now_fn=clock)
+    slowest = max(rows, key=lambda r: r["elapsed_s"])
+    assert slowest["command"] == "get b", rows
+
+
+# ------------------------------------------- timeout vs answered-but-empty ---
+# These are DIFFERENT failures and conflating them destroys the diagnosis.
+# "answered with nothing" is #764's shape. "never answered" is the owner's
+# symptom. Both must be visible, and both must carry timing.
+
+def test_a_command_that_never_answers_still_records_its_elapsed_time():
+    clock = Clock()
+    def transport(cmd):
+        clock.advance(3.0)          # burned the full cap
+        return b""
+    rows = pio_flash._run_batch(["get gone"], transport, read_time=3, now_fn=clock)
+    assert rows[0]["answered"] is False, rows[0]
+    assert rows[0]["elapsed_s"] == 3.0, rows[0]
+
+
+def test_timeout_and_empty_reply_are_separately_visible():
+    clock = Clock()
+    def transport(cmd):
+        clock.advance(0.05)
+        return b"\r\n" if cmd == "get quiet" else b""
+    rows = pio_flash._run_batch(["get quiet", "get gone"], transport,
+                                read_time=3, now_fn=clock)
+    quiet, gone = rows
+    assert (quiet["answered"], quiet["empty_reply"]) == (True, True), quiet
+    assert (gone["answered"], gone["empty_reply"]) == (False, False), gone
+
+
+# ------------------------------------------------------------- first byte ---
+
+def test_first_byte_latency_is_recorded_when_the_transport_reports_it():
+    """Updated after review: the transport reports timing via the explicit
+    TransportReply type, not a bare tuple. See
+    test_a_bare_tuple_is_not_mistaken_for_timing_data for why."""
+    """Time-to-first-byte separates 'the device was slow to start answering'
+    from 'the device answered at length'. A transport may return
+    (data, first_byte_s); one that returns plain bytes still works."""
+    def transport(cmd):
+        return pio_flash.TransportReply(data=b"> ok\r\n", first_byte_s=0.12)
+    rows = pio_flash._run_batch(["get x"], transport, read_time=3)
+    assert rows[0]["first_byte_s"] == 0.12, rows[0]
+    assert rows[0]["answered"] is True
+
+
+def test_a_plain_bytes_transport_still_works_and_reports_no_first_byte():
+    rows = pio_flash._run_batch(["get x"], lambda c: b"> ok\r\n", read_time=3)
+    assert rows[0]["answered"] is True
+    assert rows[0]["first_byte_s"] is None, rows[0]
+
+
+# ---------------------------------------------------- timing survives redaction ---
+
+def test_a_redacted_secret_reply_still_reports_true_timing_and_length():
+    """Redaction must not cost the measurement. #852 asserts a secret key
+    ANSWERED and how long it took, without recording what it said."""
+    clock = Clock()
+    def transport(cmd):
+        clock.advance(0.33)
+        return b"> deadbeefcafe\r\n"
+    rows = pio_flash._run_batch(["get prv.key"], transport, read_time=3, now_fn=clock)
+    r = rows[0]
+    assert "deadbeef" not in r["reply"], r
+    assert r["elapsed_s"] == 0.33, r
+    assert r["answered"] is True
+    assert r["reply_bytes"] == 16, r
+
+
+# ------------------------------------------------------------------ skipped ---
+
+def test_skipped_rows_carry_no_timing():
+    """A command that was never attempted must not report a duration -- a zero
+    there would read as 'answered instantly' in any summary."""
+    def dead(cmd):
+        raise OSError("gone")
+    rows = pio_flash._run_batch([f"get k{i}" for i in range(8)], dead, read_time=3)
+    skipped = [r for r in rows if r.get("skipped")]
+    assert skipped, "expected an abort"
+    assert all(r.get("elapsed_s") is None for r in skipped), skipped[0]
+
+
+# ===========================================================================
+# Gemini review follow-ups (#851). Two were real measurement defects.
+# ===========================================================================
+
+def test_transport_reply_is_an_explicit_type_not_a_bare_tuple():
+    """`isinstance(result, tuple)` was a weak contract: any 2-tuple returned for
+    an unrelated reason would be silently unpacked as timing data. An explicit
+    type cannot be hit by accident."""
+    r = pio_flash.TransportReply(data=b"> ok\r\n", first_byte_s=0.07)
+    rows = pio_flash._run_batch(["get x"], lambda c: r, read_time=3)
+    assert rows[0]["first_byte_s"] == 0.07, rows[0]
+    assert rows[0]["answered"] is True
+
+
+def test_a_bare_tuple_is_not_mistaken_for_timing_data():
+    """A transport returning (data, status) for some other purpose must not have
+    its second element silently recorded as a latency."""
+    rows = pio_flash._run_batch(["get x"], lambda c: (b"> ok\r\n", "some-status"),
+                                read_time=3)
+    assert rows[0]["first_byte_s"] is None, rows[0]
+
+
+def test_first_byte_is_measured_from_the_same_origin_as_elapsed():
+    """Both timers must start when the command starts. Measuring first-byte from
+    AFTER the write/flush leaves the two figures uncorrelatable -- you cannot say
+    where the time went, which is the only reason to collect them."""
+    clock = Clock()
+    state = {}
+
+    def timed(cmd):
+        state["t0"] = clock()
+        clock.advance(0.10)                       # write + flush
+        first = round(clock() - state["t0"], 4)   # relative to command start
+        clock.advance(0.40)                       # reply streams in
+        return pio_flash.TransportReply(data=b"> ok\r\n", first_byte_s=first)
+
+    rows = pio_flash._run_batch(["get x"], timed, read_time=3, now_fn=clock)
+    r = rows[0]
+    assert r["elapsed_s"] == 0.5, r
+    assert r["first_byte_s"] == 0.10, r
+    assert r["first_byte_s"] <= r["elapsed_s"], "first byte cannot follow completion"
+
+
+def test_read_until_idle_anchors_first_byte_to_a_supplied_origin():
+    """So the caller can anchor it to the moment the command was written, rather
+    than to whenever the read loop happened to start."""
+    clock = Clock()
+    seq = [b"", b"", b"> hi\r\n", b"", b"", b"", b"", b""]
+
+    def read_fn():
+        clock.advance(0.01)
+        return seq.pop(0) if seq else b""
+
+    st = {}
+    origin = clock() - 0.20          # pretend the write happened 0.20s ago
+    pio_flash._read_until_idle(read_fn, idle_s=0.05, max_s=5.0,
+                               now_fn=clock, sleep_fn=lambda d: None,
+                               stats=st, origin=origin)
+    assert abs(st["first_byte_s"] - 0.23) < 0.001, st
+
+
+def test_first_byte_granularity_is_declared():
+    """The read loop can only notice data when a blocking read returns, so
+    first_byte_s carries an error of up to one read timeout. Consumers must be
+    able to discover that rather than over-trusting the number."""
+    assert isinstance(pio_flash.FIRST_BYTE_GRANULARITY_NOTE, str)
+    assert "granularity" in pio_flash.FIRST_BYTE_GRANULARITY_NOTE.lower()
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"FAIL {name}: {e}")
+            except Exception as e:
+                failures += 1
+                print(f"ERROR {name}: {type(e).__name__}: {e}")
+    print(f"\n{failures} failure(s)")
+    sys.exit(1 if failures else 0)

--- a/scripts/test_pio_flash_send_batch.py
+++ b/scripts/test_pio_flash_send_batch.py
@@ -238,6 +238,90 @@ def test_empty_content_is_still_visible_as_a_finding():
     assert rows[0]["empty_reply"] is True, rows[0]
 
 
+
+# =========================================================================
+# Port-open settle (found on ST-P, an ESP32-S3)
+#
+# Opening a serial port asserts DTR/RTS and REBOOTS an ESP32. The batch path
+# allowed 0.2s, which was only ever adequate because the first board tested
+# was an nRF52 that does not reboot on open. On ESP32 the first commands land
+# mid-boot and answer empty or garbled -- the #764 signature -- so the sweep
+# would have reported false defects indistinguishable from real ones.
+# =========================================================================
+
+class _FakeClock:
+    """Controllable time. Real sleeps would make these tests take 12 seconds."""
+
+    def __init__(self):
+        self.t = 0.0
+
+    def now(self):
+        return self.t
+
+    def sleep(self, d):
+        self.t += d
+
+
+def test_settle_waits_out_a_boot_banner_before_returning():
+    """A device that chatters on open is booting. Do not send into that."""
+    clk = _FakeClock()
+    chunks = [b"ESP-ROM:esp32s3", b"boot: loading app", b"MeshCore v1.16", b"", b"", b""]
+
+    def read():
+        clk.t += 0.1
+        return chunks.pop(0) if chunks else b""
+
+    got = pio_flash._await_device_ready(read, quiet_s=0.6, grace_s=1.0,
+                                        max_s=12.0, now_fn=clk.now,
+                                        sleep_fn=clk.sleep)
+    assert b"ESP-ROM" in got and b"MeshCore" in got, got
+    assert clk.t >= 0.6, "returned before the device went quiet"
+
+
+def test_settle_returns_fast_when_the_board_is_already_up():
+    """A silent board must not cost the full 12s window every run. This is why
+    it is not _read_until_idle, which waits for a first byte for the whole
+    window and would burn max_s on every quiet device."""
+    clk = _FakeClock()
+
+    def read():
+        clk.t += 0.01
+        return b""
+
+    got = pio_flash._await_device_ready(read, quiet_s=0.6, grace_s=1.0,
+                                        max_s=12.0, now_fn=clk.now,
+                                        sleep_fn=clk.sleep)
+    assert got == b"", got
+    assert clk.t < 2.0, f"silent board burned {clk.t}s; grace is 1.0s"
+
+
+def test_settle_is_bounded_when_the_device_never_stops_chattering():
+    """A board in a boot loop would otherwise hang the run forever."""
+    clk = _FakeClock()
+
+    def read():
+        clk.t += 0.1
+        return b"rst:0x3 PANIC "
+
+    pio_flash._await_device_ready(read, quiet_s=0.6, grace_s=1.0, max_s=5.0,
+                                  now_fn=clk.now, sleep_fn=clk.sleep)
+    assert clk.t <= 5.5, f"ran {clk.t}s past a 5.0s bound"
+
+
+def test_settle_returns_the_banner_rather_than_discarding_it():
+    """The drained bytes are evidence that a reset happened. Dropping them
+    silently would hide the very behaviour that broke the ESP32 run."""
+    clk = _FakeClock()
+    chunks = [b"rst:0x1 (POWERON)", b"", b"", b""]
+
+    def read():
+        clk.t += 0.2
+        return chunks.pop(0) if chunks else b""
+
+    got = pio_flash._await_device_ready(read, now_fn=clk.now, sleep_fn=clk.sleep)
+    assert got == b"rst:0x1 (POWERON)", got
+
+
 if __name__ == "__main__":
     failures = 0
     for name, fn in sorted(globals().items()):

--- a/scripts/test_pio_flash_send_batch.py
+++ b/scripts/test_pio_flash_send_batch.py
@@ -322,6 +322,27 @@ def test_settle_returns_the_banner_rather_than_discarding_it():
     assert got == b"rst:0x1 (POWERON)", got
 
 
+
+def test_settle_grace_covers_a_silent_boot_stage():
+    """Adversarial review, HIGH: silence is AMBIGUOUS -- an already-booted board
+    and a board in a silent boot stage look identical. At a 1.0s grace an ESP32
+    whose banner had not started yet was declared ready, and command 1 collided
+    with the banner, returning empty -- indistinguishable from #764."""
+    assert pio_flash.SETTLE_GRACE_S >= 3.0, pio_flash.SETTLE_GRACE_S
+    clk = _FakeClock()
+    chunks = [b""] * 25 + [b"ESP-ROM:esp32s3", b"", b"", b""]
+
+    def read():
+        clk.t += 0.1
+        return chunks.pop(0) if chunks else b""
+
+    got = pio_flash._await_device_ready(read, quiet_s=0.6,
+                                        grace_s=pio_flash.SETTLE_GRACE_S,
+                                        max_s=12.0, now_fn=clk.now,
+                                        sleep_fn=clk.sleep)
+    assert b"ESP-ROM" in got, "banner after 2.5s of silence was missed"
+
+
 if __name__ == "__main__":
     failures = 0
     for name, fn in sorted(globals().items()):

--- a/scripts/test_pio_flash_send_batch.py
+++ b/scripts/test_pio_flash_send_batch.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Tests for `pio-flash send-batch` (#850).
+
+Pure. No serial port, no device, no flashing. The batch core takes an injected
+transport so the sequencing, classification and fail-soft behaviour can be
+tested without hardware.
+
+Why batch exists: `send` is one command per run, and the flash discipline is one
+human approval per run of the tool. Sweeping the CLI surface is 47 `get` keys
+(#852), so at one approval each it costs 47 approvals and therefore never gets
+run. The tool's granularity is what makes the work impossible, not the work.
+"""
+import os
+import sys
+import importlib.util
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "pio_flash", os.path.join(os.path.dirname(os.path.abspath(__file__)), "pio-flash.py"))
+pio_flash = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pio_flash)
+
+
+def fake(mapping, missing=b""):
+    """Transport stub: command -> raw bytes the device would emit."""
+    return lambda cmd: mapping.get(cmd, missing)
+
+
+# ------------------------------------------------------- read-only gating ---
+# The approval model exists because a wrong-device flash happened. Batch must
+# not become the way a config mutation gets scripted past a single approval.
+
+def test_get_commands_are_allowed():
+    for cmd in ("get radio", "get name", "get prv.key"):
+        assert pio_flash._is_read_only_command(cmd), cmd
+
+
+def test_set_commands_are_refused():
+    for cmd in ("set name foo", "set password hunter2", "set freq 910.5"):
+        assert not pio_flash._is_read_only_command(cmd), cmd
+
+
+def test_side_effecting_commands_are_refused():
+    """These change device state or transmit. A sweep has no business issuing
+    them, and one approval must not cover forty of them."""
+    for cmd in ("reboot", "advert", "erase", "start ota", "factory reset"):
+        assert not pio_flash._is_read_only_command(cmd), cmd
+
+
+def test_batch_refuses_the_whole_run_if_any_command_mutates():
+    """Refuse up front, not halfway through. A partially-executed batch is the
+    worst outcome: some state changed, and the operator approved none of it."""
+    try:
+        pio_flash._run_batch(["get radio", "set name foo"], fake({}), read_time=0)
+    except pio_flash.BatchRefused as e:
+        assert "set name foo" in str(e), str(e)
+    else:
+        assert False, "expected the batch to be refused before sending anything"
+
+
+def test_nothing_is_sent_when_the_batch_is_refused():
+    sent = []
+    def spy(cmd):
+        sent.append(cmd)
+        return b"> ok\r\n"
+    try:
+        pio_flash._run_batch(["get radio", "reboot"], spy, read_time=0)
+    except pio_flash.BatchRefused:
+        pass
+    assert sent == [], f"commands were sent despite refusal: {sent}"
+
+
+# ------------------------------------------------------------- the results ---
+
+def test_every_command_gets_a_result_in_order():
+    rows = pio_flash._run_batch(
+        ["get radio", "get name"],
+        fake({"get radio": b"> 910.525,62.5,7,5\r\n", "get name": b"> Offband-T096-R\r\n"}),
+        read_time=0)
+    assert [r["command"] for r in rows] == ["get radio", "get name"]
+    assert rows[0]["reply"].strip() == "> 910.525,62.5,7,5"
+
+
+def test_ordinary_replies_are_not_redacted():
+    rows = pio_flash._run_batch(
+        ["get radio"], fake({"get radio": b"> 910.525,62.5,7,5\r\n"}), read_time=0)
+    assert "910.525,62.5,7,5" in rows[0]["reply"], rows[0]
+
+
+def test_secret_reply_is_redacted_but_still_recorded_as_answered():
+    """#852 needs to assert a secret key ANSWERED without recording what it
+    said. Redacted, non-empty, length preserved."""
+    rows = pio_flash._run_batch(
+        ["get prv.key"], fake({"get prv.key": b"> deadbeefcafe\r\n"}), read_time=0)
+    r = rows[0]
+    assert "deadbeef" not in r["reply"], r
+    assert "redacted" in r["reply"], r
+    assert r["answered"] is True, r
+
+
+def test_mixed_batch_redacts_only_the_secret_one():
+    rows = pio_flash._run_batch(
+        ["get prv.key", "get radio"],
+        fake({"get prv.key": b"> deadbeefcafe\r\n", "get radio": b"> 910.525,62.5,7,5\r\n"}),
+        read_time=0)
+    assert "deadbeef" not in rows[0]["reply"]
+    assert "910.525,62.5,7,5" in rows[1]["reply"]
+
+
+# --------------------------------------------------------------- fail-soft ---
+
+def test_a_silent_command_is_recorded_and_the_run_continues():
+    """An empty reply is a FINDING -- it is the #764 shape. It must be recorded
+    as answered=False, not dropped, and must not abort the remaining commands."""
+    rows = pio_flash._run_batch(
+        ["get radio", "get broken", "get name"],
+        fake({"get radio": b"> 910.525\r\n", "get name": b"> Offband\r\n"}, missing=b""),
+        read_time=0)
+    assert len(rows) == 3
+    assert rows[1]["answered"] is False
+    assert rows[2]["answered"] is True, "run must continue past a silent command"
+
+
+def test_a_transport_exception_does_not_discard_earlier_results():
+    """A device that stops responding mid-run must yield a partial result with
+    the failure recorded -- not an exception that throws away 40 good replies."""
+    def flaky(cmd):
+        if cmd == "get boom":
+            raise OSError("device went away")
+        return b"> ok\r\n"
+    rows = pio_flash._run_batch(["get a", "get boom", "get b"], flaky, read_time=0)
+    assert len(rows) == 3
+    assert rows[0]["answered"] is True
+    assert rows[1]["answered"] is False and "error" in rows[1], rows[1]
+    assert rows[2]["answered"] is True
+
+
+def test_unknown_key_fallback_is_recorded_as_answered():
+    """`??: cadfoo` IS a reply. Distinguishing it from silence is the whole
+    point -- one is correct behaviour, the other is a defect."""
+    rows = pio_flash._run_batch(
+        ["get cadfoo"], fake({"get cadfoo": b"??: cadfoo\r\n"}), read_time=0)
+    assert rows[0]["answered"] is True
+    assert "??:" in rows[0]["reply"]
+
+
+# ===========================================================================
+# Gemini review follow-ups (#850). Three of five findings were real.
+# ===========================================================================
+
+# --- read until idle, not for a fixed window -------------------------------
+# A fixed read window truncates a slow reply (falsely "unanswered") and burns
+# the full window on a fast one -- 47 keys x 2s = 94s of deliberate waiting.
+# It also makes #851 impossible: every command would report the same duration.
+
+class FakeClock:
+    def __init__(self): self.t = 0.0
+    def __call__(self): return self.t
+    def sleep(self, d): self.t += d
+
+
+def test_read_stops_after_idle_gap_rather_than_burning_the_window():
+    clock = FakeClock()
+    chunks = [b"> 910.525", b",62.5,7,5\r\n", b"", b"", b""]
+    def read_fn():
+        clock.sleep(0.01)
+        return chunks.pop(0) if chunks else b""
+    data = pio_flash._read_until_idle(read_fn, idle_s=0.05, max_s=10.0,
+                                      now_fn=clock, sleep_fn=clock.sleep)
+    assert data == b"> 910.525,62.5,7,5\r\n", data
+    assert clock.t < 1.0, f"should return on idle, not burn the window (t={clock.t})"
+
+
+def test_read_waits_for_a_slow_first_byte():
+    """A reply that starts late must not be reported as absent."""
+    clock = FakeClock()
+    seq = [b"", b"", b"", b"> late\r\n", b"", b"", b""]
+    def read_fn():
+        clock.sleep(0.02)
+        return seq.pop(0) if seq else b""
+    data = pio_flash._read_until_idle(read_fn, idle_s=0.05, max_s=10.0,
+                                      now_fn=clock, sleep_fn=clock.sleep)
+    assert b"late" in data, data
+
+
+def test_read_is_capped_by_max_so_a_chattering_device_cannot_hang_the_run():
+    clock = FakeClock()
+    def read_fn():
+        clock.sleep(0.01)
+        return b"noise "
+    data = pio_flash._read_until_idle(read_fn, idle_s=0.05, max_s=0.5,
+                                      now_fn=clock, sleep_fn=clock.sleep)
+    assert clock.t <= 1.0, f"max_s must bound the read (t={clock.t})"
+    assert data, "partial data should still be returned"
+
+
+# --- persistent transport failure aborts -----------------------------------
+
+def test_persistent_transport_failure_aborts_the_rest():
+    """A disconnected device should not produce 47 identical exceptions after a
+    long wait. Abort, and say the remainder was skipped."""
+    calls = []
+    def dead(cmd):
+        calls.append(cmd)
+        raise OSError("device went away")
+    cmds = [f"get k{i}" for i in range(10)]
+    rows = pio_flash._run_batch(cmds, dead, read_time=0)
+    assert len(rows) == 10, "every command still needs a row"
+    assert len(calls) <= 4, f"should stop retrying a dead port, tried {len(calls)}"
+    assert any(r.get("skipped") for r in rows), "remainder must be marked skipped"
+
+
+def test_an_isolated_failure_does_not_abort():
+    """One bad command is not a dead device -- the run must continue."""
+    def flaky(cmd):
+        if cmd == "get boom":
+            raise OSError("transient")
+        return b"> ok\r\n"
+    rows = pio_flash._run_batch(["get a", "get boom", "get b", "get c"], flaky, read_time=0)
+    assert rows[3]["answered"] is True, "run aborted on a single transient failure"
+    assert not any(r.get("skipped") for r in rows)
+
+
+# --- answered means the transport yielded bytes ----------------------------
+
+def test_whitespace_only_reply_counts_as_answered():
+    """`answered` is about whether the device responded AT ALL. Content is a
+    separate question -- conflating them turns a valid quiet reply into a
+    phantom failure and sends someone debugging nothing."""
+    rows = pio_flash._run_batch(["get quiet"], fake({"get quiet": b"\r\n"}), read_time=0)
+    assert rows[0]["answered"] is True, rows[0]
+    assert rows[0]["reply"].strip() == "", rows[0]
+
+
+def test_empty_content_is_still_visible_as_a_finding():
+    """#764's shape: matched the key, wrote nothing. Must remain detectable."""
+    rows = pio_flash._run_batch(["get quiet"], fake({"get quiet": b"\r\n"}), read_time=0)
+    assert rows[0]["empty_reply"] is True, rows[0]
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"FAIL {name}: {e}")
+            except Exception as e:
+                failures += 1
+                print(f"ERROR {name}: {type(e).__name__}: {e}")
+    print(f"\n{failures} failure(s)")
+    sys.exit(1 if failures else 0)

--- a/scripts/test_pio_flash_send_redaction.py
+++ b/scripts/test_pio_flash_send_redaction.py
@@ -117,6 +117,72 @@ def test_undecodable_bytes_do_not_crash_or_vanish():
     assert "junk" in out, out
 
 
+
+# =========================================================================
+# Adversarial-review findings (#892 Gemini gate)
+# =========================================================================
+
+def test_a_SHORT_secret_survives_nothing_even_with_the_marker_destroyed():
+    """CRITICAL, found by review. Every locating rule needs something to match
+    on -- a `>` marker, or a value long enough to look opaque. A log splice can
+    destroy the marker and leave a SHORT secret behind:
+
+        [D][main.cpp:123] Loop hunter2
+
+    No `>`, 7 characters, no keyword. Nothing matched and it was emitted
+    verbatim. On a command already classified secret we do not need to FIND the
+    value -- we refuse to emit the line."""
+    r = pio_flash._ReplyRedactor(secret=True)
+    out = _drain(r, [b"[D][main.cpp:123] Loop hunter2\r\n"])
+    assert "hunter2" not in out, out
+    assert "redacted" in out, out
+
+
+def test_the_unknown_key_fallback_stays_visible_on_a_secret_command():
+    """`??:` echoes the KEY, never a value. The sweep needs it to report a
+    broken key, so it must survive the fail-closed path."""
+    r = pio_flash._ReplyRedactor(secret=True)
+    out = _drain(r, [b"??: bridge.secret\r\n"])
+    assert "bridge.secret" in out, out
+
+
+def test_a_clean_secret_reply_still_reports_its_TRUE_length():
+    """Fail-closed must not clobber the good path: the sweep asserts a secret
+    key ANSWERED using the length in the marker."""
+    r = pio_flash._ReplyRedactor(secret=True)
+    out = _drain(r, [b"  > abcdefghij\r\n"])
+    assert "abcdefghij" not in out and "10" in out, out
+
+
+def test_a_non_secret_command_is_never_blanket_redacted():
+    """The fail-closed rule must be scoped to secret commands only, or every
+    ordinary reply becomes unreadable and the sweep can assert nothing."""
+    r = pio_flash._ReplyRedactor(secret=False)
+    out = _drain(r, [b"  > 910.525,62.5,7,5\r\n"])
+    assert "910.525" in out, out
+
+
+
+def test_device_emitted_redaction_marker_cannot_suppress_fail_closed():
+    """CRITICAL, second-pass review. The fail-closed branch used to skip when
+    the literal "<redacted:" appeared in the output -- but that string can come
+    FROM THE DEVICE. Whether we redacted is OUR fact; read it from our own
+    output, never from device text."""
+    r = pio_flash._ReplyRedactor(secret=True)
+    out = _drain(r, [b"hunter2 <redacted:benign>\r\n"])
+    assert "hunter2" not in out, out
+
+
+def test_a_fallback_must_BE_the_reply_not_merely_appear_in_it():
+    """HIGH, second-pass review. `??:` anywhere on the line used to bypass the
+    guard, so `... ??: prv.key > <key>` leaked."""
+    r = pio_flash._ReplyRedactor(secret=True)
+    out = _drain(r, [b"unknown ??: prv.key hunter2\r\n"])
+    assert "hunter2" not in out, out
+    clean = pio_flash._ReplyRedactor(secret=True)
+    assert "bridge.secret" in _drain(clean, [b"??: bridge.secret\r\n"])
+
+
 if __name__ == "__main__":
     failures = 0
     for name, fn in sorted(globals().items()):

--- a/scripts/test_pio_flash_send_timing.py
+++ b/scripts/test_pio_flash_send_timing.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Tests for round-trip timing on a single `pio-flash send` (#896).
+
+Pure. No serial port, no device.
+
+Why single `send` needs its own timing when batch already has it: batch is
+`get`-only by construction and stays that way -- volatile commands must not ride
+in on one approval. That means batch refuses every command #893 asks about:
+
+    wifi          REFUSED        get radio     ACCEPTED
+    wifi on 5     REFUSED        get prv.key   ACCEPTED
+
+So the instrument built in #851 cannot take the measurement #893 needs. Single
+`send` is one command under one approval with a human watching, which is the
+right shape for a state-touching command -- and it is the only shape that can
+time one.
+"""
+import os
+import sys
+import importlib.util
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "pio_flash", os.path.join(os.path.dirname(os.path.abspath(__file__)), "pio-flash.py"))
+pio_flash = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pio_flash)
+
+
+class Clock:
+    def __init__(self): self.t = 0.0
+    def __call__(self): return self.t
+    def advance(self, d): self.t += d
+
+
+# ------------------------------------------------------------ the measurement ---
+
+def test_timing_is_reported_for_a_single_command():
+    clock = Clock()
+
+    def transport(cmd):
+        clock.advance(0.30)
+        return pio_flash.TransportReply(data=b"> ok\r\n", first_byte_s=0.05)
+
+    row = pio_flash._timed_send("wifi", transport, now_fn=clock)
+    assert row["elapsed_s"] == 0.30, row
+    assert row["first_byte_s"] == 0.05, row
+    assert row["answered"] is True, row
+
+
+def test_volatile_commands_are_accepted_here():
+    """The whole point. Batch refuses these; single send must not, because a
+    human approved this one run and is watching it."""
+    clock = Clock()
+    for cmd in ("wifi", "wifi on 5", "wifi off", "wifi reset", "advert"):
+        row = pio_flash._timed_send(cmd, lambda c: b"> ok\r\n", now_fn=clock)
+        assert row["command"] == cmd
+        assert row["answered"] is True, cmd
+
+
+def test_batch_still_refuses_what_single_send_allows():
+    """Guards the boundary: adding timing here must not have relaxed the batch
+    gate. If this ever fails, volatile commands can ride in on one approval."""
+    for cmd in ("wifi", "wifi on 5", "wifi off", "wifi reset"):
+        assert not pio_flash._is_read_only_command(cmd), cmd
+
+
+# ------------------------------------------------------- no second implementation ---
+
+def test_it_reuses_the_shared_timing_helpers():
+    """Two timing implementations drift, and the copy that drifts is the one
+    that lies. `_timed_send` must lean on the same helpers batch uses."""
+    assert hasattr(pio_flash, "_read_until_idle")
+    assert hasattr(pio_flash, "TransportReply")
+    import inspect
+    src = inspect.getsource(pio_flash._timed_send)
+    assert "TransportReply" in src, "should consume the shared reply type"
+
+
+def test_a_plain_bytes_transport_still_works():
+    row = pio_flash._timed_send("get radio", lambda c: b"> 910.525\r\n")
+    assert row["answered"] is True
+    assert row["first_byte_s"] is None, row
+    assert "910.525" in row["reply"], row
+
+
+# --------------------------------------------------------------- the failure modes ---
+
+def test_a_silent_command_is_reported_as_unanswered_with_its_elapsed_time():
+    """"Never answered" is the #893 symptom and must carry a duration -- knowing
+    it waited the full window is the finding."""
+    clock = Clock()
+
+    def silent(cmd):
+        clock.advance(3.0)
+        return b""
+
+    row = pio_flash._timed_send("wifi", silent, now_fn=clock)
+    assert row["answered"] is False, row
+    assert row["elapsed_s"] == 3.0, row
+
+
+def test_answered_but_empty_stays_distinct_from_silence():
+    """#764's shape. Same distinction batch makes; it must not be lost here."""
+    row = pio_flash._timed_send("get quiet", lambda c: b"\r\n")
+    assert row["answered"] is True and row["empty_reply"] is True, row
+
+
+def test_a_transport_error_is_recorded_not_raised():
+    clock = Clock()
+
+    def boom(cmd):
+        clock.advance(0.2)
+        raise OSError("port vanished")
+
+    row = pio_flash._timed_send("wifi", boom, now_fn=clock)
+    assert row["answered"] is False
+    assert "error" in row, row
+    assert row["elapsed_s"] == 0.2, row
+
+
+# ------------------------------------------------------------------- redaction ---
+
+def test_a_secret_reply_is_still_redacted_and_still_timed():
+    """Timing must not cost the redaction, and redaction must not cost the
+    timing. #849 exists because output on this path reached a transcript."""
+    clock = Clock()
+
+    def transport(cmd):
+        clock.advance(0.4)
+        return b"> deadbeefcafe\r\n"
+
+    row = pio_flash._timed_send("get prv.key", transport, now_fn=clock)
+    assert "deadbeef" not in row["reply"], row
+    assert row["elapsed_s"] == 0.4, row
+    assert row["reply_bytes"] == 16, row
+
+CRLF = b"\r\n"
+
+
+
+# ===========================================================================
+# Gemini review follow-ups (#896)
+# ===========================================================================
+
+def test_read_until_idle_streams_chunks_as_they_arrive():
+    """Restores what the refactor cost: `send` used to print output as it
+    landed. Buffering everything until idle means a slow multi-line reply shows
+    nothing for seconds and then dumps -- the user loses any signal that the
+    command is still working."""
+    clock = Clock()
+    seen = []
+    chunks = [b"line one" + b"\r\n", b"line two" + b"\r\n", b"", b"", b"", b"", b""]
+
+    def read_fn():
+        clock.advance(0.01)
+        return chunks.pop(0) if chunks else b""
+
+    pio_flash._read_until_idle(read_fn, idle_s=0.05, max_s=5.0,
+                               now_fn=clock, sleep_fn=lambda d: None,
+                               on_chunk=seen.append)
+    assert seen, "no chunks were streamed"
+    assert b"".join(seen) == b"line one" + b"\r\n" + b"line two" + b"\r\n", seen
+
+
+def test_streaming_is_optional_and_absent_by_default():
+    clock = Clock()
+    chunks = [b"x" + b"\r\n", b"", b"", b"", b"", b""]
+    def read_fn():
+        clock.advance(0.01)
+        return chunks.pop(0) if chunks else b""
+    data = pio_flash._read_until_idle(read_fn, idle_s=0.05, max_s=5.0,
+                                      now_fn=clock, sleep_fn=lambda d: None)
+    assert data == b"x" + b"\r\n"
+
+
+def test_send_idle_default_is_looser_than_batch():
+    """A multi-stage reply that pauses between stages would be TRUNCATED by an
+    aggressive idle gap. Batch only issues `get` keys, which answer in one shot;
+    single `send` reaches commands that may print in stages, so its default must
+    be more forgiving."""
+    assert pio_flash.SEND_IDLE_DEFAULT > pio_flash.BATCH_IDLE_DEFAULT, (
+        pio_flash.SEND_IDLE_DEFAULT, pio_flash.BATCH_IDLE_DEFAULT)
+
+
+def test_a_transport_returning_a_string_is_refused_not_crashed():
+    """The shared path is now used by two callers, so a bad transport crashes
+    both. A str would have reached the redactor and raised TypeError."""
+    row = pio_flash._timed_send("get x", lambda c: "not bytes")
+    assert row["answered"] is False, row
+    assert "error" in row, row
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"FAIL {name}: {e}")
+            except Exception as e:
+                failures += 1
+                print(f"ERROR {name}: {type(e).__name__}: {e}")
+    print(f"\n{failures} failure(s)")
+    sys.exit(1 if failures else 0)

--- a/scripts/test_pio_flash_send_timing.py
+++ b/scripts/test_pio_flash_send_timing.py
@@ -190,6 +190,58 @@ def test_a_transport_returning_a_string_is_refused_not_crashed():
     assert "error" in row, row
 
 
+# ===========================================================================
+# Found on HARDWARE (T096, COM42), not by any fake clock.
+# ===========================================================================
+
+def test_round_trip_excludes_the_idle_wait():
+    """First real run: elapsed_s 1.2188, first_byte_s 0.2136 -- a difference of
+    1.005, which is exactly SEND_IDLE_DEFAULT. elapsed_s was round-trip PLUS the
+    idle timeout, so every measurement carried a constant inflation, and one
+    that changes with --idle-time. Two runs at different settings were not
+    comparable, and #893's 20-25s would have been compared against an offset
+    this tool invented.
+
+    No fake-clock test could catch this: the clock only advanced by what the
+    stub chose, so the idle tail never existed to be measured.
+    """
+    clock = Clock()
+    seq = [b"> ok" + b"\r\n"] + [b""] * 40
+
+    def read_fn():
+        clock.advance(0.01)
+        return seq.pop(0) if seq else b""
+
+    st = {}
+    pio_flash._read_until_idle(read_fn, idle_s=0.5, max_s=10.0,
+                               now_fn=clock, sleep_fn=lambda d: None,
+                               stats=st, origin=0.0)
+    assert st["first_byte_s"] == 0.01, st
+    assert "last_byte_s" in st, "the true round trip must be recorded"
+    assert st["last_byte_s"] == 0.01, st
+    assert clock() > 0.5, "the read did wait out the idle gap"
+
+
+def test_timed_send_reports_round_trip_separately_from_wall_time():
+    clock = Clock()
+
+    def transport(cmd):
+        clock.advance(2.0)      # includes an idle tail the caller must not be charged
+        return pio_flash.TransportReply(data=b"> ok" + b"\r\n",
+                                        first_byte_s=0.2, last_byte_s=0.3)
+
+    row = pio_flash._timed_send("get radio", transport, now_fn=clock)
+    assert row["elapsed_s"] == 2.0, row
+    assert row["round_trip_s"] == 0.3, row
+    assert row["round_trip_s"] < row["elapsed_s"], row
+
+
+def test_round_trip_is_none_when_nothing_answered():
+    row = pio_flash._timed_send("get gone", lambda c: b"")
+    assert row["answered"] is False
+    assert row["round_trip_s"] is None, row
+
+
 if __name__ == "__main__":
     failures = 0
     for name, fn in sorted(globals().items()):


### PR DESCRIPTION
Closes #901 on merge. Epic #892, under Feature #891.

**Scripts only.** No firmware source, no pio env, no variant touched — `git diff --name-only origin/firmware-base...HEAD` is entirely `scripts/`.

## Why this exists

Three CLI `get` keys returned an empty reply for **ten months** (#764). Nothing caught it: the code compiled, no compiler called it dead, and the serial console concealed it because that caller zeroes its buffer and suppresses empty replies. Only the over-the-air path exposed it — as uninitialised stack on the wire (#765).

#775 (merged) is the **structural** guard. This is the **runtime** half: sweep every key against a real device and assert the shape of every reply.

## What landed

| Task | What |
|---|---|
| #849 | secret redaction at source |
| #850 | `send-batch` — N read-only commands, one open port, **one approval** |
| #851 | per-command latency capture |
| #896 | round-trip timing on single `send` |
| #852 | the CLI surface sweep |

Batch is `get`-only **by construction** — volatile commands are refused, not deny-listed. The sweep does **not** invoke `pio-flash` itself: flash discipline is one human approval per RUN, and a wrapper that shells out hides the run behind another layer. The operator issues it.

The key list is read **from firmware source every run**. Hand-listing is precisely how three keys hid for ten months.

## Hardware verification — ST-P, `heltec_v4_repeater_telemetry` @ `firmware-base`

79 commands live:

- **47/47 keys answer, 0 empty**
- **32/32 junk-suffix probes fall through, 0 prefix-match leaks**
- **#764/#765 re-confirmed fixed on ESP32-S3** — previously verified only on nRF52

```
get radio               -> > 910.525,62.5,7,5
get agc.reset.interval  -> > 0
```

The run also found **#899** (P1): unconfigured broker slots spam NVS ERROR at 29.3/sec — 97.1% of all serial output — and splice CLI replies mid-word.

## Three defects only hardware could surface

Recorded because each is a class, not a one-off:

1. **`round_trip_s`** — `elapsed_s` measured until the read loop *returned*, and that return waits for the idle timeout. Every reading silently carried the tool's own 1.0s timeout. Invisible against instant fakes; obvious on a board answering in 0.2s.
2. **ESP32 port-open settle** — opening a port asserts DTR/RTS and **reboots an ESP32**. The 0.2s settle was tuned on an nRF52, which doesn't. On ESP32 the first commands land mid-boot and return empty — **indistinguishable from the #764 defect being hunted.** The tool would have manufactured its own findings. Suppressing DTR was rejected: Arduino's ESP32 USB-CDC gates TX on DTR, so a device opened with it deasserted may never reply.
3. **Redaction anchor** — the redactor anchored on a reply starting its line. #899's UART splicing moves it off column 0, so a node private key was written to a capture file in full. *A firmware defect disabled a security control in a separate program by invalidating a structural assumption.*

## Adversarial review — `gemini-2.5-pro`, two passes, 6 findings

**Fixed (5):**

| Sev | Finding | Fix |
|---|---|---|
| CRITICAL | short secret leaked when a splice destroyed the `>` marker (`Loop hunter2` — 7 chars, no marker, no keyword) | fail closed: on a secret command, if no rule fired, replace the whole line. We don't need to *find* a value to refuse to print it |
| CRITICAL | the fail-closed branch was suppressed by `<redacted:` **arriving from the device** | keyed on `red == stripped` — whether we redacted is our own fact, read from our own output |
| HIGH | `??:` carve-out matched anywhere, so `... ??: prv.key > <key>` bypassed the guard | requires `startswith` |
| HIGH | settle exited early on a silent boot stage | grace 1.0 → 3.0s, ambiguity documented |
| HIGH/MED | timing overclaimed under chatter; a single legitimate log-bearing reply could void a run | `timings-void` finding, slow-detection disabled, threshold 2+ |
| LOW | unbounded `--commands-file` | `is_file()` + size check before read + count cap |

**Justified, not fixed (1 + notes):**

- **Settle is a timeout, not a probe.** A stage silent >3.0s still defeats it. A timeout cannot distinguish "up" from "quiet" in principle. Documented in-code as residual.
- **Marker length on the fail-closed path** is the line length, not the value length. The sweep asserts marker *presence*, not an exact length, and this only arises on a capture already known corrupted.
- **TOCTOU on `--commands-file`.** An attacker who can swap files between `stat()` and `read()` already owns the machine; this is a local dev tool. The FIFO/size-0 half *was* real and is fixed.
- **`#ifdef` blindness.** Enumeration is not preprocessor-aware, so compile-gated keys report `unknown-key` on envs excluding them — observed live (5 `bridge.*` keys). Real gap, recorded against #852.

## Evidence

**110 assertions across six suites, green after rebase onto current `firmware-base`.** Pure — no serial port, no device, no `pio-flash` invocation.

```
test_pio_flash_send_redaction.py   18    test_pio_flash_batch_latency.py   13
test_pio_flash_send_batch.py       24    test_pio_flash_send_timing.py     16
test_cli_sweep.py                  22    test_cli_dispatch.py              17
```

Re-analysing the real ST-P capture after the review fixes yields **one honest `timings-void` finding** where it previously produced **67 bogus `slow` findings**.

## Not claimed

- **#893 is not answered.** Every timing from the ST-P run is void — the 0.17–17.2s spread is idle-detection tripping over 29 log lines/sec, not latency. The 0.201s serial baseline from the T096 (quiet board) is the only clean number. **#893 needs #899 fixed first.**
- **CI runs none of these suites** (#862). These 110 assertions gate nothing on a PR yet.
