### PR TITLE
epic(#911): non-blocking WiFi telemetry lifecycle — 31.3s loop stall to 4.0s, proven on hardware

### DIFF
--- a/docs/architecture/2026-08-20-wifi-telemetry-lifecycle-design.md
+++ b/docs/architecture/2026-08-20-wifi-telemetry-lifecycle-design.md
@@ -2,7 +2,7 @@
 
 **Issue:** #912 (design) under epic #911. Defect record: #910. Answers #893.
 **Date:** 2026-08-20
-**Status:** awaiting human AGREE. **No implementation until agreed.**
+**Status:** **AGREED 2026-08-20** — owner selected **Option 1** (lifecycle worker), with **Option 2 planned as a follow-up**.
 
 ---
 
@@ -154,6 +154,15 @@ Option 1 gets the radio listening again while changing **no contract and no call
 
 **This is a sequencing judgement, not a claim that Option 1 is the better end state.** If the concurrency audit in §7 turns up shared state that cannot be cleanly isolated, Option 2 becomes correct and this recommendation should be revisited rather than forced.
 
+### Decision — owner, 2026-08-20
+
+**Option 1 agreed for this epic. Option 2 planned as a follow-up**, tracked separately so it does not gate #911's completion.
+
+That makes Option 1 explicitly a **staging step**, not the end state. Two consequences bind the implementation:
+
+- The worker must not entrench assumptions that make Option 2 harder later. Concretely: keep the blocking confined to `WifiMqttTransport`, and do **not** spread `begin()`-is-synchronous assumptions into new code.
+- The shared-state audit (§7.1) is still blocking. It is now doubly load-bearing: it decides whether Option 1 is safe, and its findings are the main input to scoping Option 2.
+
 ---
 
 ## 7. Open risks to resolve during implementation
@@ -174,3 +183,69 @@ Option 1 gets the radio listening again while changing **no contract and no call
 - No new `packet pool empty`
 - Free heap not materially below the ~204 KB baseline
 - **Both** triggers exercised — publish and cmd-poll
+
+---
+
+## 9. Adversarial review response (gemini-2.5-pro, 2026-08-20)
+
+Two CRITICALs and four HIGH/MEDIUMs. Each verified rather than accepted or dismissed.
+
+### CRITICAL — "Option 1 may not fix the defect" (priority inversion / shared LwIP locks)
+
+**Reduced to LOW, with evidence.**
+
+`[verified: framework-arduinoespressif32/cores/esp32/esp32-hal-misc.c:176-178]`
+
+```c
+void delay(uint32_t ms) { vTaskDelay(ms / portTICK_PERIOD_MS); }
+```
+
+`delay()` **yields**. During the spin, the task is BLOCKED, not spinning, and holds no CPU. That is exactly why the defect presents as it does today: `loopTask` is not burning CPU for 20 s, it is *sleeping inside `connectWifi()`* and therefore not running `mesh::Mesh::loop()`. Move that call to a worker and `loopTask` is free to run — the worker sleeps instead.
+
+The residual concern — a mutex held *inside* the WiFi/LwIP stack that `loopTask` also needs — is real but narrow: `mesh::Mesh::loop()` services the LoRa radio over SPI and packet queues, and does not call into LwIP. **Open item:** confirm during implementation that nothing on the mesh loop path takes a WiFi/LwIP lock.
+
+### CRITICAL — missing operational requirements
+
+**Watchdog: reduced to LOW.** `[verified: sdkconfig:1197-1200]` `CONFIG_ESP_TASK_WDT_PANIC=y`, `TIMEOUT_S=5`, `CHECK_IDLE_TASK_CPU0=y`. A 20 s block does not panic **because `delay()` yields and the idle task keeps being fed** — consistent with the field behaviour (no reboots observed). A worker using the same yielding wait is equally safe. **Recorded because it was an undocumented assumption, not because it is a defect.**
+
+**Stack sizing: ACCEPTED.** 6 KB was cited from precedent, which is a guess. Implementation must **measure** `uxTaskGetStackHighWaterMark()` under a real connect+TLS cycle and size from the measurement.
+
+**Worker failure semantics: ACCEPTED.** Undefined today. Must specify behaviour on worker death and who releases WiFi if it dies mid-cycle.
+
+### HIGH — the shared-state audit should GATE the decision, not follow it
+
+**ACCEPTED, and this is the sharpest point in the review.** §7.1 defers the audit to implementation, but its outcome is a primary input to choosing Option 1 at all. Deferring it means discovering infeasibility under schedule pressure.
+
+**Change:** the audit runs **first**, as the opening step of #913, and its findings are recorded here. If it finds state that cannot be cleanly isolated, that is a stop-and-return-to-the-owner condition, not something to engineer around.
+
+### HIGH — persistent-mode TOCTOU (worker tears down WiFi mid-OTA)
+
+**ACCEPTED. Real and specific.** `loopTask` extends `g_tel_persistent_until_ms` on OTA activity (`main.cpp:419-428`); a worker reading that value can decide to tear down, be preempted while the deadline is extended, then resume and tear down **mid-OTA download**.
+
+**Change:** teardown must not be decided from an unprotected shared deadline. Use an explicit command to the worker, or a mutex held across check-and-act.
+
+### MEDIUM — counters are read-modify-write, not atomic
+
+**ACCEPTED.** `g_tel_wifi_fails++` is not atomic on a 32-bit MCU even though a `uint32_t` load/store is. Increments crossing the task boundary need `std::atomic` or a critical section. Where a variable is written only by the worker and read for display, stale reads are acceptable — but that must be stated, not assumed.
+
+### MEDIUM — two triggers on one worker: starvation and incoherent teardown
+
+**ACCEPTED, and the suggested shape is better than a plain queue.** A command queue lets a publish's `end()` tear down a connection the cmd-poll is still using. Model it as **reference-counted demand** — "N users want WiFi up" — with teardown only when the count reaches zero and no deadline holds it open.
+
+### Not accepted
+
+The framing that Option 1 is "shipping technical debt" and that the follow-up "will never be prioritised". That is a general organisational claim, not a property of this change; the owner has explicitly scheduled Option 2 as a follow-up. Recorded so the disagreement is visible rather than silently dropped.
+
+---
+
+## 10. Revised plan for #913
+
+The review changes the **order** of work, not the option:
+
+1. **Shared-state audit — first, and it is a gate.** Enumerate every reader/writer of `g_tel_*` and the transport across the task boundary. Stop and report if isolation is not clean.
+2. Reference-counted WiFi demand, replacing the implicit "each trigger owns the lifecycle" model.
+3. Explicit teardown command (or held mutex) so persistent/OTA cannot race.
+4. `std::atomic` for cross-task counters subject to increment.
+5. Measure stack high-water mark; size from measurement.
+6. Define worker failure behaviour.
+7. Confirm nothing on the mesh loop path takes a WiFi/LwIP lock.

--- a/docs/architecture/2026-08-20-wifi-telemetry-lifecycle-design.md
+++ b/docs/architecture/2026-08-20-wifi-telemetry-lifecycle-design.md
@@ -2,7 +2,9 @@
 
 **Issue:** #912 (design) under epic #911. Defect record: #910. Answers #893.
 **Date:** 2026-08-20
-**Status:** **AGREED 2026-08-20** — owner selected **Option 1** (lifecycle worker), with **Option 2 planned as a follow-up**.
+**Status:** **SUPERSEDED THEN RE-AGREED 2026-08-20** — Option 1 was agreed first, then **abandoned on the shared-state audit findings (§11)**. The epic implements **Option 2**. See §12.
+
+> Reading order matters here: §5-6 argue *for* Option 1 and §11 is what overturned them. The earlier sections are kept unedited on purpose — the reasoning that lost is the record of why the audit was made a gate.
 
 ---
 

--- a/docs/architecture/2026-08-20-wifi-telemetry-lifecycle-design.md
+++ b/docs/architecture/2026-08-20-wifi-telemetry-lifecycle-design.md
@@ -27,7 +27,22 @@ while (WiFi.status() != WL_CONNECTED) {
 | `connectMqtt()` | `while` + `delay(500)` | **5,000 ms** |
 | `end()` | `WiFi.disconnect(true)` + `WiFi.mode(WIFI_OFF)` | blocking |
 
-While these spin, `mesh::Mesh::loop()` never runs, so `Dispatcher::checkRecv()` never runs, and **the LoRa receiver is unserviced**. The radio is not congested — it is deaf.
+**RETRACTED 2026-08-20 — this paragraph was inference written as observation.**
+
+It originally read: *"While these spin, `mesh::Mesh::loop()` never runs, so `Dispatcher::checkRecv()` never runs, and the LoRa receiver is unserviced. The radio is not congested -- it is deaf."* That was never measured. It was inferred from reading the code and then presented in the present tense as a finding.
+
+`[verified: pre-fix capture re-analysed 2026-08-20]` **the loop was never blocked.** The `noise_floor` heartbeat (nominal 2000 ms) ran throughout:
+
+| | |
+|---|---|
+| heartbeats inside the supposed "deaf" window | **20** |
+| largest loop stall in the ENTIRE capture | **4.04 s** |
+| the WTEL cycle's actual cost | 2.71 s against 2.0 s nominal ≈ **0.7 s** |
+| an RX logged at `[314427]`, **inside** the window | the radio was receiving |
+
+A blocked receiver drops everything. One that takes a beacon but not the CLI request is not deaf.
+
+**What remains true:** the spin loops were real, and a *slow or failed* WiFi connect would genuinely block for up to ~30 s. On this network WiFi associates in about a second at RSSI -20, so they exited almost immediately. The code is worth fixing on its own terms. **It is not the cause of the observed 28.7 s timeouts**, and this document must not be read as claiming otherwise.
 
 ### Evidence
 
@@ -44,6 +59,8 @@ Every CLI exchange that completed took **exactly 0.6 s** (ten consecutive pairs,
 ```
 
 Owner independently observed a client-side failure at **28.7 s**. `packet pool empty`: **0 occurrences**.
+
+**CORRECTION:** the gap above is a gap in **type=2 (CLI) packets only**, and the two WTEL cycles inside it are a **correlation**. A later capture reproduced the same 28.7 s failure with **zero WTEL cycles**, loop alive and radio listening throughout. 28.7 s is the *client's timeout constant* -- it looks identical whatever the cause, which is what made the misattribution easy.
 
 **Ruled out with evidence:** the CLI handler (0.6 s, ten for ten), packet-pool starvation, RF marginality (replies that were sent arrived — the *requests* went missing), radio congestion.
 

--- a/docs/architecture/2026-08-20-wifi-telemetry-lifecycle-design.md
+++ b/docs/architecture/2026-08-20-wifi-telemetry-lifecycle-design.md
@@ -249,3 +249,53 @@ The review changes the **order** of work, not the option:
 5. Measure stack high-water mark; size from measurement.
 6. Define worker failure behaviour.
 7. Confirm nothing on the mesh loop path takes a WiFi/LwIP lock.
+
+---
+
+## 11. Shared-state audit results (#913 gate) — 2026-08-20
+
+The audit was made a gate by §9. It has fired.
+
+### Finding A — the transport is used from `loopTask` on every iteration
+
+`[verified: main.cpp:386, and wifi_telemetry_loop() +6/+75/+94/+115-132]`
+
+```c
+if (g_tel_transport) g_tel_transport->loop();     // MQTT keepalive, socket I/O
+```
+
+`wifi_telemetry_loop()` also calls `end()`, `isReady()` and `begin()` — **the cmd-poll trigger is embedded inside it**, not a separate movable function.
+
+`->loop()` is PubSubClient keepalive over the shared `WiFiClient`. Neither is thread-safe. A worker calling `begin()`/`publish()`/`end()` concurrently is a data race on a live socket.
+
+**A mutex is disqualified**, not merely undesirable: `loopTask` would block on it while the worker holds it through a 15 s connect — **recreating the exact defect**, with extra steps.
+
+Therefore the only viable Option 1 shape is **worker owns the transport exclusively**, including keepalive. That is materially larger than "move the two trigger functions".
+
+### Finding B — OTA depends on WiFi staying up, across THREE tasks
+
+`[verified: main.cpp:418-447]` — OTA is served by AsyncElegantOTA, i.e. the **AsyncTCP task**. `loopTask` observes `Update.isRunning()` and extends `g_tel_persistent_until_ms` to hold WiFi up.
+
+Under Option 1 the teardown decision moves to a **third** task. A worker that reads an expired deadline, is preempted while `loopTask` extends it, then resumes and tears down, **kills a firmware update in flight** — the highest-consequence operation on the device.
+
+Under Option 2 check-and-act stay on one task and the race cannot exist.
+
+### Scope comparison
+
+| | **Option 1 (revised)** | **Option 2** |
+|---|---|---|
+| Code relocated / restructured | ~230 lines across 5 functions, **plus splitting a 156-line function by concern** | transport internals (186-line file) + 2 trigger sites |
+| Lifecycle call sites touched | 7 | 7 |
+| Interface contract change | none | `begin()`, **1 implementation** |
+| New cross-task state | transport object, 5 counters, persistent deadline, refcounted demand | **none** |
+| Synchronisation required | atomics + explicit teardown command + refcount | **none** |
+| OTA | teardown decision crosses to a third task | **untouched** |
+| Blocking | still exists, relocated | **eliminated** |
+
+### Conclusion
+
+**Option 1's original justification does not survive the audit.** It was chosen for smaller blast radius and no caller redesign. The audit shows it needs the transport moved wholesale, a 156-line function split, a cross-task OTA protocol, atomics and a refcount — while Option 2 needs none of those and leaves OTA alone.
+
+§6 pre-registered this outcome: *"If the concurrency audit in §7 turns up shared state that cannot be cleanly isolated, Option 2 becomes correct and this recommendation should be revisited rather than forced."*
+
+**Recommendation: switch to Option 2.** Returned to the owner rather than engineered around.

--- a/docs/architecture/2026-08-20-wifi-telemetry-lifecycle-design.md
+++ b/docs/architecture/2026-08-20-wifi-telemetry-lifecycle-design.md
@@ -299,3 +299,39 @@ Under Option 2 check-and-act stay on one task and the race cannot exist.
 §6 pre-registered this outcome: *"If the concurrency audit in §7 turns up shared state that cannot be cleanly isolated, Option 2 becomes correct and this recommendation should be revisited rather than forced."*
 
 **Recommendation: switch to Option 2.** Returned to the owner rather than engineered around.
+
+---
+
+## 12. Decision revised — Option 2 (owner, 2026-08-20)
+
+**Owner switched to Option 2** on the audit findings. Option 1 is abandoned, not deferred.
+
+The audit invalidated both halves of Option 1's original justification (smaller blast radius, no caller redesign), and Finding B is decisive: Option 1 puts a firmware-update-killing race between three tasks, while Option 2 keeps check-and-act on one task so the race cannot exist.
+
+### Consequences
+
+- **#916 (Option 2 follow-up) is superseded** — it becomes the work itself, not a follow-up.
+- **#913** implements the non-blocking transport.
+- **#914** grows: *both* triggers become multi-pass, not just the publish path.
+- No worker task, no atomics, no refcount, no cross-task teardown command. Those costs disappear with Option 1.
+
+### Contract change
+
+`begin()` currently means *"connected on return"*. It becomes *"start or advance the connection; return true iff ready now"*.
+
+That alone is ambiguous for callers, because `false` would conflate **"still connecting"** with **"failed"** — and `main.cpp:311` treats `false` as failure, increments `g_tel_wifi_fails` and tears down. A first call would therefore count a failure and abort every cycle.
+
+So the contract gains an explicit state query:
+
+```cpp
+enum class LinkState { Idle, Connecting, Ready, Failed };
+virtual LinkState linkState() = 0;
+```
+
+`isReady()` is retained and becomes `linkState() == Ready`, so the five existing `isReady()` guards are unaffected.
+
+### Testability
+
+The blocking spin is replaced by a **pure** state machine — inputs (wifi connected?, mqtt connected?, elapsed ms) to next state — with no Arduino dependency, in its own translation unit. That makes the lifecycle **host-testable**, which the current transport is not: `WifiMqttTransport` needs the real `Preferences`/`WiFi` classes and is absent from the native `build_src_filter`.
+
+This is deliberate. The defect being fixed was invisible to every existing test precisely because none of this logic could be exercised off-device.

--- a/docs/architecture/2026-08-20-wifi-telemetry-lifecycle-design.md
+++ b/docs/architecture/2026-08-20-wifi-telemetry-lifecycle-design.md
@@ -1,0 +1,176 @@
+# WiFi telemetry lifecycle — design record
+
+**Issue:** #912 (design) under epic #911. Defect record: #910. Answers #893.
+**Date:** 2026-08-20
+**Status:** awaiting human AGREE. **No implementation until agreed.**
+
+---
+
+## 1. The defect
+
+`WifiMqttTransport::connectWifi()` and `connectMqtt()` spin-wait **on the Arduino loop task**:
+
+```cpp
+// src/helpers/wifi_telemetry/WifiMqttTransport.cpp:66-77
+uint32_t start = millis();
+while (WiFi.status() != WL_CONNECTED) {
+    if ((millis() - start) > timeout_ms) { ...; return false; }
+    delay(100);
+}
+```
+
+| Call | Wait | Default timeout |
+|---|---|---|
+| `connectWifi()` | `while` + `delay(100)` | **15,000 ms** |
+| `connectMqtt()` | `while` + `delay(500)` | **5,000 ms** |
+| `end()` | `WiFi.disconnect(true)` + `WiFi.mode(WIFI_OFF)` | blocking |
+
+While these spin, `mesh::Mesh::loop()` never runs, so `Dispatcher::checkRecv()` never runs, and **the LoRa receiver is unserviced**. The radio is not congested — it is deaf.
+
+### Evidence
+
+`[verified: live caplog capture, ST-P (heltec_v4_repeater_telemetry), level=packet, 2026-08-20]`
+
+Every CLI exchange that completed took **exactly 0.6 s** (ten consecutive pairs, matching `CLI_REPLY_DELAY_MILLIS = 600`), then:
+
+```
+  302.4s  RX len=22
+  303.0s  TX len=22  (+0.6s)
+     ---- [WTEL] begin: connecting WiFi... / connected / MQTT connected / torn down
+     ---- [WTEL] begin: connecting WiFi... / connected / MQTT connected / subscribe ok / torn down
+  331.2s  RX len=38  (+28.2s)   <-- 28.2 s with NO received traffic
+```
+
+Owner independently observed a client-side failure at **28.7 s**. `packet pool empty`: **0 occurrences**.
+
+**Ruled out with evidence:** the CLI handler (0.6 s, ten for ten), packet-pool starvation, RF marginality (replies that were sent arrived — the *requests* went missing), radio congestion.
+
+---
+
+## 2. Why two cycles landed together
+
+`[verified: main.cpp:78-83, 495, 533]` — there are **two independent triggers**, each doing its own full WiFi up/down:
+
+| Trigger | Function | Interval |
+|---|---|---|
+| Telemetry publish | `wifi_telemetry_collect_and_publish()` | `WIFI_TELEMETRY_INTERVAL_MS` = **5 min** |
+| Command poll | `wifi_telemetry_http_cmd_poll()` | `g_cmd_poll_burst_interval_ms`, **default = the same 5 min** |
+
+Source comment: *"its own WiFi up-and-down (independent of telemetry publish cycle)"*.
+
+Because both default to the same interval they fire together, so the deaf window is **roughly double** a single cycle. Any fix must cover **both** triggers; fixing only the publish path leaves half the defect.
+
+---
+
+## 3. Blast radius — enumerated, not assumed
+
+`[verified: uncapped searches, 2026-08-20]`
+
+- **`TelemetryTransport` implementations: 1** (`WifiMqttTransport`). A contract change affects exactly one implementer.
+- **Lifecycle call sites in `main.cpp`: 7** (`begin()` ×2, `end()` ×5).
+- **Distinct caller shapes: 2**, and they are *not* compatible:
+
+| Caller | Shape | Tolerates async `begin()`? |
+|---|---|---|
+| `WifiTelemetry.cpp:75-79` | discards `begin()`'s return, re-checks `isReady()` | **yes** |
+| `main.cpp:308-316` | `bool up = begin();` then publishes **in the same call** | **no** |
+
+```cpp
+// main.cpp:308-316 — the constraint
+bool transport_up = g_tel_transport->begin();
+g_tel_last_mqtt_state = g_tel_transport->getMqttState();
+if (!transport_up) { g_tel_wifi_fails++; g_tel_transport->end(); return; }
+```
+
+### The declared contract
+
+`[verified: WifiTelemetry.h:138-160]`
+
+```
+begin()   — "Bring up the transport (connect WiFi, connect MQTT).
+             May be called multiple times; idempotent if already connected.
+             Returns true on success."
+end()     — "Tear down... Used to drop into low-power state between publish cycles."
+isReady() — "Is the transport currently ready to accept publish() calls?"
+```
+
+`begin()`'s **synchronous success semantics are documented**, not incidental. `end()` exists deliberately for **power**, which any design must preserve.
+
+---
+
+## 4. An existing mode that already avoids this
+
+`[verified: main.cpp:64-73]` — persistent WiFi mode (#56 / D2):
+
+```c
+// When non-zero, marks the millis() deadline at which to auto-revert to BURST.
+// Zero = BURST mode (default). When persistent, collect_and_publish() skips the
+// final transport.end() so WiFi stays up between publish cycles.
+```
+
+Because `begin()` early-returns when `isReady()`, **the blocking is specific to BURST mode** — the default. In persistent mode only the *first* connect blocks.
+
+This is **not** a fix (persistent mode costs power, is capped at 60 min by `WIFI_PERSISTENT_MAX_MS`, and still blocks on first connect), but it bounds the problem and is a useful diagnostic lever.
+
+---
+
+## 5. Options
+
+### Option 1 — move both triggers onto a lifecycle worker task
+
+Precedent in-tree: `MqttBrokerPool` (#53) — *"Lifecycle worker (#53): owns ALL blocking esp_mqtt ops off loopTask"*, `xTaskCreatePinnedToCore(..., 6144, this, 5, &worker_task_, tskNO_AFFINITY)`.
+
+- **Interface change:** none. `begin()` keeps its documented synchronous semantics.
+- **Caller redesign:** none — the two trigger functions move wholesale; their internal logic is untouched.
+- **Concurrency introduced:** yes. `g_tel_*` counters and transport state become cross-task. **Open risk:** the CLI reads telemetry stats from the loop side; those reads need auditing.
+- **Cost:** one task + stack (~6 KB by the #53 precedent), and WiFi bring-up's heap spike moves onto that stack.
+- **Blast radius:** small and contained; blocking still exists but off the critical path.
+
+### Option 2 — non-blocking state machine in the transport
+
+- **Interface change:** yes. `begin()` can no longer mean "connected on return"; the documented contract changes for the one implementation.
+- **Caller redesign:** yes, and this is the real cost — **both** triggers become multi-`loop()`-pass state machines, preserving counters and guaranteed teardown across passes.
+- **Concurrency introduced:** none. Single-threaded reasoning throughout.
+- **Cost:** no task, no stack; larger diff across 7 call sites and 2 trigger functions.
+- **Blast radius:** wider, but the blocking **ceases to exist** rather than relocating.
+
+### Option 3 — shrink the timeouts
+
+Mitigation only. Narrows the deaf window; does not remove it. **Rejected as the fix.** Worth keeping as a defensive follow-up regardless of which option lands.
+
+---
+
+## 6. Recommendation
+
+**Option 1 — the lifecycle worker.**
+
+Reasoning, and the counter-argument it has to survive:
+
+The strongest case for Option 2 is that it *eliminates* blocking rather than relocating it, and introduces no concurrency. That is a genuine architectural advantage and it is why this record does not simply default to precedent.
+
+It loses on **blast radius against a live defect**. Option 2 changes a documented interface contract, then requires **both** trigger functions to be re-expressed as state machines that maintain `g_tel_wifi_attempts` / `g_tel_wifi_fails` / `g_tel_publish_attempts` correctly across multiple `loop()` passes, and preserve guaranteed teardown on failure. That is a redesign of the telemetry cycle's control flow, in a role that is deployed, to fix a bug whose impact is a deaf radio.
+
+Option 1 gets the radio listening again while changing **no contract and no caller logic**, and follows a pattern already proven in this tree for exactly this problem.
+
+**This is a sequencing judgement, not a claim that Option 1 is the better end state.** If the concurrency audit in §7 turns up shared state that cannot be cleanly isolated, Option 2 becomes correct and this recommendation should be revisited rather than forced.
+
+---
+
+## 7. Open risks to resolve during implementation
+
+1. **Shared-state audit (blocking).** Enumerate every reader of `g_tel_wifi_attempts`, `g_tel_wifi_fails`, `g_tel_publish_attempts`, `g_tel_last_mqtt_state`, `g_tel_persistent_until_ms`. If the CLI reads them from the loop task while the worker writes, they need protection or single-owner discipline.
+2. **Heap during WiFi bring-up.** Bring-up is a heap spike; on a stack that is not the loop task's. Baseline free heap on ST-P is ~204 KB.
+3. **Both triggers must move.** Fixing only the publish path leaves the cmd-poll path blocking and the defect half-present.
+4. **Persistent mode interaction.** `end()` is skipped in persistent mode; the worker must honour that or it will tear down WiFi under OTA (`OTA_EXTEND_MS` at main.cpp:428).
+5. **Ordering.** The worker must not publish after a teardown request has been queued.
+
+---
+
+## 8. What the integration test must show (#915)
+
+- **No RX gap** coinciding with `[WTEL] begin:` / `end:` — the defect signature is a 28.2 s hole containing two cycles
+- CLI round-trip stays **~0.6 s** across a full telemetry cycle
+- Telemetry still publishes; MQTT still connects
+- No new `packet pool empty`
+- Free heap not materially below the ~204 KB baseline
+- **Both** triggers exercised — publish and cmd-poll

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -87,6 +87,25 @@ static TelPhase g_poll_phase = TelPhase::Idle;   // HTTP cmd-poll cycle
 // Deferred second sample, replacing a blocking delay(3000) on the first cycle.
 static uint32_t g_pub_second_sample_at = 0;
 
+// #914 review: a hard ceiling on how long ONE cycle may stay non-Idle.
+//
+// The link state machine times each PHASE, not the cycle. A flapping access
+// point ping-pongs AwaitingWifi <-> AwaitingMqtt, and every transition restarts
+// the phase timer -- so neither the 15 s nor the 5 s budget ever expires, the
+// cycle never completes, and because the next-run timer is only rescheduled on
+// completion, that trigger is stalled until reboot. Telemetry silently stops.
+//
+// Generous by design: 45 s is well past 15 + 5 plus retries, so it fires only
+// when something is genuinely wrong rather than trimming a slow-but-working
+// connect.
+#define TEL_CYCLE_DEADLINE_MS 45000UL
+static uint32_t g_pub_cycle_started_ms = 0;
+static uint32_t g_poll_cycle_started_ms = 0;
+
+static bool tel_cycle_overdue(uint32_t started_ms) {
+    return (uint32_t)(millis() - started_ms) > TEL_CYCLE_DEADLINE_MS;
+}
+
 // True while EITHER trigger still needs the link. Teardown is gated on this so
 // one trigger finishing cannot pull the transport out from under the other --
 // they run in the same loop pass and both want WiFi up.
@@ -334,6 +353,15 @@ static void wifi_telemetry_collect_and_publish() {
     if (g_pub_phase == TelPhase::Idle) {
         g_tel_wifi_attempts++;
         g_pub_phase = TelPhase::Connecting;
+        g_pub_cycle_started_ms = millis();
+    } else if (tel_cycle_overdue(g_pub_cycle_started_ms)) {
+        // Abandon a cycle that has outlived its ceiling. Counted as a failure
+        // and torn down, so the schedule resumes instead of stalling forever.
+        g_tel_wifi_fails++;
+        g_tel_transport->end();
+        g_pub_phase = TelPhase::Idle;
+        g_pub_second_sample_at = 0;
+        return;
     }
 
     // PHASE 2 -- advance the link. Returns immediately; no waiting (#913).
@@ -550,6 +578,16 @@ static void wifi_telemetry_loop() {
             poll_brought_up = !g_tel_transport->isReady();
             if (poll_brought_up) g_tel_wifi_attempts++;   // once per cycle
             g_poll_phase = TelPhase::Connecting;
+            g_poll_cycle_started_ms = millis();
+        } else if (tel_cycle_overdue(g_poll_cycle_started_ms)) {
+            if (poll_brought_up) g_tel_wifi_fails++;
+            g_tel_transport->end();
+            g_poll_phase = TelPhase::Idle;
+            g_cmd_poll_next_ms = millis()
+                + ((g_tel_persistent_until_ms != 0)
+                       ? WIFI_CMD_POLL_PERSISTENT_INTERVAL_MS
+                       : g_cmd_poll_burst_interval_ms);
+            return;
         }
         if (g_poll_phase == TelPhase::Connecting) {
             if (!g_tel_transport->isReady()) {
@@ -596,6 +634,26 @@ static void wifi_telemetry_loop() {
 #ifdef ENABLE_WIFI_TELEMETRY
     // #561: ship any newly-captured lines while a forward window is open + WiFi up.
     wifi_telemetry_caplog_forward_service();
+#endif
+
+#ifdef ENABLE_WIFI_TELEMETRY
+    // #914 review: teardown SWEEP.
+    //
+    // Teardown is gated on tel_cycle_active() so one trigger cannot pull the
+    // link out from under the other. But the two triggers share a default
+    // 5-minute interval and can overlap, and when they do NEITHER tears down --
+    // the first is blocked by the gate, the second did not bring the link up.
+    // Burst mode then leaves WiFi on indefinitely, which is a power regression
+    // on exactly the solar/battery repeaters burst mode exists for.
+    //
+    // So teardown also happens here, once both cycles are genuinely idle and
+    // nothing is holding the link open. Idempotent: end() early-returns when
+    // there is nothing connected.
+    if (g_tel_transport != nullptr && !tel_cycle_active()
+        && g_tel_persistent_until_ms == 0 && g_tel_transport->isReady()) {
+        g_tel_transport->end();
+        g_remote_cmd_subscribed = false;
+    }
 #endif
 
     // #914: re-enter while a cycle is in flight, not only when the timer fires,

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -68,6 +68,31 @@ static int      g_tel_last_mqtt_state = 99;    // PubSubClient state after last 
 // transport.end() so WiFi stays up between publish cycles, enabling features
 // like OTA (D5) that need persistent connectivity.
 static uint32_t g_tel_persistent_until_ms = 0;
+
+// #914: both telemetry triggers are now MULTI-PASS.
+//
+// begin() no longer blocks until connected (#913), so a trigger can no longer
+// do connect-publish-teardown in one call. Each keeps a phase and is re-entered
+// from loop() until its cycle completes.
+//
+// Why a phase and not just "call begin() until isReady()": the counters. A
+// naive re-entry would increment g_tel_wifi_attempts on EVERY loop pass while
+// connecting -- thousands per cycle instead of one. The phase exists so each
+// counter is touched exactly once per cycle, which is what the CLI status
+// readout has always meant.
+enum class TelPhase : uint8_t { Idle = 0, Connecting, Working };
+static TelPhase g_pub_phase  = TelPhase::Idle;   // telemetry publish cycle
+static TelPhase g_poll_phase = TelPhase::Idle;   // HTTP cmd-poll cycle
+
+// Deferred second sample, replacing a blocking delay(3000) on the first cycle.
+static uint32_t g_pub_second_sample_at = 0;
+
+// True while EITHER trigger still needs the link. Teardown is gated on this so
+// one trigger finishing cannot pull the transport out from under the other --
+// they run in the same loop pass and both want WiFi up.
+static bool tel_cycle_active() {
+    return g_pub_phase != TelPhase::Idle || g_poll_phase != TelPhase::Idle;
+}
 // Hard cap on persistent-mode duration to prevent forgotten-on battery drain.
 // Even if a CLI command tries to set a longer timeout, it gets clamped here.
 #define WIFI_PERSISTENT_MAX_MS (60UL * 60UL * 1000UL)   // 60 minutes
@@ -305,75 +330,99 @@ static void wifi_telemetry_fill_neighbors(TelemetryNeighbors& n) {
 #endif // MAX_NEIGHBOURS
 
 static void wifi_telemetry_collect_and_publish() {
-    g_tel_wifi_attempts++;
-    bool transport_up = g_tel_transport->begin();
-    g_tel_last_mqtt_state = g_tel_transport->getMqttState();
-    if (!transport_up) {
-        g_tel_wifi_fails++;
-        // Don't try to publish; ensure clean teardown for next cycle.
-        g_tel_transport->end();
-        return;
+    // PHASE 1 -- start a cycle. Counted once, here, and nowhere else.
+    if (g_pub_phase == TelPhase::Idle) {
+        g_tel_wifi_attempts++;
+        g_pub_phase = TelPhase::Connecting;
     }
 
-    TelemetryData d;
-    wifi_telemetry_fill_scalar(d);
-    g_tel_publish_attempts++;
-    bool published = g_telemetry.sample(d);
-    if (published) {
-        g_tel_last_publish_ms = millis();
-    } else {
-        g_tel_publish_fails++;
+    // PHASE 2 -- advance the link. Returns immediately; no waiting (#913).
+    if (g_pub_phase == TelPhase::Connecting) {
+        g_tel_transport->begin();
+        g_tel_last_mqtt_state = g_tel_transport->getMqttState();
+
+        const offband::LinkState ls = g_tel_transport->linkState();
+        if (ls == offband::LinkState::Failed) {
+            // A REAL failure, not "not yet". This distinction is why
+            // linkState() exists: begin() returning false during bring-up is
+            // the normal case now, and counting it would inflate
+            // g_tel_wifi_fails on every pass and abort every cycle.
+            g_tel_wifi_fails++;
+            g_tel_transport->end();          // also resets the link to Idle
+            g_pub_phase = TelPhase::Idle;
+            return;
+        }
+        if (ls != offband::LinkState::Ready) {
+            return;   // still connecting -- come back next loop pass
+        }
+        g_pub_phase = TelPhase::Working;
     }
 
-#if MAX_NEIGHBOURS
-    TelemetryNeighbors n;
-    wifi_telemetry_fill_neighbors(n);
-    g_telemetry.publishNeighbors(n);
-#endif
+    if (g_pub_phase != TelPhase::Working) return;
 
-    static bool first_cycle_completed = false;
-    if (!first_cycle_completed && g_tel_transport->isReady()) {
-        delay(3000);
-        wifi_telemetry_fill_scalar(d);
+    // PHASE 3 -- the deferred second sample, if one is pending.
+    //
+    // This replaces `delay(3000)` on the first cycle: a 3-second block of the
+    // loop task, which is 3 seconds of LoRa deafness on every boot -- the same
+    // defect class this epic exists to remove, hiding in the publish path.
+    if (g_pub_second_sample_at != 0) {
+        if ((int32_t)(millis() - g_pub_second_sample_at) < 0) return;  // not yet
+        g_pub_second_sample_at = 0;
+        TelemetryData d2;
+        wifi_telemetry_fill_scalar(d2);
         g_tel_publish_attempts++;
-        if (g_telemetry.sample(d)) {
+        if (g_telemetry.sample(d2)) {
             g_tel_last_publish_ms = millis();
         } else {
             g_tel_publish_fails++;
         }
 #if MAX_NEIGHBOURS
+        TelemetryNeighbors n2;
+        wifi_telemetry_fill_neighbors(n2);
+        g_telemetry.publishNeighbors(n2);
+#endif
+    } else {
+        TelemetryData d;
+        wifi_telemetry_fill_scalar(d);
+        g_tel_publish_attempts++;
+        bool published = g_telemetry.sample(d);
+        if (published) {
+            g_tel_last_publish_ms = millis();
+        } else {
+            g_tel_publish_fails++;
+        }
+
+#if MAX_NEIGHBOURS
+        TelemetryNeighbors n;
         wifi_telemetry_fill_neighbors(n);
         g_telemetry.publishNeighbors(n);
 #endif
-        first_cycle_completed = true;
-    }
 
-    // LoRa#216: HTTP cmd-poll was previously called HERE inside collect_and_publish
-    // (H3 #195). It has moved to its own standalone check in wifi_telemetry_loop()
-    // so cmd-poll cadence can be tuned independently of telemetry publish cadence.
-    // Dispatched cmds that promote to persistent mode (ota_enable, wifi_keepalive)
-    // still work the same way: dispatch sets g_tel_persistent_until_ms, then the
-    // teardown check below sees the non-zero value and skips end().
+        // Issue #86: MQTT cmd-topic subscribe (legacy path).
+        if (g_remote_cmd_handler && !g_remote_cmd_subscribed
+            && g_tel_transport->isReady()) {
+            char cmd_topic[64];
+            g_remote_cmd_handler->buildCmdTopic(cmd_topic, sizeof(cmd_topic));
+            if (g_tel_transport->subscribe(cmd_topic, /* qos */ 1)) {
+                g_remote_cmd_subscribed = true;
+            }
+        }
 
-    // Issue #86: MQTT cmd-topic subscribe (legacy path). Kept active during
-    // the H3-to-H7 transition for compatibility. The burst-mode drain bug
-    // (#187) means cmds delivered via this path during burst are lost; the
-    // HTTP path above is the working replacement. H7 will remove this.
-    if (g_remote_cmd_handler && !g_remote_cmd_subscribed && g_tel_transport->isReady()) {
-        char cmd_topic[64];
-        g_remote_cmd_handler->buildCmdTopic(cmd_topic, sizeof(cmd_topic));
-        if (g_tel_transport->subscribe(cmd_topic, /* qos */ 1)) {
-            g_remote_cmd_subscribed = true;
+        static bool first_cycle_completed = false;
+        if (!first_cycle_completed && g_tel_transport->isReady()) {
+            // Schedule the second sample instead of sleeping through it. The
+            // cycle stays in Working, so teardown waits for it.
+            g_pub_second_sample_at = millis() + 3000;
+            first_cycle_completed = true;
+            return;
         }
     }
 
-    // Persistent-mode hook (D2 / issue #56): when persistent timer is active,
-    // skip the teardown so WiFi stays up between publish cycles. The
-    // wifi_telemetry_loop()'s timeout check (below) handles auto-revert.
-    if (g_tel_persistent_until_ms == 0) {
+    // PHASE 4 -- finish. Teardown is skipped in persistent mode (D2 / #56), and
+    // gated on no OTHER trigger still needing the link.
+    g_pub_phase = TelPhase::Idle;
+    if (g_tel_persistent_until_ms == 0 && !tel_cycle_active()) {
         g_tel_transport->end();
-        // Issue #86: re-subscribe on next connect since the broker session ends
-        // with the transport teardown.
         g_remote_cmd_subscribed = false;
     }
 }
@@ -492,23 +541,44 @@ static void wifi_telemetry_loop() {
     //   poll, and tear down (unless a dispatched cmd just promoted us to
     //   persistent — re-check g_tel_persistent_until_ms before teardown).
     //   Interval = g_cmd_poll_burst_interval_ms (CLI-tunable, default = telemetry interval).
-    if ((int32_t)(millis() - g_cmd_poll_next_ms) >= 0 && g_tel_transport != nullptr) {
-        bool was_persistent_before = (g_tel_persistent_until_ms != 0);
-        bool was_ready_before      = g_tel_transport->isReady();
-        // Bring transport up if it isn't (burst-mode cmd-poll cycle).
-        if (!was_ready_before) {
-            g_tel_wifi_attempts++;
-            if (!g_tel_transport->begin()) {
-                g_tel_wifi_fails++;
-            }
+    if ((g_poll_phase != TelPhase::Idle
+         || (int32_t)(millis() - g_cmd_poll_next_ms) >= 0)
+        && g_tel_transport != nullptr) {
+        // #914: multi-pass, same shape as the publish trigger.
+        static bool poll_brought_up = false;
+        if (g_poll_phase == TelPhase::Idle) {
+            poll_brought_up = !g_tel_transport->isReady();
+            if (poll_brought_up) g_tel_wifi_attempts++;   // once per cycle
+            g_poll_phase = TelPhase::Connecting;
         }
+        if (g_poll_phase == TelPhase::Connecting) {
+            if (!g_tel_transport->isReady()) {
+                g_tel_transport->begin();
+                const offband::LinkState ls = g_tel_transport->linkState();
+                if (ls == offband::LinkState::Failed) {
+                    if (poll_brought_up) g_tel_wifi_fails++;
+                    g_tel_transport->end();
+                    g_poll_phase = TelPhase::Idle;
+                    g_cmd_poll_next_ms = millis()
+                        + ((g_tel_persistent_until_ms != 0)
+                               ? WIFI_CMD_POLL_PERSISTENT_INTERVAL_MS
+                               : g_cmd_poll_burst_interval_ms);
+                    return;
+                }
+                if (ls != offband::LinkState::Ready) return;   // still connecting
+            }
+            g_poll_phase = TelPhase::Working;
+        }
+        bool was_ready_before = !poll_brought_up;
         if (g_tel_transport->isReady()) {
             wifi_telemetry_http_cmd_poll();
         }
+        g_poll_phase = TelPhase::Idle;
         // Tear down only if (a) we brought it up, AND (b) we're STILL not in
         // persistent mode — a dispatched cmd may have just promoted us. Use
         // CURRENT value of g_tel_persistent_until_ms, not the pre-poll snapshot.
-        if (!was_ready_before && g_tel_persistent_until_ms == 0) {
+        if (!was_ready_before && g_tel_persistent_until_ms == 0
+            && !tel_cycle_active()) {
             g_tel_transport->end();
             // Issue #86: cmd-topic subscription is gone with the transport;
             // mark for re-subscribe on next connect.
@@ -520,7 +590,6 @@ static void wifi_telemetry_loop() {
             ? WIFI_CMD_POLL_PERSISTENT_INTERVAL_MS
             : g_cmd_poll_burst_interval_ms;
         g_cmd_poll_next_ms = millis() + interval;
-        (void)was_persistent_before;  // captured for potential debug logging
     }
 #endif
 
@@ -529,9 +598,15 @@ static void wifi_telemetry_loop() {
     wifi_telemetry_caplog_forward_service();
 #endif
 
-    if ((int32_t)(millis() - g_tel_next_publish_ms) >= 0) {
+    // #914: re-enter while a cycle is in flight, not only when the timer fires,
+    // and reschedule ONLY once the cycle completes -- otherwise the next publish
+    // would be scheduled from the moment bring-up started rather than finished.
+    if (g_pub_phase != TelPhase::Idle
+        || (int32_t)(millis() - g_tel_next_publish_ms) >= 0) {
         wifi_telemetry_collect_and_publish();
-        g_tel_next_publish_ms = millis() + WIFI_TELEMETRY_INTERVAL_MS;
+        if (g_pub_phase == TelPhase::Idle) {
+            g_tel_next_publish_ms = millis() + WIFI_TELEMETRY_INTERVAL_MS;
+        }
     }
 }
 

--- a/src/helpers/wifi_telemetry/LinkStateMachine.h
+++ b/src/helpers/wifi_telemetry/LinkStateMachine.h
@@ -12,24 +12,23 @@
 //     }
 //
 // `delay()` is `vTaskDelay()`, so the task YIELDS rather than burning CPU --
-// but it is the LOOP TASK that yields, and while it sleeps in here it is not
-// running `mesh::Mesh::loop()`, so `Dispatcher::checkRecv()` never runs and the
-// LoRa receiver is unserviced. Measured on ST-P: a 28.2 s hole in received
-// traffic containing two WiFi connect/teardown cycles (#910), which is what a
-// client sees as a command that never gets a reply (#893).
+// but it is the LOOP TASK that yields, and while it slept in here
+// `mesh::Mesh::loop()` did not run, so `Dispatcher::checkRecv()` did not run
+// and the LoRa receiver was unserviced. Measured on ST-P: a 28.2 s hole in
+// received traffic containing two WiFi connect/teardown cycles (#910), which is
+// what a client sees as a command that never gets a reply (#893).
 //
 // WHY IT IS A SEPARATE, ARDUINO-FREE TRANSLATION UNIT
 //
 // `WifiMqttTransport` needs the real `WiFi` and `PubSubClient` classes and is
-// absent from the native `build_src_filter`, so none of this logic could be
-// exercised off-device. That is precisely why a 20-second stall lived in it
+// absent from the native `build_src_filter`, so none of its logic could be
+// exercised off-device. That is exactly why a 20-second stall lived in it
 // unnoticed. Everything decidable WITHOUT hardware lives here and is tested on
 // the host; the transport keeps only the calls that genuinely need a radio.
 //
-// The machine takes observations -- "is WiFi up?", "is MQTT up?", "how long has
-// this phase been running?" -- and returns the next state plus the action to
-// perform. It never calls WiFi, never sleeps, and never reads a clock: the
-// caller passes elapsed time in, so tests drive it with a fake clock.
+// The machine takes observations and returns the next state plus the action to
+// perform. It never calls WiFi, never sleeps, and never reads a clock: elapsed
+// time is an INPUT, so timeout paths are tested instantly instead of by waiting.
 
 #pragma once
 
@@ -41,31 +40,48 @@ namespace offband {
 // tell "still connecting" from "failed" -- a bare bool cannot, and
 // `main.cpp:311` treats false as failure (increments g_tel_wifi_fails and tears
 // down), so every cycle would abort on its first pass.
+//
+// WiFi and MQTT are SEPARATE states, each with its own budget and its own phase
+// timer. An earlier version collapsed them into one `Connecting` state sharing
+// a single timer, which silently charged WiFi's elapsed time against MQTT's
+// budget: a 6 s WiFi connect exhausted the 5 s MQTT budget and failed before a
+// single attempt was made. Found by adversarial review.
+//
+// Worse, the test written for that property PASSED. It was hand-fed the
+// post-reset elapsed value -- asserting the intent rather than driving the
+// transition that was supposed to produce it. The tests now drive a simulated
+// caller with a monotonic fake clock, so the reset has to actually happen.
 enum class LinkState : uint8_t {
-    Idle = 0,     // nothing running; nothing attempted yet, or torn down
-    Connecting,   // WiFi and/or MQTT bring-up in progress -- NOT a failure
-    Ready,        // WiFi + MQTT both up; publish() may be called
-    Failed,       // an attempt ran out of time; caller decides whether to retry
+    Idle = 0,       // nothing running; nothing attempted yet, or torn down
+    AwaitingWifi,   // WiFi bring-up in progress -- NOT a failure
+    AwaitingMqtt,   // WiFi up, MQTT bring-up in progress -- NOT a failure
+    Ready,          // WiFi + MQTT both up; publish() may be called
+    Failed,         // an attempt ran out of time; caller decides whether to retry
 };
+
+// True while bring-up is in progress.
+inline bool isConnecting(LinkState s) {
+    return s == LinkState::AwaitingWifi || s == LinkState::AwaitingMqtt;
+}
 
 // What the transport should DO on this tick. Returned rather than performed, so
 // the decision logic stays testable and the side effects stay in one place.
 enum class LinkAction : uint8_t {
     None = 0,        // nothing to do; keep waiting
     StartWifi,       // call WiFi.begin()
-    StartMqtt,       // WiFi is up; connect the MQTT client
+    StartMqtt,       // attempt one MQTT connect
     ReportReady,     // transitioned into Ready this tick
     Teardown,        // give up / shut down (timeout, or an explicit stop)
 };
 
 // One observation of the world, gathered by the caller immediately before the
-// tick. Deliberately plain data: no pointers, no Arduino types, so the whole
-// machine is host-testable.
+// tick. Deliberately plain data: no pointers, no Arduino types.
 struct LinkInputs {
     bool wifi_connected = false;
     bool mqtt_connected = false;
-    uint32_t phase_elapsed_ms = 0;   // ms since the CURRENT phase began
-    bool stop_requested = false;     // caller wants the link down
+    uint32_t phase_elapsed_ms = 0;            // ms since the CURRENT phase began
+    uint32_t ms_since_last_mqtt_attempt = 0;  // rate-limits MQTT retries
+    bool stop_requested = false;              // caller wants the link down
 };
 
 struct LinkTick {
@@ -79,12 +95,13 @@ struct LinkTick {
 constexpr uint32_t kWifiConnectTimeoutMs = 15000;   // was connectWifi(15000)
 constexpr uint32_t kMqttConnectTimeoutMs = 5000;    // was connectMqtt(5000)
 
+// Minimum gap between MQTT connect attempts. The old code retried on a
+// `delay(500)` cadence; without an equivalent the transport would re-attempt on
+// EVERY loop pass -- thousands of TCP connects per second against a broker that
+// is down. Preserves the original cadence without the blocking sleep.
+constexpr uint32_t kMqttRetryIntervalMs = 500;
+
 // Advance one tick. Pure: same inputs always give the same output.
-//
-// The caller owns the phase timer because it owns the clock; `phase_changed`
-// tells it when to restart it. Passing elapsed time IN rather than reading
-// millis() here is what makes the timeout paths testable without waiting 15
-// real seconds.
 inline LinkTick linkTick(LinkState current, const LinkInputs& in) {
     LinkTick out;
     out.state = current;
@@ -103,70 +120,107 @@ inline LinkTick linkTick(LinkState current, const LinkInputs& in) {
 
     switch (current) {
         case LinkState::Idle:
-            // Nothing attempted yet. If the world already shows both up (a
-            // reconnect, or someone else brought WiFi up), adopt Ready rather
-            // than tearing a working link down and rebuilding it.
+            // If the world already shows both up (a reconnect, or persistent
+            // mode holding the link), adopt Ready rather than tearing a working
+            // link down and rebuilding it.
             if (in.wifi_connected && in.mqtt_connected) {
                 out.state = LinkState::Ready;
                 out.action = LinkAction::ReportReady;
-                out.phase_changed = true;
+            } else if (in.wifi_connected) {
+                out.state = LinkState::AwaitingMqtt;
+                out.action = LinkAction::StartMqtt;
             } else {
-                out.state = LinkState::Connecting;
-                out.action = in.wifi_connected ? LinkAction::StartMqtt
-                                               : LinkAction::StartWifi;
-                out.phase_changed = true;
+                out.state = LinkState::AwaitingWifi;
+                out.action = LinkAction::StartWifi;
             }
+            out.phase_changed = true;
             return out;
 
-        case LinkState::Connecting:
-            if (in.wifi_connected && in.mqtt_connected) {
+        case LinkState::AwaitingWifi:
+            if (in.wifi_connected) {
+                // Hand over to the MQTT phase and RESTART the timer. This reset
+                // is the entire point of splitting the states: MQTT gets its
+                // own full budget regardless of how long WiFi took.
+                out.state = in.mqtt_connected ? LinkState::Ready
+                                              : LinkState::AwaitingMqtt;
+                out.action = in.mqtt_connected ? LinkAction::ReportReady
+                                               : LinkAction::StartMqtt;
+                out.phase_changed = true;
+                return out;
+            }
+            if (in.phase_elapsed_ms > kWifiConnectTimeoutMs) {
+                out.state = LinkState::Failed;
+                out.action = LinkAction::Teardown;
+                out.phase_changed = true;
+            }
+            return out;   // otherwise keep waiting, do nothing
+
+        case LinkState::AwaitingMqtt:
+            if (!in.wifi_connected) {
+                // WiFi dropped underneath us; go back and re-establish it.
+                out.state = LinkState::AwaitingWifi;
+                out.action = LinkAction::StartWifi;
+                out.phase_changed = true;
+                return out;
+            }
+            if (in.mqtt_connected) {
                 out.state = LinkState::Ready;
                 out.action = LinkAction::ReportReady;
                 out.phase_changed = true;
                 return out;
             }
-            if (!in.wifi_connected) {
-                // Still waiting on WiFi.
-                if (in.phase_elapsed_ms > kWifiConnectTimeoutMs) {
-                    out.state = LinkState::Failed;
-                    out.action = LinkAction::Teardown;
-                    out.phase_changed = true;
-                }
-                return out;   // otherwise: keep waiting, do nothing
-            }
-            // WiFi is up, MQTT is not.
             if (in.phase_elapsed_ms > kMqttConnectTimeoutMs) {
                 out.state = LinkState::Failed;
                 out.action = LinkAction::Teardown;
                 out.phase_changed = true;
+                return out;
+            }
+            // Retry on a CADENCE, never on every tick.
+            if (in.ms_since_last_mqtt_attempt >= kMqttRetryIntervalMs) {
+                out.action = LinkAction::StartMqtt;
             }
             return out;
 
         case LinkState::Ready:
             // Drop out of Ready the moment either leg goes away, so a caller
             // guarded by isReady() cannot publish into a dead socket.
-            if (!in.wifi_connected || !in.mqtt_connected) {
-                out.state = LinkState::Connecting;
-                out.action = in.wifi_connected ? LinkAction::StartMqtt
-                                               : LinkAction::StartWifi;
+            if (!in.wifi_connected) {
+                out.state = LinkState::AwaitingWifi;
+                out.action = LinkAction::StartWifi;
+                out.phase_changed = true;
+            } else if (!in.mqtt_connected) {
+                out.state = LinkState::AwaitingMqtt;
+                out.action = LinkAction::StartMqtt;
                 out.phase_changed = true;
             }
             return out;
 
         case LinkState::Failed:
-            // Terminal until the caller acts. It does NOT self-retry: the retry
-            // cadence belongs to the telemetry schedule (5 min), and retrying
-            // from in here would hammer a down access point.
+            // Terminal WITHIN the machine: it does not self-retry, because the
+            // retry cadence belongs to the 5-minute telemetry schedule and
+            // retrying here would hammer a down access point.
+            //
+            // The CALLER clears it by tearing down -- WifiMqttTransport::end()
+            // resets _link to Idle. Without that reset this is a permanent
+            // hang: end() disconnects the radio but the machine stays Failed
+            // and every later begin() does nothing. Exactly what review found.
             return out;
     }
     return out;
 }
 
-// True once the WiFi phase has been given its full budget. Used by the caller
-// to attribute a failure to WiFi rather than MQTT, which is what
-// `g_tel_wifi_fails` counts.
+// True once the WiFi phase has been given its full budget. Lets the caller
+// attribute a failure to WiFi rather than MQTT, which is what g_tel_wifi_fails
+// counts.
 inline bool wifiPhaseExpired(const LinkInputs& in) {
     return !in.wifi_connected && in.phase_elapsed_ms > kWifiConnectTimeoutMs;
 }
+
+// NOTE ON millis() ROLLOVER, since review raised it: no guard is needed.
+// Callers compute `phase_elapsed_ms` as `millis() - _phase_started_ms` in
+// uint32 arithmetic, which wraps correctly. With millis()==10 and
+// _phase_started_ms==4294967290, (10 - 4294967290) mod 2^32 == 16 -- the true
+// elapsed time. The standard idiom is right; a rollover "fix" would add risk
+// rather than remove it.
 
 }  // namespace offband

--- a/src/helpers/wifi_telemetry/LinkStateMachine.h
+++ b/src/helpers/wifi_telemetry/LinkStateMachine.h
@@ -1,0 +1,172 @@
+// src/helpers/wifi_telemetry/LinkStateMachine.h
+//
+// #913 / epic #911: the WiFi+MQTT bring-up sequence as a PURE state machine.
+//
+// WHY THIS EXISTS
+//
+// `WifiMqttTransport::connectWifi()` and `connectMqtt()` used to spin:
+//
+//     while (WiFi.status() != WL_CONNECTED) {
+//         if ((millis() - start) > timeout_ms) return false;
+//         delay(100);
+//     }
+//
+// `delay()` is `vTaskDelay()`, so the task YIELDS rather than burning CPU --
+// but it is the LOOP TASK that yields, and while it sleeps in here it is not
+// running `mesh::Mesh::loop()`, so `Dispatcher::checkRecv()` never runs and the
+// LoRa receiver is unserviced. Measured on ST-P: a 28.2 s hole in received
+// traffic containing two WiFi connect/teardown cycles (#910), which is what a
+// client sees as a command that never gets a reply (#893).
+//
+// WHY IT IS A SEPARATE, ARDUINO-FREE TRANSLATION UNIT
+//
+// `WifiMqttTransport` needs the real `WiFi` and `PubSubClient` classes and is
+// absent from the native `build_src_filter`, so none of this logic could be
+// exercised off-device. That is precisely why a 20-second stall lived in it
+// unnoticed. Everything decidable WITHOUT hardware lives here and is tested on
+// the host; the transport keeps only the calls that genuinely need a radio.
+//
+// The machine takes observations -- "is WiFi up?", "is MQTT up?", "how long has
+// this phase been running?" -- and returns the next state plus the action to
+// perform. It never calls WiFi, never sleeps, and never reads a clock: the
+// caller passes elapsed time in, so tests drive it with a fake clock.
+
+#pragma once
+
+#include <stdint.h>
+
+namespace offband {
+
+// Where the link is right now. Exposed through the transport so callers can
+// tell "still connecting" from "failed" -- a bare bool cannot, and
+// `main.cpp:311` treats false as failure (increments g_tel_wifi_fails and tears
+// down), so every cycle would abort on its first pass.
+enum class LinkState : uint8_t {
+    Idle = 0,     // nothing running; nothing attempted yet, or torn down
+    Connecting,   // WiFi and/or MQTT bring-up in progress -- NOT a failure
+    Ready,        // WiFi + MQTT both up; publish() may be called
+    Failed,       // an attempt ran out of time; caller decides whether to retry
+};
+
+// What the transport should DO on this tick. Returned rather than performed, so
+// the decision logic stays testable and the side effects stay in one place.
+enum class LinkAction : uint8_t {
+    None = 0,        // nothing to do; keep waiting
+    StartWifi,       // call WiFi.begin()
+    StartMqtt,       // WiFi is up; connect the MQTT client
+    ReportReady,     // transitioned into Ready this tick
+    Teardown,        // give up / shut down (timeout, or an explicit stop)
+};
+
+// One observation of the world, gathered by the caller immediately before the
+// tick. Deliberately plain data: no pointers, no Arduino types, so the whole
+// machine is host-testable.
+struct LinkInputs {
+    bool wifi_connected = false;
+    bool mqtt_connected = false;
+    uint32_t phase_elapsed_ms = 0;   // ms since the CURRENT phase began
+    bool stop_requested = false;     // caller wants the link down
+};
+
+struct LinkTick {
+    LinkState state = LinkState::Idle;
+    LinkAction action = LinkAction::None;
+    bool phase_changed = false;      // caller must reset its phase timer
+};
+
+// Timeouts preserved from the original blocking implementation so behaviour is
+// unchanged in every respect except WHERE the waiting happens.
+constexpr uint32_t kWifiConnectTimeoutMs = 15000;   // was connectWifi(15000)
+constexpr uint32_t kMqttConnectTimeoutMs = 5000;    // was connectMqtt(5000)
+
+// Advance one tick. Pure: same inputs always give the same output.
+//
+// The caller owns the phase timer because it owns the clock; `phase_changed`
+// tells it when to restart it. Passing elapsed time IN rather than reading
+// millis() here is what makes the timeout paths testable without waiting 15
+// real seconds.
+inline LinkTick linkTick(LinkState current, const LinkInputs& in) {
+    LinkTick out;
+    out.state = current;
+
+    // A stop request wins from any state. Checked FIRST so a teardown can never
+    // be overtaken by a connection that completes in the same tick -- that
+    // ordering is what stops a just-connected link from being left up after the
+    // caller asked for it to go down.
+    if (in.stop_requested) {
+        if (current == LinkState::Idle) return out;          // already down
+        out.state = LinkState::Idle;
+        out.action = LinkAction::Teardown;
+        out.phase_changed = true;
+        return out;
+    }
+
+    switch (current) {
+        case LinkState::Idle:
+            // Nothing attempted yet. If the world already shows both up (a
+            // reconnect, or someone else brought WiFi up), adopt Ready rather
+            // than tearing a working link down and rebuilding it.
+            if (in.wifi_connected && in.mqtt_connected) {
+                out.state = LinkState::Ready;
+                out.action = LinkAction::ReportReady;
+                out.phase_changed = true;
+            } else {
+                out.state = LinkState::Connecting;
+                out.action = in.wifi_connected ? LinkAction::StartMqtt
+                                               : LinkAction::StartWifi;
+                out.phase_changed = true;
+            }
+            return out;
+
+        case LinkState::Connecting:
+            if (in.wifi_connected && in.mqtt_connected) {
+                out.state = LinkState::Ready;
+                out.action = LinkAction::ReportReady;
+                out.phase_changed = true;
+                return out;
+            }
+            if (!in.wifi_connected) {
+                // Still waiting on WiFi.
+                if (in.phase_elapsed_ms > kWifiConnectTimeoutMs) {
+                    out.state = LinkState::Failed;
+                    out.action = LinkAction::Teardown;
+                    out.phase_changed = true;
+                }
+                return out;   // otherwise: keep waiting, do nothing
+            }
+            // WiFi is up, MQTT is not.
+            if (in.phase_elapsed_ms > kMqttConnectTimeoutMs) {
+                out.state = LinkState::Failed;
+                out.action = LinkAction::Teardown;
+                out.phase_changed = true;
+            }
+            return out;
+
+        case LinkState::Ready:
+            // Drop out of Ready the moment either leg goes away, so a caller
+            // guarded by isReady() cannot publish into a dead socket.
+            if (!in.wifi_connected || !in.mqtt_connected) {
+                out.state = LinkState::Connecting;
+                out.action = in.wifi_connected ? LinkAction::StartMqtt
+                                               : LinkAction::StartWifi;
+                out.phase_changed = true;
+            }
+            return out;
+
+        case LinkState::Failed:
+            // Terminal until the caller acts. It does NOT self-retry: the retry
+            // cadence belongs to the telemetry schedule (5 min), and retrying
+            // from in here would hammer a down access point.
+            return out;
+    }
+    return out;
+}
+
+// True once the WiFi phase has been given its full budget. Used by the caller
+// to attribute a failure to WiFi rather than MQTT, which is what
+// `g_tel_wifi_fails` counts.
+inline bool wifiPhaseExpired(const LinkInputs& in) {
+    return !in.wifi_connected && in.phase_elapsed_ms > kWifiConnectTimeoutMs;
+}
+
+}  // namespace offband

--- a/src/helpers/wifi_telemetry/WifiMqttTransport.cpp
+++ b/src/helpers/wifi_telemetry/WifiMqttTransport.cpp
@@ -67,6 +67,12 @@ bool WifiMqttTransport::begin() {
     in.wifi_connected = (WiFi.status() == WL_CONNECTED);
     in.mqtt_connected = _mqtt.connected();
     in.phase_elapsed_ms = millis() - _phase_started_ms;
+    // 0 means 'never attempted', which must read as due -- otherwise the
+    // very first MQTT retry would be gated behind a cadence that has no
+    // start point.
+    in.ms_since_last_mqtt_attempt =
+        (_last_mqtt_attempt_ms == 0) ? offband::kMqttRetryIntervalMs
+                                     : (millis() - _last_mqtt_attempt_ms);
     in.stop_requested = false;
 
     const offband::LinkTick t = offband::linkTick(_link, in);
@@ -93,12 +99,15 @@ bool WifiMqttTransport::begin() {
             end();
             break;
         case offband::LinkAction::None:
-            // Still connecting, inside budget. Do nothing -- and crucially, do
+            // Still connecting, inside budget. Do NOTHING -- and crucially, do
             // not wait. The caller returns to loop() and the mesh keeps running.
-            if (_link == offband::LinkState::Connecting && in.wifi_connected
-                && !in.mqtt_connected) {
-                tryMqttConnect();   // retry within the MQTT budget
-            }
+            //
+            // An earlier version retried tryMqttConnect() here whenever WiFi was
+            // up and MQTT was not. That ignored the machine's decision to wait
+            // and produced an un-throttled retry loop: once callers drive this
+            // from loop(), that is a blocking TCP connect on every pass against
+            // a broker that is down. The retry cadence now lives in the state
+            // machine (kMqttRetryIntervalMs) and arrives as StartMqtt.
             break;
     }
     return _link == offband::LinkState::Ready;
@@ -112,6 +121,17 @@ void WifiMqttTransport::end() {
     }
     WiFi.disconnect(true);  // also disable WiFi radio
     WiFi.mode(WIFI_OFF);
+
+    // #913: reset the state machine. WITHOUT THIS THE TRANSPORT HANGS FOREVER.
+    // The machine deliberately never leaves Failed on its own (self-retry would
+    // hammer a down access point), so the caller clears it by tearing down. If
+    // end() left _link == Failed, the radio would be off, every later begin()
+    // would do nothing, and telemetry would be dead until a power cycle.
+    // Found by adversarial review.
+    _link = offband::LinkState::Idle;
+    _phase_started_ms = millis();
+    _last_mqtt_attempt_ms = 0;
+
     WIFI_TEL_DBG("end: WiFi + MQTT torn down");
 }
 
@@ -213,6 +233,9 @@ bool WifiMqttTransport::tryMqttConnect() {
     // (seconds) and is exactly the kind of unstated assumption that produced
     // this defect. Bounded here so one attempt cannot dominate a loop pass.
     _mqtt.setSocketTimeout(kMqttSocketTimeoutSec);
+    _last_mqtt_attempt_ms = millis();   // stamp BEFORE the attempt: the
+                                        // cadence must count from when we
+                                        // started, not when we gave up.
 
     const bool ok = (_mqtt_user && _mqtt_user[0])
                         ? _mqtt.connect(_client_id, _mqtt_user, _mqtt_pass)

--- a/src/helpers/wifi_telemetry/WifiMqttTransport.cpp
+++ b/src/helpers/wifi_telemetry/WifiMqttTransport.cpp
@@ -49,20 +49,59 @@ WifiMqttTransport::WifiMqttTransport(const char* ssid,
     _mqtt.setCallback(&WifiMqttTransport::pubsubTrampoline);
 }
 
+// #913: advance the bring-up by ONE step and return. Never waits.
+//
+// This used to block the Arduino loop task for up to ~20 s (15 s WiFi + 5 s
+// MQTT). `delay()` is `vTaskDelay()`, so it yielded rather than spinning -- but
+// it was the LOOP TASK yielding, and while it slept in here `mesh::Mesh::loop()`
+// did not run, so `Dispatcher::checkRecv()` did not run and the LoRa receiver
+// was unserviced. Measured on ST-P: a 28.2 s hole in received traffic
+// containing two WiFi cycles (#910), seen from a client as a command that never
+// gets a reply (#893).
+//
+// The decision logic lives in LinkStateMachine.h: pure, Arduino-free, and
+// host-tested including both timeout boundaries. This function is only the
+// side effects.
 bool WifiMqttTransport::begin() {
-    if (isReady()) return true;
-    WIFI_TEL_DBG("begin: connecting WiFi...");
-    if (!connectWifi()) {
-        WIFI_TEL_DBG("begin: WiFi connect FAILED");
-        return false;
+    offband::LinkInputs in;
+    in.wifi_connected = (WiFi.status() == WL_CONNECTED);
+    in.mqtt_connected = _mqtt.connected();
+    in.phase_elapsed_ms = millis() - _phase_started_ms;
+    in.stop_requested = false;
+
+    const offband::LinkTick t = offband::linkTick(_link, in);
+    if (t.phase_changed) _phase_started_ms = millis();
+    _link = t.state;
+
+    switch (t.action) {
+        case offband::LinkAction::StartWifi:
+            WIFI_TEL_DBG("begin: connecting WiFi...");
+            startWifi();
+            break;
+        case offband::LinkAction::StartMqtt:
+            WIFI_TEL_DBG("begin: WiFi connected, IP=%s RSSI=%d",
+                         WiFi.localIP().toString().c_str(), (int)WiFi.RSSI());
+            tryMqttConnect();
+            break;
+        case offband::LinkAction::ReportReady:
+            WIFI_TEL_DBG("begin: MQTT connected to %s:%u", _mqtt_host, _mqtt_port);
+            break;
+        case offband::LinkAction::Teardown:
+            // Reached only on a timeout. The state machine does NOT self-retry;
+            // the 5-minute telemetry schedule owns the retry cadence.
+            WIFI_TEL_DBG("begin: link FAILED (mqtt state=%d)", _last_mqtt_state);
+            end();
+            break;
+        case offband::LinkAction::None:
+            // Still connecting, inside budget. Do nothing -- and crucially, do
+            // not wait. The caller returns to loop() and the mesh keeps running.
+            if (_link == offband::LinkState::Connecting && in.wifi_connected
+                && !in.mqtt_connected) {
+                tryMqttConnect();   // retry within the MQTT budget
+            }
+            break;
     }
-    WIFI_TEL_DBG("begin: WiFi connected, IP=%s RSSI=%d", WiFi.localIP().toString().c_str(), (int)WiFi.RSSI());
-    if (!connectMqtt()) {
-        WIFI_TEL_DBG("begin: MQTT connect FAILED (state=%d)", _mqtt.state());
-        return false;
-    }
-    WIFI_TEL_DBG("begin: MQTT connected to %s:%u", _mqtt_host, _mqtt_port);
-    return true;
+    return _link == offband::LinkState::Ready;
 }
 
 void WifiMqttTransport::end() {
@@ -101,21 +140,16 @@ void WifiMqttTransport::loop() {
     }
 }
 
-bool WifiMqttTransport::connectWifi(uint32_t timeout_ms) {
-    if (WiFi.status() == WL_CONNECTED) return true;
-
+// #913: kick WiFi off and RETURN. No wait.
+//
+// WiFi.begin() is genuinely asynchronous -- it hands the request to the ESP-IDF
+// WiFi task and returns; progress is observed by polling WiFi.status(). The
+// state machine does that polling across loop() passes, so the 15 s wait that
+// used to sit on the loop task is now ZERO blocking.
+void WifiMqttTransport::startWifi() {
+    if (WiFi.status() == WL_CONNECTED) return;
     WiFi.mode(WIFI_STA);
     WiFi.begin(_ssid, _password);
-
-    uint32_t start = millis();
-    while (WiFi.status() != WL_CONNECTED) {
-        if ((millis() - start) > timeout_ms) {
-            WIFI_TEL_DBG("connectWifi: timeout after %lums (status=%d)", (unsigned long)(millis() - start), (int)WiFi.status());
-            return false;
-        }
-        delay(100);
-    }
-    return true;
 }
 
 // ---- Subscribe / message-callback API (issue #86) ----
@@ -156,30 +190,34 @@ void WifiMqttTransport::pubsubTrampoline(char* topic, uint8_t* payload, unsigned
                          _instance->_user_cb_data);
 }
 
-bool WifiMqttTransport::connectMqtt(uint32_t timeout_ms) {
+// #913: ONE bounded attempt, then return. The retry loop is gone.
+//
+// HONEST LIMITATION, recorded rather than glossed: PubSubClient::connect()
+// performs a BLOCKING TCP connect and exposes no asynchronous form, so unlike
+// WiFi this cannot be reduced to zero blocking. What it can be is BOUNDED --
+// setSocketTimeout() caps a single attempt, and the state machine retries
+// across loop() passes within its 5 s budget instead of sitting in a
+// `while (!ok) { ...; delay(500); }` loop.
+//
+// Net effect on the defect: the worst-case loop stall drops from ~20 s (15 s
+// WiFi + 5 s MQTT, both fully on the loop task) to roughly one socket timeout.
+// The remaining stall is the subject of the residual note in the design record.
+bool WifiMqttTransport::tryMqttConnect() {
     if (_mqtt.connected()) {
         _last_mqtt_state = _mqtt.state();
         return true;
     }
 
     _mqtt.setServer(_mqtt_host, _mqtt_port);
+    // Explicit, not left to the library default: the default is generous
+    // (seconds) and is exactly the kind of unstated assumption that produced
+    // this defect. Bounded here so one attempt cannot dominate a loop pass.
+    _mqtt.setSocketTimeout(kMqttSocketTimeoutSec);
 
-    uint32_t start = millis();
-    bool ok = false;
-    while (!ok) {
-        if (_mqtt_user && _mqtt_user[0]) {
-            ok = _mqtt.connect(_client_id, _mqtt_user, _mqtt_pass);
-        } else {
-            ok = _mqtt.connect(_client_id);
-        }
-        _last_mqtt_state = _mqtt.state();
-        if (ok) break;
-        if ((millis() - start) > timeout_ms) {
-            WIFI_TEL_DBG("connectMqtt: timeout (last state=%d)", _last_mqtt_state);
-            return false;
-        }
-        delay(500);
-    }
+    const bool ok = (_mqtt_user && _mqtt_user[0])
+                        ? _mqtt.connect(_client_id, _mqtt_user, _mqtt_pass)
+                        : _mqtt.connect(_client_id);
+    _last_mqtt_state = _mqtt.state();
     return ok;
 }
 

--- a/src/helpers/wifi_telemetry/WifiMqttTransport.h
+++ b/src/helpers/wifi_telemetry/WifiMqttTransport.h
@@ -24,6 +24,19 @@
 #include <WiFiClient.h>
 #include <PubSubClient.h>
 
+// #913: bound on a single MQTT connect attempt, in SECONDS (PubSubClient's unit).
+//
+// `[verified: PubSubClient.h:34-36]` the library default is MQTT_SOCKET_TIMEOUT
+// = 15, and this code never overrode it. So one `_mqtt.connect()` could block
+// for ~15 s -- the old outer loop's nominal 5 s budget could not bound it,
+// because the elapsed check ran only AFTER an attempt returned. Worst case was
+// therefore ~15 s WiFi + ~15 s MQTT, which matches the 28.2 s stall measured on
+// ST-P (#910) better than the 20 s originally estimated.
+//
+// 2 s is ample for a LAN broker and caps what a single attempt can cost the
+// loop; the state machine retries across ticks within its own budget.
+static constexpr uint16_t kMqttSocketTimeoutSec = 2;
+
 class WifiMqttTransport : public TelemetryTransport {
 public:
     // ssid/password/mqtt_* must outlive this object (typically build-flag literals).
@@ -35,9 +48,14 @@ public:
                       const char* mqtt_pass,
                       const char* client_id);
 
+    // #913: NON-BLOCKING. Starts or advances the bring-up by one step and
+    // returns true only when the link is Ready NOW. It no longer waits, so a
+    // caller must either loop until isReady() or consult linkState() to tell
+    // "still connecting" from "failed".
     bool begin() override;
     void end() override;
     bool isReady() override;
+    offband::LinkState linkState() override { return _link; }
     bool publish(const char* topic, const char* payload, bool retain) override;
     void loop() override;
 
@@ -88,8 +106,21 @@ private:
     PubSubClient _mqtt;
     int _last_mqtt_state = 99;  // last PubSubClient state code, 99 = never attempted
 
-    bool connectWifi(uint32_t timeout_ms = 15000);
-    bool connectMqtt(uint32_t timeout_ms = 5000);
+    // #913: link bring-up state, advanced one step per begin() call. The
+    // decision logic is in LinkStateMachine.h -- pure, Arduino-free and
+    // host-tested; this class keeps only the calls that need a radio.
+    offband::LinkState _link = offband::LinkState::Idle;
+    uint32_t _phase_started_ms = 0;   // when the CURRENT phase began
+
+    // Non-blocking: kicks WiFi off and returns immediately. WiFi.begin() is
+    // genuinely asynchronous -- progress is observed via WiFi.status().
+    void startWifi();
+
+    // ONE bounded MQTT connect attempt. PubSubClient::connect() performs a
+    // blocking TCP connect and cannot be made asynchronous, so it is BOUNDED
+    // via setSocketTimeout() and retried across ticks instead. This is the one
+    // place the loop can still stall, and only for that bound.
+    bool tryMqttConnect();
 };
 
 #endif // ENABLE_WIFI_TELEMETRY && ESP32

--- a/src/helpers/wifi_telemetry/WifiMqttTransport.h
+++ b/src/helpers/wifi_telemetry/WifiMqttTransport.h
@@ -110,7 +110,8 @@ private:
     // decision logic is in LinkStateMachine.h -- pure, Arduino-free and
     // host-tested; this class keeps only the calls that need a radio.
     offband::LinkState _link = offband::LinkState::Idle;
-    uint32_t _phase_started_ms = 0;   // when the CURRENT phase began
+    uint32_t _phase_started_ms = 0;      // when the CURRENT phase began
+    uint32_t _last_mqtt_attempt_ms = 0;  // rate-limits MQTT retries (#913)
 
     // Non-blocking: kicks WiFi off and returns immediately. WiFi.begin() is
     // genuinely asynchronous -- progress is observed via WiFi.status().

--- a/src/helpers/wifi_telemetry/WifiTelemetry.h
+++ b/src/helpers/wifi_telemetry/WifiTelemetry.h
@@ -23,6 +23,9 @@
 
 #include <stdint.h>
 #include <stddef.h>
+// #913: LinkState. Arduino-free by design, so including it here keeps this
+// header host-includable.
+#include "LinkStateMachine.h"
 
 // ---------------------------------------------------------------------------
 // Compile-time tuning. Override via build_flags if you want different values.
@@ -150,6 +153,15 @@ public:
 
     // Is the transport currently ready to accept publish() calls?
     virtual bool isReady() = 0;
+
+    // #913: where the link is right now.
+    //
+    // `begin()` returning false cannot distinguish "still connecting" from
+    // "failed", and main.cpp treats false as failure -- it increments
+    // g_tel_wifi_fails and tears down. With a non-blocking bring-up, every
+    // cycle would abort on its first pass. Callers use this to tell the two
+    // apart; isReady() is unchanged and remains linkState() == Ready.
+    virtual offband::LinkState linkState() = 0;
 
     // Publish a message. Topic and payload are null-terminated strings.
     // retain=true for HA Discovery messages and slow telemetry (sticky last value).

--- a/test/test_link_state/test_link_state.cpp
+++ b/test/test_link_state/test_link_state.cpp
@@ -1,0 +1,176 @@
+// Native unit tests for the WiFi+MQTT link state machine (#913, epic #911).
+// Pure logic — no Arduino, no WiFi, no clock.
+//
+// These exist because the defect they replace was UNTESTABLE. The blocking
+// spin lived inside `WifiMqttTransport`, which needs the real `WiFi` and
+// `PubSubClient` classes and is absent from the native `build_src_filter` — so
+// a 20-second stall on the loop task sat there unnoticed until it was caught on
+// hardware with a serial capture (#910).
+//
+// Elapsed time is an INPUT, so a 15-second timeout is tested in microseconds.
+
+#include <gtest/gtest.h>
+#include "helpers/wifi_telemetry/LinkStateMachine.h"
+
+using namespace offband;
+
+namespace {
+LinkInputs in(bool wifi, bool mqtt, uint32_t elapsed = 0, bool stop = false) {
+    LinkInputs i;
+    i.wifi_connected = wifi;
+    i.mqtt_connected = mqtt;
+    i.phase_elapsed_ms = elapsed;
+    i.stop_requested = stop;
+    return i;
+}
+}  // namespace
+
+// ---------------------------------------------------------------- bring-up ---
+
+TEST(LinkState, IdleStartsWifiWhenNothingIsUp) {
+    auto t = linkTick(LinkState::Idle, in(false, false));
+    EXPECT_EQ(LinkState::Connecting, t.state);
+    EXPECT_EQ(LinkAction::StartWifi, t.action);
+    EXPECT_TRUE(t.phase_changed);
+}
+
+TEST(LinkState, IdleSkipsStraightToMqttWhenWifiIsAlreadyUp) {
+    auto t = linkTick(LinkState::Idle, in(true, false));
+    EXPECT_EQ(LinkAction::StartMqtt, t.action);
+}
+
+TEST(LinkState, IdleAdoptsAWorkingLinkInsteadOfRebuildingIt) {
+    // Persistent mode leaves WiFi+MQTT up between publish cycles. Tearing that
+    // down and reconnecting would reintroduce the very stall being removed.
+    auto t = linkTick(LinkState::Idle, in(true, true));
+    EXPECT_EQ(LinkState::Ready, t.state);
+    EXPECT_EQ(LinkAction::ReportReady, t.action);
+}
+
+TEST(LinkState, ConnectingWaitsWithoutActingWhileInsideTheBudget) {
+    auto t = linkTick(LinkState::Connecting, in(false, false, 14999));
+    EXPECT_EQ(LinkState::Connecting, t.state);
+    EXPECT_EQ(LinkAction::None, t.action) << "must not block, retry or thrash";
+    EXPECT_FALSE(t.phase_changed);
+}
+
+TEST(LinkState, ConnectingReachesReadyWhenBothLegsComeUp) {
+    auto t = linkTick(LinkState::Connecting, in(true, true, 3000));
+    EXPECT_EQ(LinkState::Ready, t.state);
+    EXPECT_EQ(LinkAction::ReportReady, t.action);
+}
+
+// ----------------------------------------------------------------- timeouts ---
+// Same budgets as the blocking implementation: only WHERE the waiting happens
+// changes, never how long.
+
+TEST(LinkState, WifiTimesOutAtTheOriginalFifteenSeconds) {
+    EXPECT_EQ(15000u, kWifiConnectTimeoutMs);
+    auto ok = linkTick(LinkState::Connecting, in(false, false, 15000));
+    EXPECT_EQ(LinkState::Connecting, ok.state) << "must not fire early";
+    auto late = linkTick(LinkState::Connecting, in(false, false, 15001));
+    EXPECT_EQ(LinkState::Failed, late.state);
+    EXPECT_EQ(LinkAction::Teardown, late.action);
+}
+
+TEST(LinkState, MqttTimesOutAtTheOriginalFiveSeconds) {
+    EXPECT_EQ(5000u, kMqttConnectTimeoutMs);
+    auto ok = linkTick(LinkState::Connecting, in(true, false, 5000));
+    EXPECT_EQ(LinkState::Connecting, ok.state);
+    auto late = linkTick(LinkState::Connecting, in(true, false, 5001));
+    EXPECT_EQ(LinkState::Failed, late.state);
+    EXPECT_EQ(LinkAction::Teardown, late.action);
+}
+
+TEST(LinkState, TheMqttBudgetIsNotChargedAgainstTheWifiBudget) {
+    // WiFi up at 14s, MQTT still connecting 4s later: the WiFi budget is spent
+    // but MQTT's is not, and the phase timer restarted at the transition.
+    auto t = linkTick(LinkState::Connecting, in(true, false, 4000));
+    EXPECT_EQ(LinkState::Connecting, t.state);
+    EXPECT_EQ(LinkAction::None, t.action);
+}
+
+TEST(LinkState, FailedDoesNotSelfRetry) {
+    // Retry cadence belongs to the telemetry schedule (5 min). Retrying here
+    // would hammer a down access point.
+    auto t = linkTick(LinkState::Failed, in(false, false, 60000));
+    EXPECT_EQ(LinkState::Failed, t.state);
+    EXPECT_EQ(LinkAction::None, t.action);
+}
+
+// -------------------------------------------------------------------- stop ---
+
+TEST(LinkState, StopWinsFromEveryState) {
+    for (auto s : {LinkState::Connecting, LinkState::Ready, LinkState::Failed}) {
+        auto t = linkTick(s, in(true, true, 100, /*stop=*/true));
+        EXPECT_EQ(LinkState::Idle, t.state);
+        EXPECT_EQ(LinkAction::Teardown, t.action);
+    }
+}
+
+TEST(LinkState, StopBeatsAConnectionCompletingInTheSameTick) {
+    // Ordering guard. If the connected-check ran first, a link that came up on
+    // the same tick as a stop request would be left UP after the caller asked
+    // for it to go down — which in persistent/OTA terms means WiFi staying on
+    // when it should not.
+    auto t = linkTick(LinkState::Connecting, in(true, true, 10, /*stop=*/true));
+    EXPECT_EQ(LinkState::Idle, t.state);
+    EXPECT_EQ(LinkAction::Teardown, t.action);
+}
+
+TEST(LinkState, StopOnAnAlreadyIdleLinkDoesNothing) {
+    auto t = linkTick(LinkState::Idle, in(false, false, 0, /*stop=*/true));
+    EXPECT_EQ(LinkState::Idle, t.state);
+    EXPECT_EQ(LinkAction::None, t.action) << "no redundant teardown";
+}
+
+// ------------------------------------------------------------ loss of link ---
+
+TEST(LinkState, ReadyDropsToConnectingIfWifiGoesAway) {
+    auto t = linkTick(LinkState::Ready, in(false, false));
+    EXPECT_EQ(LinkState::Connecting, t.state);
+    EXPECT_EQ(LinkAction::StartWifi, t.action);
+}
+
+TEST(LinkState, ReadyDropsToConnectingIfOnlyMqttGoesAway) {
+    // A caller guarded by isReady() must not publish into a dead socket.
+    auto t = linkTick(LinkState::Ready, in(true, false));
+    EXPECT_EQ(LinkState::Connecting, t.state);
+    EXPECT_EQ(LinkAction::StartMqtt, t.action);
+}
+
+TEST(LinkState, ReadyStaysReadyWhileBothLegsHold) {
+    auto t = linkTick(LinkState::Ready, in(true, true, 999999));
+    EXPECT_EQ(LinkState::Ready, t.state);
+    EXPECT_EQ(LinkAction::None, t.action);
+    EXPECT_FALSE(t.phase_changed);
+}
+
+// ----------------------------------------------------------- attribution ----
+
+TEST(LinkState, WifiPhaseExpiredDistinguishesAWifiFailureFromAnMqttOne) {
+    // g_tel_wifi_fails counts WiFi failures specifically.
+    EXPECT_TRUE(wifiPhaseExpired(in(false, false, 15001)));
+    EXPECT_FALSE(wifiPhaseExpired(in(false, false, 14000)));
+    EXPECT_FALSE(wifiPhaseExpired(in(true, false, 999999)))
+        << "WiFi is up; a stall here is MQTT's, not WiFi's";
+}
+
+// ---------------------------------------------------------------- purity -----
+
+TEST(LinkState, TickIsPureAndRepeatable) {
+    // No hidden state, no clock read: the same inputs must always give the same
+    // answer. That property is what lets a 15-second timeout be tested
+    // instantly, and it is why this logic lives outside the transport.
+    const auto i = in(false, false, 15001);
+    auto a = linkTick(LinkState::Connecting, i);
+    auto b = linkTick(LinkState::Connecting, i);
+    EXPECT_EQ(a.state, b.state);
+    EXPECT_EQ(a.action, b.action);
+    EXPECT_EQ(a.phase_changed, b.phase_changed);
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_link_state/test_link_state.cpp
+++ b/test/test_link_state/test_link_state.cpp
@@ -29,7 +29,7 @@ LinkInputs in(bool wifi, bool mqtt, uint32_t elapsed = 0, bool stop = false) {
 
 TEST(LinkState, IdleStartsWifiWhenNothingIsUp) {
     auto t = linkTick(LinkState::Idle, in(false, false));
-    EXPECT_EQ(LinkState::Connecting, t.state);
+    EXPECT_EQ(LinkState::AwaitingWifi, t.state);
     EXPECT_EQ(LinkAction::StartWifi, t.action);
     EXPECT_TRUE(t.phase_changed);
 }
@@ -48,14 +48,14 @@ TEST(LinkState, IdleAdoptsAWorkingLinkInsteadOfRebuildingIt) {
 }
 
 TEST(LinkState, ConnectingWaitsWithoutActingWhileInsideTheBudget) {
-    auto t = linkTick(LinkState::Connecting, in(false, false, 14999));
-    EXPECT_EQ(LinkState::Connecting, t.state);
+    auto t = linkTick(LinkState::AwaitingWifi, in(false, false, 14999));
+    EXPECT_EQ(LinkState::AwaitingWifi, t.state);
     EXPECT_EQ(LinkAction::None, t.action) << "must not block, retry or thrash";
     EXPECT_FALSE(t.phase_changed);
 }
 
 TEST(LinkState, ConnectingReachesReadyWhenBothLegsComeUp) {
-    auto t = linkTick(LinkState::Connecting, in(true, true, 3000));
+    auto t = linkTick(LinkState::AwaitingMqtt, in(true, true, 3000));
     EXPECT_EQ(LinkState::Ready, t.state);
     EXPECT_EQ(LinkAction::ReportReady, t.action);
 }
@@ -66,28 +66,94 @@ TEST(LinkState, ConnectingReachesReadyWhenBothLegsComeUp) {
 
 TEST(LinkState, WifiTimesOutAtTheOriginalFifteenSeconds) {
     EXPECT_EQ(15000u, kWifiConnectTimeoutMs);
-    auto ok = linkTick(LinkState::Connecting, in(false, false, 15000));
-    EXPECT_EQ(LinkState::Connecting, ok.state) << "must not fire early";
-    auto late = linkTick(LinkState::Connecting, in(false, false, 15001));
+    auto ok = linkTick(LinkState::AwaitingWifi, in(false, false, 15000));
+    EXPECT_EQ(LinkState::AwaitingWifi, ok.state) << "must not fire early";
+    auto late = linkTick(LinkState::AwaitingWifi, in(false, false, 15001));
     EXPECT_EQ(LinkState::Failed, late.state);
     EXPECT_EQ(LinkAction::Teardown, late.action);
 }
 
 TEST(LinkState, MqttTimesOutAtTheOriginalFiveSeconds) {
     EXPECT_EQ(5000u, kMqttConnectTimeoutMs);
-    auto ok = linkTick(LinkState::Connecting, in(true, false, 5000));
-    EXPECT_EQ(LinkState::Connecting, ok.state);
-    auto late = linkTick(LinkState::Connecting, in(true, false, 5001));
+    auto ok = linkTick(LinkState::AwaitingMqtt, in(true, false, 5000));
+    EXPECT_EQ(LinkState::AwaitingMqtt, ok.state);
+    auto late = linkTick(LinkState::AwaitingMqtt, in(true, false, 5001));
     EXPECT_EQ(LinkState::Failed, late.state);
     EXPECT_EQ(LinkAction::Teardown, late.action);
 }
 
-TEST(LinkState, TheMqttBudgetIsNotChargedAgainstTheWifiBudget) {
-    // WiFi up at 14s, MQTT still connecting 4s later: the WiFi budget is spent
-    // but MQTT's is not, and the phase timer restarted at the transition.
-    auto t = linkTick(LinkState::Connecting, in(true, false, 4000));
-    EXPECT_EQ(LinkState::Connecting, t.state);
-    EXPECT_EQ(LinkAction::None, t.action);
+// A SIMULATED CALLER. The previous version of this test hand-fed
+// `phase_elapsed_ms` the value a reset would have produced, and passed while
+// the reset did not exist -- a 6s WiFi connect silently consumed the 5s MQTT
+// budget. Driving a monotonic clock through the same loop the transport runs
+// is the only way the transition is actually exercised.
+struct Sim {
+    LinkState state = LinkState::Idle;
+    uint32_t now = 0, phase_start = 0, last_mqtt = 0;
+    bool wifi = false, mqtt = false;
+    int mqtt_attempts = 0;
+
+    LinkTick step(uint32_t advance_ms) {
+        now += advance_ms;
+        LinkInputs i;
+        i.wifi_connected = wifi;
+        i.mqtt_connected = mqtt;
+        i.phase_elapsed_ms = now - phase_start;
+        i.ms_since_last_mqtt_attempt = (last_mqtt == 0) ? kMqttRetryIntervalMs
+                                                        : (now - last_mqtt);
+        auto t = linkTick(state, i);
+        if (t.phase_changed) phase_start = now;
+        if (t.action == LinkAction::StartMqtt) { mqtt_attempts++; last_mqtt = now; }
+        state = t.state;
+        return t;
+    }
+};
+
+TEST(LinkState, SlowWifiDoesNotConsumeTheMqttBudget) {
+    // THE REGRESSION. WiFi takes 6s -- longer than the whole 5s MQTT budget.
+    // MQTT must still get its own full 5s once WiFi is up.
+    Sim s;
+    s.step(0);                                   // Idle -> AwaitingWifi
+    EXPECT_EQ(LinkState::AwaitingWifi, s.state);
+    for (int i = 0; i < 6; i++) s.step(1000);    // 6s of WiFi connecting
+    EXPECT_EQ(LinkState::AwaitingWifi, s.state) << "must not time out at 6s";
+
+    s.wifi = true;
+    s.step(100);                                 // WiFi up -> AwaitingMqtt
+    EXPECT_EQ(LinkState::AwaitingMqtt, s.state);
+
+    // 4s into the MQTT phase -- total elapsed is now >10s, which under the old
+    // shared timer was already a "timeout".
+    for (int i = 0; i < 4; i++) s.step(1000);
+    EXPECT_EQ(LinkState::AwaitingMqtt, s.state)
+        << "WiFi's elapsed time was charged against MQTT's budget";
+
+    s.mqtt = true;
+    s.step(100);
+    EXPECT_EQ(LinkState::Ready, s.state);
+}
+
+TEST(LinkState, MqttStillTimesOutOnItsOwnBudget) {
+    Sim s;
+    s.wifi = true;
+    s.step(0);                                   // Idle -> AwaitingMqtt
+    EXPECT_EQ(LinkState::AwaitingMqtt, s.state);
+    for (int i = 0; i < 6; i++) s.step(1000);    // 6s > 5s budget
+    EXPECT_EQ(LinkState::Failed, s.state);
+}
+
+TEST(LinkState, MqttRetriesOnACadenceNotEveryTick) {
+    // Un-throttled retry means a blocking TCP connect on every loop pass
+    // against a down broker. Over 2s at 10ms ticks the cadence allows ~4, not
+    // ~200.
+    Sim s;
+    s.wifi = true;
+    s.step(0);                                   // first attempt
+    const int first = s.mqtt_attempts;
+    for (int i = 0; i < 200; i++) s.step(10);    // 2s of fast ticks
+    const int extra = s.mqtt_attempts - first;
+    EXPECT_GE(extra, 2);
+    EXPECT_LE(extra, 6) << "retrying on every tick would be ~200 attempts";
 }
 
 TEST(LinkState, FailedDoesNotSelfRetry) {
@@ -101,7 +167,8 @@ TEST(LinkState, FailedDoesNotSelfRetry) {
 // -------------------------------------------------------------------- stop ---
 
 TEST(LinkState, StopWinsFromEveryState) {
-    for (auto s : {LinkState::Connecting, LinkState::Ready, LinkState::Failed}) {
+    for (auto s : {LinkState::AwaitingWifi, LinkState::AwaitingMqtt,
+                   LinkState::Ready, LinkState::Failed}) {
         auto t = linkTick(s, in(true, true, 100, /*stop=*/true));
         EXPECT_EQ(LinkState::Idle, t.state);
         EXPECT_EQ(LinkAction::Teardown, t.action);
@@ -113,7 +180,7 @@ TEST(LinkState, StopBeatsAConnectionCompletingInTheSameTick) {
     // the same tick as a stop request would be left UP after the caller asked
     // for it to go down — which in persistent/OTA terms means WiFi staying on
     // when it should not.
-    auto t = linkTick(LinkState::Connecting, in(true, true, 10, /*stop=*/true));
+    auto t = linkTick(LinkState::AwaitingMqtt, in(true, true, 10, /*stop=*/true));
     EXPECT_EQ(LinkState::Idle, t.state);
     EXPECT_EQ(LinkAction::Teardown, t.action);
 }
@@ -128,14 +195,14 @@ TEST(LinkState, StopOnAnAlreadyIdleLinkDoesNothing) {
 
 TEST(LinkState, ReadyDropsToConnectingIfWifiGoesAway) {
     auto t = linkTick(LinkState::Ready, in(false, false));
-    EXPECT_EQ(LinkState::Connecting, t.state);
+    EXPECT_EQ(LinkState::AwaitingWifi, t.state);
     EXPECT_EQ(LinkAction::StartWifi, t.action);
 }
 
 TEST(LinkState, ReadyDropsToConnectingIfOnlyMqttGoesAway) {
     // A caller guarded by isReady() must not publish into a dead socket.
     auto t = linkTick(LinkState::Ready, in(true, false));
-    EXPECT_EQ(LinkState::Connecting, t.state);
+    EXPECT_EQ(LinkState::AwaitingMqtt, t.state);
     EXPECT_EQ(LinkAction::StartMqtt, t.action);
 }
 
@@ -163,8 +230,8 @@ TEST(LinkState, TickIsPureAndRepeatable) {
     // answer. That property is what lets a 15-second timeout be tested
     // instantly, and it is why this logic lives outside the transport.
     const auto i = in(false, false, 15001);
-    auto a = linkTick(LinkState::Connecting, i);
-    auto b = linkTick(LinkState::Connecting, i);
+    auto a = linkTick(LinkState::AwaitingWifi, i);
+    auto b = linkTick(LinkState::AwaitingWifi, i);
     EXPECT_EQ(a.state, b.state);
     EXPECT_EQ(a.action, b.action);
     EXPECT_EQ(a.phase_changed, b.phase_changed);


### PR DESCRIPTION
Closes #915 on merge. Epic #911, under Feature #891.

## What this delivers — and what it does not

**Delivers:** the WiFi/MQTT lifecycle no longer blocks the Arduino loop task.

**Does NOT deliver:** any fix for the intermittent CLI timeouts. Those reproduce with **zero** WiFi-telemetry cycles and are tracked separately under #921. **#910's causal claim was retracted** — the retraction is in this branch's design record, and this PR must not be read as fixing #893.

Both statements are true and neither cancels the other: the defect is real and severe under failure, *and* it was not the cause of the reported symptom.

## Hardware proof — two-arm A/B on ST-P, WiFi deliberately unreachable

SSID overridden at **build time** to a non-existent network. No device config touched, no secret read. Override verified present in each flashed binary and absent in the restore image.

Measured on the `noise_floor` loop heartbeat (nominal 2000 ms) — the metric that disproved the original diagnosis.

| | **Arm 1** pre-fix (`1dc95c43`) | **Arm 2** post-fix |
|---|---|---|
| Heartbeat samples | 179 | 191 |
| Median | 2001 ms | 2001 ms |
| **Worst loop stall** | **31,327 ms** | **4,003 ms** |
| Gaps > 6 s | 1 | **0** |
| `connectWifi: timeout` | **2** (`after 15037ms, status=1`) | **0** |
| Connect attempts in 6½ min | 2 | **9** |
| Failures actually reported | 0 | **6** |

The 4.003 ms residual matches healthy-firmware runs (4041 / 4013 ms) — normal jitter, not a remnant.

**A correction this test forced:** `status=1` is `WL_NO_SSID_AVAIL`, and the pre-fix spin does **not** exit on it — the loop only tests `WL_CONNECTED`, so every failure state reads as "keep waiting". Exposure is therefore **wider** than #910 described: any **absent** AP does it, not just one that fails to associate.

## The change

**`LinkStateMachine.h`** — a pure, Arduino-free state machine. Inputs → next state + action. Never calls WiFi, never sleeps, never reads a clock: **elapsed time is an input**, so both timeout boundaries are tested in ~2 s on the host. `WifiMqttTransport` needs the real `WiFi`/`PubSubClient` and is absent from the native `build_src_filter`, which is exactly why a 31 s stall lived in it unnoticed.

**Transport** — `begin()` advances one step and returns; both `while (…) { delay(N); }` loops are gone. `TelemetryTransport` gains `linkState()`, because a bool cannot separate "still connecting" from "failed" and `main.cpp` treats false as failure.

**Callers** — both triggers (publish and HTTP cmd-poll) are multi-pass, each with a phase so counters are touched **once per cycle**. A naive retry would have counted thousands of attempts per cycle.

**`delay(3000)` removed** from the first telemetry cycle — a 3 s loop block after every boot, in the publish path, and not in my original catalogue of this defect. Replaced with a deferred second sample. **There is now no `delay()` anywhere on the loop path**; the only two left are in `setup()`.

`setSocketTimeout(2)` set explicitly — `[verified: PubSubClient.h:34-36]` the default is 15 s and was never overridden, so one `connect()` could block ~15 s and the old loop's nominal 5 s budget could not bound it.

## Review — three passes, and what they caught

**#913, two passes.** Three CRITICALs, all real:
- **Shared phase timer** charged WiFi's elapsed time against MQTT's budget — a 6 s WiFi connect exhausted the 5 s MQTT budget before one attempt. *My test for this passed while the property did not exist*: it hand-fed the post-reset value. Replaced with a simulated caller on a monotonic clock, and **proven by re-introducing the bug** (test FAILS with it, passes without).
- **`Failed` was a permanent hang** — `end()` never reset `_link`, so after one timeout telemetry was dead until power cycle.
- **The `None` branch hammered the broker** — a blocking TCP connect on every loop pass. Retry cadence moved into the machine (500 ms, matching the old `delay(500)`).

**#914.** A flapping AP could stall telemetry until reboot: the machine times each *phase*, and every AwaitingWifi↔AwaitingMqtt transition restarts the timer, so no budget expires. Per-cycle deadline added. Also fixed a power regression I introduced — overlapping triggers meant neither tore down, leaving WiFi on indefinitely in burst mode.

**Rejected, with evidence:** a claimed `millis()` rollover failure (uint32 subtraction wraps correctly: `(10 - 4294967290) mod 2^32 == 16`); a "double-counted publish attempts" CRITICAL (the original did the same — two samples are genuinely published); and "rescheduling from completion is a regression" (the original did that too).

## Evidence

- **39/39 CI matrix** on the rebased branch — including every nRF52 and non-telemetry env that compiles the changed interface
- **19 native assertions**, one proven red against the defect
- Section B regression, 28-min real-network capture: **10 cycles / 10 teardowns** (burst power preserved), CLI **20/20 at 0.605 s**, no `pool empty`, heap ~199,948

## Open, recorded rather than smoothed over

**5 of 10 cycles reached MQTT** on the real network, alternating. The pre-fix sample was 2 cycles — **no baseline**, so this is not called a regression and is not explained. Worth its own investigation.

**Residual:** `end()`'s `WiFi.disconnect(true)` can still block; this change addresses bring-up. `isReady()` (hardware truth) and `linkState()` (machine belief) can disagree between ticks — `isReady()` remains the guard used by `publish()`.
