### PR TITLE
fix(#899): route optional NVS string reads through a type-checked helper

### DIFF
--- a/scripts/check_nvs_guarded_reads.py
+++ b/scripts/check_nvs_guarded_reads.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+r"""Refuse an unguarded `Preferences::getString()` on an optional pref (#899).
+
+WHY THIS EXISTS
+
+Arduino's `Preferences::getString(key, default)` takes a default parameter
+precisely so that a MISSING key is a normal outcome -- and then logs at ERROR
+when it uses that default:
+
+    // framework-arduinoespressif32/libraries/Preferences/src/Preferences.cpp:483
+    esp_err_t err = nvs_get_str(_handle, key, value, &len);
+    if(err){
+        log_e("nvs_get_str len fail: %s %s", key, nvs_error(err));
+        return String(defaultValue);
+    }
+
+Any caller using that API as designed emits ERROR spam by construction. Our
+broker config makes it continuous: `writeBrokerConfig` deliberately REMOVES
+empty fields rather than storing blanks (#182), so absent keys are the designed
+steady state, and the MQTT pool worker re-drives every slot on a 500 ms cycle.
+
+Measured on ST-P (`heltec_v4_repeater_telemetry`, brokers unconfigured):
+
+    10,135 ERROR lines in 346 s  =  29.3/sec, median gap 9 ms
+    884,912 of 911,485 serial bytes  =  97.1% of ALL output
+
+That is not merely noise. The log path and the CLI reply path write the same
+UART with no mutual exclusion and interleave MID-WRITE, so replies came back
+spliced inside a word (`not _supportesd`, `??: lonXil`) -- mojibake on a CLI
+reply, and the same corruption defeated secret redaction in `pio-flash`.
+
+WHAT THIS CHECKS
+
+Only `getString` is guarded, and that is deliberate rather than an oversight:
+the numeric getters log at `log_v` (VERBOSE), not `log_e` --
+
+    // Preferences.cpp, getUChar
+    log_v("nvs_get_u8 fail: %s %s", key, nvs_error(err));
+
+-- which is why exactly the string keys appeared in the capture while
+`enabled`, `port` and `transport` did not. Widening to `getUChar` would flag
+code that emits nothing. (If a future core release promotes those to `log_e`,
+this check must widen with it -- noted because it is an assumption about
+third-party code, not a fact about ours.)
+
+The rule is a bare-call ban rather than "an isKey must appear nearby":
+proximity checks need data-flow analysis to be sound, and a regex pretending to
+do one is how a guard develops false positives and gets switched off. One
+helper, one place to audit, mechanically checkable.
+
+    BAD:   String u = p.getString(kKeyBrokerUsername, "");
+    GOOD:  String u = prefStr(p, kKeyBrokerUsername);
+
+The helper is allowed exactly one `getString`, inside its own type check.
+
+SCOPE
+
+Repo-wide. An earlier version scoped this to `src/helpers/wifi_observer/` on the
+assumption that a wider net would flag too much existing code and get switched
+off. That assumption was never measured, and the measurement contradicted it:
+after the fix the whole tree contains THREE bare call sites. A narrow guard
+bought nothing and guaranteed the defect would recur elsewhere.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_TARGETS = ["src", "examples"]
+
+# `.` AND `->`: a pointer receiver (`pp->getString(k)`) is the same defect, and
+# matching only the dot operator meant one keystroke defeated the guard.
+#
+# Requires a NON-EMPTY argument list. That is what separates a Preferences read
+# (always passes a key) from `HTTPClient::getString()`, which takes none -- a
+# real call in examples/simple_repeater/main.cpp that a repo-wide guard would
+# otherwise flag forever. DOTALL so a call split across lines still matches.
+_GET_STRING = re.compile(
+    r"\b([A-Za-z_][A-Za-z0-9_]*)\s*(?:\.|->)\s*getString\s*\(\s*(?!\))",
+    re.DOTALL,
+)
+
+# A macro that hides the call. It cannot be resolved without a preprocessor, so
+# it is REPORTED rather than silently missed.
+_MACRO_HIDING = re.compile(r"^[ \t]*#[ \t]*define\b[^\n]*getString[ \t]*\(", re.MULTILINE)
+
+HELPER_NAME = "prefStr"
+_HELPER_DEF = re.compile(r"\b" + HELPER_NAME + r"\s*\(")
+
+# Skip directories that are not ours to police.
+_SKIP_PARTS = {".pio", "build", "node_modules", ".git"}
+
+
+def _strip_comments(text: str) -> str:
+    """Blank `//` and `/* */` comments, preserving length and newlines.
+
+    Length preservation matters: findings are located by counting newlines up to
+    a match offset, so deleting characters would shift every reported line.
+
+    Blanking also closes two holes at once -- a commented-out call can no longer
+    read as a violation, and a comment containing the guard keyword can no
+    longer forge the helper exemption.
+    """
+    out = list(text)
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        # String and char literals are skipped WHOLE. Without this, the `//` in
+        #     const char* url = "http://example.com"; auto v = p.getString(k);
+        # starts a comment and blanks the rest of the line -- silently swallowing
+        # a real violation. A guard that misses quietly is worse than no guard.
+        if c in ('"', "'"):
+            quote = c
+            i += 1
+            while i < n:
+                if text[i] == "\\":
+                    i += 2
+                    continue
+                if text[i] == quote:
+                    i += 1
+                    break
+                i += 1
+            continue
+        if c == "/" and nxt == "/":
+            while i < n and text[i] != "\n":
+                out[i] = " "
+                i += 1
+        elif c == "/" and nxt == "*":
+            while i < n and not (text[i] == "*" and i + 1 < n and text[i + 1] == "/"):
+                if text[i] != "\n":
+                    out[i] = " "
+                i += 1
+            if i < n:
+                out[i] = " "
+                if i + 1 < n:
+                    out[i + 1] = " "
+            i += 2
+        else:
+            i += 1
+    return "".join(out)
+
+
+def _find_helper_span(lines):
+    """(start, end) 1-based line range of the helper definition, or None.
+
+    Requires the TYPE CHECK to be present inside the definition. A helper that
+    lost its guard is NOT a valid exemption -- otherwise renaming any function
+    to `prefStr` would silently disable this check for every caller.
+
+    Comments are already blanked by the time this runs, so the keyword cannot be
+    forged in a comment.
+    """
+    for i, line in enumerate(lines):
+        if not _HELPER_DEF.search(line):
+            continue
+        if ";" in line and "{" not in line:
+            continue  # forward declaration
+        window = lines[i:i + 14]
+        body = "\n".join(window)
+        if "{" in body and ("PT_STR" in body or "isKey" in body):
+            return (i + 1, i + len(window))
+    return None
+
+
+def analyze_source(text: str, rel: str):
+    """Findings for one translation unit."""
+    findings = []
+    text = _strip_comments(text)
+    lines = text.split("\n")
+
+    # Now that the scan is repo-wide, `getString(args)` is no longer proof of a
+    # Preferences read: an unrelated class can define its own, e.g.
+    #     class MyJsonParser { String getString(const char* key); };
+    # and flagging that would be wrong forever -- which is how a guard earns a
+    # reputation for false positives and gets switched off.
+    #
+    # A translation unit that never NAMES Preferences cannot hold a Preferences
+    # read (barring an exotic typedef), so it is skipped. This is a deliberate
+    # trade: it can miss a read reached through an aliased type, in exchange for
+    # not crying wolf on the ~250 files that have nothing to do with NVS.
+    if "Preferences" not in text:
+        return findings
+
+    for m in _MACRO_HIDING.finditer(text):
+        findings.append({
+            "file": rel,
+            "line": text[:m.start()].count("\n") + 1,
+            "kind": "macro-hides-getString",
+            "detail": ("a macro wrapping getString cannot be checked statically; "
+                       f"call {HELPER_NAME}() directly instead"),
+            "text": m.group(0).strip()[:120],
+        })
+
+    helper_span = _find_helper_span(lines)
+
+    # Scanned over the WHOLE text, not line by line: a call split as
+    #     String v = p.
+    #         getString(k);
+    # is invisible to a per-line search.
+    for m in _GET_STRING.finditer(text):
+        line_no = text[:m.start()].count("\n") + 1
+        if helper_span and helper_span[0] <= line_no <= helper_span[1]:
+            continue
+        findings.append({
+            "file": rel,
+            "line": line_no,
+            "kind": "unguarded-getString",
+            "detail": (f"`{m.group(1)}.getString(...)` logs at ERROR when the key "
+                       f"is absent; route it through {HELPER_NAME}()"),
+            "text": lines[line_no - 1].strip()[:120] if line_no <= len(lines) else "",
+        })
+    return findings
+
+
+def iter_sources(target: Path):
+    if target.is_file():
+        yield target
+        return
+    # Headers too, not just .cpp. The exempt helper lives in a header, and if
+    # this only scanned .cpp then the one place `getString` is legitimately
+    # called bare would be the one place never checked -- so the helper could
+    # silently lose its guard while this still reported clean.
+    for p in sorted(list(target.rglob("*.cpp")) + list(target.rglob("*.h"))):
+        if _SKIP_PARTS.intersection(p.parts):
+            continue
+        yield p
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("targets", nargs="*",
+                    help="files or directories; defaults to src/ and examples/")
+    ap.add_argument("--json-out", help="write findings as JSON for CI to archive")
+    ap.add_argument("--advisory", action="store_true",
+                    help="report findings but exit 0 (matches check_cli_dispatch)")
+    args = ap.parse_args(argv)
+
+    root = Path(__file__).resolve().parent.parent
+    targets = [Path(t) for t in args.targets] if args.targets else \
+              [root / t for t in DEFAULT_TARGETS]
+
+    findings, scanned = [], 0
+    for t in targets:
+        if not t.exists():
+            print(f"check_nvs_guarded_reads: missing {t}", file=sys.stderr)
+            return 2
+        for src in iter_sources(t):
+            rel = src.relative_to(root).as_posix() if root in src.parents else src.as_posix()
+            findings.extend(analyze_source(
+                src.read_text(encoding="utf-8", errors="replace"), rel))
+            scanned += 1
+
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(findings, indent=2), encoding="utf-8")
+
+    if not findings:
+        print(f"check_nvs_guarded_reads: {scanned} file(s) clean")
+        return 0
+
+    for f in sorted(findings, key=lambda x: (x["file"], x["line"])):
+        print(f"{f['file']}:{f['line']}: {f['kind']}: {f['detail']}")
+        print(f"    {f['text']}")
+    print(f"\n{len(findings)} finding(s) across {scanned} file(s). See #899.")
+    return 0 if args.advisory else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_nvs_guarded_reads.py
+++ b/scripts/test_nvs_guarded_reads.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Tests for the unguarded-getString guard (#899).
+
+Pure. No device, no NVS, no build.
+
+`ConfigSchema.cpp` cannot be unit-tested on the host: `readBrokerConfig` lives
+inside `#ifdef ARDUINO` and needs the real `Preferences` class, and no host shim
+for it exists in this tree (the "host round-trip test" mentioned in that file's
+comments is aspirational -- nothing references it). Extracting a seam is the
+#714 testable-surface problem and is not this task.
+
+So the fix is proven two ways instead, and this file is the first:
+
+  1. this static guard, shown RED on the pre-fix tree (13 findings) and green
+     after -- per #712, a guard must be demonstrated catching the real defect
+  2. hardware re-verification on ST-P: the NVS ERROR rate must go to 0/sec
+
+Every "bypass" case below came from adversarial review of the FIRST version of
+this guard, which each of them defeated.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location(
+    "check_nvs", os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                              "check_nvs_guarded_reads.py"))
+check_nvs = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check_nvs)
+
+
+# The guard skips any translation unit that never NAMES Preferences, so every
+# fixture has to look like one. Appended at the END so it cannot shift the line
+# numbers of the fixture above it, and as real code rather than a comment
+# because comments are blanked before matching.
+_TU = "\nPreferences _tu;\n"
+
+
+def kinds(src):
+    return [f["kind"] for f in check_nvs.analyze_source(src + _TU, "t.cpp")]
+
+
+# ------------------------------------------------------- the defect itself ---
+
+def test_a_bare_getString_is_a_finding():
+    """The shape that produced 29.3 ERROR lines/sec on ST-P."""
+    src = 'void f(){ String u = p.getString(kKeyBrokerUsername, ""); }'
+    assert kinds(src) == ["unguarded-getString"], kinds(src)
+
+
+def test_the_helper_call_is_not_a_finding():
+    src = 'void f(){ String u = prefStr(p, kKeyBrokerUsername); }'
+    assert kinds(src) == [], kinds(src)
+
+
+# ------------------------------------------------------------- bypasses ------
+# Each of these defeated the first version of this guard.
+
+def test_a_pointer_receiver_is_caught():
+    """`->` is the same defect. Matching only the dot operator meant one
+    keystroke disabled the guard."""
+    src = 'void f(){ String s = pp->getString("bar", ""); }'
+    assert "unguarded-getString" in kinds(src), kinds(src)
+
+
+def test_a_call_split_across_lines_is_caught():
+    """A per-line search cannot see this. The scan runs over the whole text."""
+    src = 'void f(){ String v = p.\n    getString(kKeyMqttIata, ""); }'
+    assert "unguarded-getString" in kinds(src), kinds(src)
+
+
+def test_a_macro_hiding_the_call_is_reported():
+    """A macro cannot be resolved without a preprocessor, so it is REPORTED
+    rather than silently missed -- the guard says what it cannot check."""
+    src = '#define GET_PREF(p, k) p.getString(k, "")\nvoid f(){ GET_PREF(p, kX); }'
+    assert "macro-hides-getString" in kinds(src), kinds(src)
+
+
+def test_a_fake_helper_cannot_forge_the_exemption_with_a_comment():
+    """The exemption requires the TYPE CHECK in the definition. Comments are
+    blanked before matching, so mentioning PT_STR in a comment cannot buy it --
+    otherwise renaming any function to prefStr would disable the guard for
+    every caller."""
+    src = ('// this comment mentions PT_STR and isKey to fool the guard\n'
+           'inline String prefStr(Preferences& p, const char* key, const char* d) {\n'
+           '    return p.getString(key, d);\n}')
+    assert "unguarded-getString" in kinds(src), kinds(src)
+
+
+def test_the_real_helper_IS_exempt():
+    """The genuine article, with its type check, is the one allowed bare call."""
+    src = ('inline String prefStr(Preferences& p, const char* key, const char* d) {\n'
+           '    return p.getType(key) == PT_STR ? p.getString(key, d) : String(d);\n}')
+    assert kinds(src) == [], kinds(src)
+
+
+# --------------------------------------------------------- false positives ---
+
+def test_HTTPClient_getString_is_NOT_flagged():
+    """`http.getString()` takes NO arguments and is a real call in
+    examples/simple_repeater/main.cpp. A repo-wide guard that flagged it would
+    be wrong forever, which is how guards get switched off. The non-empty
+    argument list is what separates a Preferences read from this."""
+    src = 'void f(){ HTTPClient http; String body = http.getString(); }'
+    assert kinds(src) == [], kinds(src)
+
+
+def test_a_commented_out_call_is_not_a_finding():
+    """Comments are blanked before matching, so dead code cannot fail the build."""
+    src = 'void f(){ // String u = p.getString(kKey, "");\n }'
+    assert kinds(src) == [], kinds(src)
+
+
+def test_a_block_commented_call_is_not_a_finding():
+    src = 'void f(){ /* String u = p.getString(kKey, ""); */ }'
+    assert kinds(src) == [], kinds(src)
+
+
+def test_line_numbers_survive_comment_stripping():
+    """Comments are blanked length-preservingly rather than removed, because
+    findings are located by counting newlines to a match offset -- deleting
+    characters would misreport every line after the first comment."""
+    src = ('// leading comment\n'
+           '/* block\n   spanning lines */\n'
+           'void f(){ String u = p.getString(kKey, ""); }\n')
+    f = check_nvs.analyze_source(src + _TU, "t.cpp")
+    assert len(f) == 1 and f[0]["line"] == 4, f
+
+
+def test_a_slash_slash_inside_a_STRING_does_not_blank_the_line():
+    """Found by adversarial review, and it was a silent MISS -- the worst kind.
+
+        const char* url = "http://example.com"; auto v = p.getString(k);
+
+    The `//` inside the URL started a comment, blanking the rest of the line
+    including a real violation, and the guard reported the file clean."""
+    src = 'void f(){ const char* url = "http://x.com"; auto v = p.getString("k"); }'
+    assert "unguarded-getString" in kinds(src), kinds(src)
+
+
+def test_a_char_literal_slash_does_not_blank_the_line():
+    src = "void f(){ char c = '/'; auto v = p.getString(\"k\"); }"
+    assert "unguarded-getString" in kinds(src), kinds(src)
+
+
+def test_an_escaped_quote_inside_a_string_does_not_desync_the_scanner():
+    """A mishandled escape would leave the scanner believing it is still inside
+    a string, swallowing the remainder of the file."""
+    src = 'void f(){ const char* s = "a\\"b"; auto v = p.getString("k"); }'
+    assert "unguarded-getString" in kinds(src), kinds(src)
+
+
+def test_an_unrelated_class_with_its_own_getString_is_NOT_flagged():
+    """Repo-wide scanning made `getString(args)` stop being proof of an NVS
+    read. A file that never names Preferences cannot hold one, and flagging it
+    would be wrong forever -- which is how guards get switched off."""
+    src = ('class MyJsonParser { public: String getString(const char* key); };\n'
+           'void f(){ MyJsonParser parser; String n = parser.getString("user"); }')
+    # deliberately NOT passed through kinds(): no Preferences in this unit
+    assert check_nvs.analyze_source(src, "t.cpp") == [], \
+        check_nvs.analyze_source(src, "t.cpp")
+
+
+def test_the_same_call_IS_flagged_once_the_unit_uses_Preferences():
+    """The skip must be scoped to units with nothing to do with NVS, not act as
+    a blanket escape hatch."""
+    src = 'void f(){ Preferences p; String n = p.getString("user"); }'
+    assert "unguarded-getString" in [f["kind"] for f in
+                                     check_nvs.analyze_source(src, "t.cpp")]
+
+
+# -------------------------------------------------------------- reporting ---
+
+def test_a_finding_names_the_receiver_and_points_at_the_helper():
+    f = check_nvs.analyze_source('void f(){ String u = p.getString(k, ""); }' + _TU,
+                                 "t.cpp")
+    assert "p.getString" in f[0]["detail"], f
+    assert "prefStr" in f[0]["detail"], f
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"FAIL {name}: {e}")
+            except Exception as e:
+                failures += 1
+                print(f"ERROR {name}: {type(e).__name__}: {e}")
+    print(f"\n{failures} failure(s)")
+    sys.exit(1 if failures else 0)

--- a/src/helpers/config/WifiConfigProvider.cpp
+++ b/src/helpers/config/WifiConfigProvider.cpp
@@ -15,6 +15,7 @@
 
 #ifdef ARDUINO
   #include <Preferences.h>
+#include "../prefs/PrefsRead.h"   // #899: prefStr() -- type-checked optional read
   #include <WiFi.h>   // WiFi.status()/localIP() for wifi.status
 #endif
 
@@ -163,7 +164,7 @@ bool handleGetWifi(char* reply, size_t reply_size, const char* field) {
                      "ERROR: cannot open NVS namespace 'wifi'\n");
             return true;
         }
-        String s = p.getString("ssid", "");
+        String s = offband::prefStr(p, "ssid");
         p.end();
         snprintf(reply, reply_size, "wifi.ssid = %s\n",
                  s.isEmpty() ? "(unset)" : s.c_str());
@@ -222,7 +223,7 @@ bool handleGetWifi(char* reply, size_t reply_size, const char* field) {
         String ssid;
         {
             Preferences p;
-            if (p.begin("wifi", /*readOnly=*/true)) { ssid = p.getString("ssid", ""); p.end(); }
+            if (p.begin("wifi", /*readOnly=*/true)) { ssid = offband::prefStr(p, "ssid"); p.end(); }
         }
         if (ssid.isEmpty()) {
             snprintf(reply, reply_size, "wifi.status = AwaitingSetup\n");

--- a/src/helpers/prefs/PrefsRead.h
+++ b/src/helpers/prefs/PrefsRead.h
@@ -1,0 +1,74 @@
+// src/helpers/prefs/PrefsRead.h
+//
+// #899: read an OPTIONAL string pref without the ERROR-log storm.
+//
+// Arduino's Preferences::getString(key, default) takes a default parameter
+// precisely so that a missing key is a normal outcome -- and then logs at
+// ERROR when it uses that default:
+//
+//     // framework-arduinoespressif32/libraries/Preferences/src/Preferences.cpp:483
+//     esp_err_t err = nvs_get_str(_handle, key, value, &len);
+//     if(err){
+//         log_e("nvs_get_str len fail: %s %s", key, nvs_error(err));
+//         return String(defaultValue);
+//     }
+//
+// Any caller using that API as designed emits ERROR spam by construction. Our
+// broker config makes it continuous: writeBrokerConfig deliberately REMOVES
+// empty fields rather than storing blanks (#182), so absent keys are the
+// DESIGNED steady state, and the pool worker re-reads every slot on a 500 ms
+// cycle. Measured on ST-P with brokers unconfigured: 29.3 ERROR lines/sec,
+// 97.1% of all serial output, splicing CLI replies mid-word.
+//
+// Only getString needs this. The numeric getters log at log_v (VERBOSE):
+//
+//     // Preferences.cpp, getUChar
+//     log_v("nvs_get_u8 fail: %s %s", key, nvs_error(err));
+//
+// which is why exactly the string keys appeared in the capture while `enabled`,
+// `port` and `transport` did not.
+//
+// COST, because it is not free: isKey() -> getType() probes up to TEN
+// nvs_get_* calls to identify the type, and for a MISSING key it runs all ten
+// before returning PT_INVALID. We trade one failing probe plus a ~60-byte UART
+// write for ten flash lookups. Worth it -- flash reads are microseconds, while
+// 60 bytes at 115200 baud is ~5 ms AND corrupts any reply sharing the UART --
+// but it is a real cost on a hot path, not a pure win.
+//
+// Behaviour is otherwise IDENTICAL to getString: a missing key still yields the
+// default. That is what makes this safe for every caller, including the CLI
+// display path (`get mqtt.broker.<N>.<key>`), which must keep showing a
+// disabled-but-configured broker's stored values.
+
+#pragma once
+
+#ifdef ARDUINO
+#include <Arduino.h>
+#include <Preferences.h>
+
+namespace offband {
+
+// The ONE place `getString` may be called bare. scripts/check_nvs_guarded_reads.py
+// refuses to accept this as the exempt helper unless the type check below is
+// still present.
+//
+// getType(key) == PT_STR, NOT isKey(key). isKey() is literally
+// `getType(key) != PT_INVALID`, so this costs exactly the same -- but isKey
+// returns true for a key that exists holding a NON-string type, and getString
+// would then fail with ESP_ERR_NVS_TYPE_MISMATCH and log at ERROR anyway,
+// reintroducing the defect. Requiring PT_STR closes that. Found by review.
+//
+// KNOWN AND ACCEPTED -- a TOCTOU window: readBrokerConfig runs on the MQTT
+// worker task while the CLI can write config from another task, so a key can be
+// erased between the type check and the read, producing ONE stray ERROR line.
+// That is a single line in a rare race, against 29.3 lines/sec continuously
+// before this change. The Arduino API exposes no atomic "read if present", so
+// closing it entirely would mean reaching past Preferences to the raw nvs
+// handle -- a much larger change for a far smaller problem.
+inline String prefStr(Preferences& p, const char* key, const char* dflt = "") {
+    return p.getType(key) == PT_STR ? p.getString(key, dflt) : String(dflt);
+}
+
+}  // namespace offband
+
+#endif  // ARDUINO

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -4,6 +4,7 @@
 #ifdef ARDUINO
   #include <Arduino.h>
   #include <Preferences.h>
+  #include "../prefs/PrefsRead.h"   // #899: prefStr() -- isKey-guarded optional read
   #if defined(ESP_PLATFORM)
     #include <nvs.h>        // #181: nvs_get_stats() -- write-failure diagnostic (real device only)
     #include <helpers/diagnostics/CrashLog.h>   // #181: crashLogf() -- persistent + Serial failure log
@@ -67,7 +68,7 @@ static void logCfgWriteFailure(const char*, const char*) {}
 bool readGlobalIata(char* out, size_t out_len) {
     Preferences p;
     p.begin(kNvsMqtt, /*readOnly=*/true);
-    String v = p.getString(kKeyMqttIata, "");
+    String v = prefStr(p, kKeyMqttIata);
     p.end();
     if (v.isEmpty()) {
         if (out_len > 0) out[0] = '\0';
@@ -149,7 +150,7 @@ bool readBrokerConfig(uint8_t slot, BrokerConfig& out) {
     // storing blanks. Any #181 migration blob is ignored here and is cleaned up on
     // the next write.
     out.enabled   = p.getBool(kKeyBrokerEnabled, false);
-    String url    = p.getString(kKeyBrokerUrl, "");
+    String url    = prefStr(p, kKeyBrokerUrl);
     strncpy(out.url, url.c_str(), sizeof(out.url));
     out.url[sizeof(out.url) - 1] = '\0';
     out.transport = (BrokerTransport)p.getUChar(kKeyBrokerTransport, (uint8_t)BrokerTransport::Tcp);
@@ -161,25 +162,25 @@ bool readBrokerConfig(uint8_t slot, BrokerConfig& out) {
     }
     out.port      = p.getUShort(kKeyBrokerPort, default_port);
     out.auth_type = (BrokerAuthType)p.getUChar(kKeyBrokerAuthType, (uint8_t)BrokerAuthType::None);
-    String u  = p.getString(kKeyBrokerUsername, "");
-    String pw = p.getString(kKeyBrokerPassword, "");
-    String jw = p.getString(kKeyBrokerJwtToken, "");
-    String tp = p.getString(kKeyBrokerTopicPrefix, kDefaultTopicPrefix);
-    String io = p.getString(kKeyBrokerIataOverride, "");
+    String u  = prefStr(p, kKeyBrokerUsername);
+    String pw = prefStr(p, kKeyBrokerPassword);
+    String jw = prefStr(p, kKeyBrokerJwtToken);
+    String tp = prefStr(p, kKeyBrokerTopicPrefix, kDefaultTopicPrefix);
+    String io = prefStr(p, kKeyBrokerIataOverride);
     strncpy(out.username,      u.c_str(),  sizeof(out.username));      out.username[sizeof(out.username)-1] = '\0';
     strncpy(out.password,      pw.c_str(), sizeof(out.password));      out.password[sizeof(out.password)-1] = '\0';
     strncpy(out.jwt_token,     jw.c_str(), sizeof(out.jwt_token));     out.jwt_token[sizeof(out.jwt_token)-1] = '\0';
     strncpy(out.topic_prefix,  tp.c_str(), sizeof(out.topic_prefix));  out.topic_prefix[sizeof(out.topic_prefix)-1] = '\0';
     strncpy(out.iata_override, io.c_str(), sizeof(out.iata_override)); out.iata_override[sizeof(out.iata_override)-1] = '\0';
     // Plan 2 v2 additions
-    String ja = p.getString(kKeyBrokerJwtAudience, "");
+    String ja = prefStr(p, kKeyBrokerJwtAudience);
     out.jwt_refresh_sec = p.getULong(kKeyBrokerJwtRefresh, 3600);
-    String cc = p.getString(kKeyBrokerCaCertName, "");
+    String cc = prefStr(p, kKeyBrokerCaCertName);
     strncpy(out.jwt_audience,  ja.c_str(), sizeof(out.jwt_audience));  out.jwt_audience[sizeof(out.jwt_audience)-1]  = '\0';
     strncpy(out.ca_cert_name,  cc.c_str(), sizeof(out.ca_cert_name));  out.ca_cert_name[sizeof(out.ca_cert_name)-1]  = '\0';
     // #63 additions: JWT identity claims
-    String jo = p.getString(kKeyBrokerJwtOwner, "");
-    String je = p.getString(kKeyBrokerJwtEmail, "");
+    String jo = prefStr(p, kKeyBrokerJwtOwner);
+    String je = prefStr(p, kKeyBrokerJwtEmail);
     strncpy(out.jwt_owner,     jo.c_str(), sizeof(out.jwt_owner));     out.jwt_owner[sizeof(out.jwt_owner)-1]         = '\0';
     strncpy(out.jwt_email,     je.c_str(), sizeof(out.jwt_email));     out.jwt_email[sizeof(out.jwt_email)-1]         = '\0';
     p.end();

--- a/src/helpers/wifi_observer/WifiBootstrap.cpp
+++ b/src/helpers/wifi_observer/WifiBootstrap.cpp
@@ -1,6 +1,7 @@
 // src/helpers/wifi_observer/WifiBootstrap.cpp
 #include "WifiBootstrap.h"
 #include "WifiObserverConfig.h"
+#include "../prefs/PrefsRead.h"   // #899: prefStr() -- isKey-guarded optional read
 
 #ifdef OFFBAND_OBSERVER_BLE_COMPANION
 // Plan 3 Task 10 (Strycher/LoRa#272): system channel for first-
@@ -108,7 +109,7 @@ void WifiBootstrap::begin() {
     // TODO(future Task): wire rescue button sampling.
     Preferences prefs;
     prefs.begin("wifi", /*readOnly=*/true);
-    String ssid = prefs.getString("ssid", "");
+    String ssid = prefStr(prefs, "ssid");
     // #45: "wifi enable"/"wifi disable" policy flag (default enabled). Read
     // alongside the creds so a disabled node skips STA without losing creds.
     bool wifi_enabled = prefs.getBool("enabled", true);
@@ -147,7 +148,7 @@ void WifiBootstrap::begin() {
         {
             Preferences p2;
             p2.begin("wifi", /*readOnly=*/true);
-            pwd = p2.getString("pwd", "");
+            pwd = prefStr(p2, "pwd");
             p2.end();
         }
         // PSK redacted from logs per CLAUDE.md security note.


### PR DESCRIPTION
Closes #908 on merge. Fixes #899, under Feature #891.

**Touches firmware** (unlike #892), so the full `ci-green` matrix is the real gate here.

## The defect is an API contract violated by its own implementation

Arduino's `Preferences::getString(key, default)` takes a default **precisely so a missing key is normal**, then logs at ERROR when it uses it:

```c
// Preferences.cpp:483
esp_err_t err = nvs_get_str(_handle, key, value, &len);
if(err){
    log_e("nvs_get_str len fail: %s %s", key, nvs_error(err));
    return String(defaultValue);
}
```

Any caller using that API as designed emits ERROR spam by construction. Our config makes it *continuous*: `writeBrokerConfig` deliberately **removes** empty fields rather than storing blanks (#182), so absent keys are the designed steady state, and the MQTT pool worker re-drives every slot on a 500 ms cycle.

Only `getString` is affected — the numeric getters log at `log_v`, which is why exactly the string keys appeared in the capture while `enabled`, `port` and `transport` did not.

## Why not the obvious fix

Short-circuiting `readBrokerConfig` on a disabled slot was proposed and **rejected by the owner**, for two reasons — the second worse than the first:

1. A slot can be **disabled but still hold a valid URL** — a legacy broker kept deliberately rather than cleared. Gating on `!enabled && empty-url` still reads every key for it.
2. `readBrokerConfig` is **shared with the CLI display path**. `ObserverCli.cpp:460` (`get mqtt.broker.<N>.<key>`) calls it with no enabled check and prints `cfg.username`. Any gate inside the reader makes the CLI report **empty for that legacy broker** — silently hiding config still present in NVS. Worse than log spam.

## The fix

```cpp
inline String prefStr(Preferences& p, const char* key, const char* dflt = "") {
    return p.getType(key) == PT_STR ? p.getString(key, dflt) : String(dflt);
}
```

**`getType(key) == PT_STR`, not `isKey(key)`.** `isKey()` is literally `getType(key) != PT_INVALID`, so this costs the same — but `isKey` returns true for a key holding a **non-string** type, and `getString` would then fail with `ESP_ERR_NVS_TYPE_MISMATCH` and log at ERROR anyway, reintroducing the defect. Found by review.

15 call sites converted (`ConfigSchema.cpp` 11, `WifiBootstrap.cpp` 2, `WifiConfigProvider.cpp` 2). Behaviour is otherwise **identical** — a missing key still yields the default — so every caller including the CLI display path is unchanged.

## Hardware verification — ST-P, same 79-command sweep before and after

| | Before | After |
|---|---|---|
| NVS ERROR lines | **10,135** | **0** |
| Rate | 29.3/sec | **0.0/sec** |
| Share of all serial bytes | **97.1%** | **0.0%** |
| Replies with spliced log output | **79/79** | **0/79** |

`cli_sweep analyse` → **79 commands, no findings.** Replies that were previously corrupted mid-word are intact (`get txdelay -> > 0.5`), and `get prv.key` is confirmed **redacted on real hardware**.

## Read the numbers correctly — this is not a latency fix

**Time-to-first-byte: 0.014 s before, 0.015 s after.** The device was always answering in ~14 ms. The large apparent round-trip improvement was the measuring tool's idle-detection waiting out the chatter, not device speed. UART utilisation from the spam was only **~15.8%** — nowhere near saturation.

So **#893's ~20–25 s is not explained by this** and does not live in the CLI handler or the serial path. It stays open, now finally measurable.

**#871 also stays open.** This removes the traffic that made splicing constant; it does not serialise the two UART writers. Any other component logging while a reply is in flight reproduces it.

## The guard

`scripts/check_nvs_guarded_reads.py` bans bare `getString` **repo-wide**, with the helper as the single exemption — granted only while the helper still contains its type check, so renaming a function to `prefStr` cannot disable it.

**Proven red on the pre-fix tree (15 findings, exit 1) and clean after (260 files, exit 0)** — per #712, a guard must be demonstrated catching the real defect.

Scope is repo-wide because I **measured instead of assuming**: my first version was scoped to one directory on the reasoning that a wider net would flag too much existing code. The tree contains three bare call sites in total. The narrow guard bought nothing and guaranteed recurrence.

## Adversarial review — two passes, 12 findings

**Fixed:** type mismatch (`isKey` → `getType == PT_STR`); scope too narrow (now repo-wide); `->` pointer receivers; calls split across lines; macros hiding the call (now *reported*, not missed); a fake helper forging the exemption via a comment; and — a **silent miss**, the worst kind — a `//` inside a string literal (`"http://…"`) blanking the rest of the line and swallowing a real violation.

**Justified, not fixed:**
- **TOCTOU** — a key erased between the type check and the read yields **one** stray line, against 29.3/sec continuously before. The Arduino API exposes no atomic "read if present".
- **Cost** — `getType()` probes up to ten `nvs_get_*` calls for a missing key. We trade one failing probe plus a ~60-byte UART write for ten index lookups. Worth it, but a real cost on a hot path.
- **`log_v` assumption** — if a future core release promotes the numeric getters to `log_e`, this guard must widen with it. An assumption about third-party code, recorded as such.

## Why no unit test on the firmware path

`readBrokerConfig` lives inside `#ifdef ARDUINO` and needs the real `Preferences` class; **no host shim exists in this tree** (the "host round-trip test" named in `ConfigSchema.cpp`'s comments is aspirational — nothing references it). Extracting a seam is the #714 testable-surface problem, not this task. Proven instead by the guard above plus the hardware table.

## Evidence

- **17 guard assertions green**
- Builds SUCCESS: `heltec_v4_repeater_telemetry`, `heltec_v4_companion_observer_wifi`, `Heltec_v3_companion_observer_wifi`
- Rebased onto current `firmware-base`, re-verified after rebase
