### PR TITLE
epic: RC52 headless bring-up — nRF52840 variant, FEM capability, diagnostics, all roles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,17 @@ jobs:
           - Xiao_S3_WIO_companion_radio_usb
           - Xiao_S3_WIO_companion_radio_wifi
           - Xiao_C6_repeater_
+          # #854 (epic #879): Heltec RadioCore RC52 (nRF52840 + HT-RA62A/SX1262).
+          # Owner-directed 2026-08-21: RC52 goes into CI as it is built out, so the
+          # build is validated, but deliberately NOT into .github/release-envs.txt
+          # until #880 (display) lands and it has had further testing. CI-only here.
+          # (No observer env exists: observer is ESP32/WiFi-only, and nRF52840 has
+          # no WiFi -- same reason Heltec_t096 has none above.)
+          # Envs carry the RC32 _without_display_ convention: this board has no
+          # display support yet (#880), so every shipping env today is headless.
+          - heltec_rc52_without_display_repeater
+          - heltec_rc52_without_display_companion_radio_ble
+          - heltec_rc52_without_display_companion_radio_usb
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,6 @@ jobs:
           - heltec_rc52_without_display_companion_radio_ble_diag
           - heltec_rc52_without_display_companion_radio_usb_diag
           - heltec_rc52_without_display_room_server_diag
-          - heltec_rc52_without_display_sensor_diag
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,10 +261,15 @@ jobs:
           # no WiFi -- same reason Heltec_t096 has none above.)
           # Envs carry the RC32 _without_display_ convention: this board has no
           # display support yet (#880), so every shipping env today is headless.
-          - heltec_rc52_without_display_repeater
-          - heltec_rc52_without_display_companion_radio_ble
-          - heltec_rc52_without_display_companion_radio_usb
-          - heltec_rc52_without_display_room_server
+          # OWNER DIRECTIVE 2026-08-22 (#889): until a near-release beta, every env
+          # BUILT is a full diagnostic build -- forced caplog + boot beacon + UART
+          # mirror. CI therefore builds the _diag envs, not their plain parents.
+          # The parents still exist so the release-time diag/non-diag pairs are
+          # already there, correctly named, when we get to beta.
+          - heltec_rc52_without_display_repeater_diag
+          - heltec_rc52_without_display_companion_radio_ble_diag
+          - heltec_rc52_without_display_companion_radio_usb_diag
+          - heltec_rc52_without_display_room_server_diag
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,7 @@ jobs:
           - heltec_rc52_without_display_companion_radio_ble_diag
           - heltec_rc52_without_display_companion_radio_usb_diag
           - heltec_rc52_without_display_room_server_diag
+          - heltec_rc52_without_display_sensor_diag
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,7 @@ jobs:
           - heltec_rc52_without_display_repeater
           - heltec_rc52_without_display_companion_radio_ble
           - heltec_rc52_without_display_companion_radio_usb
+          - heltec_rc52_without_display_room_server
     steps:
       - uses: actions/checkout@v5
 

--- a/boards/heltec_rc52.json
+++ b/boards/heltec_rc52.json
@@ -1,0 +1,60 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "nrf52840_s140_v6.ld"
+    },
+    "core": "nRF5",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DARDUINO_NRF52840_FEATHER -DNRF52840_XXAA -DHELTEC_RC52",
+    "f_cpu": "64000000L",
+    "hwids": [
+      ["0x239A","0x8071"],
+      ["0x239A","0x0071"],
+      ["0x239A","0x8072"]
+    ],
+    "usb_product": "Heltec RC52",
+    "mcu": "nrf52840",
+    "variant": "Heltec_RC52_Board",
+    "bsp": {
+      "name": "adafruit"
+    },
+    "softdevice": {
+      "sd_flags": "-DS140",
+      "sd_name": "s140",
+      "sd_version": "6.1.1",
+      "sd_fwid": "0x00B6"
+    },
+    "bootloader": {
+      "settings_addr": "0xFF000"
+    }
+  },
+  "connectivity": [
+    "bluetooth"
+  ],
+  "debug": {
+    "jlink_device": "nRF52840_xxAA",
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52.cfg"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Heltec RadioCore RC52",
+  "upload": {
+    "maximum_ram_size": 237568,
+    "maximum_size": 815104,
+    "speed": 115200,
+    "protocol": "nrfutil",
+    "protocols": [
+      "jlink",
+      "nrfjprog",
+      "nrfutil",
+      "stlink"
+    ],
+    "use_1200bps_touch": true,
+    "require_upload_port": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://heltec.org/",
+  "vendor": "Heltec"
+}

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -294,7 +294,14 @@ void NRF52Board::configureVoltageWake(uint8_t ain_channel, uint8_t refsel) {
       ain_channel, ref_num);
   }
 
-  // Configure VBUS (USB power) wake alongside LPCOMP
+  // Configure VBUS (USB power) wake alongside LPCOMP. Behaviour unchanged --
+  // this is the same block, extracted so a board can arm USB wake on its own.
+  configureUsbWake();
+}
+
+// Arm USB-attach wake from SYSTEMOFF. Exiting SYSTEMOFF is a reset, so plugging
+// in restarts the node and the new boot reports RESETREAS accordingly.
+void NRF52Board::configureUsbWake() {
   uint8_t sd_enabled = 0;
   sd_softdevice_is_enabled(&sd_enabled);
   if (sd_enabled) {

--- a/src/helpers/NRF52Board.h
+++ b/src/helpers/NRF52Board.h
@@ -48,6 +48,16 @@ protected:
   bool checkBootVoltage(const PowerMgtConfig* config);
   void enterSystemOff(uint8_t reason);
   void configureVoltageWake(uint8_t ain_channel, uint8_t refsel);
+
+  // Arm USB-attach (VBUS) wake from SYSTEMOFF. Extracted from
+  // configureVoltageWake() so a board can have "plug it in to bring it back"
+  // WITHOUT LPCOMP -- which is not free on every board. On one whose battery
+  // divider is FET-gated (RC52), keeping LPCOMP fed through SYSTEMOFF means
+  // holding the gate transistor on, and a board that shut down to protect a
+  // depleted cell would then drain it faster while off than it could recover.
+  // USB wake costs no standing current at all.
+  void configureUsbWake();
+
   virtual void initiateShutdown(uint8_t reason);
 #endif
 

--- a/variants/heltec_rc52/RC52Board.cpp
+++ b/variants/heltec_rc52/RC52Board.cpp
@@ -3,8 +3,40 @@
 #include <Arduino.h>
 #include <Wire.h>
 
+#ifdef NRF52_POWER_MANAGEMENT
+// #953: this exists to turn ON the RESETREAS capture and turn NOTHING else on.
+//
+// voltage_bootlock = 0 DISABLES boot protection (NRF52Board.h:22). That is not a
+// placeholder -- it is required by the standing decision in variant.h: RC52's
+// battery polarity is schematic-derived and NOT measured, and #602 showed an
+// unverified reading can deep-sleep a fully charged board before USB init. So
+// nothing here may gate boot on a voltage.
+//
+// With bootlock 0, checkBootVoltage() runs initPowerMgr() -- which is the whole
+// point, since that is where the reset reason captured pre-SystemInit is read --
+// then returns at the `== 0` check, before initiateShutdown() or any LPCOMP
+// configuration can be reached. The LPCOMP fields are consumed only by
+// configureVoltageWake(), which sits behind that same unreachable path.
+//
+// #857 fills in a real threshold once the battery path is measured.
+const PowerMgtConfig power_config = {
+  .lpcomp_ain_channel = 0,
+  .lpcomp_refsel      = 0,
+  .voltage_bootlock   = 0,   // 0 = boot protection DISABLED. See above; do not
+                             // set this until #857 has measured the divider.
+};
+#endif
+
 void RC52Board::begin() {
   NRF52Board::begin();
+
+#ifdef NRF52_POWER_MANAGEMENT
+  // Cannot shut down here: bootlock is 0, so this returns immediately after
+  // initPowerMgr(). Present so RESETREAS reaches getResetReasonString(), which
+  // is what puts a real cause in the "[boot] <role> up; reset=..." line the
+  // mirror UART now carries (#953).
+  checkBootVoltage(&power_config);
+#endif
 
   Wire.begin();
 

--- a/variants/heltec_rc52/RC52Board.cpp
+++ b/variants/heltec_rc52/RC52Board.cpp
@@ -126,11 +126,24 @@ bool RC52Board::setLoRaFemLnaEnabled(bool enable) {
     // missed on the way up.
     //
     // ⚠ THIS DIVERGES FROM n30nex, the only shipping RC52 implementation, which
-    // asserts FEM_EN before VFEM_Ctrl. [hypothesis: DISPROVEN 2026-08-24] The
-    // reorder was expected to recover the -6.9 dB TX deficit; a same-chain
-    // re-measure came back +14.1 dBm, flat vs the +15.1 baseline, so the
-    // power-order hypothesis is dead. The reorder stands on general
-    // power-sequencing grounds only, not as a fix. See #931 / #858 / #975.
+    // asserts FEM_EN before VFEM_Ctrl.
+    //
+    // [hypothesis: DISPROVEN -- and the premise it rested on never existed]
+    // The reorder was made to chase a reported -6.9 dB TX deficit. There is no
+    // deficit. A four-board sweep on 2026-08-25 put RC52, RC32, RCC6 and
+    // RAK4631 ALL at +20.30 dBm at tx 22 -- one FEM board and three without,
+    // three MCU families, two vendors -- against a -1.70 dB figure that is the
+    // measurement chain, not the radio. The earlier -6.9 dB AND its first
+    // "correction" to -2.04 dB were both sampling artifacts: a 2 MHz sweep for a
+    // 62.5 kHz signal parked the analyser on the carrier ~3% of the time, so
+    // most 150 ms bursts were never sampled. Resolved by zero-span gating.
+    // [verified: owner-operated bench, four boards, OliveValley, 2026-08-25]
+    //
+    // So this reorder fixed nothing, because nothing was broken. It stands ONLY
+    // on general power-sequencing grounds -- do not drive a control input into
+    // an unpowered rail -- which is reason enough to keep it and no reason to
+    // cite it as an RF fix. Do not resurrect a FEM TX-power investigation from
+    // the numbers this comment used to carry. See #931 / #858 / #975 / #963.
     //
     // VFEM_Ctrl drives EN (pin 3) of U14, a TLV75733PDBVR 3.3 V LDO, ACTIVE HIGH,
     // turning on VDD_FEM. Polarity DERIVED from the schematic, not a sibling

--- a/variants/heltec_rc52/RC52Board.cpp
+++ b/variants/heltec_rc52/RC52Board.cpp
@@ -3,7 +3,7 @@
 #include <Arduino.h>
 #include <Wire.h>
 
-#include "../../src/helpers/diagnostics/CrashLog.h"   // #857 boot-voltage self-report
+#include <helpers/diagnostics/CrashLog.h>   // #857 boot-voltage self-report
 
 #ifdef NRF52_POWER_MANAGEMENT
 // #953 enabled NRF52_POWER_MANAGEMENT here for the RESETREAS capture; #857 then
@@ -58,10 +58,22 @@ void RC52Board::begin() {
   NRF52Board::begin();
 
 #ifdef NRF52_POWER_MANAGEMENT
-  // Cannot shut down here: bootlock is 0, so this returns immediately after
-  // initPowerMgr(). Present so RESETREAS reaches getResetReasonString(), which
-  // is what puts a real cause in the "[boot] <role> up; reset=..." line the
-  // mirror UART now carries (#953).
+  // Two jobs: initPowerMgr() surfaces RESETREAS to getResetReasonString() -- what
+  // puts a real cause in the "[boot] <role> up; reset=..." line the mirror UART
+  // carries (#953) -- AND the low-voltage boot gate.
+  //
+  // ⚠ THE GATE IS ARMED. PWRMGT_VOLTAGE_BOOTLOCK is 3300 mV (variant.h), so
+  // this CAN shut the board down here. An earlier version of this comment said
+  // "bootlock is 0, so this returns immediately"; that was true before #857 set
+  // the threshold and was not updated when it did. Corrected 2026-08-25.
+  //
+  // ⚠ Consequence specific to this board: a false trip has no automatic escape.
+  // initiateShutdown() below arms USB-attach wake ONLY -- no LPCOMP cell-recovery
+  // wake, for the FET-gated-divider reason documented there -- so a board that
+  // boot-locks stays locked until someone plugs in USB. The single-sample nature
+  // of the check (a sag can read as a depleted cell) is tracked fleet-wide on
+  // #982; do not "fix" it by zeroing the threshold, which trades a false trip for
+  // a brownout boot loop on a genuinely flat cell.
   checkBootVoltage(&power_config);
 
   // #857: self-report the boot reading on the mirror UART, next to the reset

--- a/variants/heltec_rc52/RC52Board.cpp
+++ b/variants/heltec_rc52/RC52Board.cpp
@@ -24,6 +24,36 @@ const PowerMgtConfig power_config = {
 };
 #endif
 
+#ifdef NRF52_POWER_MANAGEMENT
+// #857: the ONLY practical wake source on this board.
+//
+// The base NRF52Board::initiateShutdown() goes straight to SYSTEMOFF with no
+// wake armed at all, which leaves a boot-locked board dead until someone finds
+// the RST pin. This adds USB-attach wake and nothing else.
+//
+// WHY NOT LPCOMP / cell-recovery wake, which is what the other nRF52 boards use:
+// it needs the battery voltage present at an LPCOMP pin while the board is off.
+// P0.31 is AIN7 so the pin is capable, but RC52's divider is FET-GATED --
+// [verified: rc52.pdf, 2026-08-23] VBAT -> Q3 (AO3401A, P-ch) -> R17 390K ->
+// ADC_IN -> R18 100K -> GND, with Q3's gate held at VBAT by R13 (10K) and pulled
+// down by Q2 (S9013) whose base is driven through R15 (1K).
+//
+// Holding that divider connected through SYSTEMOFF means holding Q2 on, which
+// costs roughly (3.3 - 0.7) / 1K = 2.6 mA CONTINUOUSLY. A board that shut down
+// to protect a depleted cell would then drain it at 2.6 mA while "off" -- faster
+// than it could plausibly recover. Self-defeating, so it is not armed.
+//
+// T096 can afford LPCOMP because its divider has no gate at all and simply costs
+// ~8 uA all the time. That is a hardware difference, not a firmware one.
+//
+// USB wake costs nothing standing. Exiting SYSTEMOFF is a reset, so plugging in
+// restarts the node -- and since #953 the boot line names the reason it woke.
+void RC52Board::initiateShutdown(uint8_t reason) {
+  configureUsbWake();
+  enterSystemOff(reason);
+}
+#endif
+
 void RC52Board::begin() {
   NRF52Board::begin();
 

--- a/variants/heltec_rc52/RC52Board.cpp
+++ b/variants/heltec_rc52/RC52Board.cpp
@@ -84,6 +84,28 @@ uint16_t RC52Board::getBattMilliVolts() {
 }
 
 void RC52Board::powerOff() {
+  // ORDER: de-assert the FEM control BEFORE dropping its rail.
+  //
+  // The first version dropped VFEM_Ctrl and left FEM_EN driven HIGH for the
+  // entire sleep -- a push-pull output holding 3.3 V into an unpowered input.
+  // That forward-biases the input's ESD structure and can back-power the
+  // module through a signal pin, for hours, on battery.
+  //
+  // This is the one sequencing question on this board with no counter-argument:
+  // whichever power-UP order is correct, nothing defends leaving a control line
+  // asserted into a dead rail. Found by the Gemini adversarial review, #879.
+  pinMode(RADIOCORE_FEM_EN, OUTPUT);
+  digitalWrite(RADIOCORE_FEM_EN, LOW);
+
+  // [hypothesis: untested] The power-UP order in begin() -- FEM_EN settled
+  // before the rail rises -- is deliberately NOT flipped to mirror this. The
+  // same review argued for VFEM_Ctrl first on a general CMOS back-powering
+  // argument. Two things stop that from being adopted: n30nex ships FEM_EN
+  // first (v1.1.0-rc.4, corroborated 2026-08-20), and no HT-RA62A datasheet
+  // exists to say whether the module's FEM_EN input is referenced to VDD_FEM
+  // or to the main supply -- the FEM is INSIDE the module. Reversing it would
+  // trade one untested hypothesis for another. Tracked under epic #929.
+
   // Drop the FEM rail before sleeping so the LDO is not left enabled into a
   // low-power state.
   pinMode(RADIOCORE_VFEM_CTRL, OUTPUT);

--- a/variants/heltec_rc52/RC52Board.cpp
+++ b/variants/heltec_rc52/RC52Board.cpp
@@ -19,35 +19,29 @@ void RC52Board::begin() {
   // ---------------------------------------------------------------------------
 
   // ---------------------------------------------------------------------------
-  // FEM_EN: pulled to a DEFINED level, but not actively asserted.
+  // FEM_EN -- ACTIVE HIGH. Asserted here.
   //
-  // Unlike VFEM_Ctrl, FEM_EN is not an LDO enable whose polarity a part number
-  // settles -- the schematic routes it to pin 11 of the HT-RA62A module (U6), and
-  // Heltec publishes no datasheet for that module (schematic only; RC52/datasheet/
-  // and RC52/pinmap/ both 404). So its asserted sense is UNESTABLISHED and this
-  // scaffold must not guess it.
+  // Heltec publishes no HT-RA62A datasheet (schematic only; RC52/datasheet/ and
+  // RC52/pinmap/ both 404), and the schematic cannot settle this either: the FEM
+  // is INSIDE the module. U6 exposes FEM_EN on pin 11, VDD_FEM on 25 and
+  // LNA_Ctrl on 36, and stops there.
   //
-  // [hypothesis: untested] The pulldown below rests on the general argument that
-  // a floating CMOS input can sit at an intermediate voltage and hold the
-  // receiving buffer partly conducting, wasting current. That is textbook
-  // reasoning, NOT a measurement of THIS module: there is no HT-RA62A datasheet,
-  // no current figure, and nothing has been scoped on this pin. It is also not
-  // known whether the module biases the pin internally, which would make the
-  // pulldown either redundant or a fight against an internal pull-up.
+  // What settles it is a shipping implementation. n30nex/NeonPocketMC-RC52
+  // (v1.1.0-rc.4) drives it HIGH in its board begin(), alongside VFEM_Ctrl HIGH:
   //
-  // What would settle it (#858): scope P0.26 at boot with the pulldown removed to
-  // see whether it actually floats, and measure module supply current in both
-  // states. If it does not float, this line should be deleted rather than kept.
+  //     digitalWrite(RADIOCORE_FEM_EN, HIGH);
+  //     digitalWrite(RADIOCORE_VFEM_CTRL, HIGH);
   //
-  // INPUT_PULLDOWN, if the reasoning holds, gives a defined level without this
-  // code asserting that LOW means "enabled" -- it may well mean enabled, and that
-  // is also #858's to establish.
+  // Its VFEM_Ctrl polarity matches this board's schematic derivation
+  // independently, which is what makes the FEM_EN half credible rather than
+  // merely present. [verified: n30nex HeltecRC52Board.cpp, read 2026-08-20]
   //
-  // Consequence to expect: RF performance on this headless scaffold is NOT
-  // characterised and should not be measured or trusted until #858 lands. The
-  // scaffold exists to build and to boot (#855), not to be an RF reference.
-  // ---------------------------------------------------------------------------
-  pinMode(RADIOCORE_FEM_EN, INPUT_PULLDOWN);
+  // Corroboration by implementation, NOT by datasheet -- so if RF behaves oddly,
+  // this line is a legitimate suspect. An earlier revision left the pin on
+  // INPUT_PULLDOWN, asserting nothing; that was worse, because it left the FEM
+  // in a state nobody had chosen.
+  pinMode(RADIOCORE_FEM_EN, OUTPUT);
+  digitalWrite(RADIOCORE_FEM_EN, HIGH);
 
   // ---------------------------------------------------------------------------
   // FEM supply rail -- raised only now that FEM_EN is at a defined level.

--- a/variants/heltec_rc52/RC52Board.cpp
+++ b/variants/heltec_rc52/RC52Board.cpp
@@ -3,27 +3,24 @@
 #include <Arduino.h>
 #include <Wire.h>
 
+#include "../../src/helpers/diagnostics/CrashLog.h"   // #857 boot-voltage self-report
+
 #ifdef NRF52_POWER_MANAGEMENT
-// #953: this exists to turn ON the RESETREAS capture and turn NOTHING else on.
+// #953 enabled NRF52_POWER_MANAGEMENT here for the RESETREAS capture; #857 then
+// established the battery path well enough to arm boot protection too.
 //
-// voltage_bootlock = 0 DISABLES boot protection (NRF52Board.h:22). That is not a
-// placeholder -- it is required by the standing decision in variant.h: RC52's
-// battery polarity is schematic-derived and NOT measured, and #602 showed an
-// unverified reading can deep-sleep a fully charged board before USB init. So
-// nothing here may gate boot on a voltage.
-//
-// With bootlock 0, checkBootVoltage() runs initPowerMgr() -- which is the whole
-// point, since that is where the reset reason captured pre-SystemInit is read --
-// then returns at the `== 0` check, before initiateShutdown() or any LPCOMP
-// configuration can be reached. The LPCOMP fields are consumed only by
-// configureVoltageWake(), which sits behind that same unreachable path.
-//
-// #857 fills in a real threshold once the battery path is measured.
+// checkBootVoltage() does two things: initPowerMgr(), which reads the reset
+// reason captured pre-SystemInit, and the low-voltage boot gate. Both are wanted
+// now. The gate was held off until the reading was corroborated -- see variant.h
+// for the three-way comparison (RC52 4130 mV vs MAX17048 4147 vs INA219 4144,
+// -0.36%) that settled it.
 const PowerMgtConfig power_config = {
+  // Unused on this board: only configureVoltageWake() reads them, and that is
+  // reached only from a board-specific initiateShutdown() override, which RC52
+  // does not have. See variant.h -- the board will not self-wake on recovery.
   .lpcomp_ain_channel = 0,
   .lpcomp_refsel      = 0,
-  .voltage_bootlock   = 0,   // 0 = boot protection DISABLED. See above; do not
-                             // set this until #857 has measured the divider.
+  .voltage_bootlock   = PWRMGT_VOLTAGE_BOOTLOCK,
 };
 #endif
 
@@ -36,6 +33,27 @@ void RC52Board::begin() {
   // is what puts a real cause in the "[boot] <role> up; reset=..." line the
   // mirror UART now carries (#953).
   checkBootVoltage(&power_config);
+
+  // #857: self-report the boot reading on the mirror UART, next to the reset
+  // reason. This is the CROSS-CHECK, made permanent instead of one-shot.
+  //
+  // Why here and not in shared code: getBattMilliVolts() is an ADC read, and
+  // adding one to crashLogStandardInit would change boot behaviour for every
+  // board in the fleet to answer a question about this one.
+  //
+  // What it is for: #602's failure was GROSS -- a fully charged board reading as
+  // dead, divider disabled or inverted -- not a percent-level error. Printing the
+  // value every boot, on the wire the bench already reads, lets it be compared
+  // against the MAX17048 + INA219 on the same battery (which agree to within
+  // 0-2 mV) without a CLI query, a monitor, or a host. If it lands within tens of
+  // mV, the path is proven and a bootlock threshold is safe to set.
+  //
+  // ADC_MULTIPLIER is 4.90, nominal from R17/R18 in the vendor schematic. At 1%
+  // parts that spans ~4.82-4.98, and the nRF52 internal 3.0V reference adds ~2%,
+  // so expect agreement to roughly +/-3.5% (~+/-145 mV at 4.15 V) -- NOT exact
+  // agreement. Anything inside that band confirms the path.
+  offband::crashLogf("[boot] vbat=%u mV (multiplier %.2f, nominal)",
+                     (unsigned)getBattMilliVolts(), (double)ADC_MULTIPLIER);
 #endif
 
   Wire.begin();

--- a/variants/heltec_rc52/RC52Board.cpp
+++ b/variants/heltec_rc52/RC52Board.cpp
@@ -9,12 +9,13 @@ void RC52Board::begin() {
   Wire.begin();
 
   // ---------------------------------------------------------------------------
-  // ORDER MATTERS HERE: settle FEM_EN BEFORE powering the FEM rail.
+  // ORDER: settle FEM_EN before raising the FEM rail.
   //
-  // If VFEM_Ctrl is raised first, there is a window in which the module is
-  // powered while its enable input is still floating -- which is the exact
-  // condition the pulldown below exists to avoid, just narrowed to a few
-  // microseconds. Define the control level first, then apply power.
+  // [hypothesis: untested] The reasoning is that raising VFEM_Ctrl first leaves a
+  // window in which the module is powered while its enable input is still
+  // floating. That is an argument, not a measurement -- see the FEM_EN block
+  // below for why the whole pulldown decision is unverified. The ordering costs
+  // nothing either way, so it is kept, but it is NOT evidence-backed.
   // ---------------------------------------------------------------------------
 
   // ---------------------------------------------------------------------------
@@ -26,12 +27,21 @@ void RC52Board::begin() {
   // and RC52/pinmap/ both 404). So its asserted sense is UNESTABLISHED and this
   // scaffold must not guess it.
   //
-  // But leaving it hi-Z is worse than picking a level: a floating CMOS input can
-  // sit at an intermediate voltage and hold the module's input buffer in a
-  // partially-conducting state, which wastes current and can stress the part.
-  // INPUT_PULLDOWN gives a defined, stable, low-current level without this code
-  // asserting that LOW means "enabled" -- it may well mean enabled, and that is
-  // exactly what #858 has to establish by measurement.
+  // [hypothesis: untested] The pulldown below rests on the general argument that
+  // a floating CMOS input can sit at an intermediate voltage and hold the
+  // receiving buffer partly conducting, wasting current. That is textbook
+  // reasoning, NOT a measurement of THIS module: there is no HT-RA62A datasheet,
+  // no current figure, and nothing has been scoped on this pin. It is also not
+  // known whether the module biases the pin internally, which would make the
+  // pulldown either redundant or a fight against an internal pull-up.
+  //
+  // What would settle it (#858): scope P0.26 at boot with the pulldown removed to
+  // see whether it actually floats, and measure module supply current in both
+  // states. If it does not float, this line should be deleted rather than kept.
+  //
+  // INPUT_PULLDOWN, if the reasoning holds, gives a defined level without this
+  // code asserting that LOW means "enabled" -- it may well mean enabled, and that
+  // is also #858's to establish.
   //
   // Consequence to expect: RF performance on this headless scaffold is NOT
   // characterised and should not be measured or trusted until #858 lands. The

--- a/variants/heltec_rc52/RC52Board.cpp
+++ b/variants/heltec_rc52/RC52Board.cpp
@@ -1,0 +1,97 @@
+#include "RC52Board.h"
+
+#include <Arduino.h>
+#include <Wire.h>
+
+void RC52Board::begin() {
+  NRF52Board::begin();
+
+  Wire.begin();
+
+  // ---------------------------------------------------------------------------
+  // ORDER MATTERS HERE: settle FEM_EN BEFORE powering the FEM rail.
+  //
+  // If VFEM_Ctrl is raised first, there is a window in which the module is
+  // powered while its enable input is still floating -- which is the exact
+  // condition the pulldown below exists to avoid, just narrowed to a few
+  // microseconds. Define the control level first, then apply power.
+  // ---------------------------------------------------------------------------
+
+  // ---------------------------------------------------------------------------
+  // FEM_EN: pulled to a DEFINED level, but not actively asserted.
+  //
+  // Unlike VFEM_Ctrl, FEM_EN is not an LDO enable whose polarity a part number
+  // settles -- the schematic routes it to pin 11 of the HT-RA62A module (U6), and
+  // Heltec publishes no datasheet for that module (schematic only; RC52/datasheet/
+  // and RC52/pinmap/ both 404). So its asserted sense is UNESTABLISHED and this
+  // scaffold must not guess it.
+  //
+  // But leaving it hi-Z is worse than picking a level: a floating CMOS input can
+  // sit at an intermediate voltage and hold the module's input buffer in a
+  // partially-conducting state, which wastes current and can stress the part.
+  // INPUT_PULLDOWN gives a defined, stable, low-current level without this code
+  // asserting that LOW means "enabled" -- it may well mean enabled, and that is
+  // exactly what #858 has to establish by measurement.
+  //
+  // Consequence to expect: RF performance on this headless scaffold is NOT
+  // characterised and should not be measured or trusted until #858 lands. The
+  // scaffold exists to build and to boot (#855), not to be an RF reference.
+  // ---------------------------------------------------------------------------
+  pinMode(RADIOCORE_FEM_EN, INPUT_PULLDOWN);
+
+  // ---------------------------------------------------------------------------
+  // FEM supply rail -- raised only now that FEM_EN is at a defined level.
+  //
+  // VFEM_Ctrl drives the EN pin (pin 3) of U14, a TLV75733PDBVR -- a TI 3.3 V LDO
+  // whose enable is ACTIVE HIGH. Driving it high turns on VDD_FEM, the front-end
+  // module's supply. This polarity is DERIVED from the schematic, not copied from
+  // a sibling board: [verified: RC52-L62_V1.02, U14 = TLV75733PDBVR, VFEM_Ctrl ->
+  // EN]. #602 is what happens when a battery/enable polarity is inherited instead.
+  // ---------------------------------------------------------------------------
+  pinMode(RADIOCORE_VFEM_CTRL, OUTPUT);
+  digitalWrite(RADIOCORE_VFEM_CTRL, HIGH);
+
+  delay(1);
+}
+
+uint16_t RC52Board::getBattMilliVolts() {
+  // The divider feeding BATTERY_PIN is gated by ADC_CTRL and is OFF at reset (R16
+  // pulls the enable transistor low), so it costs no idle current -- enable it,
+  // settle, sample, disable.
+  //
+  // Read at 12-bit against the internal 3.0 V reference, matching MV_LSB and the
+  // established pattern on this repo's other nRF52 boards. variant.h declares
+  // ADC_RESOLUTION 14 because the vendor BSP does; the read here is deliberately
+  // 12-bit and the two are consistent, not contradictory.
+  analogReadResolution(12);
+  analogReference(AR_INTERNAL_3_0);
+
+  pinMode(BATTERY_PIN, INPUT);
+  pinMode(ADC_CTRL, OUTPUT);
+  digitalWrite(ADC_CTRL, ADC_CTRL_ENABLED);
+
+  delay(10);
+  int adcvalue = analogRead(BATTERY_PIN);
+  digitalWrite(ADC_CTRL, ADC_CTRL_DISABLED);
+
+  // ADC_MULTIPLIER is the NOMINAL divider ratio (390K + 100K) / 100K = 4.90.
+  // Unmeasured on hardware -- #857.
+  return (uint16_t)((float)adcvalue * MV_LSB * ADC_MULTIPLIER);
+}
+
+void RC52Board::powerOff() {
+  // Drop the FEM rail before sleeping so the LDO is not left enabled into a
+  // low-power state.
+  pinMode(RADIOCORE_VFEM_CTRL, OUTPUT);
+  digitalWrite(RADIOCORE_VFEM_CTRL, LOW);
+
+  // Return the battery divider gate to its inactive sense.
+  pinMode(ADC_CTRL, OUTPUT);
+  digitalWrite(ADC_CTRL, ADC_CTRL_DISABLED);
+
+  NRF52Board::powerOff();
+}
+
+const char* RC52Board::getManufacturerName() const {
+  return "Heltec RC52";
+}

--- a/variants/heltec_rc52/RC52Board.cpp
+++ b/variants/heltec_rc52/RC52Board.cpp
@@ -88,82 +88,69 @@ void RC52Board::begin() {
 
   Wire.begin();
 
-  // ---------------------------------------------------------------------------
-  // ORDER: raise the FEM rail FIRST, then assert FEM_EN. (#879 review gate.)
-  //
-  // This was the other way round until 2026-08-24, on the argument that powering
-  // the module while its enable input floated was the greater risk. That argument
-  // was tagged [hypothesis: untested] and it was the wrong call: driving 3.3 V
-  // into a control input of an UNPOWERED chip forward-biases that pin's ESD diode
-  // and back-powers the module through it. Unreliable start-up is the mild
-  // outcome; pin degradation is the durable one.
-  //
-  // Two things say the new order is the right one. Our own powerOff() already
-  // does the correct inverse -- FEM_EN low, THEN the rail down (see below) -- so
-  // the principle was applied on the way down and simply missed on the way up.
-  // And a bench measurement now exists: rc52-bench-1 reads +15.1 dBm against a
-  // +22 dBm chip setting with the FEM enabled, -6.9 dB, with the TX-power clamp
-  // and IPEX4 seating both eliminated [verified: tinySA, owner-operated
-  // 2026-08-23, see #963]. A FEM that never came up cleanly fits that sign and
-  // rough magnitude.
-  //
-  // ⚠ THIS DIVERGES FROM THE ONLY SHIPPING IMPLEMENTATION WE HAVE. n30nex asserts
-  // FEM_EN before VFEM_Ctrl (quoted below). The working hypothesis is that it
-  // carries the same latent defect and nobody measured its conducted output --
-  // that is a hypothesis, not a finding. [hypothesis: untested] Whether this
-  // reordering recovers the missing 6.9 dB is UNPROVEN until the same rig
-  // re-measures it. Tracked on #858 / #975.
-  // ---------------------------------------------------------------------------
+  // Bring the FEM up to a defined ON state. The powered-up sequence and all of
+  // its evidence live in setLoRaFemLnaEnabled() now that the same path is a
+  // runtime capability (#983) -- this is the boot default before any app applies
+  // the persisted radio_fem_rxgain pref (which itself defaults ON).
+  setLoRaFemLnaEnabled(true);
+}
 
-  // ---------------------------------------------------------------------------
-  // FEM_EN -- ACTIVE HIGH. Asserted here.
-  //
-  // Heltec publishes no HT-RA62A datasheet (schematic only; RC52/datasheet/ and
-  // RC52/pinmap/ both 404), and the schematic cannot settle this either: the FEM
-  // is INSIDE the module. U6 exposes FEM_EN on pin 11, VDD_FEM on 25 and
-  // LNA_Ctrl on 36, and stops there.
-  //
-  // What settles it is a shipping implementation. n30nex/NeonPocketMC-RC52
-  // (v1.1.0-rc.4) drives it HIGH in its board begin(), alongside VFEM_Ctrl HIGH:
-  //
-  //     digitalWrite(RADIOCORE_FEM_EN, HIGH);
-  //     digitalWrite(RADIOCORE_VFEM_CTRL, HIGH);
-  //
-  // Its VFEM_Ctrl polarity matches this board's schematic derivation
-  // independently, which is what makes the FEM_EN half credible rather than
-  // merely present. [verified: n30nex HeltecRC52Board.cpp, read 2026-08-20]
-  //
-  // Corroboration by implementation, NOT by datasheet -- so if RF behaves oddly,
-  // this line is a legitimate suspect. An earlier revision left the pin on
-  // INPUT_PULLDOWN, asserting nothing; that was worse, because it left the FEM
-  // in a state nobody had chosen.
-  //
-  // NOTE: the assertion itself now happens BELOW, after the rail is up. Only the
-  // ordering changed; the polarity and its evidence are untouched.
+// FEM module power as the OFFBAND_CAP_FEM_LNA capability (#983). See RC52Board.h
+// for why "enable" here means WHOLE-MODULE power (FEM_EN + VFEM_CTRL), not the
+// RX-LNA-path toggle it is on T096/HV4 -- the RXEN/LNA line stays with RadioLib.
+bool RC52Board::setLoRaFemLnaEnabled(bool enable) {
+  if (enable) {
+    // -------------------------------------------------------------------------
+    // ORDER: raise the FEM rail FIRST, then assert FEM_EN. (#879 review gate.)
+    //
+    // This was the other way round until 2026-08-24, on the argument that
+    // powering the module while its enable input floated was the greater risk.
+    // That argument was tagged [hypothesis: untested] and it was the wrong call:
+    // driving 3.3 V into a control input of an UNPOWERED chip forward-biases that
+    // pin's ESD diode and back-powers the module through it. Unreliable start-up
+    // is the mild outcome; pin degradation is the durable one. powerOff() (and
+    // the disable path below) already do the correct inverse -- FEM_EN low, THEN
+    // the rail down -- so the principle was applied on the way down and simply
+    // missed on the way up.
+    //
+    // ⚠ THIS DIVERGES FROM n30nex, the only shipping RC52 implementation, which
+    // asserts FEM_EN before VFEM_Ctrl. [hypothesis: DISPROVEN 2026-08-24] The
+    // reorder was expected to recover the -6.9 dB TX deficit; a same-chain
+    // re-measure came back +14.1 dBm, flat vs the +15.1 baseline, so the
+    // power-order hypothesis is dead. The reorder stands on general
+    // power-sequencing grounds only, not as a fix. See #931 / #858 / #975.
+    //
+    // VFEM_Ctrl drives EN (pin 3) of U14, a TLV75733PDBVR 3.3 V LDO, ACTIVE HIGH,
+    // turning on VDD_FEM. Polarity DERIVED from the schematic, not a sibling
+    // board: [verified: RC52-L62_V1.02, U14 = TLV75733PDBVR, VFEM_Ctrl -> EN].
+    // FEM_EN is ACTIVE HIGH; no HT-RA62A datasheet exists (FEM is inside the
+    // module), so its polarity is corroborated by n30nex, not derived
+    // [verified: n30nex HeltecRC52Board.cpp, read 2026-08-20] -- a legitimate
+    // suspect if RF behaves oddly.
+    // -------------------------------------------------------------------------
+    pinMode(RADIOCORE_VFEM_CTRL, OUTPUT);
+    digitalWrite(RADIOCORE_VFEM_CTRL, HIGH);
 
-  // ---------------------------------------------------------------------------
-  // FEM supply rail -- raised FIRST, so the module is powered before any control
-  // input is driven into it.
-  //
-  // VFEM_Ctrl drives the EN pin (pin 3) of U14, a TLV75733PDBVR -- a TI 3.3 V LDO
-  // whose enable is ACTIVE HIGH. Driving it high turns on VDD_FEM, the front-end
-  // module's supply. This polarity is DERIVED from the schematic, not copied from
-  // a sibling board: [verified: RC52-L62_V1.02, U14 = TLV75733PDBVR, VFEM_Ctrl ->
-  // EN]. #602 is what happens when a battery/enable polarity is inherited instead.
-  // ---------------------------------------------------------------------------
-  pinMode(RADIOCORE_VFEM_CTRL, OUTPUT);
-  digitalWrite(RADIOCORE_VFEM_CTRL, HIGH);
+    // The LDO must be up before its load's enable is driven. TLV75733PDBVR
+    // start-up is hundreds of microseconds; 1 ms is generous and runs rarely.
+    delay(1);
 
-  // The LDO needs to actually be up before we drive its load's enable pin.
-  // TLV75733PDBVR start-up is specified in the hundreds of microseconds; 1 ms is
-  // generous and this runs once at boot, so the cost is irrelevant.
-  delay(1);
+    pinMode(RADIOCORE_FEM_EN, OUTPUT);
+    digitalWrite(RADIOCORE_FEM_EN, HIGH);
+    delay(1);
+  } else {
+    // Inverse order: de-assert FEM_EN BEFORE dropping the rail, so a push-pull
+    // output never holds 3.3 V into an unpowered input (the back-powering the
+    // enable path above avoids). Same reasoning as powerOff().
+    pinMode(RADIOCORE_FEM_EN, OUTPUT);
+    digitalWrite(RADIOCORE_FEM_EN, LOW);
 
-  // FEM_EN -- asserted now that VDD_FEM is live. See the ORDER block above.
-  pinMode(RADIOCORE_FEM_EN, OUTPUT);
-  digitalWrite(RADIOCORE_FEM_EN, HIGH);
+    pinMode(RADIOCORE_VFEM_CTRL, OUTPUT);
+    digitalWrite(RADIOCORE_VFEM_CTRL, LOW);
+  }
 
-  delay(1);
+  _fem_lna_enabled = enable;
+  return true;
 }
 
 uint16_t RC52Board::getBattMilliVolts() {
@@ -192,32 +179,10 @@ uint16_t RC52Board::getBattMilliVolts() {
 }
 
 void RC52Board::powerOff() {
-  // ORDER: de-assert the FEM control BEFORE dropping its rail.
-  //
-  // The first version dropped VFEM_Ctrl and left FEM_EN driven HIGH for the
-  // entire sleep -- a push-pull output holding 3.3 V into an unpowered input.
-  // That forward-biases the input's ESD structure and can back-power the
-  // module through a signal pin, for hours, on battery.
-  //
-  // This is the one sequencing question on this board with no counter-argument:
-  // whichever power-UP order is correct, nothing defends leaving a control line
-  // asserted into a dead rail. Found by the Gemini adversarial review, #879.
-  pinMode(RADIOCORE_FEM_EN, OUTPUT);
-  digitalWrite(RADIOCORE_FEM_EN, LOW);
-
-  // [hypothesis: untested] The power-UP order in begin() -- FEM_EN settled
-  // before the rail rises -- is deliberately NOT flipped to mirror this. The
-  // same review argued for VFEM_Ctrl first on a general CMOS back-powering
-  // argument. Two things stop that from being adopted: n30nex ships FEM_EN
-  // first (v1.1.0-rc.4, corroborated 2026-08-20), and no HT-RA62A datasheet
-  // exists to say whether the module's FEM_EN input is referenced to VDD_FEM
-  // or to the main supply -- the FEM is INSIDE the module. Reversing it would
-  // trade one untested hypothesis for another. Tracked under epic #929.
-
-  // Drop the FEM rail before sleeping so the LDO is not left enabled into a
-  // low-power state.
-  pinMode(RADIOCORE_VFEM_CTRL, OUTPUT);
-  digitalWrite(RADIOCORE_VFEM_CTRL, LOW);
+  // Drop the FEM through the capability setter: FEM_EN low BEFORE the rail, so a
+  // push-pull output never holds 3.3 V into an unpowered input for the sleep.
+  // Single source of truth for the sequence -- see setLoRaFemLnaEnabled().
+  setLoRaFemLnaEnabled(false);
 
   // Return the battery divider gate to its inactive sense.
   pinMode(ADC_CTRL, OUTPUT);

--- a/variants/heltec_rc52/RC52Board.cpp
+++ b/variants/heltec_rc52/RC52Board.cpp
@@ -89,13 +89,30 @@ void RC52Board::begin() {
   Wire.begin();
 
   // ---------------------------------------------------------------------------
-  // ORDER: settle FEM_EN before raising the FEM rail.
+  // ORDER: raise the FEM rail FIRST, then assert FEM_EN. (#879 review gate.)
   //
-  // [hypothesis: untested] The reasoning is that raising VFEM_Ctrl first leaves a
-  // window in which the module is powered while its enable input is still
-  // floating. That is an argument, not a measurement -- see the FEM_EN block
-  // below for why the whole pulldown decision is unverified. The ordering costs
-  // nothing either way, so it is kept, but it is NOT evidence-backed.
+  // This was the other way round until 2026-08-24, on the argument that powering
+  // the module while its enable input floated was the greater risk. That argument
+  // was tagged [hypothesis: untested] and it was the wrong call: driving 3.3 V
+  // into a control input of an UNPOWERED chip forward-biases that pin's ESD diode
+  // and back-powers the module through it. Unreliable start-up is the mild
+  // outcome; pin degradation is the durable one.
+  //
+  // Two things say the new order is the right one. Our own powerOff() already
+  // does the correct inverse -- FEM_EN low, THEN the rail down (see below) -- so
+  // the principle was applied on the way down and simply missed on the way up.
+  // And a bench measurement now exists: rc52-bench-1 reads +15.1 dBm against a
+  // +22 dBm chip setting with the FEM enabled, -6.9 dB, with the TX-power clamp
+  // and IPEX4 seating both eliminated [verified: tinySA, owner-operated
+  // 2026-08-23, see #963]. A FEM that never came up cleanly fits that sign and
+  // rough magnitude.
+  //
+  // ⚠ THIS DIVERGES FROM THE ONLY SHIPPING IMPLEMENTATION WE HAVE. n30nex asserts
+  // FEM_EN before VFEM_Ctrl (quoted below). The working hypothesis is that it
+  // carries the same latent defect and nobody measured its conducted output --
+  // that is a hypothesis, not a finding. [hypothesis: untested] Whether this
+  // reordering recovers the missing 6.9 dB is UNPROVEN until the same rig
+  // re-measures it. Tracked on #858 / #975.
   // ---------------------------------------------------------------------------
 
   // ---------------------------------------------------------------------------
@@ -120,11 +137,13 @@ void RC52Board::begin() {
   // this line is a legitimate suspect. An earlier revision left the pin on
   // INPUT_PULLDOWN, asserting nothing; that was worse, because it left the FEM
   // in a state nobody had chosen.
-  pinMode(RADIOCORE_FEM_EN, OUTPUT);
-  digitalWrite(RADIOCORE_FEM_EN, HIGH);
+  //
+  // NOTE: the assertion itself now happens BELOW, after the rail is up. Only the
+  // ordering changed; the polarity and its evidence are untouched.
 
   // ---------------------------------------------------------------------------
-  // FEM supply rail -- raised only now that FEM_EN is at a defined level.
+  // FEM supply rail -- raised FIRST, so the module is powered before any control
+  // input is driven into it.
   //
   // VFEM_Ctrl drives the EN pin (pin 3) of U14, a TLV75733PDBVR -- a TI 3.3 V LDO
   // whose enable is ACTIVE HIGH. Driving it high turns on VDD_FEM, the front-end
@@ -134,6 +153,15 @@ void RC52Board::begin() {
   // ---------------------------------------------------------------------------
   pinMode(RADIOCORE_VFEM_CTRL, OUTPUT);
   digitalWrite(RADIOCORE_VFEM_CTRL, HIGH);
+
+  // The LDO needs to actually be up before we drive its load's enable pin.
+  // TLV75733PDBVR start-up is specified in the hundreds of microseconds; 1 ms is
+  // generous and this runs once at boot, so the cost is irrelevant.
+  delay(1);
+
+  // FEM_EN -- asserted now that VDD_FEM is live. See the ORDER block above.
+  pinMode(RADIOCORE_FEM_EN, OUTPUT);
+  digitalWrite(RADIOCORE_FEM_EN, HIGH);
 
   delay(1);
 }

--- a/variants/heltec_rc52/RC52Board.h
+++ b/variants/heltec_rc52/RC52Board.h
@@ -15,12 +15,8 @@
 // exactly the failure mode #602 and #835 came from):
 //
 //   * No LoRaFEMControl. That class drives the KCT8103L's CSD/CTX pins on the
-//     T096/V4. The RC52's FEM is an HT-RA62A whose LNA line IS the RadioLib RXEN
-//     pin -- CustomSX1262::std_init() wires it from SX126X_RXEN on its own. FEM
-//     characterisation is #858.
-//   * No setLoRaFemLnaEnabled() / canControlLoRaFemLna() override. Claiming that
-//     capability would mean taking RXEN away from RadioLib's rf-switch; that is a
-//     design decision for #858, not a scaffold detail.
+//     T096/V4. The RC52's FEM is an HT-RA62A with a different control surface --
+//     see the FEM/LNA capability note below.
 //   * No power-management / SafeBoot voltage gating. The battery divider ratio is
 //     schematic-derived but UNMEASURED -- see variant.h and #857.
 //   * No display. Headless by design (#854); the nRF52 display port is #872.
@@ -35,6 +31,31 @@ public:
   const char* getManufacturerName() const override;
   void powerOff() override;
 
+  // ---------------------------------------------------------------------------
+  // FEM/LNA runtime control -- the stock OFFBAND_CAP_FEM_LNA capability (#983).
+  //
+  // Same framework as T096/HV4 -- the three MainBoard virtuals, the
+  // OFFBAND_CAP_FEM_LNA bit, the `fem on/off` CLI, the persisted radio_fem_rxgain
+  // pref -- but a DIFFERENT physical effect under the hood, because the hardware
+  // differs and this was an owner-approved divergence (2026-08-24):
+  //
+  //   T096/HV4 (KCT8103L): "off" pulls the LNA out of the RX path only. TX and
+  //   module power are untouched.
+  //
+  //   RC52 (HT-RA62A): "off" cuts WHOLE-MODULE power (FEM_EN + VFEM_CTRL low) --
+  //   TX and RX both. It does NOT touch the LNA/RXEN line (P1.07); that stays with
+  //   RadioLib's rf-switch, which is what the earlier "can't do it" note got wrong
+  //   -- it mapped the capability to RXEN instead of to the two board-owned power
+  //   pins. Same label, different meaning; documented so `fem off` on RC52 is not
+  //   read as "RX gain only".
+  //
+  // begin() brings the module up through setLoRaFemLnaEnabled(true), so boot is a
+  // defined FEM-ON state before any app applies the (default-ON) pref.
+  // ---------------------------------------------------------------------------
+  bool canControlLoRaFemLna() const override { return true; }
+  bool setLoRaFemLnaEnabled(bool enable) override;
+  bool isLoRaFemLnaEnabled() const override { return _fem_lna_enabled; }
+
 #ifdef NRF52_POWER_MANAGEMENT
 protected:
   // #857: arm USB-attach wake before SYSTEMOFF -- "plug it in to bring it back".
@@ -42,4 +63,9 @@ protected:
   // on this board's FET-gated divider.
   void initiateShutdown(uint8_t reason) override;
 #endif
+
+private:
+  // Mirrors the FEM module-power state so isLoRaFemLnaEnabled() can report it
+  // without reading a write-only GPIO back. begin() sets it via the setter.
+  bool _fem_lna_enabled = false;
 };

--- a/variants/heltec_rc52/RC52Board.h
+++ b/variants/heltec_rc52/RC52Board.h
@@ -34,4 +34,12 @@ public:
   uint16_t getBattMilliVolts() override;
   const char* getManufacturerName() const override;
   void powerOff() override;
+
+#ifdef NRF52_POWER_MANAGEMENT
+protected:
+  // #857: arm USB-attach wake before SYSTEMOFF -- "plug it in to bring it back".
+  // Deliberately NOT LPCOMP; see the implementation for why that is impractical
+  // on this board's FET-gated divider.
+  void initiateShutdown(uint8_t reason) override;
+#endif
 };

--- a/variants/heltec_rc52/RC52Board.h
+++ b/variants/heltec_rc52/RC52Board.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <MeshCore.h>
+#include <Arduino.h>
+#include <helpers/NRF52Board.h>
+
+// Heltec RadioCore RC52 -- nRF52840 + HT-RA62A (SX1262 + FEM).
+//
+// NRF52BoardDCDC (not plain NRF52Board): the schematic fits L2 and L4, both
+// 10uH/80mA, against the nRF52840's DCC and DCCH pins -- i.e. both DC/DC
+// converters are populated, so enabling them is correct and saves current.
+// [verified: RC52-L62_V1.02 schematic, read 2026-08-19]
+//
+// Deliberately NOT here (each belongs to a later task, and inventing them now is
+// exactly the failure mode #602 and #835 came from):
+//
+//   * No LoRaFEMControl. That class drives the KCT8103L's CSD/CTX pins on the
+//     T096/V4. The RC52's FEM is an HT-RA62A whose LNA line IS the RadioLib RXEN
+//     pin -- CustomSX1262::std_init() wires it from SX126X_RXEN on its own. FEM
+//     characterisation is #858.
+//   * No setLoRaFemLnaEnabled() / canControlLoRaFemLna() override. Claiming that
+//     capability would mean taking RXEN away from RadioLib's rf-switch; that is a
+//     design decision for #858, not a scaffold detail.
+//   * No power-management / SafeBoot voltage gating. The battery divider ratio is
+//     schematic-derived but UNMEASURED -- see variant.h and #857.
+//   * No display. Headless by design (#854); the nRF52 display port is #872.
+
+class RC52Board : public NRF52BoardDCDC {
+public:
+  RC52Board() : NRF52Board("RC52_OTA") {}
+
+  void begin();
+
+  uint16_t getBattMilliVolts() override;
+  const char* getManufacturerName() const override;
+  void powerOff() override;
+};

--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -215,6 +215,45 @@ build_flags =
   -D OFFBAND_LOG_MIRROR_TX_PIN=PIN_SERIAL1_TX   ; P0.08 -- carrier header pin 11
   -D OFFBAND_LOG_MIRROR_BAUD=115200
 
+[env:heltec_rc52_without_display_sensor]
+extends = heltec_rc52
+build_src_filter = ${heltec_rc52.build_src_filter}
+  +<../examples/simple_sensor>
+build_flags =
+  ${heltec_rc52.build_flags}
+  -D ADVERT_NAME='"RC52 Sensor"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  ; ENV_PIN_SDA / ENV_PIN_SCL are deliberately NOT set, and that is the correct
+  ; configuration rather than an omission.
+  ;
+  ; Those defines select a SECOND I2C bus: EnvironmentSensorManager.cpp:7-11
+  ; switches TELEM_WIRE to &Wire1 when both are present. RC52 declares
+  ; WIRE_INTERFACES_COUNT (1) -- there is no Wire1 -- so setting them fails to
+  ; compile with "'Wire1' was not declared in this scope". Copying T096's sensor
+  ; env, which uses PIN_WIRE1_*, does exactly that.
+  ;
+  ; Left unset, TELEM_WIRE falls through to &Wire, which IS this board's real
+  ; I2C at P0.06 / P0.29. The default is the right bus here.
+  ; !! DO NOT REMOVE THIS UNTIL A SENSOR IS ACTUALLY WIRED.
+  ;
+  ; EnvironmentSensorManager blind-scans all 128 I2C addresses before touching
+  ; any sensor library. #294: on the Photon-1W C6 that scan WEDGES the I2C
+  ; peripheral at 0x0d and never returns -- setup() never reaches loop() and the
+  ; node is dead on the mesh. Nothing in this tree sets this guard today, so
+  ; every sensor env in the fleet still scans.
+  ;
+  ; RC52's bus is UNPOPULATED. Whether its carrier fits I2C pull-ups is not
+  ; established; without them SDA/SCL float and a sweep is exactly the #294
+  ; failure, in setup(), on the board we are bringing up. The sensor role is
+  ; being harnessed WITHOUT attached sensors, so there is nothing to find and
+  ; nothing to gain by looking.
+  ;
+  ; When a sensor is wired: drop this flag, or replace the sweep with a targeted
+  ; probe of that part's address. Do not simply delete it and hope.
+  -D ENV_SKIP_I2C_SENSOR_SCAN=1
+
 [env:heltec_rc52_without_display_repeater_diag]
 extends = env:heltec_rc52_without_display_repeater
 build_flags =
@@ -242,6 +281,12 @@ build_flags =
 ; CrashLog-disabled diag twin. The A/B that settled #855 on this board, kept as
 ; a diag build so the comparison is made with instrumentation rather than by
 ; watching a USB port appear and disappear.
+[env:heltec_rc52_without_display_sensor_diag]
+extends = env:heltec_rc52_without_display_sensor
+build_flags =
+  ${env:heltec_rc52_without_display_sensor.build_flags}
+  ${rc52_diag.build_flags}
+
 [env:heltec_rc52_without_display_companion_radio_usb_diag_nocrashlog]
 extends = env:heltec_rc52_without_display_companion_radio_usb_diag
 build_flags =

--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -81,7 +81,7 @@ lib_deps =
 upload_protocol = nrfutil
 
 ; ---------------------------------------------------------------------------
-[env:heltec_rc52_repeater]
+[env:heltec_rc52_without_display_repeater]
 extends = heltec_rc52
 build_src_filter = ${heltec_rc52.build_src_filter}
   +<../examples/simple_repeater>
@@ -94,7 +94,7 @@ build_flags =
   -D MAX_NEIGHBOURS=50
 
 ; ---------------------------------------------------------------------------
-[env:heltec_rc52_room_server]
+[env:heltec_rc52_without_display_room_server]
 extends = heltec_rc52
 build_src_filter = ${heltec_rc52.build_src_filter}
   +<../examples/simple_room_server>
@@ -107,7 +107,7 @@ build_flags =
   -D ROOM_PASSWORD='"hello"'
 
 ; ---------------------------------------------------------------------------
-[env:heltec_rc52_companion_radio_ble]
+[env:heltec_rc52_without_display_companion_radio_ble]
 extends = heltec_rc52
 board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
 board_upload.maximum_size = 712704
@@ -127,7 +127,7 @@ lib_deps =
   densaugeo/base64 @ ~1.4.0
 
 ; ---------------------------------------------------------------------------
-[env:heltec_rc52_companion_radio_usb]
+[env:heltec_rc52_without_display_companion_radio_usb]
 extends = heltec_rc52
 board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
 board_upload.maximum_size = 712704
@@ -159,8 +159,8 @@ lib_deps =
 ;
 ; Flash both and compare across RST and a fast replug. If the stock USB env hangs
 ; and this one does not, CrashLog init is the cause.
-[env:heltec_rc52_companion_radio_usb_nocrashlog]
-extends = env:heltec_rc52_companion_radio_usb
+[env:heltec_rc52_without_display_companion_radio_usb_nocrashlog]
+extends = env:heltec_rc52_without_display_companion_radio_usb
 build_flags =
-  ${env:heltec_rc52_companion_radio_usb.build_flags}
+  ${env:heltec_rc52_without_display_companion_radio_usb.build_flags}
   -D OFFBAND_CRASHLOG_DISABLED

--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -148,7 +148,10 @@ build_flags =
   -D MAX_GROUP_CHANNELS=40
   -D ENABLE_USB_INTERFACE
 build_src_filter = ${heltec_rc52.build_src_filter}
-  +<helpers/nrf52/*.cpp>
+  ; #879 review gate: was +<helpers/nrf52/*.cpp>. That directory holds exactly one
+  ; file, SerialBLEInterface.cpp, so the wildcard linked a BLE transport into a
+  ; USB-CDC build -- and would silently absorb anything added there later. The BLE
+  ; env names its one file explicitly; this env needs none of them.
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =

--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -164,3 +164,86 @@ extends = env:heltec_rc52_without_display_companion_radio_usb
 build_flags =
   ${env:heltec_rc52_without_display_companion_radio_usb.build_flags}
   -D OFFBAND_CRASHLOG_DISABLED
+
+; =============================================================================
+; DIAGNOSTIC ENVS -- #889. OWNER DIRECTIVE 2026-08-22.
+;
+; Until we reach a beta-level build the owner is ready or near-ready to release
+; publicly, EVERY environment built is a full diagnostic build. Not "a diag
+; variant exists alongside" -- during bring-up there is no plain build to reach
+; for, and CI builds the _diag envs below rather than their parents.
+;
+; At beta or stable the matrix ships diag AND non-diag versions of every role we
+; issue. That is why the parents above are kept rather than simply having their
+; flags changed: the pairs already exist, correctly named, when we get there.
+;
+; NAMING: the suffix is `_diag`, the RCC6 vocabulary, on every board. RC32's
+; `_testdiag` is a second name for one concept and was ruled unacceptable -- a
+; tester downloading two boards' assets should not meet two conventions, and
+; tooling that globs for diag builds should not have to match both.
+;
+; WHY EACH FLAG -- this block is the union of what RC32 and RCC6 each learned,
+; not a copy of whichever predecessor got opened first:
+;
+;   OFFBAND_FORCE_CAPLOG -- pins runtime logging ON inside loadPrefs(), before
+;     anything else runs. caplog_enabled defaults to 0 (CommonCLI.h:87), and
+;     every MESH_DEBUG_PRINTLN is gated on g_meshLogEnabled, which stays false
+;     until prefs load -- so without this the boot path is mute on exactly the
+;     boot being investigated. RCC6 added it (#631) BECAUSE the RC32 bring-up
+;     had been blind. RC52 shipping without it was a regression below both.
+;
+;   OFFBAND_BOOT_BEACON -- markers from constructor(101), ahead of every other
+;     static ctor. This is what made the RC32 CrashLog fault legible.
+;
+;   OFFBAND_LOG_MIRROR_UART -- MeshLog mirrored to the header UART, a wire that
+;     survives the failure that killed USB. On an RC52 companion `Serial` is
+;     USB-CDC, which dies with the chip, so every log captured that way came
+;     from a boot that succeeded.
+;
+; TX is P0.08 = carrier header pin 11. The carrier is INVERTED against the RCC6:
+; this board transmits on 11, not 12, and ground is pin 20, not 19. Nothing
+; about the RCC6 wiring transfers.
+;
+; Requires the #888 nRF52 UARTE port; on branches without it BootBeacon.h raises
+; a compile-time #error rather than silently emitting nothing.
+; =============================================================================
+[rc52_diag]
+build_flags =
+  -D OFFBAND_FORCE_CAPLOG
+  -D OFFBAND_BOOT_BEACON
+  -D OFFBAND_LOG_MIRROR_UART=1
+  -D OFFBAND_LOG_MIRROR_TX_PIN=PIN_SERIAL1_TX   ; P0.08 -- carrier header pin 11
+  -D OFFBAND_LOG_MIRROR_BAUD=115200
+
+[env:heltec_rc52_without_display_repeater_diag]
+extends = env:heltec_rc52_without_display_repeater
+build_flags =
+  ${env:heltec_rc52_without_display_repeater.build_flags}
+  ${rc52_diag.build_flags}
+
+[env:heltec_rc52_without_display_room_server_diag]
+extends = env:heltec_rc52_without_display_room_server
+build_flags =
+  ${env:heltec_rc52_without_display_room_server.build_flags}
+  ${rc52_diag.build_flags}
+
+[env:heltec_rc52_without_display_companion_radio_ble_diag]
+extends = env:heltec_rc52_without_display_companion_radio_ble
+build_flags =
+  ${env:heltec_rc52_without_display_companion_radio_ble.build_flags}
+  ${rc52_diag.build_flags}
+
+[env:heltec_rc52_without_display_companion_radio_usb_diag]
+extends = env:heltec_rc52_without_display_companion_radio_usb
+build_flags =
+  ${env:heltec_rc52_without_display_companion_radio_usb.build_flags}
+  ${rc52_diag.build_flags}
+
+; CrashLog-disabled diag twin. The A/B that settled #855 on this board, kept as
+; a diag build so the comparison is made with instrumentation rather than by
+; watching a USB port appear and disappear.
+[env:heltec_rc52_without_display_companion_radio_usb_diag_nocrashlog]
+extends = env:heltec_rc52_without_display_companion_radio_usb_diag
+build_flags =
+  ${env:heltec_rc52_without_display_companion_radio_usb_diag.build_flags}
+  -D OFFBAND_CRASHLOG_DISABLED

--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -1,0 +1,168 @@
+; ---------------------------------------------------------------------------
+; Heltec RadioCore RC52 -- nRF52840 + HT-RA62A (SX1262 + FEM)
+;
+; HEADLESS BY DESIGN (#854). There is no display env here. NV3001BDisplay does
+; not compile for nRF52 today -- its hardware-SPI path calls ESP32-only SPI APIs
+; and its `SPIClass spi;` member has no nRF52 default constructor, so even
+; NV3001B_USE_SOFTWARE_SPI=1 does not sidestep it. Adding a display env is #872.
+;
+; No WiFi on nRF52840, so there is NO observer env and none of the MQTT/TLS-heap
+; configuration that the RCC6 carries. That whole thread is inapplicable here.
+;
+; Pins come from Heltec's own BSP (HelTecAutomation/Heltec_nRF52 ::
+; variants/heltec_rc52/variant.h) read directly on 2026-08-19, cross-checked
+; against the RC52-L62_V1.02 schematic. Nothing is carried over from the RC32 or
+; RCC6 -- the carrier is NOT pin-consistent across the family.
+; ---------------------------------------------------------------------------
+
+[heltec_rc52]
+extends = nrf52_base
+board = heltec_rc52
+board_build.ldscript = boards/nrf52840_s140_v6.ld
+build_flags = ${nrf52_base.build_flags}
+  -I lib/nrf52/s140_nrf52_6.1.1_API/include
+  -I lib/nrf52/s140_nrf52_6.1.1_API/include/nrf52
+  -I variants/heltec_rc52
+  -D HELTEC_RC52
+  ; --- LoRa (SX1262) on SPI0. P1.xx pins are 32 + n. ---
+  -D P_LORA_NSS=13        ; P0.13
+  -D P_LORA_DIO_1=11      ; P0.11
+  -D P_LORA_BUSY=24       ; P0.24
+  -D P_LORA_RESET=32      ; P1.00
+  -D P_LORA_SCLK=25       ; P0.25
+  -D P_LORA_MISO=14       ; P0.14
+  -D P_LORA_MOSI=22       ; P0.22
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D SX126X_DIO2_AS_RF_SWITCH=true
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
+  -D SX126X_CURRENT_LIMIT=140
+  -D SX126X_RX_BOOSTED_GAIN=1
+  ; --- TX power: PROVISIONAL, owned by #858 ---
+  ; This board has a FEM and Heltec publishes NO datasheet for the HT-RA62A
+  ; module (schematic only; RC52/datasheet/ and RC52/pinmap/ both 404), so its
+  ; gain is UNKNOWN and the total output at the antenna cannot be derived yet.
+  ;
+  ; 9 dBm is therefore chosen to UNDER-drive, not because RC52's FEM gain was
+  ; derived. The direction is deliberate: under-driving costs range, which is a
+  ; finding for #858; over-driving risks regulatory limits and the part itself.
+  ; #858 must measure the actual output and set both values properly.
+  ;
+  ; MAX is pinned EQUAL to the default, deliberately. An earlier draft left it at
+  ; 22 (the SX1262 ceiling, as the sibling boards use) -- an adversarial review
+  ; caught that as inconsistent with the caution above, and it was right: MAX is
+  ; the runtime-configurable ceiling, so 22 would let a `set tx_power` push the
+  ; SX1262 to 22 dBm into a FEM of unknown gain, i.e. an unknown and possibly
+  ; illegal output. Until #858 measures the real antenna power there is no value
+  ; above 9 that can be justified from evidence, so none is permitted. The review
+  ; proposed 14; that is safer than 22 but is still a chosen-not-derived number,
+  ; which is the habit this project is trying to break. #858 raises this.
+  -D LORA_TX_POWER=9
+  -D MAX_LORA_TX_POWER=9
+  ; --- Battery: divider gate. Ratio + polarity live in variant.h. ---
+  -D PIN_VBAT_READ=BATTERY_PIN
+  ; --- Headless: no display, no LED (PIN_LED1 is -1 in the vendor BSP) ---
+  -D DISPLAY_CLASS=NullDisplayDriver
+build_src_filter = ${nrf52_base.build_src_filter}
+  +<helpers/*.cpp>
+  +<../variants/heltec_rc52>
+  ; DISPLAY_CLASS is NullDisplayDriver here, so the inert driver and the button
+  ; handler both need compiling in -- same as heltec_rc32's _without_display_ envs.
+  +<helpers/ui/NullDisplayDriver.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  ; EnvironmentSensorManager is referenced by every role's main.cpp, so its
+  ; sources must link. NOTE: sensor_base's build_flags are deliberately NOT
+  ; inherited -- that block turns on the whole I2C sensor suite AND
+  ; ENV_INCLUDE_GPS=1, and this board has no GPS. The result is a working but
+  ; empty sensor manager, which is the right scope for a scaffold. Enabling
+  ; actual sensors on the broken-out I2C (SDA P0.06 / SCL P0.29) is a separate
+  ; decision, not part of #854.
+  +<helpers/sensors>
+lib_deps =
+  ${nrf52_base.lib_deps}
+upload_protocol = nrfutil
+
+; ---------------------------------------------------------------------------
+[env:heltec_rc52_repeater]
+extends = heltec_rc52
+build_src_filter = ${heltec_rc52.build_src_filter}
+  +<../examples/simple_repeater>
+build_flags =
+  ${heltec_rc52.build_flags}
+  -D ADVERT_NAME='"RC52 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+
+; ---------------------------------------------------------------------------
+[env:heltec_rc52_room_server]
+extends = heltec_rc52
+build_src_filter = ${heltec_rc52.build_src_filter}
+  +<../examples/simple_room_server>
+build_flags =
+  ${heltec_rc52.build_flags}
+  -D ADVERT_NAME='"RC52 Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+
+; ---------------------------------------------------------------------------
+[env:heltec_rc52_companion_radio_ble]
+extends = heltec_rc52
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_flags =
+  ${heltec_rc52.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+build_src_filter = ${heltec_rc52.build_src_filter}
+  +<helpers/nrf52/SerialBLEInterface.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${heltec_rc52.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+; ---------------------------------------------------------------------------
+[env:heltec_rc52_companion_radio_usb]
+extends = heltec_rc52
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_flags =
+  ${heltec_rc52.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D ENABLE_USB_INTERFACE
+build_src_filter = ${heltec_rc52.build_src_filter}
+  +<helpers/nrf52/*.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${heltec_rc52.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+; ---------------------------------------------------------------------------
+; #855 -- CrashLog A/B pair.
+;
+; CrashLog is enabled fleet-wide (#472) and on the RC32 it produced a boot HANG,
+; not a delay: the board completes static constructors and board.begin(), then
+; dies inside crashLogBegin() reading the retained ring from the previous reset.
+; It presents as a dead board after RST, which reads as hardware.
+;
+; The nRF52 retention path EXISTS in this repo -- .noinit (NOLOAD) is defined in
+; boards/nrf52840_s140_v*.ld by #361 and CrashLog.h maps OFFBAND_RETAINED to it
+; -- so RC52 is NOT exempt by construction and has to be ruled out on hardware.
+;
+; Flash both and compare across RST and a fast replug. If the stock USB env hangs
+; and this one does not, CrashLog init is the cause.
+[env:heltec_rc52_companion_radio_usb_nocrashlog]
+extends = env:heltec_rc52_companion_radio_usb
+build_flags =
+  ${env:heltec_rc52_companion_radio_usb.build_flags}
+  -D OFFBAND_CRASHLOG_DISABLED

--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -20,6 +20,16 @@ extends = nrf52_base
 board = heltec_rc52
 board_build.ldscript = boards/nrf52840_s140_v6.ld
 build_flags = ${nrf52_base.build_flags}
+  ; #953: enables NRF52Board's RESETREAS capture -- a constructor(101) that reads
+  ; NRF_POWER->RESETREAS BEFORE SystemInit() clears it -- so a reset reason can be
+  ; reported instead of "Not available". Every other nRF52 variant already sets
+  ; this (t096, t114, t1, tower_v2, rak3401, muziworks, gat562_*); RC52 was the
+  ; only one without it, which is why its crash log had no cause to name.
+  ;
+  ; It does NOT enable boot-voltage gating: RC52Board's power_config sets
+  ; voltage_bootlock = 0, honouring the standing "no gating on an unverified
+  ; reading" decision in variant.h. See that file and #857.
+  -D NRF52_POWER_MANAGEMENT
   -I lib/nrf52/s140_nrf52_6.1.1_API/include
   -I lib/nrf52/s140_nrf52_6.1.1_API/include/nrf52
   -I variants/heltec_rc52

--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -38,27 +38,25 @@ build_flags = ${nrf52_base.build_flags}
   -D SX126X_DIO3_TCXO_VOLTAGE=1.8
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
-  ; --- TX power: PROVISIONAL, owned by #858 ---
-  ; This board has a FEM and Heltec publishes NO datasheet for the HT-RA62A
-  ; module (schematic only; RC52/datasheet/ and RC52/pinmap/ both 404), so its
-  ; gain is UNKNOWN and the total output at the antenna cannot be derived yet.
+  ; --- TX power: 22, matching the rest of the RA62A-HF family (#858) ---
+  ; The family rule is: derate the SX1262 only when a DISCRETE external PA adds
+  ; gain. heltec_t096 uses 9 because its KCT8103L contributes ~13 dB (9 + 13 = 22
+  ; at the antenna). The RA62A-HF MODULE has no external TX PA -- its FEM is
+  ; receive-side, exposing only LNA_Ctrl -- so the module's output IS the SX1262's.
   ;
-  ; 9 dBm is therefore chosen to UNDER-drive, not because RC52's FEM gain was
-  ; derived. The direction is deliberate: under-driving costs range, which is a
-  ; finding for #858; over-driving risks regulatory limits and the part itself.
-  ; #858 must measure the actual output and set both values properly.
+  ; heltec_rc32 and heltec_rcc6 both ship 22 on this same module, and
+  ; n30nex/NeonPocketMC-RC52 ships 22 as well. Four independent agreements.
   ;
-  ; MAX is pinned EQUAL to the default, deliberately. An earlier draft left it at
-  ; 22 (the SX1262 ceiling, as the sibling boards use) -- an adversarial review
-  ; caught that as inconsistent with the caution above, and it was right: MAX is
-  ; the runtime-configurable ceiling, so 22 would let a `set tx_power` push the
-  ; SX1262 to 22 dBm into a FEM of unknown gain, i.e. an unknown and possibly
-  ; illegal output. Until #858 measures the real antenna power there is no value
-  ; above 9 that can be justified from evidence, so none is permitted. The review
-  ; proposed 14; that is safer than 22 but is still a chosen-not-derived number,
-  ; which is the habit this project is trying to break. #858 raises this.
-  -D LORA_TX_POWER=9
-  -D MAX_LORA_TX_POWER=9
+  ; An earlier revision pinned both values to 9, reasoning "there is a FEM, FEMs
+  ; have gain, so under-drive". That conflated two different topologies and left
+  ; the board unable to be configured even up to the family norm. The schematic
+  ; cannot arbitrate it either -- the FEM is inside U6, so the interface is
+  ; visible and the gain is not. The family comparison is the evidence.
+  ;
+  ; Absolute output at the antenna is still unmeasured; that is a calibration
+  ; step for final testing, not a reason to ship a value nothing else uses.
+  -D LORA_TX_POWER=22
+  -D MAX_LORA_TX_POWER=22
   ; --- Battery: divider gate. Ratio + polarity live in variant.h. ---
   -D PIN_VBAT_READ=BATTERY_PIN
   ; --- Headless: no display, no LED (PIN_LED1 is -1 in the vendor BSP) ---

--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -215,44 +215,45 @@ build_flags =
   -D OFFBAND_LOG_MIRROR_TX_PIN=PIN_SERIAL1_TX   ; P0.08 -- carrier header pin 11
   -D OFFBAND_LOG_MIRROR_BAUD=115200
 
-[env:heltec_rc52_without_display_sensor]
-extends = heltec_rc52
-build_src_filter = ${heltec_rc52.build_src_filter}
-  +<../examples/simple_sensor>
-build_flags =
-  ${heltec_rc52.build_flags}
-  -D ADVERT_NAME='"RC52 Sensor"'
-  -D ADVERT_LAT=0.0
-  -D ADVERT_LON=0.0
-  -D ADMIN_PASSWORD='"password"'
-  ; ENV_PIN_SDA / ENV_PIN_SCL are deliberately NOT set, and that is the correct
-  ; configuration rather than an omission.
-  ;
-  ; Those defines select a SECOND I2C bus: EnvironmentSensorManager.cpp:7-11
-  ; switches TELEM_WIRE to &Wire1 when both are present. RC52 declares
-  ; WIRE_INTERFACES_COUNT (1) -- there is no Wire1 -- so setting them fails to
-  ; compile with "'Wire1' was not declared in this scope". Copying T096's sensor
-  ; env, which uses PIN_WIRE1_*, does exactly that.
-  ;
-  ; Left unset, TELEM_WIRE falls through to &Wire, which IS this board's real
-  ; I2C at P0.06 / P0.29. The default is the right bus here.
-  ; !! DO NOT REMOVE THIS UNTIL A SENSOR IS ACTUALLY WIRED.
-  ;
-  ; EnvironmentSensorManager blind-scans all 128 I2C addresses before touching
-  ; any sensor library. #294: on the Photon-1W C6 that scan WEDGES the I2C
-  ; peripheral at 0x0d and never returns -- setup() never reaches loop() and the
-  ; node is dead on the mesh. Nothing in this tree sets this guard today, so
-  ; every sensor env in the fleet still scans.
-  ;
-  ; RC52's bus is UNPOPULATED. Whether its carrier fits I2C pull-ups is not
-  ; established; without them SDA/SCL float and a sweep is exactly the #294
-  ; failure, in setup(), on the board we are bringing up. The sensor role is
-  ; being harnessed WITHOUT attached sensors, so there is nothing to find and
-  ; nothing to gain by looking.
-  ;
-  ; When a sensor is wired: drop this flag, or replace the sweep with a targeted
-  ; probe of that part's address. Do not simply delete it and hope.
-  -D ENV_SKIP_I2C_SENSOR_SCAN=1
+; ============================================================
+; NO SENSOR ENV FOR RC52 -- REMOVED DELIBERATELY, #889.
+;
+; The sensor role cannot be made functional on this board with the information
+; the manufacturer has published. Removed rather than left building, because an
+; env that compiles and is exercised in CI reads as a supported role.
+;
+; WHY, from the vendor schematic (rc52.pdf, Altium, 1 sheet, 2026-07-27):
+;   * The schematic contains NO net named SDA, SCL, I2C, IIC or TWI. There is no
+;     I2C bus on this board -- not a second one, not a first one.
+;   * Heltec's own variant declares one regardless: WIRE_INTERFACES_COUNT (1),
+;     PIN_WIRE_SDA (0 + 6), PIN_WIRE_SCL (0 + 29). Our variant.h:120-122 is
+;     character-identical to upstream, so these are Heltec's values, not ours.
+;   * P0.06 and P0.29 are NOT ROUTED. Each is named exactly once in the whole
+;     schematic -- inside the nRF52840 symbol, no net attached. Routed pins are
+;     named 3-5 times. Neither reaches the 40-pin P1 (HC-PBB40C) nor the 20-pin
+;     P2 carrier connector. They terminate at the ball, under the package.
+;   * So Wire is NOMINAL: two unused balls assigned so the library instantiates.
+;     Nothing can ever be detected on it. Wire1 does not exist at all -- the core
+;     builds it only under WIRE_INTERFACES_COUNT > 1 from PIN_WIRE1_SDA/SCL,
+;     which upstream does not define.
+;
+; This is the RadioCore family pattern, not an RC52 quirk. docs/radiocore/README.md
+; already records the same thing for RC32, where upstream assigns I2C SDA 21 /
+; SCL 18 plus sensor power 46 and sensor reset 2 -- none of which are on that
+; module's 20-pin header either. RC52's schematic upgrades that from
+; [hypothesis: untested] to verified: these variants target a complete Heltec
+; product, not the bare socketed module we actually have.
+;
+; WHAT WOULD MAKE IT VIABLE -- and it is not a firmware change:
+; manufacturer documentation for the CARRIER showing whether a sensor connector
+; exists and which module pins it lands on. nRF52 TWI is not pin-locked, so if a
+; carrier sensor header maps to routed pins, repointing PIN_WIRE_SDA/SCL at them
+; is straightforward. Until that arrives there is nothing to point at.
+;
+; Do not re-add a sensor env from a hardware-free build success. It built and it
+; booted; it detected nothing and never could.
+; ============================================================
+
 
 [env:heltec_rc52_without_display_repeater_diag]
 extends = env:heltec_rc52_without_display_repeater
@@ -281,11 +282,6 @@ build_flags =
 ; CrashLog-disabled diag twin. The A/B that settled #855 on this board, kept as
 ; a diag build so the comparison is made with instrumentation rather than by
 ; watching a USB port appear and disappear.
-[env:heltec_rc52_without_display_sensor_diag]
-extends = env:heltec_rc52_without_display_sensor
-build_flags =
-  ${env:heltec_rc52_without_display_sensor.build_flags}
-  ${rc52_diag.build_flags}
 
 [env:heltec_rc52_without_display_companion_radio_usb_diag_nocrashlog]
 extends = env:heltec_rc52_without_display_companion_radio_usb_diag

--- a/variants/heltec_rc52/target.cpp
+++ b/variants/heltec_rc52/target.cpp
@@ -1,0 +1,46 @@
+#include "target.h"
+
+#include <Arduino.h>
+#include <helpers/ArduinoHelpers.h>
+
+RC52Board board;
+
+// LoRa lives on SPI0. std_init() below calls spi->setPins(MISO, SCLK, MOSI) on
+// nRF52 before begin(), so the P_LORA_* pins in platformio.ini are what actually
+// configure the bus.
+RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, SPI);
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+VolatileRTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+
+// No GPS on this board -- the vendor BSP defines no GPS pins, so there is no
+// MicroNMEALocationProvider here and nothing to gate on ENV_INCLUDE_GPS.
+EnvironmentSensorManager sensors;
+
+#ifdef DISPLAY_CLASS
+  // NullDisplayDriver takes no constructor argument (unlike the panel drivers on
+  // sibling boards, which take a peripheral-power pin) -- there is no display
+  // rail to gate on a headless build.
+  DISPLAY_CLASS display;
+
+  // USER button: P1.10, external pull-up, ACTIVE LOW -> reverse = true. The
+  // external pull-up is why pulldownup is left at its default false.
+  MomentaryButton user_btn(PIN_USER_BTN, 1000, true);
+#endif
+
+bool radio_init() {
+  rtc_clock.begin(Wire);
+
+  // The FEM's LNA control line (P1.07) is SX126X_RXEN, and CustomSX1262::std_init()
+  // picks that up and calls setRfSwitchPins() itself -- there is deliberately no
+  // manual rf-switch wiring here. TX side is DIO2 (SX126X_DIO2_AS_RF_SWITCH), so
+  // there is no TXEN pin on this board.
+  return radio.std_init(&SPI);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);  // create new random identity
+}

--- a/variants/heltec_rc52/target.h
+++ b/variants/heltec_rc52/target.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <RC52Board.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/radiolib/CustomSX1262Wrapper.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <helpers/sensors/EnvironmentSensorManager.h>
+#include <helpers/sensors/LocationProvider.h>
+
+// Headless variant (#854). DISPLAY_CLASS is bound to NullDisplayDriver rather
+// than left undefined, following heltec_rc32's `_without_display_` envs: that
+// keeps the button/UI surface compiled in -- and the RC52 does have a real USER
+// button (P1.10) -- while the panel itself is inert.
+//
+// The real panel is NOT here because NV3001BDisplay does not compile for nRF52
+// today. Adding it is #872.
+#ifdef DISPLAY_CLASS
+#include <helpers/ui/MomentaryButton.h>
+#include <helpers/ui/NullDisplayDriver.h>
+#endif
+
+extern RC52Board board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern EnvironmentSensorManager sensors;
+
+#ifdef DISPLAY_CLASS
+  extern DISPLAY_CLASS display;
+  extern MomentaryButton user_btn;
+#endif
+
+bool radio_init();
+mesh::LocalIdentity radio_new_identity();

--- a/variants/heltec_rc52/variant.cpp
+++ b/variants/heltec_rc52/variant.cpp
@@ -1,0 +1,23 @@
+#include "variant.h"
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+
+// Identity map across the whole nRF52840 GPIO space: index N -> P0.N for 0..31,
+// P1.(N-32) for 32..47. That is what lets variant.h address pins as (0 + n) and
+// (32 + n), matching the vendor BSP's own notation exactly.
+//
+// P0.00 / P0.01 are masked (0xff) because they are XL1 / XL2, the 32.768 kHz
+// crystal pins -- the board fits the crystal (USE_LFXO), so they are not GPIO.
+const uint32_t g_ADigitalPinMap[] = {
+  0xff, 0xff, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
+  14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+  27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+  40, 41, 42, 43, 44, 45, 46, 47
+};
+
+void initVariant()
+{
+  // The USER button has an external pull-up and is active low, so a plain INPUT
+  // is correct here -- do not add INPUT_PULLUP.
+  pinMode(PIN_USER_BTN, INPUT);
+}

--- a/variants/heltec_rc52/variant.h
+++ b/variants/heltec_rc52/variant.h
@@ -1,0 +1,201 @@
+/*
+ * variant.h -- Heltec RadioCore RC52 (nRF52840 + HT-RA62A / SX1262 + FEM)
+ *
+ * Every pin below is taken from Heltec's own board support package:
+ *   HelTecAutomation/Heltec_nRF52 :: variants/heltec_rc52/variant.h
+ * read directly 2026-08-19 (see OffbandMesh/meshcore-firmware#854). Nothing here
+ * is guessed or carried over from a sibling RadioCore board -- the carrier is NOT
+ * pin-consistent across the family (see the warning block below).
+ *
+ * MIT (this file); vendor values reproduced for interoperability.
+ */
+
+#pragma once
+
+#include "WVariant.h"
+
+////////////////////////////////////////////////////////////////////////////////
+// !! THE CARRIER IS NOT PIN-CONSISTENT ACROSS THE RADIOCORE FAMILY
+//
+// Do not carry wiring or assumptions over from the RC32 or RCC6:
+//
+//   header pin | RCC6      | RC52
+//   -----------|-----------|---------------------
+//   19         | GND       | VDD        <-- swapped
+//   20         | VDD_3V3   | GND        <-- swapped
+//   11         | U0RXD     | nRF_TX (P0.08)
+//   12         | U0TXD     | nRF_RX (P0.07)
+//
+// Ground a probe on pin 20 (or 1, or 3) -- NOT pin 19. The RCC6 handoff says the
+// opposite and it is wrong for this board; following it puts ground on VDD.
+// A sniffer listens on pin 11, because that is the pin the RC52 transmits on.
+////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////
+// Clock
+
+#define USE_LFXO                        // 32.768 kHz crystal is fitted
+#define VARIANT_MCK             (64000000ul)
+
+////////////////////////////////////////////////////////////////////////////////
+// Number of pins
+
+#define PINS_COUNT              (48)
+#define NUM_DIGITAL_PINS        (48)
+#define NUM_ANALOG_INPUTS       (1)
+#define NUM_ANALOG_OUTPUTS      (0)
+
+////////////////////////////////////////////////////////////////////////////////
+// !! THERE IS NO LED ON THIS BOARD
+//
+// Vendor BSP: PIN_LED1 -1, PIN_NEOPIXEL -1, NEOPIXEL_NUM 0. No status-LED
+// heartbeat is possible on the RC52. If a board appears "dead" because nothing
+// blinks, that is this hardware fact and NOT a fault -- do not diagnose it as one.
+// P_LORA_TX_LED is deliberately left undefined (it is #ifdef-guarded upstream).
+
+#define LED_BUILTIN             (-1)
+#define PIN_LED                 LED_BUILTIN
+#define LED_RED                 LED_BUILTIN
+#define LED_BLUE                (-1)    // also stops Bluefruit blinking during advertising
+#define LED_STATE_ON            1
+
+////////////////////////////////////////////////////////////////////////////////
+// Buttons
+
+#define PIN_BUTTON1             (32 + 10)   // P1.10, external pull-up, ACTIVE LOW
+#define BUTTON_PIN              PIN_BUTTON1
+#define PIN_USER_BTN            BUTTON_PIN
+
+////////////////////////////////////////////////////////////////////////////////
+// Battery
+//
+// ADC_CTRL (P0.04) gates the divider feeding BATTERY_PIN (P0.31).
+//
+// ADC_MULTIPLIER 4.9 is DERIVED, not measured: schematic RC52-L62_V1.02 gives
+// VBAT -> Q3 (AO3401A, P-ch) -> R17 390K -> [tap] -> R18 100K -> GND, so
+// (390K + 100K) / 100K = 4.90. Independently corroborated by the vendor BSP's
+// own BAT_AMPLIFY 4.9F. Two sources; take it, do not re-derive or "improve" it.
+//
+// !! This is the NOMINAL ratio, not a calibration. At 1% parts the true value
+// spans ~4.83-4.97. Confirm on hardware before anything trusts it -- see #857.
+
+#define BATTERY_PIN             (0 + 31)    // P0.31 / AIN7
+#define ADC_CTRL                (0 + 4)     // P0.04
+#define ADC_CTRL_ENABLED        HIGH        // Q2 NPN -> gate of P-ch Q3: HIGH enables
+#define ADC_CTRL_DISABLED       LOW         // explicit; do not write !ADC_CTRL_ENABLED
+#define ADC_MULTIPLIER          (4.90F)
+#define AREF_VOLTAGE            (3.0)
+#define MV_LSB                  (3000.0F / 4096.0F)  // read at 12-bit / AR_INTERNAL_3_0
+
+// ADC_RESOLUTION mirrors the vendor BSP's declared 14-bit capability, while
+// getBattMilliVolts() deliberately reads at 12-bit (matching MV_LSB above).
+//
+// That is NOT an order-dependent bug, and a review flagged it as one -- so the
+// refutation is recorded here to stop it being re-raised:
+//   * The Adafruit nRF52 core does NOT seed its read resolution from this macro.
+//     wiring_analog_nRF52.c defaults to `static int readResolution = 10` and only
+//     changes it via analogReadResolution(). The apparent "ADC_RESOLUTION" hits in
+//     that file are its own SAADC_RESOLUTION_VAL_* enum names, not this symbol.
+//   * Nothing under src/ or examples/ reads ADC_RESOLUTION at all.
+// [verified: framework-arduinoadafruitnrf52 wiring_analog_nRF52.c + repo grep,
+//  2026-08-19]
+#define ADC_RESOLUTION          (14)        // vendor-declared capability (informational)
+
+////////////////////////////////////////////////////////////////////////////////
+// !! SafeBoot battery gating is DELIBERATELY NOT CONFIGURED HERE
+//
+// #602: on the Seeed Wio Tracker L1 Pro an INHERITED battery polarity made
+// SafeBoot disable the divider, sample it dead, read below SLEEP_MV and deep-sleep
+// before USB init -- a fully charged board presenting as completely dead.
+//
+// RC52's polarity above is schematic-derived (legitimate) but NOT measured. Until
+// #857 confirms it on this board, no PWRMGT_VOLTAGE_BOOTLOCK / LPCOMP / SafeBoot
+// voltage threshold is defined, so nothing can gate boot on an unverified reading.
+// Adding them is #857's job, after measurement -- not this scaffold's.
+////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////
+// I2C
+
+#define WIRE_INTERFACES_COUNT   (1)
+#define PIN_WIRE_SDA            (0 + 6)     // P0.06
+#define PIN_WIRE_SCL            (0 + 29)    // P0.29
+
+////////////////////////////////////////////////////////////////////////////////
+// Serial -- header UART. Board TRANSMITS on P0.08 = carrier header pin 11.
+
+#define PIN_SERIAL1_RX          (0 + 7)     // P0.07 -> header pin 12
+#define PIN_SERIAL1_TX          (0 + 8)     // P0.08 -> header pin 11
+
+////////////////////////////////////////////////////////////////////////////////
+// LoRa -- SX1262 (HT-RA62A), on SPI0
+
+#define USE_SX1262
+#define LORA_CS                 (0 + 13)    // P0.13
+#define SX126X_CS               LORA_CS
+#define SX126X_DIO1             (0 + 11)    // P0.11
+#define SX126X_BUSY             (0 + 24)    // P0.24
+#define SX126X_RESET            (32 + 0)    // P1.00
+#define SX126X_DIO2_AS_RF_SWITCH
+#define SX126X_DIO3_TCXO_VOLTAGE 1.8
+
+////////////////////////////////////////////////////////////////////////////////
+// FEM (HT-RA62A front-end module) -- NEITHER the RC32 NOR the RCC6 has one.
+//
+// FEM_LNA_CTRL (P1.07) IS the RadioLib RXEN pin: CustomSX1262::std_init() picks
+// up SX126X_RXEN and calls setRfSwitchPins(RXEN, TXEN) itself, so the RX path
+// needs no board-class code. TX switching is handled by DIO2 (above), hence
+// there is no TXEN.
+//
+// FEM_EN and VFEM_CTRL are plain enables driven in RC52Board::begin().
+// Characterising this FEM -- gain, LNA behaviour, TX power -- is #858, NOT here.
+
+#define SX126X_RXEN             (32 + 7)    // P1.07, HT-RA62A LNA_Ctrl
+#define RADIOCORE_FEM_EN        (0 + 26)    // P0.26
+#define RADIOCORE_VFEM_CTRL     (0 + 16)    // P0.16, FEM regulator enable
+
+////////////////////////////////////////////////////////////////////////////////
+// SPI
+//
+// SPI0 = LoRa. SPI1 = TFT, backed by SPIM3 (the nRF52840's single 32 MHz
+// instance) per the vendor BSP's SPI_32MHZ_INTERFACE 1.
+
+#define SPI_INTERFACES_COUNT    (2)
+#define SPI_32MHZ_INTERFACE     (1)
+
+#define PIN_SPI_MISO            (0 + 14)    // P0.14
+#define PIN_SPI_MOSI            (0 + 22)    // P0.22
+#define PIN_SPI_SCK             (0 + 25)    // P0.25
+#define PIN_SPI_NSS             LORA_CS
+
+#define PIN_SPI1_MISO           (0 + 12)    // P0.12 -- NOT wired to the panel;
+                                            // SPIClass still needs a valid pin
+#define PIN_SPI1_MOSI           (32 + 3)    // P1.03
+#define PIN_SPI1_SCK            (0 + 30)    // P0.30
+
+////////////////////////////////////////////////////////////////////////////////
+// TFT (T108 / NV3001B) -- DECLARED FOR REFERENCE, NOT USED BY THIS VARIANT.
+//
+// This variant is headless (#854). The display port is #872, because
+// NV3001BDisplay does not compile for nRF52 today: its hardware-SPI path calls
+// spi.begin(sck,miso,mosi,ss) / writeBytes() / writePattern(), all ESP32-only,
+// and its `SPIClass spi;` member is unconditional with no nRF52 default ctor --
+// so NV3001B_USE_SOFTWARE_SPI=1 does not sidestep it either.
+//
+// !! THE TFT OCCUPIES CARRIER HEADER PINS 6-10. Anything wired to those pins
+// conflicts with a display build, and SWDIO (P0.30) is also TFT_SCK, so SWD and
+// the display are mutually exclusive on this board.
+//
+// !! TFT_EN is ACTIVE LOW while TFT_BL is ACTIVE HIGH. Opposite polarities on the
+// two power/backlight controls; getting one backwards presents as a dead panel.
+
+#define PIN_TFT_SCK             (0 + 30)    // P0.30 -- also SWDIO, header pin 6
+#define PIN_TFT_MOSI            (32 + 3)    // P1.03
+#define PIN_TFT_MISO            (-1)        // write-only panel, no readback
+#define PIN_TFT_CS              (32 + 5)    // P1.05
+#define PIN_TFT_DC              (0 + 28)    // P0.28 -- header pin 7
+#define PIN_TFT_RST             (0 + 10)    // P0.10 -- header pin 10
+#define PIN_TFT_VDD_CTL         (32 + 13)   // P1.13 -- header pin 8
+#define TFT_VDD_ENABLE          LOW         // ACTIVE LOW
+#define PIN_TFT_LEDA_CTL        (0 + 9)     // P0.09 -- header pin 9
+#define TFT_LEDA_ENABLE         HIGH        // ACTIVE HIGH

--- a/variants/heltec_rc52/variant.h
+++ b/variants/heltec_rc52/variant.h
@@ -112,6 +112,14 @@
 // #857 confirms it on this board, no PWRMGT_VOLTAGE_BOOTLOCK / LPCOMP / SafeBoot
 // voltage threshold is defined, so nothing can gate boot on an unverified reading.
 // Adding them is #857's job, after measurement -- not this scaffold's.
+//
+// #953 UPDATE: NRF52_POWER_MANAGEMENT IS now defined for this board, and this
+// paragraph still holds unchanged. That flag gates two unrelated things: the
+// RESETREAS capture (wanted -- it is why the crash log can name a cause) and
+// boot-voltage gating (NOT wanted yet). RC52Board.cpp sets voltage_bootlock = 0,
+// which disables the gating outright, so checkBootVoltage() returns before it can
+// reach initiateShutdown() or configureVoltageWake(). Still no threshold defined
+// here, still nothing gating boot on an unmeasured reading.
 ////////////////////////////////////////////////////////////////////////////////
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/variants/heltec_rc52/variant.h
+++ b/variants/heltec_rc52/variant.h
@@ -108,10 +108,50 @@
 // SafeBoot disable the divider, sample it dead, read below SLEEP_MV and deep-sleep
 // before USB init -- a fully charged board presenting as completely dead.
 //
-// RC52's polarity above is schematic-derived (legitimate) but NOT measured. Until
-// #857 confirms it on this board, no PWRMGT_VOLTAGE_BOOTLOCK / LPCOMP / SafeBoot
-// voltage threshold is defined, so nothing can gate boot on an unverified reading.
-// Adding them is #857's job, after measurement -- not this scaffold's.
+// CORRECTED (2026-08-23): this block used to say the POLARITY was unverified.
+// That was wrong, and it muddled two different things. The polarity is settled by
+// circuit topology and needs no bench measurement:
+//   Q3 is an AO3401A P-channel MOSFET with its gate held at VBAT through R16
+//   (100K) -- off by default. Q2 (S9013, NPN) pulls that gate low when ADC_Ctrl
+//   is driven HIGH, which turns Q3 on and connects the divider. HIGH enables.
+//   R17 (390K) over R18 (100K) gives (390+100)/100 = 4.90.
+// [verified: rc52.pdf schematic, 2026-08-23] -- matching ADC_CTRL_ENABLED and
+// ADC_MULTIPLIER above.
+//
+// What is NOT established is the SCALE FACTOR'S ACCURACY. 4.90 is nominal; at 1%
+// parts the true ratio spans ~4.83-4.97, before ADC reference error. A
+// PWRMGT_VOLTAGE_BOOTLOCK threshold compares an ABSOLUTE voltage, so it is the
+// calibration -- not the polarity -- that it depends on. #602 is the cautionary
+// case: a fully charged board deep-sleeping before USB init because the value it
+// compared was wrong.
+//
+// RESOLVED 2026-08-23 -- the threshold IS now set, and the calibration worry was
+// overstated. The cross-check that settled it, all on the same battery within
+// seconds, captured on the mirror UART:
+//
+//     RC52 via this divider   4130 mV
+//     MAX17048 fuel gauge     4147 mV
+//     INA219 bus register     4144 mV
+//
+// -15 mV, or -0.36%, against a predicted worst case of +/-3.5%. Three independent
+// paths inside 17 mV. The nominal 4.90 is good, and #602's failure mode -- a
+// charged board reading as dead -- is ruled out, since that is an error of
+// hundreds of percent, not tenths.
+//
+// PWRMGT_VOLTAGE_BOOTLOCK is 3300, matching the fleet (8 other nRF52 variants;
+// two use 3100). At 0.36% observed error that is ~12 mV of uncertainty on the
+// comparison, against ~800 mV of headroom to a charged cell.
+#define PWRMGT_VOLTAGE_BOOTLOCK 3300   // Won't boot below this voltage (mV)
+
+// PWRMGT_LPCOMP_AIN / REFSEL are deliberately NOT defined, and RC52Board's
+// power_config leaves them 0. They are consumed ONLY by configureVoltageWake(),
+// which is reached only from a board-specific initiateShutdown() override. RC52
+// does not override it, so the base NRF52Board::initiateShutdown() runs and calls
+// enterSystemOff() directly -- LPCOMP is never configured.
+//
+// CONSEQUENCE, stated rather than discovered later: if this board ever boot-locks
+// it stays in SYSTEMOFF until a reset or USB attach. It will NOT self-wake when
+// the cell recovers. Correct for a bench board; revisit for a deployed one.
 //
 // #953 UPDATE: NRF52_POWER_MANAGEMENT IS now defined for this board, and this
 // paragraph still holds unchanged. That flag gates two unrelated things: the


### PR DESCRIPTION
Epic [#879](https://github.com/OffbandMesh/meshcore-firmware/issues/879) — RC52 headless bring-up. Third of the four RadioCore boards, and the first nRF52 one.

## What this is

Heltec RadioCore RC52: nRF52840 + HT-RA62A (SX1262 **with a FEM inside the module**). RC32 and RCC6 are shipping vetted boards; this brings the nRF52 sibling up headless — repeater, room server, companion USB/BLE — plus a `_diag` twin per role.

## What changed

| Area | Change |
|---|---|
| `variants/heltec_rc52/` (new) | variant, board class, targets, `platformio.ini` — 5 shipped envs + `_diag` twins |
| `boards/heltec_rc52.json` (new) | board definition |
| `src/helpers/NRF52Board.{cpp,h}` | **shared** — VBUS wake extracted from `configureVoltageWake()` into `configureUsbWake()` |
| `.github/workflows/ci.yml` | RC52 envs into the matrix |

**The only fleet-shared change is the `configureUsbWake()` extraction**, and it is a pure refactor: the block moved verbatim, called from exactly where it sat. RC52 needs it standalone because it **cannot use LPCOMP** — its battery divider is FET-gated, so holding the divider connected through SYSTEMOFF costs ~2.6 mA continuously. A board that shut down to protect a depleted cell would drain it faster than it could recover. USB-attach wake costs nothing standing.

## Hardware-verified

- **Display, repeater and room-server roles all render on the panel** (owner-confirmed).
- **Boot traced on the wire** via the UART mirror (P0.08, carrier header pin 11): `APP:CTOR` → `setup:ENTRY` → SafeBoot → `board.begin` → `crashLogStandardInit` → radio.
- **`fem on` / `fem off` exercised on hardware** — reports `can=yes` on RC52 and `can=no` on RC32/RCC6/RAK4631, which is the correct capability gating.
- **CrashLog init does not hang here** — the RC32 #740/#741 fault does not reproduce on this board.

## The FEM capability (#983), and its deliberate divergence

RC52 now exposes the stock `OFFBAND_CAP_FEM_LNA` capability, so `fem on/off` works on the CLI and the client shows the toggle as it does for HV4.3 and T096.

⚠ **It means something different on this board, and that is owner-approved.** On T096/HV4 (KCT8103L) "off" only pulls the LNA out of the **RX** path — `setTxModeEnable()` forces `CTX` HIGH unconditionally, so the flag has no TX effect. On RC52 (HT-RA62A) "off" cuts **whole-module power**: `FEM_EN` (P0.26) + `VFEM_CTRL` (P0.16) both low, TX and RX. It does **not** touch `SX126X_RXEN`/P1.07, which stays with RadioLib's rf-switch.

The prior code declined this capability on the grounds that claiming it "would mean taking RXEN away from RadioLib." That reasoning was wrong: it mapped the capability to the LNA pin, when two board-owned power pins were available that RadioLib never touches.

## ⚠ The TX deficit this epic chased does not exist

`[verified: owner-operated four-board bench sweep, 2026-08-25]`

| tx 22 | RC52 | RC32 | RCC6 | RAK4631 |
|---|---|---|---|---|
| | +20.30 | +20.30 | +20.30 | +20.30 |

All four ceiling identically — one FEM board and three without, three MCU families, two vendors. The **−1.70 dB is the measurement chain, not the radio**.

Both the original **−6.9 dB** and its first "correction" to **−2.04 dB** were sampling artifacts: a 2 MHz sweep for a 62.5 kHz signal parked the analyser on the carrier ~3% of each sweep, so most 150 ms bursts were never sampled. Resolved by zero-span gating.

Commit `45a794e1` strips those numbers from the source comment that cited them as evidence. **The FEM power-up reorder (#931) stands on general power-sequencing grounds only — it fixed nothing, because nothing was broken.** The comment says so explicitly, so the investigation is not resurrected from retracted figures.

Also recorded: the instrument quantises to **0.5 dB**, so board-to-board differences below that are unmeasurable on this bench.

## Review gate — Gemini 2.5 Pro, adversarial

**Fixed** — finding 4 (Low): `RC52Board.cpp` used `#include "../../src/helpers/diagnostics/CrashLog.h"`, the only file in the tree using that fragile relative form. Now `<helpers/diagnostics/CrashLog.h>`, matching how `src/` includes it.

**Found while checking the gate's premise, which the gate missed** — the comment above `checkBootVoltage()` read *"bootlock is 0, so this returns immediately."* False since #857 set the threshold; `PWRMGT_VOLTAGE_BOOTLOCK` is **3300 mV and armed**. Anyone reading it would have concluded a low-voltage trip was impossible here. Corrected, with the RC52-specific consequence recorded: a false trip has no automatic escape, because `initiateShutdown()` arms USB wake only.

**Refuted** — finding 1 (rated High): *"`powerOff()` cuts power to the entire radio module before SPI shutdown."* `[verified: rc52.pdf]` U6 has **two independent supplies** — `VDD_3V3` (pin 10, ungated) and `VDD_FEM` (pin 25, gated by `VFEM_Ctrl`). The SX1262 stays powered; there is no SPI-to-a-dead-chip path. A **residual does survive** — the radio reset drives internal DIO2 into an unpowered FEM rail — filed as [#985](https://github.com/OffbandMesh/meshcore-firmware/issues/985). Pre-existing; this branch preserved the existing ordering rather than introducing it.

**Deferred, owner-ruled** — finding 2 (High): the single-sample boot-voltage check can trip on a transient sag, and RC52 cannot self-recover. Tracked fleet-wide on [#982](https://github.com/OffbandMesh/meshcore-firmware/issues/982) (now raised by two independent gates). The gate's proposed fix — zeroing the threshold — was **rejected**: it trades a false trip for a brownout boot loop on a genuinely flat cell.

**Non-finding** — finding 3: the gate assessed its own fleet-regression concern about the `NRF52Board` extraction as *"purely theoretical… no tangible fleet risk"*, matching the independent [#944](https://github.com/OffbandMesh/meshcore-firmware/issues/944) gate verdict on the same code.

## Verification

`pio run` **8/8 SUCCESS**, re-run after rebase onto `firmware-base`:

- all five RC52 envs (`repeater`, `repeater_diag`, `room_server`, `companion_radio_ble`, `companion_radio_usb`)
- `RAK_4631_repeater`, `Heltec_t096_repeater`, `t1000e_repeater`, `heltec_v4_repeater_telemetry` — four fleet boards that compile the shared `NRF52Board` change

Secrets/private-IP scan clean over the diff and commit messages. (`ADMIN_PASSWORD="password"` / `ROOM_PASSWORD="hello"` are upstream env defaults present in 88 and 68 of 91 variants respectively, overridden at runtime on bench units.)

## Not verified here

Epic verification on hardware end-to-end is [#876](https://github.com/OffbandMesh/meshcore-firmware/issues/876), which stays open through merge. [#965](https://github.com/OffbandMesh/meshcore-firmware/issues/965) (room-server watchdog reset on first boot) is open and unfixed.

## Merge

**Ben merges.** `ci-green` is a required gate and this carries a fleet-shared change.
