### PR TITLE
bug(#711): MultiSerialInterface never overrode maxFrameSize — delegate to it

### DIFF
--- a/src/helpers/BleFrameSizing.h
+++ b/src/helpers/BleFrameSizing.h
@@ -50,34 +50,24 @@ inline uint16_t effectiveMtu(uint16_t reported, uint16_t local) {
 /// raise the result above what the link carries, which is what the previous
 /// `min(mtu - 3, MAX_FRAME_SIZE)` form did once the cached MTU was too large.
 inline size_t deliverableFrame(uint16_t effective_mtu, size_t max_frame) {
-  // What the link says it can carry, from the (possibly untrustworthy) MTU.
+  // Bound 1: what one ATT notification carries on this link.
   const size_t link = effective_mtu > ATT_NOTIFY_HEADER
                         ? (size_t)(effective_mtu - ATT_NOTIFY_HEADER)
                         : 0;
-
-  // #711 RE-FIX: the HARD ceiling, derived from OUR OWN pinned preference and from
-  // nothing the stack reported. begin() pins the local preferred MTU to max_frame,
-  // so a link at that preference delivers at most max_frame - 3 -- clamping to
-  // max_frame (the BUFFER size) was always one ATT header too generous.
+  // Bound 2: the frame BUFFER (uint8_t buf[MAX_FRAME_SIZE]) -- a link that can
+  // carry more cannot be exploited without changing MAX_FRAME_SIZE itself, which
+  // is a protocol constant the client shares. An nRF52 at MTU 247 delivers 244 and
+  // still sends 176-byte frames for this reason.
   //
-  // The first fix computed min(reported_mtu - 3, max_frame) and was a no-op whenever
-  // the reported value was >= max_frame + 3. It shipped in beta4 and STILL clipped:
-  // NimBLEDevice::getMTU() returns ble_att_preferred_mtu_val, whose NimBLE default is
-  // 256, so a device where our setMTU() did not take effect computed
-  // min(253, 176) = 176 -- exactly the pre-fix size. Tester schill, Heltec V4.3:
-  // 12751 of 12973 bytes in 75 chunks, shortfall 222 = 3 x 74 full chunks.
-  //
-  // Taking the min of both bounds is safe BY CONSTRUCTION, which is the property
-  // #450's hardcoded constant had and every computed replacement since has lost:
-  //   - setMTU() took effect  -> link is the real bound, and own == link. Exact.
-  //   - setMTU() did NOT take effect -> we may under-use a larger link by 3 bytes.
-  //     Conservative, never clipped. A 1.7% throughput cost buys correctness on
-  //     every board and every stack, including ones that misreport.
-  const size_t own = max_frame > ATT_NOTIFY_HEADER
-                       ? max_frame - ATT_NOTIFY_HEADER
-                       : 0;
-
-  return link < own ? link : own;
+  // #711: an earlier revision made bound 2 `max_frame - ATT_NOTIFY_HEADER` as a
+  // hard ceiling, on the theory that a stack could over-report its MTU. That
+  // theory was WRONG -- the bench client log showed the MTU reported accurately
+  // (176, negotiated because begin() pins our preferred to MAX_FRAME_SIZE). The
+  // real defect was that MultiSerialInterface never overrode maxFrameSize(), so
+  // this function was not reached. With that fixed, min(link, max_frame) is
+  // correct on both: ESP32 at MTU 176 -> 173, nRF52 at MTU 247 -> 176. The extra
+  // ceiling only cost 3 bytes/frame on nRF52 and bought nothing.
+  return link < max_frame ? link : max_frame;
 }
 
 }  // namespace ble_frame

--- a/src/helpers/MultiSerialInterface.h
+++ b/src/helpers/MultiSerialInterface.h
@@ -157,6 +157,31 @@ public:
     return false;
   }
 
+  // #711: MUST be overridden. Inheriting BaseSerialInterface's default returns
+  // MAX_FRAME_SIZE unconditionally, so every caller asking this wrapper how big a
+  // frame it may build got the frame-BUFFER size rather than what the transport
+  // can actually deliver -- and the BLE interfaces' MTU-aware maxFrameSize() was
+  // never consulted at all. companion_radio holds a MultiSerialInterface as its
+  // `_serial`, so that made #453/#454 and both #711 attempts dead code on the
+  // companion path. Introduced by the 1.17.0 port (#668).
+  //
+  // writeFrame() below fans a frame out to EVERY enabled interface, so the frame
+  // must fit the most constrained one: the minimum is the only safe answer, and
+  // the predicate here must stay identical to writeFrame()'s or the two disagree.
+  //
+  // Nothing enabled -> writeFrame sends nothing, so the buffer bound is the honest
+  // answer; returning 0 would surprise callers for no gain.
+  size_t maxFrameSize() const override {
+    size_t smallest = MAX_FRAME_SIZE;
+    for (const auto& iface : _interfaces) {
+      if (iface.instance && iface.instance->isEnabled()) {
+        const size_t m = iface.instance->maxFrameSize();
+        if (m < smallest) smallest = m;
+      }
+    }
+    return smallest;
+  }
+
   size_t writeFrame(const uint8_t src[], size_t len) override {
     // don't write when disabled or nothing provided
     if(!_enabled || len == 0){

--- a/test/test_frame_size/test_ble_frame_sizing.cpp
+++ b/test/test_frame_size/test_ble_frame_sizing.cpp
@@ -168,11 +168,15 @@ TEST(BleFrameSizing, TinyMtuCannotUnderflow) {
 // (esp32/nrf52 SerialBLEInterface); serial and TCP use the BaseSerialInterface
 // default maxFrameSize() -> MAX_FRAME_SIZE and never reach this function, so they
 // are unaffected structurally, not by anything this function returns.
-TEST(BleFrameSizing, GenerousMtuStillRespectsTheHardCeiling) {
-  const size_t ceiling = kMaxFrame - ATT_NOTIFY_HEADER;
-  EXPECT_EQ(deliverableFrame(kMaxFrame + ATT_NOTIFY_HEADER, kMaxFrame), ceiling);
-  EXPECT_EQ(deliverableFrame(65535, kMaxFrame), ceiling);
-  EXPECT_EQ(deliverableFrame(kNimbleDefaultMtu, kMaxFrame), ceiling);
+TEST(BleFrameSizing, GenerousMtuIsCappedByTheFrameBuffer) {
+  // A link that can carry more cannot be exploited: the frame buffer is
+  // uint8_t buf[MAX_FRAME_SIZE]. This is why an nRF52 at MTU 247 (244 deliverable)
+  // still sends 176-byte frames. Was GenerousMtuStillRespectsTheHardCeiling and
+  // expected kMaxFrame-3; the hard ceiling was reverted (#711) once the real
+  // defect turned out to be MultiSerialInterface never delegating at all.
+  EXPECT_EQ(deliverableFrame(kMaxFrame + ATT_NOTIFY_HEADER, kMaxFrame), kMaxFrame);
+  EXPECT_EQ(deliverableFrame(65535, kMaxFrame), kMaxFrame);
+  EXPECT_EQ(deliverableFrame(kNimbleDefaultMtu, kMaxFrame), kMaxFrame);
 }
 
 // Guards the local mirror of MAX_FRAME_SIZE: if the real constant moves, this suite's
@@ -182,65 +186,72 @@ TEST(BleFrameSizing, FrameBufferConstantUnchanged) {
       << "MAX_FRAME_SIZE changed; revisit the expected values in this suite";
 }
 
-// --- #711 RE-FIX: the ceiling must not depend on any reported MTU ------------
+// --- #711: the invariant, corrected ------------------------------------------
 //
-// beta4 STILL clipped 3 B off every full frame on a Heltec V4.3, with this fix in.
-// Tester schill: 12751 of 12973 bytes in 75 chunks -> shortfall 222 = 3 x 74.
-// 12973 needs 76 chunks at a 171-byte payload and 75 at 174, so the device emitted
-// 174 -- the PRE-fix size -- meaning maxFrameSize() returned MAX_FRAME_SIZE.
+// Three tester reports, all ESP32, all the same shape:
+//   madmax_2069   8461 of  8608 in 50 chunks  (147 = 3 x 49)
+//   schill       12751 of 12973 in 75 chunks  (222 = 3 x 74)
+//   hv4-bench-1  14246 of 14495 in 84 chunks  (249 = 3 x 83)
 //
-// Cause: NimBLEDevice::getMTU() returns ble_att_preferred_mtu_val, whose NimBLE
-// DEFAULT is 256. Every test below pinned `local` to kLocalMtu (176), so the suite
-// never exercised the one value that breaks it. A test that cannot fail for the
-// real input is not a guard -- that is the whole lesson of #712.
+// The bench client log settled the cause: the link negotiated MTU 176 and was
+// REPORTED accurately as 176. begin() pins our preferred MTU to MAX_FRAME_SIZE,
+// so an ESP32 link can never exceed 176 -> 173 deliverable. The firmware still
+// emitted 174-byte payloads because MultiSerialInterface never overrode
+// maxFrameSize() and returned the buffer size instead (see test_multiserial).
+//
+// An earlier revision added a hard ceiling of max_frame - 3 here, on the theory
+// that a stack might over-report its MTU. That theory was WRONG and is reverted:
+// the MTU was honest, and the ceiling cost 3 bytes/frame on nRF52 (MTU 247) for
+// no benefit. min(link, max_frame) is correct on both.
 
-// The value NimBLE hands back when our setMTU() never took effect.
+constexpr uint16_t kEsp32NegotiatedMtu = 176;   // pinned by begin(); cannot exceed
 
-// The invariant, stated independently of any MTU the stack reports: a frame must
-// never exceed what a link at our OWN configured preference can deliver. begin()
-// pins that preference to MAX_FRAME_SIZE, so the hard ceiling is MAX_FRAME_SIZE - 3.
-constexpr size_t kHardCeiling = kMaxFrame - 3;
-
-TEST(BleFrameSizing, RegressionSevenElevenB_UntrustedLocalMustNotRaiseTheCeiling) {
-  // Exactly the shipped-beta4 situation: peer says 517, local reads NimBLE's default.
-  const uint16_t effective = effectiveMtu(517, kNimbleDefaultMtu);
-  const size_t deliverable = deliverableFrame(effective, kMaxFrame);
-
-  EXPECT_LE(deliverable, kHardCeiling)
-      << "local=" << kNimbleDefaultMtu << " (NimBLE default, i.e. our setMTU did not "
-         "take effect) must not license a frame the link will clip";
-
-  const size_t payload = deliverable > 2 ? deliverable - 2 : 0;
-  EXPECT_EQ(payload, 171u) << "chunk payload must stay 171, not the pre-fix 174";
+// THE REGRESSION. On the link every field report was taken on, the payload must
+// be 171. 174 is what shipped and what clipped.
+TEST(BleFrameSizing, RegressionSevenEleven_Esp32LinkYields171NotThePreFix174) {
+  const size_t deliverable =
+      deliverableFrame(effectiveMtu(kEsp32NegotiatedMtu, kLocalMtu), kMaxFrame);
+  EXPECT_EQ(deliverable, 173u) << "MTU 176 delivers MTU-3";
+  EXPECT_EQ(deliverable > 2 ? deliverable - 2 : 0, 171u)
+      << "caplog CHUNK payload; 174 is the pre-fix size that lost 3 B per full frame";
 }
 
-// The field arithmetic, end to end. At the correct cap schill's buffer needs 76
-// chunks and loses nothing; at the broken cap it takes 75 and loses exactly 222.
-TEST(BleFrameSizing, RegressionSevenElevenB_SchillCaptureArithmetic) {
-  constexpr size_t kTotal = 12973, kHeader = 2;
+// The field arithmetic at the correct cap: nothing lost, and the chunk COUNT is
+// itself the tell -- 76 rather than the 75 schill saw, 85 rather than 84 on bench.
+TEST(BleFrameSizing, RegressionSevenEleven_FieldCapturesDeliverInFull) {
+  const size_t cap =
+      deliverableFrame(effectiveMtu(kEsp32NegotiatedMtu, kLocalMtu), kMaxFrame) - 2;
+  ASSERT_EQ(cap, 171u);
 
-  const size_t cap = deliverableFrame(effectiveMtu(517, kNimbleDefaultMtu), kMaxFrame) - kHeader;
-  size_t chunks = 0, delivered = 0;
-  for (size_t off = 0; off < kTotal; off += cap, ++chunks) {
-    const size_t n = (kTotal - off) < cap ? (kTotal - off) : cap;
-    ASSERT_LE(kHeader + n, kHardCeiling) << "chunk " << chunks << " would be clipped";
-    delivered += n;
+  struct Case { size_t total; size_t expect_chunks; } cases[] = {
+      {8608, 51}, {12973, 76}, {14495, 85},
+  };
+  for (const auto& c : cases) {
+    size_t chunks = 0, delivered = 0;
+    for (size_t off = 0; off < c.total; off += cap, ++chunks) {
+      const size_t n = (c.total - off) < cap ? (c.total - off) : cap;
+      ASSERT_LE(2 + n, 173u) << "chunk " << chunks << " would be clipped on the wire";
+      delivered += n;
+    }
+    EXPECT_EQ(delivered, c.total) << "total " << c.total;
+    EXPECT_EQ(chunks, c.expect_chunks) << "total " << c.total;
   }
-  EXPECT_EQ(delivered, kTotal);
-  EXPECT_EQ(chunks, 76u) << "76 chunks at the correct cap; the field saw 75 at the broken one";
 }
 
-// The general form: NO pair of (reported, local) may produce a frame above the
-// hard ceiling. This is the assertion that would have caught beta4 before release.
-TEST(BleFrameSizing, RegressionSevenElevenB_NoReportedLocalPairExceedsTheCeiling) {
+// The general invariant: for ANY (reported, local), the emitted frame must fit
+// both the link and the buffer. Sweeping `local` is what the original suite
+// missed -- it pinned local at 176 and went green on a fix that did not work.
+TEST(BleFrameSizing, NoReportedLocalPairExceedsLinkOrBuffer) {
   const uint16_t locals[] = {0, 1, 22, 23, 100, 169, 176, 179, 185, 247, 256, 512, 517, 65535};
   for (uint16_t reported : kReportedMtus) {
     for (uint16_t local : locals) {
-      const size_t deliverable = deliverableFrame(effectiveMtu(reported, local), kMaxFrame);
-      EXPECT_LE(deliverable, kHardCeiling)
-          << "reported=" << reported << " local=" << local
-          << " produced a frame of " << deliverable << " B, above the "
-          << kHardCeiling << " B a MAX_FRAME_SIZE-preferred link delivers";
+      const uint16_t eff = effectiveMtu(reported, local);
+      const size_t deliverable = deliverableFrame(eff, kMaxFrame);
+      const size_t link = eff > ATT_NOTIFY_HEADER ? (size_t)(eff - ATT_NOTIFY_HEADER) : 0;
+      EXPECT_LE(deliverable, link)
+          << "reported=" << reported << " local=" << local << ": frame would be clipped";
+      EXPECT_LE(deliverable, kMaxFrame)
+          << "reported=" << reported << " local=" << local << ": frame would overrun the buffer";
     }
   }
 }

--- a/test/test_multiserial/test_multiserial_framesize.cpp
+++ b/test/test_multiserial/test_multiserial_framesize.cpp
@@ -1,0 +1,128 @@
+// #711: MultiSerialInterface must delegate maxFrameSize() to its interfaces.
+//
+// THE DEFECT THIS PINS
+//   MultiSerialInterface overrides nine BaseSerialInterface methods -- enable,
+//   disable, isEnabled, isConnected, loop, isWriteBusy, writeFrame,
+//   checkRecvFrame -- and NOT maxFrameSize(). So every caller asking the wrapper
+//   "how big a frame may I build?" got BaseSerialInterface's default,
+//   MAX_FRAME_SIZE, no matter how constrained the underlying transport was.
+//
+//   companion_radio holds a MultiSerialInterface as its `_serial` (main.cpp:49,
+//   `interface_manager`), so caplogDrain()'s maxFramePayload(2) returned 174 on
+//   every board and every link. The BLE interfaces' own MTU-aware maxFrameSize()
+//   was never consulted -- which made #453, #454 and both #711 attempts dead code
+//   on this path. Introduced by the 1.17.0 MultiSerialInterface port (#668).
+//
+//   Field cost: three tester reports of identical shape, all ESP32, where the
+//   link negotiates MTU 176 (we pin setMTU(MAX_FRAME_SIZE)) and therefore
+//   delivers 173 -- so a 176-byte frame lost exactly 3 bytes, every full frame.
+//     madmax_2069  8461 of  8608 in 50 chunks  (147 = 3 x 49)
+//     schill      12751 of 12973 in 75 chunks  (222 = 3 x 74)
+//     hv4-bench-1 14246 of 14495 in 84 chunks  (249 = 3 x 83)
+//
+//   It was HARMLESS on links delivering >= MAX_FRAME_SIZE (an nRF52 at MTU 247
+//   delivers 244, and a 176-byte frame fits), which is why no nRF52 report exists
+//   and why the defect stayed invisible for months.
+
+#include <gtest/gtest.h>
+
+#include "helpers/MultiSerialInterface.h"
+
+namespace {
+
+/// A transport that reports a fixed deliverable frame size.
+class FakeInterface : public BaseSerialInterface {
+public:
+  explicit FakeInterface(size_t max_frame, bool enabled = true)
+      : _max(max_frame), _enabled(enabled) {}
+
+  void enable() override { _enabled = true; }
+  void disable() override { _enabled = false; }
+  bool isEnabled() const override { return _enabled; }
+  bool isConnected() const override { return _enabled; }
+  bool isWriteBusy() const override { return false; }
+  size_t writeFrame(const uint8_t*, size_t len) override { return len; }
+  size_t checkRecvFrame(uint8_t*) override { return 0; }
+  size_t maxFrameSize() const override { return _max; }
+
+private:
+  size_t _max;
+  bool _enabled;
+};
+
+constexpr size_t kMaxFrame = 176;
+
+}  // namespace
+
+// THE REGRESSION. A BLE interface on an MTU-176 link delivers 173. The wrapper
+// must report 173, not MAX_FRAME_SIZE.
+TEST(MultiSerialFrameSize, RegressionSevenEleven_WrapperMustNotReportTheDefault) {
+  FakeInterface ble(173);
+  MultiSerialInterface multi;
+  multi.addInterface(InterfaceType::Bluetooth, &ble);
+  multi.enable();
+
+  EXPECT_EQ(multi.maxFrameSize(), 173u)
+      << "wrapper returned its inherited default instead of delegating; a chunk "
+         "builder would emit a 176-byte frame onto a 173-byte pipe (#711)";
+  EXPECT_EQ(multi.maxFramePayload(2), 171u)
+      << "caplog CHUNK payload must be 171 on an MTU-176 link, not the 174 that "
+         "produced the madmax / schill / bench truncations";
+}
+
+// writeFrame() fans a frame out to EVERY enabled interface, so the frame must fit
+// the most constrained one. The minimum is the only safe answer.
+TEST(MultiSerialFrameSize, ReportsTheMinimumAcrossEnabledInterfaces) {
+  FakeInterface ble(173), usb(kMaxFrame), wifi(120);
+  MultiSerialInterface multi;
+  multi.addInterface(InterfaceType::Bluetooth, &ble);
+  multi.addInterface(InterfaceType::USB, &usb);
+  multi.addInterface(InterfaceType::WiFi, &wifi);
+  multi.enable();
+
+  EXPECT_EQ(multi.maxFrameSize(), 120u) << "must be the smallest, not the first or the largest";
+}
+
+// A disabled interface receives nothing from writeFrame(), so it must not drag
+// the reported size down. The predicate has to match writeFrame() exactly.
+TEST(MultiSerialFrameSize, DisabledInterfacesAreIgnored) {
+  // NOTE: MultiSerialInterface::enable() enables EVERY registered interface, so a
+  // fake constructed disabled comes back up. The realistic state this models is an
+  // interface disabled at runtime after the wrapper started (e.g. BLE turned off
+  // while USB stays up), so disable it after enable(). Caught by this test failing
+  // for the wrong reason -- the premise was wrong, not the implementation.
+  FakeInterface ble(173), wifi(64);
+  MultiSerialInterface multi;
+  multi.addInterface(InterfaceType::Bluetooth, &ble);
+  multi.addInterface(InterfaceType::WiFi, &wifi);
+  multi.enable();
+  wifi.disable();
+
+  EXPECT_EQ(multi.maxFrameSize(), 173u)
+      << "a disabled interface gets no frames and must not constrain the size";
+}
+
+// Nothing registered / nothing enabled: writeFrame sends nothing, so the buffer
+// bound is the honest answer and callers never see a surprising 0.
+TEST(MultiSerialFrameSize, NoEnabledInterfacesFallsBackToTheBufferBound) {
+  MultiSerialInterface multi;
+  multi.enable();
+  EXPECT_EQ(multi.maxFrameSize(), kMaxFrame);
+}
+
+// An interface reporting more than the frame buffer cannot raise the ceiling --
+// the buffer is uint8_t buf[MAX_FRAME_SIZE] and caps every frame regardless of
+// how generous the link is. This is why an nRF52 at MTU 247 gets 176, not 244.
+TEST(MultiSerialFrameSize, GenerousInterfaceCannotExceedTheFrameBuffer) {
+  FakeInterface big(4096);
+  MultiSerialInterface multi;
+  multi.addInterface(InterfaceType::Bluetooth, &big);
+  multi.enable();
+
+  EXPECT_EQ(multi.maxFrameSize(), kMaxFrame);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## What this changes

**This is the actual defect.** #450, #454, and both previous #711 attempts all modified code that **is not reached on the companion path**.

`MultiSerialInterface` overrides nine `BaseSerialInterface` methods — `enable`, `disable`, `isEnabled`, `isConnected`, `loop`, `isWriteBusy`, `writeFrame`, `checkRecvFrame` — and **not `maxFrameSize()`**.

`companion_radio` holds a `MultiSerialInterface` as its `_serial` (`main.cpp:49`, `interface_manager`). So `caplogDrain()`'s `maxFramePayload(2)` returned `BaseSerialInterface`'s default `MAX_FRAME_SIZE - 2 = 174` on every board and every link, and the BLE interfaces' MTU-aware `maxFrameSize()` was never consulted at all.

Introduced by the 1.17.0 MultiSerialInterface port (#668) — `main.cpp:382` already records that the legacy single-`serial_interface` wiring was not removed in that port.

Addresses #711 — **stays OPEN until `hv4-bench-1` re-tests.**

### The evidence that settled it

Bench client debug log:

```
20:55:13  MTU set to: 176            <- negotiated AND reported honestly
21:03:34  14246 of 14495 in 84 chunks
measured chunk payloads: 83 x 171 received + 1 x 53
```

MTU 176 delivers 173. The firmware wrote 176-byte frames. **3 bytes lost per full frame.** All three field reports share that signature exactly:

| | | |
|---|---|---|
| madmax_2069 | 8461 of 8608, 50 chunks | 147 = 3 × 49 |
| schill | 12751 of 12973, 75 chunks | 222 = 3 × 74 |
| hv4-bench-1 | 14246 of 14495, 84 chunks | 249 = 3 × 83 |

### The fix

`maxFrameSize()` returns the **minimum across interfaces where `instance && instance->isEnabled()`** — the same predicate `writeFrame()` uses to fan a frame out, so the two cannot disagree. Nothing enabled → `MAX_FRAME_SIZE`, since `writeFrame` sends nothing in that state and returning 0 would surprise callers for no gain.

### Hard ceiling reverted (owner-directed)

The previous attempt made `deliverableFrame()` return `min(mtu-3, max_frame-3)` on the theory that a stack might over-report its MTU. **That theory is refuted** — the MTU was reported accurately — and the ceiling cost 3 bytes/frame on nRF52 (MTU 247, delivers 244) for no benefit.

`min(link, max_frame)` is correct on both: ESP32 at MTU 176 → 173, nRF52 at 247 → 176. The `setMTU()` return check is **kept** — an independent silent-failure fix.

### A correction to the record

I previously claimed the nRF52 board class "may have been unable to deliver a caplog at all." **That was wrong.** A 176-byte frame fits a 244-byte deliverable, so nRF52 never clipped — which is precisely why every field report is ESP32. The defect is only fatal where the deliverable is **below** `MAX_FRAME_SIZE`, i.e. the ESP32 case, because `begin()` pins our preferred MTU to `MAX_FRAME_SIZE`.

## Tests

**`test/test_multiserial` drives the real `MultiSerialInterface`** with fake transports and is **verified to FAIL 3/6 with the override removed.**

It pins the exact field case (an interface reporting 173 must yield payload **171**, not 174), the minimum-across-interfaces rule, the disabled-interface predicate, and that a generous interface cannot exceed the frame buffer.

The frame-size suite is updated to the reverted invariant and now asserts the field chunk counts directly: **8608 → 51, 12973 → 76, 14495 → 85**, nothing lost.

One of my own test premises was wrong and **the test was corrected, not the code**: `MultiSerialInterface::enable()` enables *every* registered interface, so a fake constructed disabled comes back up; the realistic state is disabled *after* `enable()`.

- [x] Tests added/updated, and shown to fail without the fix
- [ ] No test: state why here (only the owner waives a test)

## Verification

- [x] `pio test` green for every native env: **271 / 8 / 7**
- [x] Builds: `heltec_v4_companion_radio_ble`, `RAK_4631_companion_radio_ble`, `Heltec_v2_companion_radio_ble`, `heltec_rc32_companion_radio_usb`
- [ ] **NOT device-verified.** `hv4-bench-1` re-test gates this. Expect **85 chunks at 171 payload** for a 14495-byte buffer, announced == received.

## Review

- [x] Gemini-reviewed (`gemini-2.5-pro`) — "approve with comments".

Three of its points, handled explicitly:

- It argued to **keep** the hard ceiling as defence-in-depth ("this part of the code is cursed"). Recorded; the owner ruled to revert, and that is not re-litigated here.
- It called the wrapper's missing `isConsoleSharedWithProtocol()` override a **critical live bug**. **Checked: it is not.** `main.cpp:491` calls it on `usb_serial_interface`, the concrete `ArduinoSerialInterface`, which *does* override it — never on the wrapper. Latent hazard, recorded against #871 rather than widened into this change.
- Its note on the pre-existing by-value `for(auto iface : _interfaces)` loops is correct; left as out of scope, new code uses `const auto&`.

## Notes

**Fourth attempt at this invariant.** The first three each changed a value's *derivation* without checking whether the function computing it was *called*. The test added here exercises the wrapper that was skipped, which is the gap all three previous test suites shared — they tested the leaf, and the leaf was never reached.

Agent: TopazElk (session cb83eacb)
