### PR TITLE
chore: auto-publish diag builds to public diag-builds pre-release (#957)

### DIFF
--- a/.github/workflows/diag-build.yml
+++ b/.github/workflows/diag-build.yml
@@ -31,6 +31,8 @@ on:
 jobs:
   diag-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # publish assets to the diag-builds pre-release
     steps:
       - name: Clone Repo
         uses: actions/checkout@v5
@@ -92,10 +94,29 @@ jobs:
           fi
           echo "Diagnostic artifacts produced:"; ls -la out/
 
-      - name: Upload diagnostic artifact
+      - name: Upload diagnostic artifact (maintainer convenience)
         uses: actions/upload-artifact@v4
         with:
           name: "diag-${{ inputs.env }}"
           path: out/*
           if-no-files-found: error
           retention-days: 90
+
+      - name: Publish to the diag-builds pre-release (public tester link)
+        # THE point of this workflow: a self-serve download link for testers, with
+        # no maintainer download+forward. On a public repo, release assets have
+        # anonymous direct-download URLs. `diag-builds` is a rolling pre-release
+        # (NOT a version release) that acts as a permanent diagnostic file-drop.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! gh release view diag-builds >/dev/null 2>&1; then
+            gh release create diag-builds --prerelease --target "$GITHUB_SHA" \
+              --title "Diagnostic Builds (rolling -- NOT a version release)" \
+              --notes "Rolling drop for one-off diagnostic firmware images. NOT a product release -- no version semantics, no CHANGELOG, do not treat as a beta. Assets are diagnostic builds (caplog pinned on + boot beacon + UART0 mesh-log mirror), replaced as needed."
+          fi
+          gh release upload diag-builds out/*.bin --clobber
+          echo "Public download links:"
+          for f in out/*.bin; do
+            echo "  https://github.com/${GITHUB_REPOSITORY}/releases/download/diag-builds/$(basename "$f")"
+          done


### PR DESCRIPTION
Completes #957's actual intent: a **tester self-serve download link, no maintainer forwarding**.

The artifact-only workflow left distribution manual — CI artifacts are auth-gated, so a maintainer had to download the .bin and forward it (Discord). This adds a publish step that drops each diag build's `.bin` into the rolling **`diag-builds`** pre-release:
- idempotent `gh release view || gh release create --prerelease`, then `gh release upload --clobber`
- job granted `permissions: contents: write`
- on a public repo, release assets have **anonymous direct-download URLs** → a permanent tester link, e.g. `https://github.com/OffbandMesh/meshcore-firmware/releases/download/diag-builds/<env>-diag-<sha>.bin`

`diag-builds` is explicitly a rolling pre-release, NOT a version release (no CHANGELOG, no beta/stable semantics). The artifact upload is kept for maintainer convenience.

Verifies on merge + a dispatch (the release-publish step can't run pre-merge). YAML validated.

Closes #957