### PR TITLE
task(#972): ungate companion UI tracing so nRF52 boards can emit it

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -658,6 +658,35 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   splash = new SplashScreen(this);
   home = new HomeScreen(this, &rtc_clock, sensors, node_prefs);
   msg_preview = new MsgPreviewScreen(this, &rtc_clock);
+#ifdef OFFBAND_UI_TRACE
+  // #951: these three are new'd with no null check, and a null `home` is SILENT --
+  // gotoHomeScreen() sets curr = nullptr, the render loop's `&& curr` guard stops
+  // firing, and the panel simply holds whatever was last blitted. On a memory-tight
+  // board that presents as "stuck on the splash screen" with a fully healthy board
+  // behind it. Log which of them actually got memory.
+  offband::crashLogf("[ui] screens alloc: splash=%d home=%d msg_preview=%d",
+                     (int)(splash != NULL), (int)(home != NULL), (int)(msg_preview != NULL));
+
+  // #856: how much did they actually need, and how much was there?
+  //
+  // sizeof() is the exact object size. The second figure is the LARGEST
+  // CONTIGUOUS BLOCK still allocatable, probed by walking malloc down until one
+  // succeeds and immediately freeing it -- that, not total free bytes, is what
+  // `new HomeScreen` has to find. Freeing 56 KB of back buffer was known to be
+  // sufficient; this says what is actually REQUIRED, so the buffer can be sized
+  // on evidence instead of on a guess.
+  {
+    size_t probe = 64u * 1024u;
+    while (probe > 256u) {
+      void* p = malloc(probe);
+      if (p) { free(p); break; }
+      probe -= 512u;
+    }
+    offband::crashLogf("[ui] sizeof: splash=%u home=%u msg=%u | largest_free_block=%u",
+                       (unsigned)sizeof(SplashScreen), (unsigned)sizeof(HomeScreen),
+                       (unsigned)sizeof(MsgPreviewScreen), (unsigned)probe);
+  }
+#endif
   setCurrScreen(splash);
 }
 
@@ -790,16 +819,22 @@ void UITask::setCurrScreen(UIScreen* c) {
   // Screen transition tracing: log every change so we can see if the
   // SplashScreen ↔ HomeScreen oscillation observed on hv3-bench is
   // a real state-machine bug.
+  // #951: nullptr is tested FIRST, and that ordering is load-bearing. If a screen
+  // pointer is itself null -- `new` returned nothing on a memory-tight board -- then
+  // `c == home` is true for a null `c`, and the old ordering printed "HOME" for a
+  // transition to nothing. The NULL arm was unreachable in exactly the case it
+  // existed to catch, and the trace read as a healthy handoff while the UI was
+  // going dark. Do not reorder these.
   const char* from = "?";
   const char* to   = "?";
-  if      (curr == splash)      from = "SPLASH";
+  if      (curr == nullptr)     from = "NULL";
+  else if (curr == splash)      from = "SPLASH";
   else if (curr == home)        from = "HOME";
   else if (curr == msg_preview) from = "MSG_PREVIEW";
-  else if (curr == nullptr)     from = "NULL";
-  if      (c == splash)         to   = "SPLASH";
+  if      (c == nullptr)        to   = "NULL";
+  else if (c == splash)         to   = "SPLASH";
   else if (c == home)           to   = "HOME";
   else if (c == msg_preview)    to   = "MSG_PREVIEW";
-  else if (c == nullptr)        to   = "NULL";
   offband::crashLogf("[ui] setCurrScreen %s -> %s", from, to);
 #endif
   curr = c;

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -6,7 +6,33 @@
 #ifdef WIFI_SSID
   #include <WiFi.h>
 #endif
-#ifdef OFFBAND_OBSERVER
+// ---------------------------------------------------------------------------
+// #972: UI state-machine tracing.
+//
+// These four crashLogf() call sites were gated on OFFBAND_OBSERVER. That flag
+// implies WiFi, and nRF52 has none -- so on RC52, RAK4631, T1000-E, Wio, T096 and
+// XIAO the tracing compiled out entirely. The instrument exists BECAUSE of a UI
+// bug (see the note above setCurrScreen: a SplashScreen <-> HomeScreen
+// oscillation observed on hv3-bench), so gating it on an unrelated radio
+// capability made it unavailable on a whole class of boards.
+//
+// Derived from both flags rather than moved to OFFBAND_BOOT_BEACON directly:
+//   * observer boards keep it exactly as before -- no regression where it works
+//     today;
+//   * OFFBAND_BOOT_BEACON brings in the RadioCore _diag envs (RC32, RCC6, RC52
+//     all set it), matching the standing rule that every env built during
+//     bring-up is a full diagnostic build;
+//   * the name says what it controls. OFFBAND_BOOT_BEACON is about BOOT; this is
+//     UI runtime tracing, and reusing that flag's name would mislead.
+//
+// crashLogf() itself is unconditional in CrashLog.h -- only the call sites were
+// ever gated.
+// ---------------------------------------------------------------------------
+#if defined(OFFBAND_OBSERVER) || defined(OFFBAND_BOOT_BEACON)
+  #define OFFBAND_UI_TRACE 1
+#endif
+
+#ifdef OFFBAND_UI_TRACE
   #include <helpers/diagnostics/CrashLog.h>
 #endif
 
@@ -52,7 +78,7 @@ public:
   }
 
   int render(DisplayDriver& display) override {
-#ifdef OFFBAND_OBSERVER
+#ifdef OFFBAND_UI_TRACE
     offband::crashLogf("[ui] SplashScreen.render() at %lu", (unsigned long)millis());
 #endif
     offband::SplashInfo si( nullptr, FIRMWARE_VERSION, FIRMWARE_BUILD_DATE );
@@ -722,7 +748,7 @@ void UITask::newMsg(uint8_t path_len, const char* from_name, const char* text, i
 
   if (_display != NULL) {
     if (!_display->isOn() && !hasConnection() && _disp_mode != 2) {  // #542 B1: not in always-off
-#ifdef OFFBAND_OBSERVER
+#ifdef OFFBAND_UI_TRACE
       offband::crashLogf("[ui] newMsg: display off + no conn -> turnOn");
 #endif
       _display->turnOn();
@@ -760,7 +786,7 @@ void UITask::userLedHandler() {
 }
 
 void UITask::setCurrScreen(UIScreen* c) {
-#ifdef OFFBAND_OBSERVER
+#ifdef OFFBAND_UI_TRACE
   // Screen transition tracing: log every change so we can see if the
   // SplashScreen ↔ HomeScreen oscillation observed on hv3-bench is
   // a real state-machine bug.
@@ -889,7 +915,7 @@ void UITask::loop() {
 #endif
 
   if (c != 0 && curr) {
-#ifdef OFFBAND_OBSERVER
+#ifdef OFFBAND_UI_TRACE
     offband::crashLogf("[ui] button event c=0x%x dispatched to curr screen", (int)c);
 #endif
     curr->handleInput(c);

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -32,6 +32,20 @@
   #define OFFBAND_UI_TRACE 1
 #endif
 
+// The heap probe is gated SEPARATELY and is OFF by default, even on builds that
+// have the tracing above. (Gemini review finding 2, #972.)
+//
+// The transition and allocation traces are a handful of crashLogf() calls. The
+// probe is a different class of thing: it calls malloc in a loop on the boot
+// path. Folding it into OFFBAND_UI_TRACE would drag that cost onto every
+// RadioCore _diag build to answer a question almost none of them are asking.
+//
+// Turn it on deliberately, for a board you are actively investigating:
+//   -D OFFBAND_UI_TRACE_HEAP
+#if defined(OFFBAND_UI_TRACE) && defined(OFFBAND_UI_TRACE_HEAP)
+  #define OFFBAND_UI_HEAP_PROBE 1
+#endif
+
 #ifdef OFFBAND_UI_TRACE
   #include <helpers/diagnostics/CrashLog.h>
 #endif
@@ -669,23 +683,58 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
 
   // #856: how much did they actually need, and how much was there?
   //
-  // sizeof() is the exact object size. The second figure is the LARGEST
-  // CONTIGUOUS BLOCK still allocatable, probed by walking malloc down until one
-  // succeeds and immediately freeing it -- that, not total free bytes, is what
-  // `new HomeScreen` has to find. Freeing 56 KB of back buffer was known to be
-  // sufficient; this says what is actually REQUIRED, so the buffer can be sized
-  // on evidence instead of on a guess.
+  // sizeof() is exact and costs nothing, so it is always logged. The heap probe
+  // below is opt-in -- see OFFBAND_UI_TRACE_HEAP above.
+  offband::crashLogf("[ui] sizeof: splash=%u home=%u msg=%u",
+                     (unsigned)sizeof(SplashScreen), (unsigned)sizeof(HomeScreen),
+                     (unsigned)sizeof(MsgPreviewScreen));
+
+#ifdef OFFBAND_UI_HEAP_PROBE
+  // LARGEST CONTIGUOUS BLOCK still allocatable -- that, not total free bytes, is
+  // what `new HomeScreen` has to find.
+  //
+  // BINARY SEARCH, not a linear walk. (Gemini review finding 1, #972.) The first
+  // version stepped down from 64 KB in 512 B decrements: up to 128 malloc calls
+  // on the boot path, and on a board with room to spare the 64 KB request
+  // SUCCEEDS -- newlib returns the block to its free list but does not hand the
+  // sbrk extension back, so a diagnostic could permanently raise the heap ceiling
+  // by 64 KB on boards that never needed it. 8 probes instead of 128, and the
+  // ceiling is sized to the question rather than to a round number.
+  //
+  // FLOOR MATTERS MORE THAN THE CEILING. The first version stepped by 512 B, so
+  // its resolution floor was 512 -- and sizeof(HomeScreen) is 480. It could not
+  // resolve the allocation it existed to measure, and reported "0" for anything
+  // under 512 B, which reads as "no memory at all" when it means "less than
+  // half a kilobyte". PROBE_FLOOR is deliberately below the smallest screen.
   {
-    size_t probe = 64u * 1024u;
-    while (probe > 256u) {
-      void* p = malloc(probe);
-      if (p) { free(p); break; }
-      probe -= 512u;
+    const size_t PROBE_CEIL  = 24u * 1024u;   // above any single screen, well under a big heap
+    const size_t PROBE_FLOOR = 64u;           // below sizeof(SplashScreen), so 0 really means 0
+
+    size_t lo = 0, hi = PROBE_CEIL, largest = 0;
+    for (int i = 0; i < 9; i++) {             // 9 halvings of 24 KB resolves to < 64 B
+      // NO `if (mid < PROBE_FLOOR) break;` here -- it was tried and it is wrong.
+      // (Gemini re-review, #972.) Breaking on the midpoint abandons the interval
+      // while the true largest block may still be inside it: with 80 B actually
+      // available the search narrows to lo=0/hi=96, computes mid=48, breaks, and
+      // reports largest=0 -- claiming no memory at all when 80 B were free. That
+      // is the exact misleading zero this rewrite existed to remove.
+      //
+      // Termination is already safe: a fixed 9 iterations, plus the hi-lo
+      // convergence check below. PROBE_FLOOR is the RESOLUTION, not a minimum
+      // probe size, so probing beneath it is intended.
+      const size_t mid = lo + (hi - lo) / 2;
+      void* p = malloc(mid);
+      if (p) { free(p); largest = mid; lo = mid; }
+      else   { hi = mid; }
+      if (hi - lo < PROBE_FLOOR) break;
     }
-    offband::crashLogf("[ui] sizeof: splash=%u home=%u msg=%u | largest_free_block=%u",
-                       (unsigned)sizeof(SplashScreen), (unsigned)sizeof(HomeScreen),
-                       (unsigned)sizeof(MsgPreviewScreen), (unsigned)probe);
+    // `largest` stays 0 unless an allocation actually succeeded, so a report of 0
+    // means nothing above PROBE_FLOOR was obtainable -- it is never a value that
+    // was merely stepped past.
+    offband::crashLogf("[ui] largest_free_block=%u (ceil=%u floor=%u)",
+                       (unsigned)largest, (unsigned)PROBE_CEIL, (unsigned)PROBE_FLOOR);
   }
+#endif
 #endif
   setCurrScreen(splash);
 }
@@ -825,6 +874,14 @@ void UITask::setCurrScreen(UIScreen* c) {
   // transition to nothing. The NULL arm was unreachable in exactly the case it
   // existed to catch, and the trace read as a healthy handoff while the UI was
   // going dark. Do not reorder these.
+  //
+  // ⚠ MAINTENANCE: this chain is hand-maintained against the screen pointers
+  // declared in UITask. Add a fourth screen and forget to add it here and its
+  // transitions log as "?" -- the trace degrades quietly rather than failing.
+  // Kept as an if/else chain deliberately: a lookup table would centralise the
+  // names but costs storage on every board for a diagnostic most never enable.
+  // (Gemini review finding 3, #972 -- accepted as a maintainability note, no
+  // functional defect.)
   const char* from = "?";
   const char* to   = "?";
   if      (curr == nullptr)     from = "NULL";


### PR DESCRIPTION
Closes #972

## What and why

The companion UI's four `crashLogf()` tracing call sites were gated on `OFFBAND_OBSERVER`. That flag implies WiFi, and **nRF52 has none** — so on every nRF52 board (RC52, RAK4631, T1000-E, Wio, T096, XIAO) this instrumentation compiled out entirely.

That is backwards. The tracing exists *because* of a UI bug — its own comment records a `SplashScreen ↔ HomeScreen` oscillation seen on hv3-bench as a real state-machine defect. Gating it on an unrelated radio capability removed it from a whole class of boards.

Gated now on `OFFBAND_UI_TRACE`, defined when either `OFFBAND_OBSERVER` **or** `OFFBAND_BOOT_BEACON` is set. Derived from both rather than moved onto the beacon flag: observer boards keep it byte-identically, `OFFBAND_BOOT_BEACON` brings in the RadioCore `_diag` envs, and the name says what it controls — `OFFBAND_BOOT_BEACON` is about *boot*, this is *UI runtime* tracing.

## It paid for itself immediately

RC52 showed its splash and never visibly progressed, on a board that was otherwise perfectly healthy — `display.begin(OK)`, `setup:DONE`, radio up, heartbeat running, no errors. With the tracing compiled in:

```
[ui] screens alloc: splash=1 home=0 msg_preview=1
[ui] setCurrScreen SPLASH -> NULL
```

`new HomeScreen(...)` returns **null**. `gotoHomeScreen()` sets `curr = nullptr`, the render loop's `&& curr` guard stops firing, and the panel holds the last blitted frame forever. Filed as #973 — it affects **60 variants**, since `new` is unchecked at all three screen allocations.

**And the trace was actively lying.** It tested `c == home` before `c == nullptr`, so with `home` null a transition to *nothing* printed `"HOME"`. The NULL arm was unreachable in exactly the case it existed to catch. That misdirected the first round of diagnosis at the display driver. Now null-first, with a comment saying not to reorder it.

## Also here

- **which screens got memory**, plus `sizeof()` of each — the unchecked `new` itself is #973 and deliberately not fixed here
- **an opt-in heap probe** reporting the largest contiguous allocatable block, which is what `new` actually has to find

## Gemini review — findings and dispositions

Run twice: once on the original, once on the rewrite, because a review of code I then changed is not a review of what ships.

| Finding | Severity | Disposition |
|---|---|---|
| Probe could raise the heap ceiling it measures | High | **Fixed.** Was 128 malloc calls stepping down from 64 KB; on a roomy board that request *succeeds* and newlib keeps the sbrk extension. Now a 9-probe binary search, ceiling 24 KB. |
| Probe should be gated separately from tracing | Medium | **Fixed.** Needs `OFFBAND_UI_TRACE` **and** `OFFBAND_UI_TRACE_HEAP`; off by default. Verified in the ELF both ways. |
| `if/else` screen-name chain is brittle | Low | **Noted, not changed.** A lookup table centralises names but costs storage on every board for a diagnostic most never enable. Documented in place. |
| "Probe reports 256 when nothing succeeds" | — | **Refuted.** The old loop decremented 65536 by 512 and landed exactly on 0. The re-review accepted the arithmetic and withdrew it. |
| `if (mid < PROBE_FLOOR) break` abandons the interval early | Low | **Fixed** (found by the re-review, in my own rewrite). With 80 B free the search reaches `lo=0/hi=96`, computes `mid=48`, breaks, reports `0` — the same misleading zero the rewrite existed to remove. |

**One defect the review did not raise, found while fixing it:** the old probe stepped by 512 B, so its resolution floor was 512 — and `sizeof(HomeScreen)` is **480**. It could not resolve the allocation it existed to measure, and reported "0" for anything under 512 B. `PROBE_FLOOR` is now 64.

## Verification

`[verified: pio run]`

| Env | Result |
|---|---|
| `Heltec_v3_companion_observer_wifi` | SUCCESS — observer boards unchanged |
| `heltec_rc32_companion_radio_usb_diag` | SUCCESS — newly traced |

Gate scope checked against the built ELF rather than asserted:

```
'[ui] largest_free_block=' default            → 0   (probe off)
'[ui] largest_free_block=' -D ..._TRACE_HEAP  → 1   (probe on)
'[ui] sizeof' / '[ui] screens alloc'          → 1   (tracing on)
```

**No behaviour change on any board.** Everything added compiles out unless its flag is set, and the observer boards that already had this tracing resolve exactly what they did before.

Hardware: the tracing itself ran for hours on `rc52-bench-1` this session via the UART mirror, and is what located #973.

Agent: RainyHeron (session 6071ff56)
