### PR TITLE
bug: terminal-Failed broker reap sticks and stops panicking (#838, #848)

### DIFF
--- a/docs/architecture/2026-08-20-broker-health-terminal-failed.md
+++ b/docs/architecture/2026-08-20-broker-health-terminal-failed.md
@@ -1,0 +1,169 @@
+# Broker Health, Backoff Escalation, and the Terminal `Failed` State
+
+**Date:** 2026-08-20
+**Status:** As-built (lands with #838 + #848)
+**Area:** `src/helpers/wifi_observer/` — `MqttBroker`, `MqttBrokerPool`, `BrokerHealth`
+**Issues:** #739 (penalty + terminal state), #838 (connect-layer escalation), #848 (Failed sticks + no crash; subsumes #823), #746 (auto-reconnect trade-off)
+
+## Why this exists
+
+The observer keeps a rotating set of TLS/wss MQTT broker connections, at most
+`OFFBAND_MAX_LIVE_TLS = 1` live at a time (heap on the ESP32 fits ~2 mbedTLS
+contexts before an OOM reboot). A configured broker can be healthy, flaky, or
+dead. This document is the design-of-record for how the pool tracks a broker's
+reliability, how it escalates backoff, and how a persistently-dead broker is
+given up on **without** starving the healthy ones, crashing the device, or
+churning a rotation slot forever.
+
+## Broker states (`BrokerState`)
+
+| State | Meaning |
+|---|---|
+| `Down` | disabled, or not yet attempted |
+| `Connecting` | TCP connect / TLS handshake in progress |
+| `Up` | connected and serving |
+| `Backoff` | failed; waiting out the (penalty-scaled) backoff window |
+| `HeldNoClock` | wss/TLS deferred until the wall clock is sane (NTP/GPS). Not a failure |
+| `HeldNoHeap` | TLS bring-up deferred: free heap below `OFFBAND_TLS_HEAP_FLOOR_BYTES`. Not a failure |
+| `HeldBudget` | TLS bring-up deferred: the pool already holds `OFFBAND_MAX_LIVE_TLS` live contexts — normal rotation waiting its turn. Not a failure |
+| `Failed` | **terminal** — given up on after sustained failure. Dropped from rotation, client reaped, logged loudly. Cleared only by operator reconfigure |
+
+## Health model — the sticky penalty (`BrokerHealth`)
+
+`BrokerHealth` is a dependency-free, host-testable policy object
+(`test/test_broker_health/`). It owns *how a broker's reliability maps to
+backoff, rehabilitation, and a terminal give-up*.
+
+- `fail_penalty` escalates on each failed connection attempt and is **sticky in
+  both directions**: a single success does **not** clear it (a flaky broker
+  cannot cheaply reset), and the broker must earn its way back with
+  `OFFBAND_BROKER_SUCCESS_BAR` (3) **consecutive** clean full-dwells.
+- Backoff length is `brokerBackoffMs(fail_penalty)` (5 / 15 / 30 / 60 / 120 s,
+  then 120 s capped) — it tracks the sticky penalty, **not** a per-attempt
+  counter that a lone success would zero.
+- Past `OFFBAND_BROKER_TERMINAL_PENALTY` (8) the broker is declared `Failed`.
+
+### Why a sticky penalty (the #739 problem)
+
+Before #739 the only backoff state was `retry_count`, reset to 0 on **any**
+successful connect. That is fine for a *dead* broker but wrong for a *flaky*
+one: an intermittent broker connects just often enough to zero its penalty, so
+it oscillates at the 5 s floor forever and keeps claiming a rotation turn equal
+to a reliable broker. Measured on hv3-bench: two ~50%-failing remote JWT brokers
+held 46 % of a soak with **no** TLS broker up.
+
+## Escalation — one choke point, time-window deduped (#838)
+
+Every failure routes through a single `MqttBroker::escalateFailureOnce(now_ms)`,
+which calls `BrokerHealth::onFailure()` at most once per
+`OFFBAND_FAIL_ESCALATE_WINDOW_MS` (5 s). The dedup decision itself lives in a
+dependency-free, host-tested seam — `offband::FailEscalateWindow`
+(`FailEscalateWindow.h`, `test/test_fail_escalate_window/`) — so the escalation
+logic that was hardware-only in #838 now has unit coverage. Callers:
+
+- `onDisconnected` — an established connection dropped.
+- `onError` — a connection error (**including a connect-layer refusal /
+  unreachable / timeout that fires `MQTT_EVENT_ERROR` with no following
+  `DISCONNECTED`**).
+- the two synchronous `tryConnect` failures (JWT re-apply, `client_start`).
+
+### Why a *time-window* dedupe
+
+A single failed attempt can surface three ways: `ERROR` alone (connect refused/
+unreachable — no `DISCONNECTED` follows), `ERROR`+`DISCONNECTED` (TLS/auth
+failure after the TCP connect), or `DISCONNECTED` alone (a clean drop). The 5 s
+window collapses the near-simultaneous ERROR+DISCONNECTED of one attempt to a
+single escalation, while genuinely separate attempts (esp-mqtt's reconnect
+cadence, or the pool's backoff-throttled retries — seconds+ apart) each count.
+
+The seam guards the window with an explicit `active_` flag rather than an
+`== 0` timestamp sentinel (so a real escalation at `millis() == 0` is not read
+as "no window", which would double-count its paired event), and `onConnected()`
+calls `reset()` so a failure after a genuine reconnect escalates immediately
+instead of being masked by the pre-success window. Both were Gemini-review
+findings (#906).
+
+**#838's core fix:** before it, escalation lived only in `onDisconnected`, so a
+**connect-layer** failure (ERROR with no DISCONNECTED — the common "server
+down" case) never escalated at all, and a dead broker never reached terminal.
+An earlier boolean-guard-reset-on-`MQTT_EVENT_BEFORE_CONNECT` design failed on
+hardware because connect-refused retries fire repeated ERRORs with no
+`BEFORE_CONNECT` between them; the time-window replaced it.
+
+## The terminal `Failed` state (#848, subsumes #823)
+
+When `fail_penalty` crosses the terminal threshold, `noteFailure()` sets
+`BrokerState::Failed`. Making that *stick* requires three things to all hold:
+
+1. **Reap the client, keep the state.** The pool's worker reaps a `Failed`
+   broker's client via `releaseClient(keep_failed = true)`. This destroys the
+   ~60 KB esp-mqtt/mbedTLS client (so esp-mqtt cannot auto-reconnect it) **but
+   preserves `state = Failed`**. A plain `releaseClient()` resets `rt_` to
+   `Down` — which was the real cause of #823: the broker looked `Down`, got
+   re-promoted, re-failed, and was reaped again in a churn loop.
+2. **Guards on every revive path.** `tryConnect()` and `reconcileSlot()`
+   early-return on `Failed`; `onConnected()` ignores a late CONNECTED for a
+   `Failed` broker (belt-and-suspenders against a racing auto-reconnect).
+3. **Excluded from the candidate set.** The worker's re-drive loop omits
+   `Failed` from the promotable states, so it never competes for the TLS budget.
+
+A `Failed` broker therefore holds no client, consumes no rotation turn, and
+stays out until an operator reconfigures it.
+
+### Worker stack sizing (the #848 crash)
+
+`esp_mqtt_client_stop` + `esp_mqtt_client_destroy` on a client that is
+**mid-connect-failure** is a deeper esp-tls/transport teardown than the clean
+rotated-out clients the pool destroys thousands of times during normal
+rotation — and it blocks the worker ~3–4 s while it joins the stuck mqtt task.
+Instrumentation measured the `mqtt_worker` stack high-water fall to **340 bytes
+free of 6144** during a terminal reap; it intermittently overflowed, tripping
+the stack canary on the adjacent IDLE0 task and panicking the device (the
+coredump writer then double-faulted on the exhausted stack, which is why the
+raw backtrace was corrupted). The worker stack is therefore **10240** bytes
+(+4 KB → ~4.4 KB worst-case headroom). This crash was latent since #739's
+reaper landed — it was never triggered because escalation never reached
+terminal until #838.
+
+## The auto-reconnect trade-off (#746)
+
+esp-mqtt's client-level auto-reconnect stays **ON**. Disabling it globally
+(reverted commit `cc8fec4a`) was catastrophic — a healthy broker terminally
+failed and rotation collapsed (`live=0/1` up to 96 %), because the pool's own
+reconnect path is not robust enough to be the sole connect driver. Auto-reconnect
+is kept as the resilience safety net. Its downside — reconnecting a still-*trying*
+(non-terminal) broker on its own ~10 s cadence, bypassing the pool's backoff — is
+an accepted trade-off: failures still escalate the sticky penalty through
+`onError`/`onDisconnected` regardless of who drives the connect, and a broker
+that reaches terminal has its client destroyed so auto-reconnect has nothing to
+resurrect.
+
+## Operator escape
+
+The only way out of `Failed` is an operator reconfigure — `mqtt enable/set/clear`
+→ `reloadSlot()`, which calls `MqttBroker::clearTerminalFailure()` (resets the
+penalty and `Failed → Down`) before the worker reconciles the slot, so the
+Failed-guards let it come back up with a clean slate.
+
+## Tunable constants
+
+| Constant | Value | Where |
+|---|---|---|
+| `OFFBAND_BROKER_SUCCESS_BAR` | 3 consecutive clean dwells to rehab | `BrokerHealth.h` |
+| `OFFBAND_BROKER_TERMINAL_PENALTY` | 8 | `BrokerHealth.h` |
+| `OFFBAND_FAIL_ESCALATE_WINDOW_MS` | 5000 | `FailEscalateWindow.h` |
+| backoff schedule | 5 / 15 / 30 / 60 / 120 s (capped) | `brokerBackoffMs()` |
+| `OFFBAND_MAX_LIVE_TLS` | 1 | build flag |
+| `mqtt_worker` stack | 10240 bytes | `MqttBrokerPool.cpp` |
+
+## Validation
+
+- `test/test_broker_health/` — 7 host tests of the sticky-penalty policy
+  (single-success-does-not-rehab, success-bar, flaky-alternating-goes-terminal,
+  etc.).
+- `test/test_fail_escalate_window/` — 6 host tests of the escalation dedup
+  (paired-collapse, separate-attempts-each-escalate, `millis()==0` no-double-count,
+  reset-unmasks-next-failure, flapping-keeps-escalating).
+- Hardware (hv3-bench): a broker's IP blocked at the router (REJECT tcp-reset)
+  drives it `p1→p8`, it reaches terminal `Failed`, **holds** (0 revivals), the
+  device does **not** panic, and the healthy broker keeps `live=1/1`.

--- a/docs/observer-cli-commands.md
+++ b/docs/observer-cli-commands.md
@@ -181,3 +181,43 @@ wifi status                       # confirm StaConnected + IP
 # ...configure a broker slot (see "Broker auth — wss/jwt" above)...
 mqtt status                       # wss reads held(no-clock) until the clock syncs, then up
 ```
+
+## Broker health & the `Failed` state
+
+`mqtt status` shows a state per broker slot. What each means for you:
+
+| State | What it means |
+|---|---|
+| `up` | connected and publishing |
+| `backoff` | last attempt failed; retrying, with the wait growing the longer it keeps failing (5s → 15s → 30s → 60s → 120s) |
+| `held(budget)` | fine — just waiting its turn; only one TLS broker is live at a time and another has the slot |
+| `held(no-clock)` | waiting for the clock to sync (NTP/GPS) before a TLS handshake — **not** a failure |
+| `held(no-heap)` | deferred because free memory is low — rare |
+| `failed(gave-up)` | **the observer has given up on this broker** — see below |
+
+### When a broker keeps failing
+
+If a broker is unreachable (server down, wrong host, blocked, bad cert), the
+observer retries with an **escalating backoff** so a flaky broker can't hog a
+connection slot from a healthy one. If it keeps failing through the full
+escalation, the observer marks it **`failed(gave-up)`**: it stops trying,
+**drops out of rotation entirely**, and frees its memory. This is deliberate —
+a permanently-dead broker should not burn a rotation turn every cycle or waste
+heap. Your other brokers are unaffected.
+
+### Clearing a `failed` broker
+
+`failed(gave-up)` is terminal — the observer will **not** retry it on its own.
+To bring it back after you've fixed the underlying problem (server back up, host
+corrected, etc.), **reconfigure the slot**, which clears the failure and starts
+it fresh:
+
+```
+mqtt set <N> url wss://your.broker:443/mqtt   # re-set any field, or
+mqtt enable <N>                               # toggle it, or
+mqtt disable <N> ; mqtt enable <N>
+mqtt status                                   # slot returns to backoff -> up
+```
+
+A reboot also clears it (state is not persisted), but reconfiguring the slot is
+the intended, no-reboot path.

--- a/src/helpers/wifi_observer/FailEscalateWindow.h
+++ b/src/helpers/wifi_observer/FailEscalateWindow.h
@@ -1,0 +1,54 @@
+#pragma once
+#include <cstdint>
+
+// Dependency-free, host-testable dedupe for broker failure-penalty escalation
+// (#838 / #906). A single failed connection attempt can surface as up to three
+// esp-mqtt events within milliseconds -- ERROR alone (connect refused /
+// unreachable, no DISCONNECTED follows), ERROR+DISCONNECTED (TLS/auth failure
+// after the TCP connect), or DISCONNECTED alone (clean drop). We want ONE
+// penalty escalation per attempt, while GENUINELY separate attempts (esp-mqtt's
+// reconnect cadence, or the pool's backoff-throttled retries -- seconds+ apart)
+// each escalate.
+//
+// shouldEscalate() collapses events that fall within OFFBAND_FAIL_ESCALATE_WINDOW_MS
+// of the last escalation into one. An explicit `active_` flag -- not
+// last_ms_ == 0 -- gates the window, so a real escalation at millis()==0 is not
+// mistaken for "no window" (which would let its paired event double-count).
+// reset() is called on a clean connect so a failure AFTER a genuine reconnect
+// escalates immediately instead of being masked by the pre-success window.
+//
+// A BEFORE_CONNECT-reset boolean was tried first and failed on hardware:
+// connect-refused retries fire repeated ERRORs with no BEFORE_CONNECT between
+// them, so the guard stayed set and the penalty stuck at 1 (a dead broker never
+// reached Failed). The time-window does not depend on any such intervening event.
+
+#ifndef OFFBAND_FAIL_ESCALATE_WINDOW_MS
+  #define OFFBAND_FAIL_ESCALATE_WINDOW_MS 5000u
+#endif
+
+namespace offband {
+
+class FailEscalateWindow {
+public:
+    // Returns true if this failure should count (escalate the penalty), false if
+    // it collapses into the currently-open window. Slides the window forward to
+    // now_ms each time it returns true.
+    bool shouldEscalate(uint32_t now_ms) {
+        if (active_ &&
+            (uint32_t)(now_ms - last_ms_) < OFFBAND_FAIL_ESCALATE_WINDOW_MS) {
+            return false;
+        }
+        active_ = true;
+        last_ms_ = now_ms;
+        return true;
+    }
+
+    // A clean connect ends the window: the next failure escalates immediately.
+    void reset() { active_ = false; }
+
+private:
+    uint32_t last_ms_ = 0;
+    bool     active_  = false;
+};
+
+}  // namespace offband

--- a/src/helpers/wifi_observer/MqttBroker.cpp
+++ b/src/helpers/wifi_observer/MqttBroker.cpp
@@ -147,7 +147,7 @@ void MqttBroker::initLock() {
 // #175: connection teardown ONLY -- no deconfigure. shutdown() is this plus the
 // #98 slot wipe; TLS rotation uses this directly so the victim stays configured
 // (and therefore visible to the pool loops, which all gate on isConfigured()).
-void MqttBroker::releaseClient() {
+void MqttBroker::releaseClient(bool keep_failed) {
 #if defined(ARDUINO) && defined(ESP_PLATFORM)
     ClientLockGuard _g(client_lock_);
     if (client_ != nullptr) {
@@ -161,7 +161,20 @@ void MqttBroker::releaseClient() {
         delete auth_;
         auth_ = nullptr;
     }
-    rt_ = BrokerRuntimeState{};
+    // #848 Facet A: the reaper reaps a TERMINALLY-FAILED broker's client but must
+    // PRESERVE the Failed state -- a plain rt_ = {} resets it to Down, which is the
+    // real cause of #823 (the broker looks Down, gets re-promoted, re-fails, is
+    // reaped again -> churn, and each heavy teardown risks the Facet-B overflow).
+    // With state kept Failed, the pool's Failed-guards (tryConnect/reconcileSlot)
+    // hold it out of rotation until an operator reconfigure clears it. Only an
+    // actual reap of a Failed broker preserves; every other caller (rotation) still
+    // gets the full reset to Down.
+    if (keep_failed && rt_.state == BrokerState::Failed) {
+        rt_ = BrokerRuntimeState{};
+        rt_.state = BrokerState::Failed;
+    } else {
+        rt_ = BrokerRuntimeState{};
+    }
     // slot_ and cfg_ deliberately RETAINED -- that is the whole difference from
     // shutdown(). A rotated-out broker must stay configured so the pool can see
     // it, honor its cooldown, and promote it back via reconcileSlot->tryConnect.
@@ -346,7 +359,7 @@ bool MqttBroker::tryConnect(uint32_t now_ms, bool tls_budget_ok) {
         if (!auth_->apply(mqcfg, now_ms)) {
             rt_.retry_count++;
             rt_.last_error_class = BrokerErrorClass::Auth;
-            noteFailure();   // #739
+            escalateFailureOnce(now_ms);   // #739/#838
             return false;
         }
         esp_mqtt_set_config(client_, &mqcfg);
@@ -373,7 +386,7 @@ bool MqttBroker::tryConnect(uint32_t now_ms, bool tls_budget_ok) {
     if (err != ESP_OK) {
         rt_.retry_count++;
         rt_.last_error_class = BrokerErrorClass::Other;
-        noteFailure();   // #739
+        escalateFailureOnce(now_ms);   // #739/#838
         return false;
     }
     started_ = true;
@@ -544,6 +557,9 @@ void MqttBroker::onConnected(uint32_t now_ms) {
     rt_.went_up_ms = now_ms;   // #175: dwell clock for TLS rotation
     rt_.retry_count = 0;
     rt_.last_error_class = BrokerErrorClass::None;
+    fail_window_.reset();   // #906: a clean connect ends the escalation window,
+                            // so a later failure escalates instead of being
+                            // masked by the pre-success failure's window.
 }
 
 void MqttBroker::onDisconnected(uint32_t now_ms, BrokerErrorClass err) {
@@ -552,7 +568,16 @@ void MqttBroker::onDisconnected(uint32_t now_ms, BrokerErrorClass err) {
     rt_.last_error_ms = now_ms;
     rt_.retry_count++;
     rt_.last_error_class = err;
-    noteFailure();   // #739: escalate penalty; may promote Backoff -> Failed
+    escalateFailureOnce(now_ms);   // #739/#838: escalate; may promote Backoff -> Failed
+}
+
+// #838/#906: escalate the health penalty once per failed attempt. The window /
+// millis()==0 / reset-on-success logic lives in FailEscalateWindow (header-only,
+// host-tested in test/test_fail_escalate_window); see that header for rationale
+// and the BEFORE_CONNECT-boolean design that failed on hardware.
+void MqttBroker::escalateFailureOnce(uint32_t now_ms) {
+    if (!fail_window_.shouldEscalate(now_ms)) return;
+    noteFailure();
 }
 
 // #739: single choke point for a connection failure. Escalates the health
@@ -565,10 +590,17 @@ void MqttBroker::noteFailure() {
 }
 
 void MqttBroker::onError(uint32_t now_ms, BrokerErrorClass err) {
-    // Errors typically precede a DISCONNECTED; record the class so the
-    // subsequent disconnect transition records a meaningful reason.
+    // Record the class so a subsequent DISCONNECTED transition (if one follows)
+    // reports a meaningful reason.
     rt_.last_error_ms = now_ms;
     rt_.last_error_class = err;
+    // #838: a connect-layer failure (refused/unreachable/connect-timeout) surfaces
+    // as MQTT_EVENT_ERROR with NO following DISCONNECTED, so escalation must happen
+    // here too -- otherwise a dead broker retries forever and never reaches Failed.
+    // escalateFailureOnce()'s window collapses the DISCONNECTED that DOES follow a
+    // mid-session TLS/auth failure into this same escalation, so it never
+    // double-counts one attempt.
+    escalateFailureOnce(now_ms);
 }
 
 #endif  // ARDUINO && ESP_PLATFORM

--- a/src/helpers/wifi_observer/MqttBroker.h
+++ b/src/helpers/wifi_observer/MqttBroker.h
@@ -8,6 +8,7 @@
 #include "ConfigSchema.h"
 #include "MqttAuth.h"
 #include "BrokerHealth.h"   // #739: connection-health / penalty tracker
+#include "FailEscalateWindow.h"   // #838/#906: per-attempt escalation dedupe
 #include "MqttPayload.h"
 
 #ifdef ARDUINO
@@ -118,7 +119,10 @@ public:
     // are gated on isConfigured()), stranding it permanently -- one-way eviction
     // instead of round-robin. With the slot still configured, the pool's normal
     // cooldown -> budget -> reconcileSlot -> tryConnect path can promote it back.
-    void releaseClient();
+    // keep_failed (#848): when true AND the broker is terminally Failed, reap the
+    // client but PRESERVE the Failed state instead of resetting rt_ to Down. Only
+    // the pool's Failed-reaper passes true; rotation (default false) still resets.
+    void releaseClient(bool keep_failed = false);
 
     // Create the per-broker client mutex. Call ONCE from the pool on
     // loopTask, before the lifecycle worker task starts (#53),
@@ -161,6 +165,20 @@ public:
     const BrokerHealth&        health() const { return health_; }
     void                       noteCleanDwell() { health_.onCleanDwell(); }
 
+    // #823: clear a TERMINAL Failed state. Failed is otherwise terminal -- the
+    // pool's reconcileSlot() refuses to revive it via begin(), so the ONLY escape
+    // is an explicit operator reconfigure (mqtt enable/set/clear -> reloadSlot),
+    // which calls this before reconciling. Resets the penalty so the reconfigured
+    // broker gets a fresh start instead of re-failing on its first hiccup. No-op
+    // for a broker that is not terminally Failed, so tweaking a healthy/backoff
+    // broker's config preserves its accumulated penalty.
+    void clearTerminalFailure() {
+        if (rt_.state == BrokerState::Failed) {
+            rt_.state = BrokerState::Down;
+            health_.reset();
+        }
+    }
+
     // #175: true if the esp_mqtt client handle currently exists. shutdown()
     // destroys it (client_ = nullptr) to free the ~60KB TLS context without
     // leaking (#327); tryConnect can only START an existing client, never create
@@ -202,6 +220,11 @@ private:
     // (after a dropped/failed connection) leaks transport + mbedTLS allocations.
     bool started_ = false;
 
+    // #838/#906: collapses the up-to-three esp-mqtt events of one failed attempt
+    // into a single penalty escalation, while separate attempts each escalate.
+    // Host-tested in test/test_fail_escalate_window. reset() on a clean connect.
+    FailEscalateWindow fail_window_;
+
     // C-style event dispatch -- esp_mqtt requires a static function.
     // The handler_args is the MqttBroker* registered via
     // esp_mqtt_client_register_event.
@@ -212,6 +235,7 @@ private:
     void onConnected(uint32_t now_ms);
     void onDisconnected(uint32_t now_ms, BrokerErrorClass err);
     void onError(uint32_t now_ms, BrokerErrorClass err);
+    void escalateFailureOnce(uint32_t now_ms);  // #838: one escalation per attempt
 #endif
 };
 

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -105,8 +105,14 @@ void MqttBrokerPool::begin(const mesh::LocalIdentity& identity,
     worker_run_  = true;
     reconcile_q_ = xQueueCreate(OFFBAND_MAX_BROKERS * 2, sizeof(uint8_t));
     if (reconcile_q_ != nullptr) {
+        // #848 Facet B: 10240 (was 6144). esp_mqtt_client_stop+destroy on a client
+        // that is MID-CONNECT-FAILURE takes a deeper esp-tls/transport teardown than
+        // a clean rotated-out client -- measured worker stack high-water fell to 340
+        // bytes free of 6144 during a terminal-Failed reap and intermittently
+        // overflowed (canary fired on the adjacent IDLE0 -> panic). +4 KB gives
+        // ~4.4 KB worst-case headroom for that teardown.
         xTaskCreatePinnedToCore(&MqttBrokerPool::workerTrampoline, "mqtt_worker",
-                                6144, this, 5, &worker_task_, tskNO_AFFINITY);
+                                10240, this, 5, &worker_task_, tskNO_AFFINITY);
     }
 #endif
 }
@@ -445,6 +451,12 @@ bool MqttBrokerPool::reloadSlot(uint8_t slot) {
     // here on) and hand it to the worker, which does the actual begin/shutdown
     // (potentially multi-second esp_mqtt teardown) OFF loopTask.
     if (identity_ == nullptr || reconcile_q_ == nullptr) return false;
+    // #823: an operator reconfigure (mqtt enable/set/clear) is the documented
+    // escape from terminal Failed. Clear it here -- BEFORE the worker runs
+    // reconcileSlot(), whose Failed-guard would otherwise refuse to bring the slot
+    // back up. reloadSlot() is operator-CLI-only (ObserverCli), so nothing
+    // automatic reaches this; a no-op for any slot that is not terminally Failed.
+    brokers_[slot].clearTerminalFailure();
     reconciling_[slot] = true;
     uint8_t s = slot;
     if (xQueueSend(reconcile_q_, &s, 0) != pdTRUE) {
@@ -471,6 +483,16 @@ void MqttBrokerPool::workerTrampoline(void* arg) {
 // worker task. begin() creates a client only if the slot is enabled.
 void MqttBrokerPool::reconcileSlot(uint8_t slot) {
     if (slot >= OFFBAND_MAX_BROKERS || identity_ == nullptr) return;
+    // #823: Failed is TERMINAL. begin() (called below) is the ONLY thing that
+    // resets rt_.state out of Failed, and reconcileSlot() is its only automatic
+    // caller -- so this is the single choke point that enforces the invariant,
+    // instead of relying on every candidate/promotion path to exclude Failed
+    // (one of them leaked, reviving the broker -- #823). The reaper leaves a
+    // Failed broker client-less; returning here keeps it that way. The ONLY escape
+    // is an operator reconfigure: reloadSlot() calls clearTerminalFailure() (state
+    // -> Down) BEFORE enqueueing, so an operator-cleared slot is no longer Failed
+    // by the time this runs and proceeds normally.
+    if (brokers_[slot].runtime().state == BrokerState::Failed) return;
     BrokerConfig cfg;
     if (!readBrokerConfig(slot, cfg) || cfg.url[0] == '\0') {
         brokers_[slot].shutdown();   // no/empty config -> ensure no client
@@ -743,7 +765,10 @@ void MqttBrokerPool::workerLoop() {
             // the global disable_auto_reconnect broke normal reconnection (soak: 96%
             // no-TLS-up, a healthy broker terminally failed).
             if (b.runtime().state == BrokerState::Failed) {
-                if (b.hasClient()) b.releaseClient();
+                // #848 Facet A: keep_failed=true so releaseClient reaps the client
+                // but PRESERVES the Failed state (a plain reap resets rt_ to Down,
+                // which let the broker be re-promoted -> the #823 churn).
+                if (b.hasClient()) b.releaseClient(/*keep_failed=*/true);
                 continue;
             }
             b.loop(now);

--- a/test/test_fail_escalate_window/test_fail_escalate_window.cpp
+++ b/test/test_fail_escalate_window/test_fail_escalate_window.cpp
@@ -1,0 +1,69 @@
+#include <gtest/gtest.h>
+#include "helpers/wifi_observer/FailEscalateWindow.h"
+
+using offband::FailEscalateWindow;
+
+// Baseline: the first failure of an attempt escalates.
+TEST(FailEscalateWindow, FirstFailureEscalates) {
+    FailEscalateWindow w;
+    EXPECT_TRUE(w.shouldEscalate(1000));
+}
+
+// The up-to-three events of ONE attempt (ERROR / ERROR+DISCONNECTED /
+// DISCONNECTED), arriving within milliseconds, collapse to a single escalation.
+TEST(FailEscalateWindow, PairedEventsCollapseToOne) {
+    FailEscalateWindow w;
+    EXPECT_TRUE(w.shouldEscalate(1000));    // ERROR
+    EXPECT_FALSE(w.shouldEscalate(1003));   // DISCONNECTED ms later -- same attempt
+    EXPECT_FALSE(w.shouldEscalate(1050));   // still inside the window
+}
+
+// Genuinely separate attempts (seconds+ apart) each escalate. The window slides
+// forward to each escalation, so it is measured from the LAST count, not the first.
+TEST(FailEscalateWindow, SeparateAttemptsEachEscalate) {
+    FailEscalateWindow w;
+    EXPECT_TRUE(w.shouldEscalate(0));                                  // attempt 1
+    EXPECT_FALSE(w.shouldEscalate(OFFBAND_FAIL_ESCALATE_WINDOW_MS - 1));
+    EXPECT_TRUE(w.shouldEscalate(OFFBAND_FAIL_ESCALATE_WINDOW_MS + 100)); // attempt 2
+    // window now anchored at +5100; a hit just after it collapses again
+    EXPECT_FALSE(w.shouldEscalate(OFFBAND_FAIL_ESCALATE_WINDOW_MS + 200));
+}
+
+// #906 finding 3: a real escalation at millis()==0 must not read as "no window".
+// The paired event a few ms later must still collapse (no double-count).
+TEST(FailEscalateWindow, EscalationAtZeroIsNotDoubleCounted) {
+    FailEscalateWindow w;
+    EXPECT_TRUE(w.shouldEscalate(0));    // first event at t=0
+    EXPECT_FALSE(w.shouldEscalate(3));   // paired event -- collapses, not double
+    EXPECT_FALSE(w.shouldEscalate(50));
+}
+
+// #906 finding 2: a clean connect ends the window, so a failure after a genuine
+// reconnect escalates immediately instead of being masked by the pre-success
+// window. Without reset(), the t=101000 failure would collapse into t=100000.
+TEST(FailEscalateWindow, ResetOnConnectUnmasksNextFailure) {
+    FailEscalateWindow w;
+    EXPECT_TRUE(w.shouldEscalate(100000));   // failure -> window @100000
+    w.reset();                               // clean connect
+    EXPECT_TRUE(w.shouldEscalate(101000));   // 1s later, still <5s: escalates ONLY because reset
+}
+
+// A flapping broker (fail, briefly up, fail...) keeps escalating across resets,
+// so it can still climb to terminal rather than sticking at penalty 1.
+TEST(FailEscalateWindow, FlappingKeepsEscalating) {
+    FailEscalateWindow w;
+    int escalations = 0;
+    uint32_t t = 0;
+    for (int i = 0; i < 8; i++) {
+        if (w.shouldEscalate(t)) escalations++;  // failure
+        t += 500;
+        w.reset();                                // brief successful connect
+        t += 500;
+    }
+    EXPECT_EQ(escalations, 8);   // every flap counts -- reaches terminal territory
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Fixes the observer MQTT broker pool's terminal-`Failed` lifecycle end-to-end. Rides testing task #906; root-fix debt tracked in #907.

## What changed and why

Three coupled defects on the broker reliability line (#177):

### #838 — connect-layer failures never escalated
Penalty escalation lived only in `onDisconnected()`, but a broker that is unreachable at the TCP-connect layer fires `MQTT_EVENT_ERROR` with **no** following `DISCONNECTED`. So a genuinely dead broker never escalated and never reached terminal `Failed` — it retried forever at the backoff floor, permanently consuming a rotation turn (exactly what #739's `Failed` state was meant to prevent).

**Fix:** all failure paths (`onError`, `onDisconnected`, both synchronous `tryConnect` failures) route through one `escalateFailureOnce(now_ms)`. The dedup decision lives in a new dependency-free, host-tested seam — `offband::FailEscalateWindow` (`FailEscalateWindow.h`) — which collapses the up-to-three esp-mqtt events of one attempt into a single escalation while counting genuinely separate attempts. (An earlier BEFORE_CONNECT-reset boolean was refuted on hardware — connect-refused retries fire repeated ERRORs with no BEFORE_CONNECT between them, pinning the penalty at 1.)

### #848 Facet A — terminal `Failed` did not stick (folds #823)
`releaseClient()` ended with `rt_ = {}`, resetting state to `Down`. So when the reaper freed a `Failed` broker's client, it **erased the Failed state** (penalty retained → `DNp8`), the broker was re-promoted, re-failed, and churned. This is the true root cause of #823 (whose "revived by reconcileSlot" framing was wrong — the state was already `Down` before reconcile ran).

**Fix:** `releaseClient(keep_failed=true)` on the reap path preserves `state=Failed` while freeing the ~60 KB client; revive paths (`tryConnect`/`reconcileSlot`/`onConnected`) early-return on `Failed`; `clearTerminalFailure()` clears it on operator reconfigure.

### #848 Facet B — the teardown panicked the device
`esp_mqtt_client_stop`+`destroy` on a **mid-connect-failure** client drove the `mqtt_worker` stack high-water to **340 bytes free of 6144**, intermittently overflowing into the adjacent IDLE0 task's stack canary → panic + reboot → penalty reset → crash-loop. (The coredump writer then double-faulted on the exhausted stack, which is why the raw backtrace was corrupted; pinned via stack-HWM instrumentation.)

**Fix:** `mqtt_worker` stack 6144 → 10240 (~4.4 KB headroom, ~13× the measured floor). This is a mitigation; the root fix (moving the deep teardown off the rotation worker, resource-class-aware) is tracked in #907.

## Gemini adversarial gate

`scripts/llm-consult.py --backend gemini --model gemini-2.5-pro`, hostile prompt, four findings:

- **F2 (med), F3 (low) — fixed.** Escalation window never reset on a clean connect (a failure after a genuine reconnect was masked); and a `millis()==0` escalation was double-counted. Both dissolved by the `FailEscalateWindow` seam (explicit `active_` flag, `reset()` on `onConnected`).
- **F1 (high) — justified + debt filed (#907).** +4 KB worker stack is a mitigation, not a root fix. `MAX_LIVE_TLS=1` → one teardown at a time; ~13× headroom; the soak drove two different wss brokers (different cert chains) to terminal with 0 crashes.
- **F4 — withdrawn by Gemini itself** (the time-window guard serialises the counter).

## Evidence

- **Host tests: 13/13** — `test/test_broker_health/` (7) + new `test/test_fail_escalate_window/` (6: paired-collapse, separate-attempts, `millis()==0` no-double-count, reset-unmasks-next, flapping-keeps-escalating). Re-run green post-rebase.
- **Firmware build** `Heltec_v3_companion_observer_wifi` **SUCCESS** (RAM 35.1%, Flash 44.5%), post-rebase.
- **Hardware (hv3-bench)** — full record in #906: connect-layer escalation p1→p8 (#838); ~45-min soak with two independent terminal reaps against two blocked wss brokers — **0 panics**, both `Failed` held (257/247 samples, 0 revivals), `live=1/1` throughout, no heap leak.

## Docs

- `docs/architecture/2026-08-20-broker-health-terminal-failed.md` — tech spec (states, sticky penalty, escalation choke point, terminal mechanics, auto-reconnect trade-off #746, constants, validation).
- `docs/observer-cli-commands.md` — user-facing "Broker health & the `Failed` state" section.

Closes #838
Closes #848
