### PR TITLE
bug: broker dwell-reset can block rotation — evict on a reconnect-proof budget-hold clock (#720)

### DIFF
--- a/src/helpers/wifi_observer/BudgetHoldClock.h
+++ b/src/helpers/wifi_observer/BudgetHoldClock.h
@@ -1,0 +1,51 @@
+#pragma once
+#include <cstdint>
+
+// Reconnect-proof clock for how long a broker has held the single TLS budget
+// slot, used to decide rotation eviction (#720). Dependency-free (no
+// Arduino/ESP headers) so it builds in [env:native] -- same pattern as
+// BrokerHealth / FailEscalateWindow / BrokerRotationSelect.
+//
+// WHY THIS EXISTS: rotation eviction used `went_up_ms` ("connected since") for
+// the victim's age. `went_up_ms` is re-stamped on EVERY transition to Up,
+// including esp-mqtt's silent auto-reconnect. With OFFBAND_MAX_LIVE_TLS = 1
+// there is one Up broker at a time; if it flaps faster than the dwell, its age
+// resets below the eviction threshold every pass, rotation never fires, and
+// every other enabled TLS broker is starved forever (the observer looks healthy:
+// one broker Up, no errors). Eviction needs a clock a reconnect does NOT reset.
+//
+// A `held_` flag -- not `since_ms_ == 0` -- marks occupancy, so a real
+// acquisition at millis()==0 is unambiguous (same sentinel discipline as
+// FailEscalateWindow). onConnected() stamps the start ONCE per occupancy;
+// reconnects (auto or pool-driven Backoff->retry, which keep the client and do
+// not release the budget) leave it. onReleased() clears it when the client is
+// destroyed (rotation eviction or terminal reap), so the next acquisition
+// stamps fresh.
+
+namespace offband {
+
+class BudgetHoldClock {
+public:
+    // Call on each transition to Up. Records the hold start once per occupancy;
+    // a reconnect (held_ already true) does not move it.
+    void onConnected(uint32_t now_ms) {
+        if (!held_) { held_ = true; since_ms_ = now_ms; }
+    }
+
+    // Call when the budget is released -- the client is destroyed (rotation
+    // eviction or terminal-Failed reap). The next onConnected() starts fresh.
+    void onReleased() { held_ = false; since_ms_ = 0; }
+
+    bool held() const { return held_; }
+
+    // How long the budget has been continuously held, wrap-safe. 0 if not held.
+    uint32_t heldMs(uint32_t now_ms) const {
+        return held_ ? (uint32_t)(now_ms - since_ms_) : 0;
+    }
+
+private:
+    bool     held_     = false;
+    uint32_t since_ms_ = 0;
+};
+
+}  // namespace offband

--- a/src/helpers/wifi_observer/MqttBroker.cpp
+++ b/src/helpers/wifi_observer/MqttBroker.cpp
@@ -175,6 +175,8 @@ void MqttBroker::releaseClient(bool keep_failed) {
     } else {
         rt_ = BrokerRuntimeState{};
     }
+    budget_hold_.onReleased();  // #720: the budget slot is freed on either path;
+                                // the next acquisition stamps a fresh hold clock.
     // slot_ and cfg_ deliberately RETAINED -- that is the whole difference from
     // shutdown(). A rotated-out broker must stay configured so the pool can see
     // it, honor its cooldown, and promote it back via reconcileSlot->tryConnect.
@@ -553,8 +555,17 @@ void MqttBroker::onConnected(uint32_t now_ms) {
     // reconnect); this is belt-and-suspenders for a connect event in flight when
     // the broker went Failed. Failed clears only by operator re-enable/reconfigure.
     if (rt_.state == BrokerState::Failed) return;
+    // #720: same belt-and-suspenders as the Failed guard above, for the rotation
+    // path. releaseClient() destroys client_ then resets state to Down; a stale
+    // MQTT_EVENT_CONNECTED already queued before the teardown can be dispatched
+    // afterwards. Without this guard it would set state=Up + stamp budget_hold_
+    // with no client behind it -- a "zombie" that occupies the TLS budget slot
+    // (rotation would evict it within a dwell, but the inconsistency is real).
+    if (!hasClient()) return;
     rt_.state = BrokerState::Up;
-    rt_.went_up_ms = now_ms;   // #175: dwell clock for TLS rotation
+    rt_.went_up_ms = now_ms;   // #175: dwell clock for TLS rotation (display/age)
+    budget_hold_.onConnected(now_ms);  // #720: eviction clock -- stamped once per
+                                       // occupancy, NOT reset by this reconnect
     rt_.retry_count = 0;
     rt_.last_error_class = BrokerErrorClass::None;
     fail_window_.reset();   // #906: a clean connect ends the escalation window,

--- a/src/helpers/wifi_observer/MqttBroker.h
+++ b/src/helpers/wifi_observer/MqttBroker.h
@@ -9,6 +9,7 @@
 #include "MqttAuth.h"
 #include "BrokerHealth.h"   // #739: connection-health / penalty tracker
 #include "FailEscalateWindow.h"   // #838/#906: per-attempt escalation dedupe
+#include "BudgetHoldClock.h"      // #720: reconnect-proof TLS-budget hold clock
 #include "MqttPayload.h"
 
 #ifdef ARDUINO
@@ -159,6 +160,11 @@ public:
     uint8_t                    slot()    const { return slot_; }
     const BrokerConfig&        config()  const { return cfg_; }
     const BrokerRuntimeState&  runtime() const { return rt_; }
+    // #720: how long this broker has continuously held the TLS budget slot,
+    // reconnect-proof (unlike runtime().went_up_ms). The rotation scheduler ages
+    // an eviction victim by THIS, not went_up_ms, so a flapping broker still
+    // rotates out instead of holding the slot forever.
+    uint32_t budgetHeldMs(uint32_t now_ms) const { return budget_hold_.heldMs(now_ms); }
     // #739: read-only health for status/rotation; noteCleanDwell() is called by
     // the pool when this broker is rotated out after holding a FULL dwell Up
     // with no error -- the only event that earns rehabilitation.
@@ -224,6 +230,11 @@ private:
     // into a single penalty escalation, while separate attempts each escalate.
     // Host-tested in test/test_fail_escalate_window. reset() on a clean connect.
     FailEscalateWindow fail_window_;
+
+    // #720: reconnect-proof clock for TLS-budget hold duration. Stamped on the
+    // first Up of an occupancy, cleared on releaseClient(); a reconnect does NOT
+    // reset it. Separate from rt_ (which a reconnect/rt_ reset would disturb).
+    BudgetHoldClock budget_hold_;
 
     // C-style event dispatch -- esp_mqtt requires a static function.
     // The handler_args is the MqttBroker* registered via

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -601,7 +601,12 @@ void MqttBrokerPool::rotateTlsIfDue(uint32_t now_ms) {
         const MqttBroker& b = brokers_[s];
         if (!b.isConfigured() || !isTlsTransport(b.config())) continue;
         if (b.runtime().state != BrokerState::Up) continue;
-        uint32_t age = now_ms - b.runtime().went_up_ms;
+        // #720: age by the reconnect-proof budget-hold clock, NOT went_up_ms.
+        // went_up_ms resets on every reconnect (incl. esp-mqtt auto-reconnect),
+        // so a broker flapping faster than the dwell never aged past the
+        // threshold below and rotation never fired -- starving every other TLS
+        // broker. budgetHeldMs() measures continuous slot occupancy instead.
+        uint32_t age = b.budgetHeldMs(now_ms);
         if (victim == 0xFF || age > best_age) { best_age = age; victim = s; }
     }
     if (victim == 0xFF) return;
@@ -713,8 +718,11 @@ void MqttBrokerPool::workerLoop() {
                     o += snprintf(L + o, (size_t)(sizeof(L) - o), " s%u:%s", (unsigned)s,
                                   stv < 8 ? AB[stv] : "?");
                     if (b.runtime().state == BrokerState::Up)
+                        // #720: show the budget-hold age -- the value eviction
+                        // actually keys off -- not went_up_ms (which resets on
+                        // reconnect), so the log matches the rotation decision.
                         o += snprintf(L + o, (size_t)(sizeof(L) - o), "/%us",
-                                      (unsigned)((now - b.runtime().went_up_ms) / 1000U));
+                                      (unsigned)(b.budgetHeldMs(now) / 1000U));
                     uint32_t cd = (rotated_out_until_ms_[s] != 0 &&
                                    (int32_t)(rotated_out_until_ms_[s] - now) > 0)
                                   ? (rotated_out_until_ms_[s] - now) / 1000U : 0U;

--- a/test/test_broker_rotation/test_broker_rotation.cpp
+++ b/test/test_broker_rotation/test_broker_rotation.cpp
@@ -1,10 +1,16 @@
 #include <gtest/gtest.h>
 #include <vector>
 #include "helpers/wifi_observer/BrokerRotationSelect.h"
+#include "helpers/wifi_observer/BudgetHoldClock.h"
 
 using offband::TlsCandidate;
 using offband::selectTlsPromotion;
 using offband::kNoSlot;
+using offband::BudgetHoldClock;
+
+// The firmware's rotation dwell -- eviction fires only once a broker has held the
+// budget this long (MqttBrokerPool.cpp MQTT_ROTATE_DWELL_MS).
+static constexpr uint32_t kDwellMs = 60000U;
 
 // ---------------------------------------------------------------------------
 // Rotation harness -- reproduces the pool's dwell cycle without hardware.
@@ -137,6 +143,72 @@ TEST(BrokerRotation, FullBudgetPromotesNothing) {
 TEST(BrokerRotation, NoEligibleCandidatesReturnsNoSlot) {
     TlsCandidate c[3];   // all default: eligible = false
     EXPECT_EQ(selectTlsPromotion(c, 3, 0, 1), kNoSlot);
+}
+
+// ===========================================================================
+// #720 -- the eviction clock. Eviction used went_up_ms, which resets on every
+// reconnect; a broker flapping faster than the dwell never aged out, so
+// rotation never fired and every other TLS broker starved. BudgetHoldClock is
+// the reconnect-proof replacement the eviction age is now taken from.
+// ===========================================================================
+
+// Baseline: a fresh hold ages from its acquisition instant.
+TEST(BudgetHoldClock, HeldTimeAdvancesFromAcquisition) {
+    BudgetHoldClock c;
+    EXPECT_FALSE(c.held());
+    EXPECT_EQ(c.heldMs(1000), 0u);       // not held -> zero
+    c.onConnected(1000);
+    EXPECT_TRUE(c.held());
+    EXPECT_EQ(c.heldMs(1000), 0u);
+    EXPECT_EQ(c.heldMs(61000), 60000u);  // aged one dwell
+}
+
+// THE #720 REGRESSION. A broker reconnecting every 30 s (faster than the 60 s
+// dwell) must still age past the dwell -- the reconnects do NOT reset the clock.
+// With went_up_ms this age would be a perpetual 5 s and eviction never fired.
+TEST(BudgetHoldClock, ReconnectDoesNotResetTheEvictionClock) {
+    BudgetHoldClock c;
+    c.onConnected(0);                    // first Up: hold starts at t=0
+    c.onConnected(30000);                // auto-reconnect -- must NOT reset
+    c.onConnected(60000);                // auto-reconnect -- must NOT reset
+    // A flapping broker's age keeps climbing; at t=65s it is evictable...
+    EXPECT_EQ(c.heldMs(65000), 65000u);
+    EXPECT_GE(c.heldMs(65000), kDwellMs);
+    // ...whereas went_up_ms (reset at the 60000 reconnect) would read 5000 and
+    // stay forever under the dwell -- the exact starvation this fixes.
+    EXPECT_LT(65000u - 60000u, kDwellMs);
+}
+
+// Anti-thrash survives: a freshly-acquired slot is NOT past the dwell yet, so
+// rotateTlsIfDue()'s `best_age < DWELL` guard still refuses to evict it early.
+TEST(BudgetHoldClock, FreshHoldIsNotYetEvictable) {
+    BudgetHoldClock c;
+    c.onConnected(100000);
+    EXPECT_LT(c.heldMs(130000), kDwellMs);   // 30 s held -> not evictable
+    EXPECT_GE(c.heldMs(160000), kDwellMs);   // 60 s held -> evictable
+}
+
+// Release clears the hold; the next acquisition starts a fresh clock (so a
+// broker rotated out and later promoted again does not inherit its old age).
+TEST(BudgetHoldClock, ReleaseResetsForNextOccupancy) {
+    BudgetHoldClock c;
+    c.onConnected(0);
+    EXPECT_GE(c.heldMs(70000), kDwellMs);
+    c.onReleased();                          // rotated out / reaped
+    EXPECT_FALSE(c.held());
+    EXPECT_EQ(c.heldMs(70000), 0u);
+    c.onConnected(200000);                   // promoted again later
+    EXPECT_EQ(c.heldMs(230000), 30000u);     // ages from the NEW acquisition
+}
+
+// millis()==0 is unambiguous: a real acquisition at t=0 is a genuine hold, not
+// mistaken for "never held" (the sentinel trap FailEscalateWindow also avoids).
+TEST(BudgetHoldClock, AcquisitionAtZeroIsAGenuineHold) {
+    BudgetHoldClock c;
+    c.onConnected(0);
+    EXPECT_TRUE(c.held());
+    c.onConnected(10);                       // reconnect a few ms later
+    EXPECT_EQ(c.heldMs(60000), 60000u);      // still anchored at t=0, not t=10
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Fixes a silent rotation-starvation bug in the observer's TLS broker pool. Under epic #177.

## What changed and why

`rotateTlsIfDue()` chose its eviction victim's age from `runtime().went_up_ms`, which `onConnected()` re-stamps on **every** transition to `Up` — including esp-mqtt's silent auto-reconnect. With `OFFBAND_MAX_LIVE_TLS = 1` there is one live broker at a time; if it flaps more often than the 60 s dwell, its age resets below the eviction threshold every pass, `rotateTlsIfDue()` returns early forever, and **every other enabled TLS broker is starved** — while the observer looks healthy (one broker `Up`, no errors).

**Fix:** a reconnect-proof clock.

- **`BudgetHoldClock.h`** (new, dependency-free seam — same pattern as `BrokerHealth` / `FailEscalateWindow` / `BrokerRotationSelect`): records the budget-hold start **once per occupancy** (`held_` bool, `millis()==0`-safe), not reset by a reconnect, cleared by `releaseClient()`.
- `MqttBroker` holds a `BudgetHoldClock budget_hold_`: `onConnected()` stamps it, `releaseClient()` clears it, `budgetHeldMs()` exposes it.
- `rotateTlsIfDue()` ages the victim by `budgetHeldMs()`, not `went_up_ms`. `went_up_ms` is kept for display only.

### Design note (deviation from the filed plan)
The issue suggested extracting a `selectEvictionVictim` seam. In the code that proved the wrong target: the eviction *selection* (oldest-held + dwell-gate) is unchanged by this fix and takes the age as input, so a selection-seam test couldn't catch the clock-choice regression. The **clock** is where the defect lives, so `BudgetHoldClock` is the extracted, host-tested seam instead — its `ReconnectDoesNotResetTheEvictionClock` test is the actual #720 guard.

## Gemini adversarial gate

`scripts/llm-consult.py --backend gemini --model gemini-2.5-pro`, hostile prompt, 3 findings:

- **F1 (raised HIGH) — fixed.** A stale `MQTT_EVENT_CONNECTED` dispatched after `releaseClient()` could set `state=Up` + stamp `budget_hold_` with no client behind it (a "zombie" holding the budget slot). Guarded: `onConnected()` now ignores a connect event when `!hasClient()`, matching the existing #848 `Failed` guard. (Gemini called it permanent starvation; it was actually self-healing — the zombie becomes the oldest eviction candidate and rotates out within a dwell — but the inconsistency is closed regardless.)
- **F2 (LOW) — fixed.** The `[rot]` diagnostic log showed `went_up_ms` age while eviction uses `budgetHeldMs`; the log now shows the budget-hold age the logic keys off, so telemetry matches the decision.
- **F3 (LOW) — justified.** Full `rt_` reset on rotation "laundering" failure history is pre-existing and intentional (a rotated-out broker was just credited a clean dwell; the sticky `health_` penalty preserves the real reliability signal). Out of #720 scope.

## Evidence

- **Host tests: 14/14** in `test/test_broker_rotation/` — the existing promotion/fairness suite plus 5 new `BudgetHoldClock` cases: reconnect-doesn't-reset (the #720 regression), fresh-hold-not-yet-evictable (anti-thrash), release-resets-for-next-occupancy, `millis()==0` genuine-hold, held-time-advances.
- **Firmware build** `Heltec_v3_companion_observer_wifi` **SUCCESS** (post-Gemini-fixes).
- **Hardware bench-repro:** in progress — an intermittent ~30 s router block to make a broker actually flap, confirming rotation resumes (queued brokers get promoted) where pre-fix it stalls. Results will be posted here before merge.

Closes #720
