### PR TITLE
epic: RC52 display — variant-local NV3001B driver, indexed palette shipped fleet-wide

### DIFF
--- a/tools/diag/rc52-display-951/evidence/951-boot-sessions.md
+++ b/tools/diag/rc52-display-951/evidence/951-boot-sessions.md
@@ -1,0 +1,124 @@
+# RC52 display bring-up — captured boot sessions (#951, #965)
+
+Curated from a continuous Feather-sniffer capture, 2026-08-23 17:39Z → 18:37Z, reading the
+MeshLog UART mirror off carrier header **pin 11** (P0.08, board TX), ground on **pin 20**.
+
+The raw capture was 1,920,700 B and contains binary runs from the DFU cycles. What matters is
+extracted here; the raw file was session-temporary and is not preserved.
+
+**Why the wire and not USB:** on this board `Serial` is USB-CDC, which dies with the chip. Every
+log ever captured that way necessarily comes from a boot that *succeeded*. The wire witnesses the
+boots that fail — which is the entire reason the `_diag` envs set `OFFBAND_LOG_MIRROR_UART`.
+
+---
+
+## Every boot recorded
+
+| Time (UTC) | Role | Reset reason | Display |
+|---|---|---|---|
+| 17:41:46 | repeater | `Soft Reset` (post-DFU) | **dark** — wrong pins (pre-`75ff23dc`) |
+| 17:49:37 | repeater | `Reset Pin` | dark — same image |
+| 18:01:02 | repeater | `Soft Reset` (post-DFU) | ✅ **renders** — first ever, corrected pins |
+| 18:04:07 | repeater | `Reset Pin` | ✅ renders |
+| 18:15:24 | room-server | `Soft Reset` (post-DFU) | ❌ **dark** — see #965 |
+| 18:15:54 | room-server | **`Watchdog`** | ✅ renders |
+| 18:34:35 | room-server | `Reset Pin` | ✅ renders |
+
+Two independent conclusions fall out of that table:
+
+1. **The repeater renders on its first post-DFU boot; the room server does not.** Same driver,
+   same panel, same artifact lineage. So the dark first boot is role-specific, not a driver or
+   a DFU property. (#965)
+2. **Only `Soft Reset` on the room-server role fails.** `Watchdog` and `Reset Pin` both render.
+
+---
+
+## The first successful render (repeater, 18:01:02)
+
+```
+[BEACON] APP:CTOR -- earliest static ctor; bootloader + platform startup COMPLETED
+[BEACON] setup:ENTRY -- before Serial.begin
+[BEACON] setup:before SafeBoot::checkAndMaybeSleep
+[BEACON] setup:post SafeBoot::checkAndMaybeSleep
+[BEACON] setup:before board.begin
+[1044] [boot] vbat=4112 mV (multiplier 4.90, nominal)
+[BEACON] setup:post board.begin
+[BEACON] setup:before crashLogStandardInit
+[CrashLog] fresh boot; no previous-boot log to recover.
+[1080] [boot] repeater up; reset=Soft Reset
+[BEACON] setup:post crashLogStandardInit
+[BEACON] setup:before board.beginBootSafety
+[BEACON] setup:post board.beginBootSafety      <- 18:01:02.462
+[1829] DEBUG: Set _preambleMillis=91           <- 18:01:03.201   (+739 ms)
+[1939] DEBUG: RadioLibWrapper: noise_floor = -120
+```
+
+**The 739 ms gap is the measurement that matters.** `display.begin()` is not beacon-instrumented
+in the role examples, but it sits between the last beacon and `radio_init()`. `RC52Display::begin()`
+contains ~430 ms of mandated delays (reset pulse 10+20+120, SWRESET 120, SLPOUT 120, DISPON 10)
+plus ~100 command writes and a full-screen clear and blit. A skipped call shows a near-zero gap.
+
+Use this gap as the cheap proxy for "did the display driver actually run" on any future RC52 boot.
+
+**No `back buffer alloc FAILED` line**, so the 56,320 B buffer allocated — the buffered path is
+what rendered.
+
+**`crashLogStandardInit` completed**, printing `fresh boot; no previous-boot log to recover`. The
+RC32 #740/#741 CrashLog boot hang does **not** reproduce on RC52.
+
+---
+
+## The failing room-server boot (18:15:24)
+
+```
+[BEACON] setup:post crashLogStandardInit       <- 18:15:24.815
+[1803] DEBUG: Set _preambleMillis=91           <- 18:15:25.551   (+736 ms)
+[1835] DEBUG: loop - skipping busy (or evicted) client 4F
+[1915] DEBUG: RadioLibWrapper: noise_floor = -119
+...                                             (~29 s of normal operation)
+[BEACON] APP:CTOR                              <- 18:15:53.520
+[1071] [boot] room-server up; reset=Watchdog   <- 18:15:54.601
+```
+
+**736 ms — the same window as the boot that rendered.** So on the dark boot the driver ran, took
+its normal init time, and produced nothing. It did not hang and it was not skipped. The board then
+served a client normally for 29 s before the watchdog fired.
+
+That is the heart of #965: a role that runs correctly, shows nothing, and resets itself once.
+
+---
+
+## Remote reset is NOT functional on this rig
+
+```
+18:35:54.163  <<< INJECT RST
+18:35:54.165  >>> RST asserted  @up=56252s
+18:35:54.265  >>> RST released -- RC32 booting
+```
+
+No boot banner followed; board `millis()` ran continuously through it ([77682] and climbing).
+Owner confirmed the RST/USER wires are landed on the wrong pins.
+
+**A failed inject is not evidence of a dead board.** SNIFFER-v3 reports `RST asserted` /
+`RST released` whether or not anything is connected to A0.
+
+Correct Feather landing, per the SNIFFER-v3 sketch header: board **pin 18 (RST) → A0**, fourth
+wire → **A1**, board TX → Feather RX (or TX under `SNIFFER_RC52`), GND → GND. Note the hardware
+log's 2026-08-19 entry describes a *different* rig (`wroom-sniffer`, GPIO17/GPIO16) which was not
+attached during this session.
+
+⚠ **RC52 has no BOOT pin.** RC32 pin 5 is `GPIO0/BOOT`, an ESP32 strap; RC52 pin 5 is `P1.10` =
+USER. The sketch's `A1`/`BOOT` naming and its `BOOTRST` command are RC32 carry-overs and mean
+nothing on this board.
+
+---
+
+## Incidental observations, not chased
+
+- The room server emits `DEBUG: loop - skipping busy (or evicted) client 4F` about every 156 ms,
+  continuously, whenever client `4F` is attached. Unexamined; may be normal, may be related to the
+  watchdog in #965.
+- Board clock reads `15/5/2024` on every boot — no RTC sync. Expected without GPS or a time source.
+- `noise_floor` sits at −112 to −120 across all boots. The radio is unaffected by any of this.
+
+Agent: RainyHeron (session 6071ff56)

--- a/variants/heltec_rc52/RC52Display.cpp
+++ b/variants/heltec_rc52/RC52Display.cpp
@@ -1,0 +1,882 @@
+// ---------------------------------------------------------------------------
+// RC52-LOCAL NV3001B DRIVER (#949, epic #948)
+//
+// See RC52Display.h for why this file duplicates src/helpers/ui/NV3001BDisplay.cpp
+// instead of porting it. Short version: porting edits a file the whole fleet
+// compiles; duplicating inside one variant cannot regress RC32 or RCC6.
+//
+// EVERYTHING except the bus layer is carried over unchanged from the shared
+// driver. If a symptom appears in the panel half, compare against that file
+// first -- a divergence there is a porting bug, not an RC52 finding.
+// ---------------------------------------------------------------------------
+
+// The RC52 base build_src_filter compiles this whole variant directory, so this
+// file is fed to the headless envs too. It must collapse to nothing there:
+// the UIColor definitions below would otherwise collide at link with the ones
+// in NullDisplayDriver.cpp, which the headless envs legitimately compile.
+// Guarding the translation unit is more robust than relying on src-filter
+// ordering, and it fails loudly at link rather than silently drawing nowhere.
+#if defined(HELTEC_RC52_WITH_DISPLAY)
+
+#include "RC52Display.h"
+#include <helpers/ui/Rgb565Blit.h>          // shared clip + native-resolution blit
+#include <helpers/ui/Rc32Palette.h>         // dark theme colour roles
+#include <helpers/ui/JbmFont.h>             // antialiased JetBrains Mono glyph table
+#include <helpers/ui/OffbandLogoRGB565.h>   // this panel's colour splash art
+#include <Arduino.h>
+#include <string.h>
+
+// These four headers are READ, not modified. #948's acceptance criterion is that
+// `git diff` touches nothing under src/helpers/ui/ -- including a shared header
+// is not a change to it, and it keeps the palette, font and artwork identical to
+// the sibling boards rather than forking a second copy of each.
+
+#ifndef SPI_FREQUENCY
+  // SPIM3 is the nRF52840's 32 MHz instance, but the panel is the limit, not the
+  // bus. 8 MHz matches what the shared driver runs on RC32 with this same glass;
+  // raising it is a separate, measured change, not a free win to assume.
+  #define SPI_FREQUENCY 8000000
+#endif
+
+#ifndef PIN_TFT_SCK
+  #error "PIN_TFT_SCK must be defined (variants/heltec_rc52/variant.h)"
+#endif
+
+#ifndef PIN_TFT_MOSI
+  #error "PIN_TFT_MOSI must be defined (variants/heltec_rc52/variant.h)"
+#endif
+
+#ifndef PIN_TFT_CS
+  #error "PIN_TFT_CS must be defined (variants/heltec_rc52/variant.h)"
+#endif
+
+#ifndef PIN_TFT_DC
+  #error "PIN_TFT_DC must be defined (variants/heltec_rc52/variant.h)"
+#endif
+
+#ifndef PIN_TFT_RST
+  #define PIN_TFT_RST -1
+#endif
+
+// Panel power and backlight. NOTE THE OPPOSITE POLARITIES -- this is the single
+// easiest thing to get backwards on this board, and either mistake presents as a
+// dead panel with no error anywhere (the panel is write-only; there is nothing
+// to fail on). Values come from the vendor BSP via variant.h, not from a sibling
+// board.
+#ifndef PIN_TFT_VDD_CTL
+  #define PIN_TFT_VDD_CTL -1
+#endif
+
+#ifndef TFT_VDD_ENABLE
+  #define TFT_VDD_ENABLE LOW     // ACTIVE LOW
+#endif
+
+#ifndef PIN_TFT_LEDA_CTL
+  #define PIN_TFT_LEDA_CTL -1
+#endif
+
+#ifndef TFT_LEDA_ENABLE
+  #define TFT_LEDA_ENABLE HIGH   // ACTIVE HIGH
+#endif
+
+#ifndef DISPLAY_ROTATION
+  #define DISPLAY_ROTATION 0
+#endif
+
+// Post-rotation drawing surface. The glass is physically 128x220 portrait; the
+// UI orientation is landscape, which is what MADCTL's MV bit produces.
+#ifndef RC52_SCREEN_WIDTH
+  #define RC52_SCREEN_WIDTH 220
+#endif
+
+#ifndef RC52_SCREEN_HEIGHT
+  #define RC52_SCREEN_HEIGHT 128
+#endif
+
+#ifndef DISPLAY_SCALE_X
+  #define DISPLAY_SCALE_X ((float)RC52_SCREEN_WIDTH / RC52_DISPLAY_LOGICAL_WIDTH)
+#endif
+
+#ifndef DISPLAY_SCALE_Y
+  #define DISPLAY_SCALE_Y ((float)RC52_SCREEN_HEIGHT / RC52_DISPLAY_LOGICAL_HEIGHT)
+#endif
+
+#define NV3001B_SWRESET 0x01
+#define NV3001B_SLPOUT  0x11
+#define NV3001B_DISPON  0x29
+#define NV3001B_CASET   0x2A
+#define NV3001B_RASET   0x2B
+#define NV3001B_RAMWR   0x2C
+#define NV3001B_MADCTL  0x36
+#define NV3001B_COLMOD  0x3A
+
+#define NV3001B_MADCTL_MY  0x80
+#define NV3001B_MADCTL_MX  0x40
+#define NV3001B_MADCTL_MV  0x20
+#define NV3001B_MADCTL_RGB 0x00
+
+#ifndef RC52_TEXT_SIZE1_SCALE_X
+  #define RC52_TEXT_SIZE1_SCALE_X 1
+#endif
+
+#ifndef RC52_TEXT_SIZE1_SCALE_Y
+  #define RC52_TEXT_SIZE1_SCALE_Y 2
+#endif
+
+// Colour scheme -- shared with RC32/RCC6 via Rc32Palette.h so the family looks
+// like one product. Values and rationale live in that header because it can be
+// unit-tested; this file cannot be compiled natively.
+//
+// These nine symbols are declared in DisplayDriver.h and must be defined exactly
+// once per link. NullDisplayDriver.cpp also defines them, which is why the
+// with-display env excludes it -- see the note at the top of this file.
+ColorVal UIColor::window_bkg    = rc32_palette::WINDOW_BKG;
+ColorVal UIColor::title_bkg     = rc32_palette::TITLE_BKG;
+ColorVal UIColor::title_txt     = rc32_palette::TITLE_TXT;
+ColorVal UIColor::primary_txt   = rc32_palette::PRIMARY_TXT;
+ColorVal UIColor::secondary_txt = rc32_palette::SECONDARY_TXT;
+ColorVal UIColor::warning_txt   = rc32_palette::WARNING_TXT;
+ColorVal UIColor::popup_bkg     = rc32_palette::POPUP_BKG;
+ColorVal UIColor::popup_txt     = rc32_palette::POPUP_TXT;
+ColorVal UIColor::corp_blue     = rc32_palette::CORP_ACCENT;
+
+static int scaleX(int x) {
+  return (int)(x * DISPLAY_SCALE_X);
+}
+
+static int scaleY(int y) {
+  return (int)(y * DISPLAY_SCALE_Y);
+}
+
+static int scaleWidth(int x, int w) {
+  if (w <= 0) return 0;
+  int scaled = scaleX(x + w) - scaleX(x);
+  return scaled > 0 ? scaled : 1;
+}
+
+static int scaleHeight(int y, int h) {
+  if (h <= 0) return 0;
+  int scaled = scaleY(y + h) - scaleY(y);
+  return scaled > 0 ? scaled : 1;
+}
+
+static uint8_t nv3001bMADCTL(uint8_t rotation) {
+  uint8_t madctl;
+  switch (rotation & 3) {
+    case 0:
+      madctl = NV3001B_MADCTL_MY | NV3001B_MADCTL_MV | NV3001B_MADCTL_RGB;
+      break;
+    case 1:
+      madctl = NV3001B_MADCTL_MY | NV3001B_MADCTL_MX | NV3001B_MADCTL_RGB;
+      break;
+    case 2:
+      madctl = NV3001B_MADCTL_RGB;
+      break;
+    default:
+      madctl = NV3001B_MADCTL_MX | NV3001B_MADCTL_MV | NV3001B_MADCTL_RGB;
+      break;
+  }
+  return madctl;
+}
+
+static void setupOptionalOutput(int pin, int level) {
+  if (pin < 0) return;
+
+  pinMode(pin, OUTPUT);
+  digitalWrite(pin, level);
+}
+
+static void writeOptionalPin(int pin, int level) {
+  if (pin < 0) return;
+
+  digitalWrite(pin, level);
+}
+
+// ---------------------------------------------------------------------------
+// Bus layer -- nRF52840 SPIM3 via the core's SPI1 instance.
+//
+// THIS IS THE ONLY PART THAT DIFFERS FROM THE SHARED DRIVER. Three nRF52 facts
+// drive it, all read from the framework rather than assumed:
+//
+// 1. SPIClass::begin() TAKES NO PINS. The ESP32 form is begin(SCK, MISO, MOSI,
+//    CS); on this core the pins come from the SPIClass constructor, and the core
+//    already built SPI1 from PIN_SPI1_* -- which are the panel's pins.
+//    [framework-arduinoadafruitnrf52/libraries/SPI/SPI.h:81, SPI.cpp:289]
+//
+// 2. transfer(void* buf, size_t) IS DESTRUCTIVE. It is transfer(buf, buf, count)
+//    and overwrites the caller's buffer. Used on the back buffer it would
+//    corrupt the frame on every flush and look exactly like display noise rather
+//    than like a bus fault. The three-argument form with rx_buf == NULL is the
+//    correct write-only call: the implementation explicitly sets rx_length to 0
+//    when rx_buf is null, so nothing is written back.
+//    [SPI.h:69-70, SPI.cpp transfer(tx,rx,count)]
+//
+// 3. EasyDMA SOURCES FROM RAM ONLY, and this core does NOT bounce-buffer -- it
+//    passes the caller's pointer straight to nrfx_spim_xfer. A flash-resident
+//    buffer therefore transfers garbage, silently. Every bulk write here is
+//    checked and bounced if needed rather than trusting call sites to remember.
+// ---------------------------------------------------------------------------
+
+// nRF52840 SRAM is 0x20000000..0x2003FFFF (256 KB). Flash -- and so any data not
+// explicitly copied into RAM -- is below 0x20000000 and cannot be a DMA source.
+//
+// This is a RANGE check, not a mask on the top byte. A mask would accept the
+// whole 16 MB 0x20xxxxxx block, i.e. any address from 0x20040000 up, which is
+// not memory on this part. The failure a mask allows is a silent DMA read from a
+// nonexistent address -- garbage on the panel with nothing to trace it to.
+// (Gemini review finding 3, #949.)
+static inline bool isRamPointer(const void* p) {
+  const uintptr_t addr = (uintptr_t)p;
+  return addr >= 0x20000000u && addr < 0x20040000u;
+}
+
+// Bounce/expansion buffer size for the two bulk paths below. Deliberately a
+// STACK buffer at each call site rather than one file-static shared by both.
+//
+// A shared static is not safe here and locking it would be the wrong fix. The
+// Gemini review (#949) raised two mechanisms; only one survived checking:
+//
+//   REFUTED -- "reused while a previous transfer is still in flight". This core
+//   calls nrfx_spim_init(&_spim, &cfg, NULL, NULL); a NULL event handler selects
+//   nrfx's BLOCKING mode, so nrfx_spim_xfer returns only once the transfer has
+//   completed. There is no in-flight window.
+//   [verified: framework-arduinoadafruitnrf52/libraries/SPI/SPI.cpp:101]
+//
+//   REAL -- two contexts rendering concurrently would interleave writes into one
+//   shared buffer and corrupt each other's pixels silently. Today nothing does:
+//   the only callers of `display` in this role are UITask.cpp and main.cpp, both
+//   on the Arduino loop task. But that is a property of today's call sites, not
+//   of this driver, and it is exactly the kind of assumption that stops being
+//   true without anyone noticing.
+//
+// A stack buffer is re-entrant by construction, needs no mutex, has no
+// initialisation order to get wrong, and costs 128 B on a render path that
+// already carries a 64 B chunk buffer. Removing the shared state beats guarding
+// it.
+#define RC52_BOUNCE_BYTES 128
+
+void RC52Display::busBegin() {
+  // Pins come from the SPI1 constructor (PIN_SPI1_MISO/SCK/MOSI in variant.h),
+  // which is why there is no pin list here. PIN_SPI1_MISO is P0.12 and is NOT
+  // wired to the panel -- the core needs a valid pin number to construct with,
+  // and this panel is write-only, so nothing ever reads it.
+  SPI1.begin();
+
+  // CS is driven by hand rather than by the peripheral: the panel needs CS held
+  // across a command-plus-data pair, which a per-transfer hardware CS would
+  // break between them.
+  pinMode(PIN_TFT_CS, OUTPUT);
+  digitalWrite(PIN_TFT_CS, HIGH);
+}
+
+void RC52Display::busBeginTransaction() {
+  SPI1.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
+}
+
+void RC52Display::busEndTransaction() {
+  SPI1.endTransaction();
+}
+
+void RC52Display::busWrite8(uint8_t b) {
+  SPI1.transfer(b);
+}
+
+void RC52Display::busWriteBytes(const uint8_t* data, size_t len) {
+  if (!data || len == 0) return;
+
+  if (isRamPointer(data)) {
+    // Write-only: rx_buf NULL means rx_length 0, so `data` is never written to.
+    SPI1.transfer((const void*)data, (void*)nullptr, len);
+    return;
+  }
+
+  // Flash-resident source. Bounce through RAM in chunks rather than handing
+  // EasyDMA an address it cannot read. Slower, but correct -- and it only
+  // happens if a caller passes a genuinely flash-resident array, which the
+  // panel-half code above does not (its CMD1/CMD2 payloads are function-local
+  // arrays, i.e. stack, i.e. already RAM).
+  uint8_t bounce[RC52_BOUNCE_BYTES];
+  size_t done = 0;
+  while (done < len) {
+    const size_t n = (len - done) < sizeof(bounce) ? (len - done) : sizeof(bounce);
+    memcpy(bounce, data + done, n);
+    SPI1.transfer((const void*)bounce, (void*)nullptr, n);
+    done += n;
+  }
+}
+
+// The ESP32 driver uses SPIClass::writePattern(), which packs repeats into the
+// hardware FIFO. This core has no equivalent, so the pattern is expanded into
+// the RAM scratch once and that buffer is re-sent -- same idea, same goal of not
+// paying per-byte call overhead on a full-screen fill.
+//
+// This runs only in the degraded unbuffered mode; with the back buffer present
+// (the normal case) fills are memory writes and never reach the bus.
+void RC52Display::busWritePattern(const uint8_t* pattern, size_t plen, uint32_t count) {
+  if (!pattern || plen == 0 || count == 0) return;
+
+  uint8_t expanded[RC52_BOUNCE_BYTES];
+
+  if (plen > sizeof(expanded)) {
+    // Not expected -- callers use a 2-byte pixel pattern. Degrade to a plain
+    // per-repeat write rather than silently truncating (SAFELANE 6).
+    while (count--) busWriteBytes(pattern, plen);
+    return;
+  }
+
+  const size_t reps_per_load = sizeof(expanded) / plen;   // >= 1, since plen <= sizeof
+  for (size_t i = 0; i < reps_per_load; i++) {
+    memcpy(expanded + i * plen, pattern, plen);
+  }
+  const size_t load_bytes = reps_per_load * plen;
+
+  while (count >= reps_per_load) {
+    SPI1.transfer((const void*)expanded, (void*)nullptr, load_bytes);
+    count -= (uint32_t)reps_per_load;
+  }
+  // Remainder: count < reps_per_load, so count*plen <= load_bytes and the read
+  // stays inside `expanded`. A partial prefix of whole repeats is exactly what
+  // is wanted -- the buffer holds nothing but back-to-back copies of `pattern`.
+  if (count) {
+    SPI1.transfer((const void*)expanded, (void*)nullptr, (size_t)count * plen);
+  }
+}
+
+void RC52Display::writeCommand(uint8_t cmd) {
+  busBeginTransaction();
+  digitalWrite(PIN_TFT_DC, LOW);
+  digitalWrite(PIN_TFT_CS, LOW);
+  busWrite8(cmd);
+  digitalWrite(PIN_TFT_CS, HIGH);
+  busEndTransaction();
+}
+
+void RC52Display::writeBytes(const uint8_t* data, size_t len) {
+  if (!data || len == 0) return;
+
+  busBeginTransaction();
+  digitalWrite(PIN_TFT_DC, HIGH);
+  digitalWrite(PIN_TFT_CS, LOW);
+  // Byte-at-a-time, as in the shared driver. These are init-sequence payloads of
+  // one or two bytes; routing them through DMA would cost more than it saves and
+  // would need the flash bounce above.
+  for (size_t i = 0; i < len; i++) {
+    busWrite8(data[i]);
+  }
+  digitalWrite(PIN_TFT_CS, HIGH);
+  busEndTransaction();
+}
+
+void RC52Display::writeCommandData(uint8_t cmd, const uint8_t* data, size_t len) {
+  writeCommand(cmd);
+  writeBytes(data, len);
+}
+
+void RC52Display::setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
+  uint16_t x2 = x + w - 1;
+  uint16_t y2 = y + h - 1;
+  uint8_t data[4];
+
+  data[0] = x >> 8;
+  data[1] = x & 0xff;
+  data[2] = x2 >> 8;
+  data[3] = x2 & 0xff;
+  writeCommandData(NV3001B_CASET, data, sizeof(data));
+
+  data[0] = y >> 8;
+  data[1] = y & 0xff;
+  data[2] = y2 >> 8;
+  data[3] = y2 & 0xff;
+  writeCommandData(NV3001B_RASET, data, sizeof(data));
+
+  writeCommand(NV3001B_RAMWR);
+}
+
+void RC52Display::writeColor(uint16_t rgb, uint32_t count) {
+  if (count == 0) return;
+
+  const uint8_t pattern[2] = { (uint8_t)(rgb >> 8), (uint8_t)(rgb & 0xff) };
+
+  busBeginTransaction();
+  digitalWrite(PIN_TFT_DC, HIGH);
+  digitalWrite(PIN_TFT_CS, LOW);
+  busWritePattern(pattern, sizeof(pattern), count);
+  digitalWrite(PIN_TFT_CS, HIGH);
+  busEndTransaction();
+}
+
+// Panel init sequence -- carried over from the shared driver BYTE FOR BYTE.
+// These are NV3001B register values from the vendor; they are not derived and
+// must not be "tidied". If the panel is blank, suspect the bus layer or the
+// EN/BL polarities before suspecting this block, which is proven on RC32.
+void RC52Display::initPanel() {
+#define CMD0(C) do { writeCommand(C); } while (0)
+#define CMD1(C, A) do { const uint8_t d[] = { A }; writeCommandData(C, d, sizeof(d)); } while (0)
+#define CMD2(C, A, B) do { const uint8_t d[] = { A, B }; writeCommandData(C, d, sizeof(d)); } while (0)
+
+  CMD0(NV3001B_SWRESET);
+  delay(120);
+  CMD1(0xFF, 0xA5);
+  CMD1(0x41, 0x00);
+  CMD1(0x50, 0x02);
+  CMD1(0x52, 0x6E);
+  CMD1(0x57, 0x02);
+  CMD1(0x46, 0x11);
+  CMD2(0x47, 0x00, 0x01);
+  CMD2(0x8F, 0x22, 0x03);
+  CMD1(0x9A, 0x78);
+  CMD1(0x9B, 0x78);
+  CMD1(0x9C, 0xA0);
+  CMD1(0x9D, 0x17);
+  CMD1(0x9E, 0xC1);
+  CMD1(0x83, 0x5A);
+  CMD1(0x84, 0xB6);
+  CMD1(0xFF, 0xA5);
+  CMD1(0x85, 0x5F);
+  CMD1(0x6E, 0x0F);
+  CMD1(0x7E, 0x0F);
+  CMD1(0x60, 0x00);
+  CMD1(0x70, 0x00);
+  CMD1(0x6D, 0x33);
+  CMD1(0x7D, 0x37);
+  CMD1(0x61, 0x09);
+  CMD1(0x71, 0x0A);
+  CMD1(0x6C, 0x2A);
+  CMD1(0x7C, 0x36);
+  CMD1(0x62, 0x11);
+  CMD1(0x72, 0x10);
+  CMD1(0x68, 0x4E);
+  CMD1(0x78, 0x4E);
+  CMD1(0x66, 0x36);
+  CMD1(0x76, 0x3C);
+  CMD1(0x1A, 0x1C);
+  CMD1(0x7B, 0x14);
+  CMD1(0x63, 0x0D);
+  CMD1(0x73, 0x0A);
+  CMD1(0x6A, 0x16);
+  CMD1(0x7A, 0x12);
+  CMD1(0x64, 0x0B);
+  CMD1(0x74, 0x0A);
+  CMD1(0x69, 0x08);
+  CMD1(0x79, 0x0A);
+  CMD1(0x65, 0x06);
+  CMD1(0x75, 0x07);
+  CMD1(0x67, 0x23);
+  CMD1(0x77, 0x44);
+  CMD1(0xE0, 0x00);
+  CMD1(0xE9, 0x30);
+  CMD1(0xEB, 0xB7);
+  CMD1(0xEC, 0x00);
+  CMD1(0xED, 0x11);
+  CMD1(0xF0, 0xB7);
+  CMD1(0x53, 0x04);
+  CMD1(0x54, 0x04);
+  CMD1(0x55, 0x40);
+  CMD1(0x56, 0x40);
+  CMD2(0xA0, 0x60, 0x01);
+  CMD1(0xA1, 0x84);
+  CMD1(0xA2, 0x85);
+  CMD2(0xAB, 0x00, 0x02);
+  CMD2(0xAC, 0x00, 0x06);
+  CMD2(0xAD, 0x00, 0x03);
+  CMD2(0xAE, 0x00, 0x07);
+  CMD1(0xC7, 0x01);
+  CMD1(0xB9, 0x82);
+  CMD1(0xBA, 0x83);
+  CMD1(0xBB, 0x00);
+  CMD1(0xBC, 0x81);
+  CMD1(0xBD, 0x02);
+  CMD1(0xBE, 0x01);
+  CMD1(0xBF, 0x04);
+  CMD1(0xC0, 0x03);
+  CMD1(0xC8, 0x55);
+  CMD1(0xC9, 0xC9);
+  CMD1(0xCA, 0xC8);
+  CMD1(0xCB, 0xCB);
+  CMD1(0xCC, 0xCA);
+  CMD1(0xCD, 0x55);
+  CMD1(0xCE, 0xCE);
+  CMD1(0xCF, 0xCD);
+  CMD1(0xD0, 0xD0);
+  CMD1(0xD1, 0xCF);
+  CMD1(0xF2, 0x46);
+  CMD1(0xA8, 0x04);
+  CMD1(0xA9, 0xB0);
+  CMD1(0xAA, 0xA3);
+  CMD1(0xB6, 0x00);
+  CMD1(0xB7, 0xB0);
+  CMD1(0xB8, 0xA3);
+  CMD1(0xC4, 0x03);
+  CMD1(0xC5, 0xB0);
+  CMD1(0xC6, 0xA3);
+  CMD1(0x80, 0x10);
+  CMD1(0xFF, 0x00);
+  CMD1(0x35, 0x00);
+  CMD0(NV3001B_SLPOUT);
+  delay(120);
+  CMD1(NV3001B_COLMOD, 0x05);
+  CMD1(NV3001B_MADCTL, nv3001bMADCTL(DISPLAY_ROTATION));
+  CMD0(NV3001B_DISPON);
+  delay(10);
+
+#undef CMD0
+#undef CMD1
+#undef CMD2
+}
+
+// Back buffer: 220 * 128 * 2 = 56,320 B.
+//
+// NO PSRAM PATH HERE. The shared driver tries ps_malloc first because the RC32's
+// S3 has 8 MB embedded; the nRF52840 has none, so internal SRAM is the only
+// option and the allocation is a real question on this board rather than a
+// formality. Repeater and room server have roughly 190 KB of region free and
+// this fits comfortably; the BLE companion has roughly 75 KB and does not
+// obviously fit. That is #856, and the failure is handled, not assumed away.
+void RC52Display::allocFrameBuffer() {
+  const size_t px = (size_t)RC52_SCREEN_WIDTH * RC52_SCREEN_HEIGHT;
+  const size_t bytes = px * sizeof(uint16_t);
+
+  frame_buf = (uint16_t*)malloc(bytes);
+
+  if (!frame_buf) {
+    // Loud, not silent (SAFELANE 6). The display still works, just unbuffered
+    // and flickering, so this must not later be diagnosed as "the driver is
+    // broken" or as a bus fault.
+    Serial.print("RC52Display: back buffer alloc FAILED (");
+    Serial.print((unsigned long)bytes);
+    Serial.println(" B) -- direct panel writes, expect flicker");
+    return;
+  }
+
+  // EasyDMA cannot source from flash; malloc'd memory is SRAM, but assert it
+  // rather than assume, because the whole blit silently transfers garbage if it
+  // is ever not true.
+  if (!isRamPointer(frame_buf)) {
+    Serial.println("RC52Display: back buffer is not in SRAM -- refusing to DMA from it");
+    free(frame_buf);
+    frame_buf = nullptr;
+  }
+}
+
+// One transfer for the whole frame. Pixels are already byte-swapped in the
+// buffer, so this is a straight byte blit with no per-pixel work.
+void RC52Display::blitFrameBuffer() {
+  if (!frame_buf || !is_on) return;
+
+  setAddrWindow(0, 0, RC52_SCREEN_WIDTH, RC52_SCREEN_HEIGHT);
+
+  busBeginTransaction();
+  digitalWrite(PIN_TFT_DC, HIGH);
+  digitalWrite(PIN_TFT_CS, LOW);
+  busWriteBytes((const uint8_t*)frame_buf,
+                (size_t)RC52_SCREEN_WIDTH * RC52_SCREEN_HEIGHT * sizeof(uint16_t));
+  digitalWrite(PIN_TFT_CS, HIGH);
+  busEndTransaction();
+}
+
+void RC52Display::fillPhysicalRect(int x, int y, int w, int h) {
+  if (!is_on || w <= 0 || h <= 0) return;
+
+  if (x < 0) {
+    w += x;
+    x = 0;
+  }
+  if (y < 0) {
+    h += y;
+    y = 0;
+  }
+  if (x + w > RC52_SCREEN_WIDTH) w = RC52_SCREEN_WIDTH - x;
+  if (y + h > RC52_SCREEN_HEIGHT) h = RC52_SCREEN_HEIGHT - y;
+  if (w <= 0 || h <= 0) return;
+
+  // Buffered path. This is the ONLY function that touches the panel, so
+  // intercepting here buffers every draw -- including drawChar(), which calls it
+  // once per lit font pixel.
+  if (frame_buf) {
+    const uint16_t swapped = (uint16_t)((color >> 8) | (color << 8));
+    for (int row = 0; row < h; row++) {
+      uint16_t* p = frame_buf + (size_t)(y + row) * RC52_SCREEN_WIDTH + x;
+      for (int col = 0; col < w; col++) p[col] = swapped;
+    }
+    return;
+  }
+
+  setAddrWindow(x, y, w, h);
+  writeColor(color, (uint32_t)w * h);
+}
+
+// Colour art at native panel resolution. Coordinates are PHYSICAL pixels and
+// deliberately do not pass through scaleX()/scaleY(): the logical canvas is
+// 128x64 against a 220x128 panel -- 1.72x horizontally, 2.0x vertically -- so art
+// drawn logically comes out non-uniformly stretched and circular arcs become
+// ellipses.
+void RC52Display::drawRGB565(int x, int y, const uint16_t* px, int w, int h) {
+  if (!is_on || !px) return;
+
+  if (frame_buf) {
+    rgb565::blitSwapped(frame_buf, RC52_SCREEN_WIDTH, RC52_SCREEN_HEIGHT, x, y, px, w, h);
+    return;
+  }
+
+  // Unbuffered fallback. A failed back-buffer allocation is a supported degraded
+  // state rather than a lost display, so this path is real and must draw rather
+  // than silently skip (SAFELANE 6). It shares clip() with the buffered path so
+  // the two cannot disagree about geometry.
+  //
+  // NOTE this is the path #856 says has never executed on hardware on ANY board.
+  // On RC52 it is reachable for real (56 KB against a companion's ~75 KB free),
+  // which makes it the first board where it must actually be exercised rather
+  // than assumed.
+  const rgb565::Clip c = rgb565::clip(RC52_SCREEN_WIDTH, RC52_SCREEN_HEIGHT, x, y, w, h);
+  if (!c.visible) return;
+
+  // Scratch buffer, deliberately SMALL and FIXED, on a path reached only after a
+  // heap allocation has already failed -- the moment to be frugal.
+  static const int CHUNK_PX = 32;
+  uint16_t chunk[CHUNK_PX];
+
+  for (int r = 0; r < c.h; r++) {
+    const uint16_t* s = px + (size_t)(c.sy + r) * w + c.sx;
+    for (int done = 0; done < c.w; done += CHUNK_PX) {
+      const int n = (c.w - done) < CHUNK_PX ? (c.w - done) : CHUNK_PX;
+      for (int i = 0; i < n; i++) {
+        const uint16_t v = s[done + i];
+        chunk[i] = (uint16_t)((v >> 8) | (v << 8));
+      }
+      setAddrWindow(c.dx + done, c.dy + r, n, 1);
+      busBeginTransaction();
+      digitalWrite(PIN_TFT_DC, HIGH);
+      digitalWrite(PIN_TFT_CS, LOW);
+      // `chunk` is stack -- SRAM -- so this is a legal DMA source.
+      busWriteBytes((const uint8_t*)chunk, (size_t)n * sizeof(uint16_t));
+      digitalWrite(PIN_TFT_CS, HIGH);
+      busEndTransaction();
+    }
+  }
+}
+
+// Blend one RGB565 pair by a 0..15 coverage. Channels are blended separately in
+// their own bit widths; doing it on the packed value would bleed carries between
+// red, green and blue.
+static inline uint16_t blend565(uint16_t fg, uint16_t bg, uint8_t cov) {
+  if (cov >= 15) return fg;
+  if (cov == 0) return bg;
+  const uint16_t fr = (fg >> 11) & 0x1F, fgn = (fg >> 5) & 0x3F, fb = fg & 0x1F;
+  const uint16_t br = (bg >> 11) & 0x1F, bgn = (bg >> 5) & 0x3F, bb = bg & 0x1F;
+  const uint16_t r = (uint16_t)((fr * cov + br * (15 - cov)) / 15);
+  const uint16_t g = (uint16_t)((fgn * cov + bgn * (15 - cov)) / 15);
+  const uint16_t b = (uint16_t)((fb * cov + bb * (15 - cov)) / 15);
+  return (uint16_t)((r << 11) | (g << 5) | b);
+}
+
+int RC52Display::physicalWidth() const { return RC52_SCREEN_WIDTH; }
+int RC52Display::physicalHeight() const { return RC52_SCREEN_HEIGHT; }
+
+const DisplayDriver::ColourArt* RC52Display::colourSplashArt() const {
+#ifdef OFFBAND_SPLASH_RGB565_W
+  static const ColourArt art{ offband_splash_rgb565,
+                              OFFBAND_SPLASH_RGB565_W, OFFBAND_SPLASH_RGB565_H,
+                              OFFBAND_SPLASH_RGB565_X, OFFBAND_SPLASH_RGB565_Y };
+  return &art;
+#else
+  return nullptr;
+#endif
+}
+
+// Antialiased JetBrains Mono. Coverage is blended against what is already in the
+// back buffer, so text antialiases correctly over any background. When the
+// buffer is absent there is nothing to read back, so coverage is thresholded
+// instead: visibly worse, but the alternative is invisible or wrongly-blended
+// text.
+void RC52Display::drawChar(int x, int y, char ch) {
+  if (ch < JBM_FIRST_CH || ch > JBM_LAST_CH) ch = '?';
+
+  const int scale = text_size <= 1 ? 1 : text_size;
+  const uint8_t* glyph = jbm_glyphs + (size_t)(ch - JBM_FIRST_CH) * JBM_BYTES_PER_GLYPH;
+
+  for (int row = 0; row < JBM_CELL_H; row++) {
+    for (int col = 0; col < JBM_CELL_W; col++) {
+      const int k = row * JBM_CELL_W + col;
+      const uint8_t byte = pgm_read_byte(glyph + (k >> 1));
+      const uint8_t cov = (k & 1) ? (byte & 0x0F) : (byte >> 4);
+      if (cov == 0) continue;
+
+      const int px = x + col * scale;
+      const int py = y + row * scale;
+
+      if (frame_buf) {
+        for (int dy = 0; dy < scale; dy++) {
+          const int ty = py + dy;
+          if (ty < 0 || ty >= RC52_SCREEN_HEIGHT) continue;
+          for (int dx = 0; dx < scale; dx++) {
+            const int tx = px + dx;
+            if (tx < 0 || tx >= RC52_SCREEN_WIDTH) continue;
+            uint16_t* dst = frame_buf + (size_t)ty * RC52_SCREEN_WIDTH + tx;
+            // Buffer holds byte-swapped pixels; unswap, blend, re-swap.
+            const uint16_t bg = (uint16_t)((*dst >> 8) | (*dst << 8));
+            const uint16_t out = blend565(color, bg, cov);
+            *dst = (uint16_t)((out >> 8) | (out << 8));
+          }
+        }
+      } else if (cov >= 8) {
+        fillPhysicalRect(px, py, scale, scale);
+      }
+    }
+  }
+}
+
+bool RC52Display::begin() {
+  if (is_on) return true;
+
+  if (periph_power) periph_power->claim();
+
+  // TFT_VDD_CTL is ACTIVE LOW and TFT_LEDA_CTL is ACTIVE HIGH. Both are asserted
+  // through the same two helpers, so the polarity lives in exactly one place per
+  // pin and cannot drift between begin() and turnOff().
+  setupOptionalOutput(PIN_TFT_VDD_CTL, TFT_VDD_ENABLE);
+  setupOptionalOutput(PIN_TFT_LEDA_CTL, !TFT_LEDA_ENABLE);   // backlight off until the panel has content
+  pinMode(PIN_TFT_CS, OUTPUT);
+  pinMode(PIN_TFT_DC, OUTPUT);
+  digitalWrite(PIN_TFT_CS, HIGH);
+  digitalWrite(PIN_TFT_DC, HIGH);
+  delay(20);
+
+  busBegin();
+  if (PIN_TFT_RST >= 0) {
+    pinMode(PIN_TFT_RST, OUTPUT);
+    digitalWrite(PIN_TFT_RST, HIGH);
+    delay(10);
+    digitalWrite(PIN_TFT_RST, LOW);
+    delay(20);
+    digitalWrite(PIN_TFT_RST, HIGH);
+    delay(120);
+  }
+
+  initPanel();
+  is_on = true;
+  allocFrameBuffer();   // before the first fill, so it lands in the buffer
+  color = 0x0000;
+  fillPhysicalRect(0, 0, RC52_SCREEN_WIDTH, RC52_SCREEN_HEIGHT);
+  blitFrameBuffer();    // push the initial clear -- begin() has no endFrame()
+  color = 0xffff;
+  text_size = 1;
+  cursor_x = 0;
+  cursor_y = 0;
+  writeOptionalPin(PIN_TFT_LEDA_CTL, TFT_LEDA_ENABLE);
+  return true;
+}
+
+void RC52Display::turnOn() {
+  begin();
+}
+
+void RC52Display::turnOff() {
+  if (!is_on) return;
+
+  writeOptionalPin(PIN_TFT_LEDA_CTL, !TFT_LEDA_ENABLE);
+  writeOptionalPin(PIN_TFT_VDD_CTL, !TFT_VDD_ENABLE);
+  is_on = false;
+  if (periph_power) periph_power->release();
+}
+
+void RC52Display::clear() {
+  uint16_t saved = color;
+  color = UIColor::window_bkg;
+  fillPhysicalRect(0, 0, RC52_SCREEN_WIDTH, RC52_SCREEN_HEIGHT);
+  color = saved;
+  // clear() is a standalone operation, not part of a startFrame/endFrame pair,
+  // so it must push its own result -- otherwise with the back buffer active it
+  // would silently do nothing visible.
+  blitFrameBuffer();
+}
+
+void RC52Display::startFrame(ColorVal bkg) {
+  color = bkg;
+  fillPhysicalRect(0, 0, RC52_SCREEN_WIDTH, RC52_SCREEN_HEIGHT);
+  color = UIColor::primary_txt;
+  text_size = 1;
+  cursor_x = 0;
+  cursor_y = 0;
+}
+
+void RC52Display::setTextSize(int sz) {
+  text_size = sz < 1 ? 1 : sz;
+}
+
+void RC52Display::setColor(ColorVal c) {
+  color = c;
+}
+
+void RC52Display::setCursor(int x, int y) {
+  cursor_x = scaleX(x);
+  cursor_y = scaleY(y);
+}
+
+void RC52Display::print(const char* str) {
+  if (!str || !is_on) return;
+
+  // Metrics come from the glyph table, not a 5x7 assumption. Must stay in step
+  // with getTextWidth() or every centring decision drifts.
+  const int scale = text_size <= 1 ? 1 : text_size;
+  while (*str) {
+    if (*str == '\n') {
+      cursor_x = 0;
+      cursor_y += JBM_CELL_H * scale;
+    } else if (*str == '\r') {
+      cursor_x = 0;
+    } else {
+      drawChar(cursor_x, cursor_y, *str);
+      cursor_x += JBM_ADVANCE * scale;
+    }
+    str++;
+  }
+}
+
+void RC52Display::fillRect(int x, int y, int w, int h) {
+  fillPhysicalRect(scaleX(x), scaleY(y), scaleWidth(x, w), scaleHeight(y, h));
+}
+
+void RC52Display::drawRect(int x, int y, int w, int h) {
+  int x1 = scaleX(x);
+  int y1 = scaleY(y);
+  int sw = scaleWidth(x, w);
+  int sh = scaleHeight(y, h);
+
+  fillPhysicalRect(x1, y1, sw, 1);
+  fillPhysicalRect(x1, y1 + sh - 1, sw, 1);
+  fillPhysicalRect(x1, y1, 1, sh);
+  fillPhysicalRect(x1 + sw - 1, y1, 1, sh);
+}
+
+void RC52Display::drawXbm(int x, int y, const uint8_t* bits, int w, int h) {
+  if (!bits || !is_on) return;
+
+  int byte_width = (w + 7) / 8;
+  for (int j = 0; j < h; j++) {
+    for (int i = 0; i < w; i++) {
+      uint8_t byte = pgm_read_byte(bits + j * byte_width + i / 8);
+      if (byte & (0x80 >> (i & 7))) {
+        fillPhysicalRect(scaleX(x + i), scaleY(y + j), scaleWidth(x + i, 1), scaleHeight(y + j, 1));
+      }
+    }
+  }
+}
+
+uint16_t RC52Display::getTextWidth(const char* str) {
+  if (!str) return 0;
+
+  uint16_t len = 0;
+  while (str[len] && str[len] != '\n' && str[len] != '\r') len++;
+  // Must agree with print()'s advance or every centring decision drifts.
+  const int scale = text_size <= 1 ? 1 : text_size;
+  return (uint16_t)((len * JBM_ADVANCE * scale) / DISPLAY_SCALE_X);
+}
+
+// The frame is drawn into RAM by fillPhysicalRect(); push it here in one
+// transfer. An empty endFrame() is what erases and redraws the panel in front of
+// the user on every update.
+void RC52Display::endFrame() {
+  blitFrameBuffer();
+}
+
+#endif  // HELTEC_RC52_WITH_DISPLAY

--- a/variants/heltec_rc52/RC52Display.cpp
+++ b/variants/heltec_rc52/RC52Display.cpp
@@ -755,6 +755,33 @@ void RC52Display::allocFrameBuffer() {
 
 // One transfer for the whole frame. Pixels are already byte-swapped in the
 // buffer, so this is a straight byte blit with no per-pixel work.
+#if defined(RC52_DISPLAY_BUFFER_INDEXED)
+// #948: FULL-COLOUR ART OVERLAY -- composited during the blit, not bypassed.
+//
+// Indexed cannot hold arbitrary art: the palette is the UI's brand colours and
+// their blend ramps, so forcing a colour logo through nearest-match posterises
+// it. The first attempt dodged that by writing art STRAIGHT TO THE PANEL and
+// skipping the buffer, reasoning that "the splash draws once at boot, so the
+// repaint costs nothing."
+//
+// That reasoning was wrong, and the hardware said so. The splash renders INSIDE
+// startFrame()/endFrame() and repeatedly -- SplashScreen::render() returns 1000,
+// so once a second for the whole boot screen -- and every endFrame() blits the
+// buffer over the entire panel. The art was painted and then immediately erased.
+// Owner-observed: "the lockup graphic flashed in and out", while the text below
+// it, which lives in the buffer, stayed put. [verified: rc52-bench-1, 2026-08-26]
+//
+// So the art is neither bypassed nor quantised. It is remembered for the frame
+// and substituted into the blit's EXISTING per-pixel unpack loop -- which only
+// runs for indexed anyway. Art pixels pass through at full RGB565; every other
+// pixel is the same palette lookup as before. One transfer, no flash, no
+// posterisation, and no extra RAM: the source stays in flash and only a pointer
+// and a rect are held. Cleared by startFrame(), so it lives exactly one frame
+// and cannot leak onto a later screen.
+static const uint16_t* s_art_px = nullptr;
+static int s_art_x = 0, s_art_y = 0, s_art_w = 0, s_art_h = 0;
+#endif
+
 void RC52Display::blitFrameBuffer() {
   if (!frame_buf || !is_on) return;
 
@@ -780,6 +807,28 @@ void RC52Display::blitFrameBuffer() {
     size_t done = 0;
     while (done < total) {
       const size_t n = (total - done) < CHUNK_PX ? (total - done) : CHUNK_PX;
+#if defined(RC52_DISPLAY_BUFFER_INDEXED)
+      // Row/col tracked incrementally: one division per 64-pixel chunk rather
+      // than per pixel. Hoisted on s_art_px so the ordinary UI path -- every
+      // frame that is not the splash -- runs byte-for-byte the loop it did
+      // before this overlay existed.
+      if (s_art_px) {
+        int y = (int)((done) / RC52_SCREEN_WIDTH);
+        int x = (int)((done) % RC52_SCREEN_WIDTH);
+        for (size_t i = 0; i < n; i++) {
+          uint16_t c;
+          const int ax = x - s_art_x, ay = y - s_art_y;
+          if (ax >= 0 && ax < s_art_w && ay >= 0 && ay < s_art_h) {
+            c = s_art_px[(size_t)ay * s_art_w + ax];   // full RGB565, untouched
+          } else {
+            c = pxUnpack(frame_buf[done + i]);
+          }
+          out[i * 2]     = (uint8_t)(c >> 8);
+          out[i * 2 + 1] = (uint8_t)(c & 0xff);
+          if (++x >= RC52_SCREEN_WIDTH) { x = 0; y++; }
+        }
+      } else
+#endif
       for (size_t i = 0; i < n; i++) {
         const uint16_t c = pxUnpack(frame_buf[done + i]);
         out[i * 2]     = (uint8_t)(c >> 8);    // big-endian, as the panel expects
@@ -839,20 +888,22 @@ void RC52Display::drawRGB565(int x, int y, const uint16_t* px, int w, int h) {
   if (!is_on || !px) return;
 
 #if defined(RC52_DISPLAY_BUFFER_INDEXED)
-  // INDEXED DELIBERATELY BYPASSES THE BUFFER FOR COLOUR ART.
+  // Colour art is composited during the blit, not written here. See the overlay
+  // note above blitFrameBuffer(): the palette cannot represent arbitrary art, and
+  // painting straight to the panel loses it to the very next endFrame() blit.
+  // Recording it keeps full RGB565 fidelity AND survives the blit.
   //
-  // The palette holds the UI's six brand colours and their blend ramps. Full
-  // colour artwork cannot be represented in it -- forcing the splash through
-  // nearest-match would posterise it badly, and widening the palette to cover
-  // arbitrary art would give back the exactness that is the entire point.
-  //
-  // Going straight to the panel costs a visible repaint, and here that costs
-  // nothing: the splash draws ONCE at boot. Flicker matters on the 5-second UI
-  // repaint cycle, not on a one-shot boot image. So the art stays full 16bpp
-  // fidelity and the UI stays pixel-exact -- the buffer is simply not the right
-  // tool for this one call.
-  //
-  // Falls through to the unbuffered path below.
+  // Cleared every startFrame(), so this is per-frame state -- art must be drawn
+  // each frame it should appear, which is exactly what SplashScreen::render()
+  // does.
+  if (frame_buf) {
+    s_art_px = px;
+    s_art_x  = x;  s_art_y = y;
+    s_art_w  = w;  s_art_h = h;
+    return;
+  }
+  // No buffer (RC52_DISPLAY_DISABLE_BACKBUFFER): fall through and paint direct,
+  // which is correct -- with nothing blitting over it, direct IS the frame.
 #else
   if (frame_buf) {
 #if defined(RC52_DISPLAY_BUFFER_8BPP)
@@ -1054,6 +1105,11 @@ void RC52Display::clear() {
 }
 
 void RC52Display::startFrame(ColorVal bkg) {
+#if defined(RC52_DISPLAY_BUFFER_INDEXED)
+  // Per-frame lifetime: art must be re-drawn each frame it should appear, so it
+  // cannot bleed onto a later screen that does not draw it.
+  s_art_px = nullptr;
+#endif
   color = bkg;
   fillPhysicalRect(0, 0, RC52_SCREEN_WIDTH, RC52_SCREEN_HEIGHT);
   color = UIColor::primary_txt;
@@ -1165,13 +1221,20 @@ void RC52Display::endFrame() {
 
   unsigned long nonbg = 0;
   if (frame_buf) {
-    // The buffer holds byte-swapped pixels; compare against the background in
-    // the same representation rather than unswapping 28k times.
-    const uint16_t bg_swapped =
-        (uint16_t)((UIColor::window_bkg >> 8) | (UIColor::window_bkg << 8));
+    // Compare against whatever the BACKGROUND WOULD BE STORED AS in this build's
+    // pixel format -- pxPack() answers that for all three (palette index, RGB332
+    // byte, or byte-swapped RGB565) -- rather than unswapping 28k pixels.
+    //
+    // ⚠ This previously hard-coded a byte-swapped uint16_t RGB565 comparand.
+    // Correct at 16bpp; WRONG the moment the buffer holds 8-bit values, because a
+    // uint8_t index can never equal a uint16_t above 255 -- so it reported
+    // px_nonbg = 28160 (every pixel) on every frame, unconditionally. It read as
+    // a rendering anomaly and is simply a broken instrument. Fixed 2026-08-26,
+    // when indexed became the shipping default and made it wrong everywhere.
+    const rc52_px_t bg_ref = pxPack(UIColor::window_bkg);
     const size_t px = (size_t)RC52_SCREEN_WIDTH * RC52_SCREEN_HEIGHT;
     for (size_t i = 0; i < px; i++) {
-      if (frame_buf[i] != bg_swapped) nonbg++;
+      if (frame_buf[i] != bg_ref) nonbg++;
     }
   }
   offband::crashLogf("[rc52disp] endFrame #%lu on=%d buf=%d px_nonbg=%lu",

--- a/variants/heltec_rc52/RC52Display.cpp
+++ b/variants/heltec_rc52/RC52Display.cpp
@@ -25,6 +25,12 @@
 #include <helpers/ui/OffbandLogoRGB565.h>   // this panel's colour splash art
 #include <Arduino.h>
 #include <string.h>
+// Unconditional: the back-buffer failure paths report through crashLogf on EVERY
+// build, not only diag ones. A silent allocation failure is a SAFELANE 6 defect
+// regardless of which env is being built, and gating the reporting on a diag flag
+// would mean the one configuration nobody is watching is also the one that says
+// nothing. crashLogf itself is unconditional in CrashLog.h.
+#include <helpers/diagnostics/CrashLog.h>
 
 // These four headers are READ, not modified. #948's acceptance criterion is that
 // `git diff` touches nothing under src/helpers/ui/ -- including a shared header
@@ -139,6 +145,141 @@ ColorVal UIColor::warning_txt   = rc32_palette::WARNING_TXT;
 ColorVal UIColor::popup_bkg     = rc32_palette::POPUP_BKG;
 ColorVal UIColor::popup_txt     = rc32_palette::POPUP_TXT;
 ColorVal UIColor::corp_blue     = rc32_palette::CORP_ACCENT;
+
+// ---------------------------------------------------------------------------
+// Back-buffer pack/unpack. EVERY read and write of frame_buf goes through these
+// two, so the storage format lives in exactly one place and the drawing code
+// below is identical for both depths.
+//
+// 16bpp stores BYTE-SWAPPED RGB565, because the panel wants big-endian and that
+// makes the blit a plain byte copy with no per-pixel work.
+//
+// 8bpp stores RGB332. The expansion back to 565 replicates high bits into the
+// low ones (r3 -> r5 as (r<<2)|(r>>1)) so full-scale stays full-scale -- a plain
+// left-shift would make white come out as 0xF7DE rather than 0xFFFF, and every
+// light colour would read slightly dark.
+// ---------------------------------------------------------------------------
+// Defined further down next to drawChar, which is its other caller; the palette
+// builder needs it here to generate the blend ramps.
+static inline uint16_t blend565(uint16_t fg, uint16_t bg, uint8_t cov);
+
+#if defined(RC52_DISPLAY_BUFFER_INDEXED)
+// ---------------------------------------------------------------------------
+// INDEXED PALETTE (#856)
+//
+// 256 entries of RGB565, built once in begin(). 512 B of .bss, which is nothing
+// against the 28,160 B the 8bpp buffer saves.
+//
+// Layout, and the ordering is deliberate -- exact colours first so the common
+// case is found immediately:
+//   [0 .. NUM_BRAND-1]        the brand colours, EXACT. Every flat fill and both
+//                             endpoints of every text blend land here.
+//   [NUM_BRAND .. ramps_end]  16-step blends for the fg/bg pairs text actually
+//                             antialiases against.
+//   [ramps_end .. used_end]   a 32-step grey ramp, so anything unanticipated has
+//                             something sane to snap to.
+//
+// Entries beyond used_end are never searched. There is no need to fill 256 slots
+// for a UI that uses six colours.
+// ---------------------------------------------------------------------------
+static uint16_t s_pal[256];
+static uint16_t s_pal_used = 0;
+
+// The fg/bg pairs drawChar blends between. Anything not listed still renders --
+// it just snaps to the nearest entry rather than having a bespoke ramp.
+struct PalPair { uint16_t fg, bg; };
+
+static void rc52BuildPalette() {
+  if (s_pal_used) return;   // built once
+
+  const uint16_t brand[] = {
+    rc32_palette::WINDOW_BKG, rc32_palette::PRIMARY_TXT, rc32_palette::SECONDARY_TXT,
+    rc32_palette::TITLE_BKG,  rc32_palette::TITLE_TXT,   rc32_palette::POPUP_BKG,
+    rc32_palette::POPUP_TXT,  rc32_palette::WARNING_TXT, rc32_palette::CORP_ACCENT,
+  };
+  const uint16_t n_brand = (uint16_t)(sizeof(brand) / sizeof(brand[0]));
+  for (uint16_t i = 0; i < n_brand; i++) s_pal[i] = brand[i];
+  s_pal_used = n_brand;
+
+  const PalPair pairs[] = {
+    { rc32_palette::PRIMARY_TXT,   rc32_palette::WINDOW_BKG },
+    { rc32_palette::TITLE_TXT,     rc32_palette::TITLE_BKG  },
+    { rc32_palette::POPUP_TXT,     rc32_palette::POPUP_BKG  },
+    { rc32_palette::SECONDARY_TXT, rc32_palette::WINDOW_BKG },
+    { rc32_palette::WARNING_TXT,   rc32_palette::WINDOW_BKG },
+  };
+  for (uint16_t p = 0; p < (uint16_t)(sizeof(pairs) / sizeof(pairs[0])); p++) {
+    for (uint8_t cov = 1; cov < 15; cov++) {          // 0 and 15 are the endpoints, already exact
+      if (s_pal_used >= 256) break;
+      s_pal[s_pal_used++] = blend565(pairs[p].fg, pairs[p].bg, cov);
+    }
+  }
+
+  for (uint16_t g = 0; g < 32 && s_pal_used < 256; g++) {
+    const uint16_t v5 = (uint16_t)(g >> 0) & 0x1F;
+    const uint16_t v6 = (uint16_t)(g << 1) & 0x3F;
+    s_pal[s_pal_used++] = (uint16_t)((v5 << 11) | (v6 << 5) | v5);
+  }
+}
+
+// Nearest entry by squared error in RGB565's own channel widths. Green is
+// weighted x2 because it carries most of the luminance, so a green error is more
+// visible than an equal-magnitude red or blue one.
+static uint8_t rc52NearestIndex(uint16_t c) {
+  const int cr = (c >> 11) & 0x1F, cg = (c >> 5) & 0x3F, cb = c & 0x1F;
+  uint32_t best = 0xFFFFFFFFu;
+  uint8_t  best_i = 0;
+  for (uint16_t i = 0; i < s_pal_used; i++) {
+    const uint16_t p = s_pal[i];
+    const int dr = ((p >> 11) & 0x1F) - cr;
+    const int dg = ((p >> 5)  & 0x3F) - cg;
+    const int db = ( p        & 0x1F) - cb;
+    const uint32_t e = (uint32_t)(dr * dr) + (uint32_t)(2 * dg * dg) + (uint32_t)(db * db);
+    if (e < best) { best = e; best_i = (uint8_t)i; if (e == 0) break; }
+  }
+  return best_i;
+}
+#endif  // RC52_DISPLAY_BUFFER_INDEXED
+
+static inline rc52_px_t pxPack(uint16_t c565) {
+#if defined(RC52_DISPLAY_BUFFER_INDEXED)
+  // Exact hit short-circuits the search, and that is the common case: every flat
+  // fill and both endpoints of every glyph are brand colours sitting in the first
+  // few slots. A tiny memo covers runs of identical blend values inside a glyph.
+  static uint16_t memo_c = 0xFFFF;
+  static uint8_t  memo_i = 0;
+  if (c565 == memo_c) return (rc52_px_t)memo_i;
+  for (uint16_t i = 0; i < s_pal_used; i++) {
+    if (s_pal[i] == c565) { memo_c = c565; memo_i = (uint8_t)i; return (rc52_px_t)i; }
+  }
+  const uint8_t idx = rc52NearestIndex(c565);
+  memo_c = c565; memo_i = idx;
+  return (rc52_px_t)idx;
+#elif defined(RC52_DISPLAY_BUFFER_8BPP)
+  const uint8_t r = (uint8_t)((c565 >> 13) & 0x07);   // top 3 of 5
+  const uint8_t g = (uint8_t)((c565 >> 8)  & 0x07);   // top 3 of 6
+  const uint8_t b = (uint8_t)((c565 >> 3)  & 0x03);   // top 2 of 5
+  return (rc52_px_t)((r << 5) | (g << 2) | b);
+#else
+  return (rc52_px_t)((c565 >> 8) | (c565 << 8));
+#endif
+}
+
+static inline uint16_t pxUnpack(rc52_px_t v) {
+#if defined(RC52_DISPLAY_BUFFER_INDEXED)
+  return s_pal[v];
+#elif defined(RC52_DISPLAY_BUFFER_8BPP)
+  const uint8_t r3 = (uint8_t)((v >> 5) & 0x07);
+  const uint8_t g3 = (uint8_t)((v >> 2) & 0x07);
+  const uint8_t b2 = (uint8_t)( v       & 0x03);
+  const uint16_t r5 = (uint16_t)((r3 << 2) | (r3 >> 1));
+  const uint16_t g6 = (uint16_t)((g3 << 3) | g3);
+  const uint16_t b5 = (uint16_t)((b2 << 3) | (b2 << 1) | (b2 >> 1));
+  return (uint16_t)((r5 << 11) | (g6 << 5) | b5);
+#else
+  return (uint16_t)((v >> 8) | (v << 8));
+#endif
+}
 
 static int scaleX(int x) {
   return (int)(x * DISPLAY_SCALE_X);
@@ -533,18 +674,70 @@ void RC52Display::initPanel() {
 // this fits comfortably; the BLE companion has roughly 75 KB and does not
 // obviously fit. That is #856, and the failure is handled, not assumed away.
 void RC52Display::allocFrameBuffer() {
-  const size_t px = (size_t)RC52_SCREEN_WIDTH * RC52_SCREEN_HEIGHT;
-  const size_t bytes = px * sizeof(uint16_t);
+  // #951 LEAK FIX -- this guard is load-bearing, do not remove it.
+  //
+  // begin() runs on EVERY turnOn(), not just once: turnOff() clears is_on, so the
+  // early-out at the top of begin() stops guarding, and the whole init sequence
+  // re-runs. Without this, every display off->on cycle allocated another buffer
+  // and abandoned the previous one.
+  //
+  // Observed on hardware 2026-08-23: the board ran buffered from boot, auto-offed
+  // after 15 s, then a message arrived, turnOn() re-entered begin(), the second
+  // 28 KB allocation failed against the leaked first one, frame_buf went null and
+  // the panel flickered from then on. It presented as "8bpp did not fix the
+  // flicker" when in fact 8bpp was working and this was eating it.
+  //
+  // Keeping the buffer across off/on is also strictly better than free-and-realloc:
+  // there is no window where a transient allocation failure can cost the buffer,
+  // and nothing is gained by returning it while the display is merely dark.
+  //
+  // The same structure exists in the shared NV3001BDisplay, which this was ported
+  // from -- see #951. Boards with more headroom leak more cycles before it bites.
+  if (frame_buf) return;
 
-  frame_buf = (uint16_t*)malloc(bytes);
+  const size_t px = (size_t)RC52_SCREEN_WIDTH * RC52_SCREEN_HEIGHT;
+  const size_t bytes = px * sizeof(rc52_px_t);   // 56,320 B at 16bpp, 28,160 B at 8bpp
+
+#ifdef RC52_DISPLAY_DISABLE_BACKBUFFER
+  // #856/#951 BENCH EXPERIMENT -- deliberately skip the back buffer.
+  //
+  // Two things at once: it hands ~56 KB back to the heap, which tests whether
+  // `new HomeScreen` failing is really a memory problem; and it is the FIRST
+  // execution of the unbuffered draw path on hardware, on ANY board in this
+  // fleet. That path was written as a supported degraded state and has never
+  // once run.
+  //
+  // Expect it to look worse, and expect that honestly:
+  //   * FLICKER. startFrame() fills the whole panel over SPI before anything is
+  //     drawn, so the erase is visible. This is the exact defect #747's back
+  //     buffer was added to fix on RC32, where it was observed and then
+  //     owner-confirmed gone.
+  //   * ALIASED TEXT. drawChar() antialiases by reading the existing pixel back
+  //     out of the buffer and blending. With no buffer there is nothing to read,
+  //     so coverage is thresholded instead.
+  //
+  // NOT a shipping configuration. Bench only.
+  frame_buf = nullptr;
+  offband::crashLogf("[rc52disp] back buffer DISABLED by build flag (%u B returned to heap)",
+                     (unsigned)bytes);
+  return;
+#endif
+
+  frame_buf = (rc52_px_t*)malloc(bytes);
 
   if (!frame_buf) {
-    // Loud, not silent (SAFELANE 6). The display still works, just unbuffered
-    // and flickering, so this must not later be diagnosed as "the driver is
-    // broken" or as a bus fault.
-    Serial.print("RC52Display: back buffer alloc FAILED (");
-    Serial.print((unsigned long)bytes);
-    Serial.println(" B) -- direct panel writes, expect flicker");
+    // Loud, not silent (SAFELANE 6) -- but loud ON A CHANNEL SOMEONE READS.
+    //
+    // This previously used Serial.print. On a _ble build `Serial` is USB-CDC and
+    // is a debug channel nothing is attached to, so the message was effectively
+    // silent on exactly the board class where it fired. It cost a wrong
+    // conclusion on 2026-08-23 ("8bpp did not fix the flicker") because the
+    // allocation failure that caused it reported into the void.
+    //
+    // crashLogf goes to the ring AND out the #953 UART mirror, which is the wire
+    // that is actually being watched during bring-up.
+    offband::crashLogf("[rc52disp] back buffer alloc FAILED (%u B) -- unbuffered, expect flicker",
+                       (unsigned)bytes);
     return;
   }
 
@@ -552,7 +745,9 @@ void RC52Display::allocFrameBuffer() {
   // rather than assume, because the whole blit silently transfers garbage if it
   // is ever not true.
   if (!isRamPointer(frame_buf)) {
-    Serial.println("RC52Display: back buffer is not in SRAM -- refusing to DMA from it");
+    // Same reasoning as the alloc-failure path above: report on the mirror, not
+    // on an unread USB-CDC debug channel.
+    offband::crashLogf("[rc52disp] back buffer is not in SRAM -- refusing to DMA from it");
     free(frame_buf);
     frame_buf = nullptr;
   }
@@ -568,8 +763,38 @@ void RC52Display::blitFrameBuffer() {
   busBeginTransaction();
   digitalWrite(PIN_TFT_DC, HIGH);
   digitalWrite(PIN_TFT_CS, LOW);
+
+#if defined(RC52_DISPLAY_BUFFER_8BPP) || defined(RC52_DISPLAY_BUFFER_INDEXED)
+  // The panel always wants 16bpp big-endian, so an 8bpp buffer is expanded on
+  // the way out. pxUnpack() is either the RGB332 expansion or a palette lookup;
+  // this loop does not care which. The SPI byte count is unchanged -- 56,320 either way -- so this
+  // costs CPU, not bus time, and the bus is the bottleneck.
+  //
+  // Expanded in chunks through a stack buffer rather than pixel-by-pixel: a
+  // per-pixel transfer would be 28,160 separate calls, which is the mistake #745
+  // fixed in the shared driver. Stack, so it is SRAM and a legal DMA source.
+  {
+    static const size_t CHUNK_PX = 64;
+    uint8_t out[CHUNK_PX * 2];
+    const size_t total = (size_t)RC52_SCREEN_WIDTH * RC52_SCREEN_HEIGHT;
+    size_t done = 0;
+    while (done < total) {
+      const size_t n = (total - done) < CHUNK_PX ? (total - done) : CHUNK_PX;
+      for (size_t i = 0; i < n; i++) {
+        const uint16_t c = pxUnpack(frame_buf[done + i]);
+        out[i * 2]     = (uint8_t)(c >> 8);    // big-endian, as the panel expects
+        out[i * 2 + 1] = (uint8_t)(c & 0xff);
+      }
+      busWriteBytes(out, n * 2);
+      done += n;
+    }
+  }
+#else
+  // 16bpp is stored pre-swapped, so the blit is a straight byte copy.
   busWriteBytes((const uint8_t*)frame_buf,
-                (size_t)RC52_SCREEN_WIDTH * RC52_SCREEN_HEIGHT * sizeof(uint16_t));
+                (size_t)RC52_SCREEN_WIDTH * RC52_SCREEN_HEIGHT * sizeof(rc52_px_t));
+#endif
+
   digitalWrite(PIN_TFT_CS, HIGH);
   busEndTransaction();
 }
@@ -593,10 +818,10 @@ void RC52Display::fillPhysicalRect(int x, int y, int w, int h) {
   // intercepting here buffers every draw -- including drawChar(), which calls it
   // once per lit font pixel.
   if (frame_buf) {
-    const uint16_t swapped = (uint16_t)((color >> 8) | (color << 8));
+    const rc52_px_t packed = pxPack(color);
     for (int row = 0; row < h; row++) {
-      uint16_t* p = frame_buf + (size_t)(y + row) * RC52_SCREEN_WIDTH + x;
-      for (int col = 0; col < w; col++) p[col] = swapped;
+      rc52_px_t* p = frame_buf + (size_t)(y + row) * RC52_SCREEN_WIDTH + x;
+      for (int col = 0; col < w; col++) p[col] = packed;
     }
     return;
   }
@@ -613,10 +838,40 @@ void RC52Display::fillPhysicalRect(int x, int y, int w, int h) {
 void RC52Display::drawRGB565(int x, int y, const uint16_t* px, int w, int h) {
   if (!is_on || !px) return;
 
+#if defined(RC52_DISPLAY_BUFFER_INDEXED)
+  // INDEXED DELIBERATELY BYPASSES THE BUFFER FOR COLOUR ART.
+  //
+  // The palette holds the UI's six brand colours and their blend ramps. Full
+  // colour artwork cannot be represented in it -- forcing the splash through
+  // nearest-match would posterise it badly, and widening the palette to cover
+  // arbitrary art would give back the exactness that is the entire point.
+  //
+  // Going straight to the panel costs a visible repaint, and here that costs
+  // nothing: the splash draws ONCE at boot. Flicker matters on the 5-second UI
+  // repaint cycle, not on a one-shot boot image. So the art stays full 16bpp
+  // fidelity and the UI stays pixel-exact -- the buffer is simply not the right
+  // tool for this one call.
+  //
+  // Falls through to the unbuffered path below.
+#else
   if (frame_buf) {
+#if defined(RC52_DISPLAY_BUFFER_8BPP)
+    // rgb565::blitSwapped writes 16bpp and cannot target an 8bpp buffer, so this
+    // does the same clip and walks it through pxPack(). Clipping still comes from
+    // the shared helper so the two depths cannot disagree about geometry.
+    const rgb565::Clip c = rgb565::clip(RC52_SCREEN_WIDTH, RC52_SCREEN_HEIGHT, x, y, w, h);
+    if (!c.visible) return;
+    for (int r = 0; r < c.h; r++) {
+      const uint16_t* s = px + (size_t)(c.sy + r) * w + c.sx;
+      rc52_px_t* d = frame_buf + (size_t)(c.dy + r) * RC52_SCREEN_WIDTH + c.dx;
+      for (int i = 0; i < c.w; i++) d[i] = pxPack(s[i]);
+    }
+#else
     rgb565::blitSwapped(frame_buf, RC52_SCREEN_WIDTH, RC52_SCREEN_HEIGHT, x, y, px, w, h);
+#endif
     return;
   }
+#endif  // !RC52_DISPLAY_BUFFER_INDEXED
 
   // Unbuffered fallback. A failed back-buffer allocation is a supported degraded
   // state rather than a lost display, so this path is real and must draw rather
@@ -711,11 +966,14 @@ void RC52Display::drawChar(int x, int y, char ch) {
           for (int dx = 0; dx < scale; dx++) {
             const int tx = px + dx;
             if (tx < 0 || tx >= RC52_SCREEN_WIDTH) continue;
-            uint16_t* dst = frame_buf + (size_t)ty * RC52_SCREEN_WIDTH + tx;
-            // Buffer holds byte-swapped pixels; unswap, blend, re-swap.
-            const uint16_t bg = (uint16_t)((*dst >> 8) | (*dst << 8));
+            rc52_px_t* dst = frame_buf + (size_t)ty * RC52_SCREEN_WIDTH + tx;
+            // Read what is already there, blend at full RGB565 precision, store
+            // back in whatever the buffer's format is. The blend arithmetic is
+            // always 565 -- at 8bpp only the stored result is quantised, not the
+            // maths, which keeps the coarsening to one step instead of two.
+            const uint16_t bg = pxUnpack(*dst);
             const uint16_t out = blend565(color, bg, cov);
-            *dst = (uint16_t)((out >> 8) | (out << 8));
+            *dst = pxPack(out);
           }
         }
       } else if (cov >= 8) {
@@ -754,6 +1012,11 @@ bool RC52Display::begin() {
 
   initPanel();
   is_on = true;
+#if defined(RC52_DISPLAY_BUFFER_INDEXED)
+  // Before anything can pack a pixel. Builds once; re-entry on turnOn() is a
+  // no-op, same as the buffer.
+  rc52BuildPalette();
+#endif
   allocFrameBuffer();   // before the first fill, so it lands in the buffer
   color = 0x0000;
   fillPhysicalRect(0, 0, RC52_SCREEN_WIDTH, RC52_SCREEN_HEIGHT);
@@ -875,7 +1138,46 @@ uint16_t RC52Display::getTextWidth(const char* str) {
 // The frame is drawn into RAM by fillPhysicalRect(); push it here in one
 // transfer. An empty endFrame() is what erases and redraws the panel in front of
 // the user on every update.
+//
+// ---------------------------------------------------------------------------
+// TEMPORARY INSTRUMENT (#951) -- diag builds only, remove once answered.
+//
+// Symptom being chased: the panel holds the SPLASH image indefinitely after the
+// UI has demonstrably moved to HomeScreen ([ui] setCurrScreen SPLASH -> HOME is
+// in the trace, and the board keeps running normally afterwards).
+//
+// That symptom is only possible because startFrame() writes to the BACK BUFFER
+// and touches no SPI at all. The panel therefore shows the last frame that was
+// actually blitted. So exactly one of these is true, and this tells us which:
+//
+//   endFrame not called       -> the render loop is not reaching us; the fault is
+//                                above the driver, in UITask/HomeScreen.
+//   called, px_nonbg == 0     -> HomeScreen drew nothing into the buffer.
+//   called, px_nonbg > 0      -> content exists and the blit is not landing; the
+//                                fault is mine, in blitFrameBuffer/the bus.
+//
+// Counting 28,160 pixels at Home's 5 s cadence is free relative to the blit.
+// ---------------------------------------------------------------------------
 void RC52Display::endFrame() {
+#ifdef OFFBAND_BOOT_BEACON
+  static unsigned long s_end_calls = 0;
+  s_end_calls++;
+
+  unsigned long nonbg = 0;
+  if (frame_buf) {
+    // The buffer holds byte-swapped pixels; compare against the background in
+    // the same representation rather than unswapping 28k times.
+    const uint16_t bg_swapped =
+        (uint16_t)((UIColor::window_bkg >> 8) | (UIColor::window_bkg << 8));
+    const size_t px = (size_t)RC52_SCREEN_WIDTH * RC52_SCREEN_HEIGHT;
+    for (size_t i = 0; i < px; i++) {
+      if (frame_buf[i] != bg_swapped) nonbg++;
+    }
+  }
+  offband::crashLogf("[rc52disp] endFrame #%lu on=%d buf=%d px_nonbg=%lu",
+                     s_end_calls, (int)is_on, (int)(frame_buf != nullptr), nonbg);
+#endif
+
   blitFrameBuffer();
 }
 

--- a/variants/heltec_rc52/RC52Display.h
+++ b/variants/heltec_rc52/RC52Display.h
@@ -1,0 +1,138 @@
+#pragma once
+
+// ---------------------------------------------------------------------------
+// RC52-LOCAL NV3001B DRIVER (#949, epic #948)
+//
+// This is a deliberate, scoped duplicate of src/helpers/ui/NV3001BDisplay.{h,cpp}
+// with one difference: the bus layer targets the nRF52840's SPIM3 instead of an
+// ESP32 SPI host. Nothing under src/helpers/ui/ is modified by this variant --
+// that is the acceptance criterion of #948, and it is why RC32 and RCC6 *cannot*
+// regress from RC52 display work rather than merely *should not*.
+//
+// The panel logic below (init sequence, MADCTL, address window, glyph raster,
+// back buffer, scaling) is carried over unchanged from the shared driver, which
+// is in production on RC32 hardware. Only the six bus* methods differ. Keeping
+// the panel half byte-identical is the point: a blank panel is then a bus
+// question, not a "did the port drift" question.
+//
+// WHY DUPLICATE RATHER THAN PORT THE SHARED DRIVER (#948):
+//   Porting means editing a file every board in the fleet compiles, regression
+//   testing two shipping boards, and gating RC52 on all of it. Duplication
+//   inside one variant is cheap and reversible; a fleet-wide refactor blocking
+//   this board is neither.
+// ---------------------------------------------------------------------------
+
+// Path-qualified, unlike the shared driver's bare "DisplayDriver.h". That form
+// only resolves because NV3001BDisplay.h sits in the same directory; this file
+// does not, so it goes through the src/ include root like every other consumer.
+#include <helpers/ui/DisplayDriver.h>
+#include <SPI.h>
+#include <helpers/RefCountedDigitalPin.h>
+
+// Logical canvas every DisplayDriver presents. 128x64 is an OLED-sized canvas
+// stretched onto a 220x128 panel; that distortion is inherited from the shared
+// driver and tracked fleet-wide as #705. Not fixed here -- matching the shared
+// driver's layout exactly is what makes this port reviewable.
+#ifndef RC52_DISPLAY_LOGICAL_WIDTH
+  #define RC52_DISPLAY_LOGICAL_WIDTH 128
+#endif
+
+#ifndef RC52_DISPLAY_LOGICAL_HEIGHT
+  #define RC52_DISPLAY_LOGICAL_HEIGHT 64
+#endif
+
+// ---------------------------------------------------------------------------
+// NO SOFTWARE-SPI PATH HERE, AND THAT IS DELIBERATE.
+//
+// The shared driver carries NV3001B_USE_SOFTWARE_SPI because the RCC6 has no
+// SPI peripheral left for the panel -- SPI0/SPI1 drive flash and SPI2 goes to
+// LoRa, so the vendor bit-bangs it.
+//
+// RC52 is not that board. The vendor BSP puts the TFT on SPI1 backed by SPIM3,
+// the nRF52840's single 32 MHz instance, with LoRa on SPI0
+// (SPI_INTERFACES_COUNT 2, SPI_32MHZ_INTERFACE 1). There is a dedicated
+// hardware SPI here and no contention to avoid. Do NOT port the RCC6 workaround
+// into this file reflexively -- it would be slower for no reason.
+// ---------------------------------------------------------------------------
+
+class RC52Display : public DisplayDriver {
+  RefCountedDigitalPin* periph_power;
+  bool is_on = false;
+  uint16_t color = 0xffff;
+  uint8_t text_size = 1;
+  int cursor_x = 0;
+  int cursor_y = 0;
+
+  // Back buffer. Every panel write funnels through fillPhysicalRect(), so when
+  // this is non-null the draw path writes here instead of over SPI and
+  // endFrame() blits the whole thing in one transfer. Pixels are stored
+  // BYTE-SWAPPED (the panel wants big-endian RGB565) so the blit is a plain
+  // byte write with no per-pixel conversion.
+  //
+  // Null is a SUPPORTED state: allocation failure degrades to direct-to-panel
+  // writes rather than losing the display (SAFELANE 6). On this board that is
+  // not hypothetical -- 220*128*2 = 56,320 B against 237,568 B of region, and
+  // the BLE companion role already spends ~162 KB of it. See #856.
+  uint16_t* frame_buf = nullptr;
+
+  void allocFrameBuffer();
+  void blitFrameBuffer();
+
+  // Bus abstraction. Every panel write goes through these six, so the whole
+  // nRF52-vs-ESP32 difference between this file and the shared driver is
+  // contained here.
+  void busBegin();
+  void busBeginTransaction();
+  void busEndTransaction();
+  void busWrite8(uint8_t b);
+  void busWriteBytes(const uint8_t* data, size_t len);
+  void busWritePattern(const uint8_t* pattern, size_t plen, uint32_t count);
+
+  void writeCommand(uint8_t cmd);
+  void writeBytes(const uint8_t* data, size_t len);
+  void writeCommandData(uint8_t cmd, const uint8_t* data, size_t len);
+  void setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
+  void writeColor(uint16_t rgb, uint32_t count);
+  void fillPhysicalRect(int x, int y, int w, int h);
+  void initPanel();
+  void drawChar(int x, int y, char ch);
+
+public:
+  // NOTE: no SPIClass member. The Arduino core already instantiates
+  //   SPIClass SPI1(_SPI1_DEV, PIN_SPI1_MISO, PIN_SPI1_SCK, PIN_SPI1_MOSI)
+  // from this variant's own pins, and those pins ARE the panel's
+  // (PIN_SPI1_MOSI == PIN_TFT_MOSI == P1.03, PIN_SPI1_SCK == PIN_TFT_SCK ==
+  // P0.30). Constructing a second SPIClass over the same SPIM instance would
+  // fight the core's. Reference it; do not construct one.
+  RC52Display(RefCountedDigitalPin* power = nullptr) :
+      DisplayDriver(RC52_DISPLAY_LOGICAL_WIDTH, RC52_DISPLAY_LOGICAL_HEIGHT), periph_power(power) { }
+
+  bool begin();
+  static const char* driverName() { return "RC52-NV3001B"; }
+
+  // POST-ROTATION drawing size, not the panel's memory orientation.
+  int physicalWidth() const override;
+  int physicalHeight() const override;
+
+  // This driver's own colour splash art. Capability and asset are one
+  // declaration, so no per-variant flag can be forgotten.
+  const ColourArt* colourSplashArt() const override;
+
+  bool isOn() override { return is_on; }
+  void turnOn() override;
+  void turnOff() override;
+  void clear() override;
+  void startFrame(ColorVal bkg = UIColor::window_bkg) override;
+  void setTextSize(int sz) override;
+  void setColor(ColorVal c) override;
+  void setCursor(int x, int y) override;
+  void print(const char* str) override;
+  void fillRect(int x, int y, int w, int h) override;
+  void drawRect(int x, int y, int w, int h) override;
+  void drawXbm(int x, int y, const uint8_t* bits, int w, int h) override;
+  // Colour art at NATIVE panel resolution -- physical pixels, deliberately
+  // bypassing scaleX()/scaleY().
+  void drawRGB565(int x, int y, const uint16_t* px, int w, int h) override;
+  uint16_t getTextWidth(const char* str) override;
+  void endFrame() override;
+};

--- a/variants/heltec_rc52/RC52Display.h
+++ b/variants/heltec_rc52/RC52Display.h
@@ -88,6 +88,15 @@
 //
 // Indexed stores the brand colours EXACTLY. Only text-antialiasing blends are
 // approximated, and only to the nearest entry in a purpose-built ramp.
+// #856: the buffer-format flags are MUTUALLY EXCLUSIVE. INDEXED is now set in the
+// shared [Heltec_RC52_with_display] base, so a bench env that adds 8BPP on top
+// would inherit both -- and because pxPack() tests INDEXED first, it would build
+// as INDEXED while its name said 8bpp, quietly turning an A/B into a comparison
+// of indexed against itself. Refuse to build instead of measuring a lie.
+#if defined(RC52_DISPLAY_BUFFER_INDEXED) && defined(RC52_DISPLAY_BUFFER_8BPP)
+  #error "RC52_DISPLAY_BUFFER_INDEXED and _8BPP are mutually exclusive. INDEXED comes from the shared display base -- add -U RC52_DISPLAY_BUFFER_INDEXED to the env that wants 8bpp."
+#endif
+
 #if defined(RC52_DISPLAY_BUFFER_INDEXED) || defined(RC52_DISPLAY_BUFFER_8BPP)
   typedef uint8_t  rc52_px_t;
 #else

--- a/variants/heltec_rc52/RC52Display.h
+++ b/variants/heltec_rc52/RC52Display.h
@@ -55,6 +55,45 @@
 // into this file reflexively -- it would be slower for no reason.
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// BACK BUFFER STORAGE FORMAT (#856)
+//
+// The full-frame buffer is what removes flicker: without it startFrame() erases
+// the physical panel over SPI before anything is drawn, and the repaint is
+// visible. Measured on this board, unbuffered: ~167 ms per frame against ~13 ms
+// buffered, and boot ~4 s slower.
+//
+// But at 16bpp it costs 220*128*2 = 56,320 B, and on this board that is the
+// difference between `new HomeScreen` succeeding and failing (#973). RGB332
+// halves it to 28,160 B and keeps the buffer -- so flicker stays fixed and 28 KB
+// comes back.
+//
+// The cost is colour fidelity: 3 bits red, 3 green, 2 blue. Text antialiasing
+// blends through fewer distinct shades, and the colour splash art quantises.
+// Both are quality, not function.
+//
+// Default stays 16bpp. This is opt-in per env so the two can be compared on the
+// same panel rather than argued about.
+// ---------------------------------------------------------------------------
+// RC52_DISPLAY_BUFFER_INDEXED -- 8 bits per pixel, but the byte is an INDEX into
+// a 256-entry RGB565 table rather than a packed colour. Same 28,160 B as RGB332
+// and the same flicker fix, without RGB332's colour error.
+//
+// Why not RGB332: measured on this palette, RGB332 shifts DEEP (#1A7A44, the
+// title-bar green) by dR -24 dG -12 dB +16 -- it loses all its red and gains
+// blue, reading visibly more blue-green. MUTED drifts +33 blue. Blue only gets
+// 2 bits in 332, i.e. four levels across the whole channel, so any colour with a
+// small blue component snaps to the nearest quarter. Owner spotted the green on
+// hardware before this was computed.
+//
+// Indexed stores the brand colours EXACTLY. Only text-antialiasing blends are
+// approximated, and only to the nearest entry in a purpose-built ramp.
+#if defined(RC52_DISPLAY_BUFFER_INDEXED) || defined(RC52_DISPLAY_BUFFER_8BPP)
+  typedef uint8_t  rc52_px_t;
+#else
+  typedef uint16_t rc52_px_t;
+#endif
+
 class RC52Display : public DisplayDriver {
   RefCountedDigitalPin* periph_power;
   bool is_on = false;
@@ -73,7 +112,7 @@ class RC52Display : public DisplayDriver {
   // writes rather than losing the display (SAFELANE 6). On this board that is
   // not hypothetical -- 220*128*2 = 56,320 B against 237,568 B of region, and
   // the BLE companion role already spends ~162 KB of it. See #856.
-  uint16_t* frame_buf = nullptr;
+  rc52_px_t* frame_buf = nullptr;
 
   void allocFrameBuffer();
   void blitFrameBuffer();

--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -142,11 +142,17 @@ build_flags =
   ; Colour splash: opt-in, and scoped to this block on purpose -- it pulls in a
   ; 16.8 KB RGB565 asset that has no business in the headless envs.
   -D OFFBAND_COLOUR_SPLASH
-  ; Rotation 0 = MY|MV = landscape. The glass is physically 128x220 portrait;
-  ; that is the GLASS, not the required UI orientation. Same mapping as RC32,
-  ; where 0 was owner-confirmed on hardware after 1/2/3 were each rejected.
-  ; UNVERIFIED ON RC52 HARDWARE -- this board has never rendered. Confirm the
-  ; orientation on the panel before treating this value as settled.
+  ; Rotation 0 = MY|MV = 0xA0 = landscape. The glass is physically 128x220
+  ; portrait; that is the GLASS, not the required UI orientation.
+  ;
+  ; ✅ OWNER-CONFIRMED ON RC52 HARDWARE 2026-08-23 -- text renders correct and
+  ; readable on the first successful render this board has ever produced (#951).
+  ;
+  ; NOTE FOR ANYONE READING HELTEC'S RCC6 TFT GUIDE: that document says the T108
+  ; is portrait and needs MADCTL 0x00, warning that 0xA0 renders only a 128x128
+  ; square with the rest jumbled. That was the leading hypothesis here and it did
+  ; NOT transfer -- 0xA0 is correct on this board, exactly as on RC32. Do not
+  ; "fix" this to 2 on the strength of the RCC6 guide.
   -D DISPLAY_ROTATION=0
   ; 8 MHz matches what the shared driver runs on RC32 with this same glass.
   ; SPIM3 can go faster; that is a separate measured change, not a free win.

--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -139,6 +139,30 @@ build_flags =
   ${heltec_rc52_common.build_flags}
   -D HELTEC_RC52_WITH_DISPLAY
   -D DISPLAY_CLASS=RC52Display
+  ; -------------------------------------------------------------------------
+  ; INDEXED-PALETTE BACK BUFFER -- the shipping default for EVERY RC52 display
+  ; env, not a bench option (#856).
+  ;
+  ; It has to live HERE, in the shared base, because it is the fix that makes
+  ; the companion role work at all: at 16bpp the 56,320 B buffer left ZERO
+  ; allocatable bytes, `new HomeScreen` (480 B) failed, and that silently stops
+  ; all rendering (#973). Indexed halves the buffer to 28,160 B (+512 B table)
+  ; and measured 16,384 B largest-free-block after the change.
+  ;
+  ; RGB332 was tried and rejected on measurement: round-tripped through this
+  ; driver's own pack/unpack, DEEP (#1A7A44, the title-bar green) came back
+  ; dR -24 dG -12 dB +16 -- all its red gone and blue added. Blue gets 2 bits in
+  ; 332. Indexed stores an INDEX into an RGB565 table, so brand colours are held
+  ; EXACTLY and only intermediate antialiasing steps approximate.
+  ; Owner-confirmed on hardware: green correct, no flicker.
+  ;
+  ; ⚠ It was previously set ONLY on the heltec_rc52_companion_radio_ble_diag_idx
+  ; bench env -- so the verified fix was never in a shipping build, and the
+  ; shipped companion still built the 56 KB buffer that #973 came from. Moved to
+  ; the base 2026-08-25. The _idx bench env now inherits it and is kept only as
+  ; the A/B partner for _8bpp and _nobuf.
+  ; -------------------------------------------------------------------------
+  -D RC52_DISPLAY_BUFFER_INDEXED
   ; Colour splash: opt-in, and scoped to this block on purpose -- it pulls in a
   ; 16.8 KB RGB565 asset that has no business in the headless envs.
   -D OFFBAND_COLOUR_SPLASH
@@ -287,31 +311,10 @@ build_flags =
 extends = env:heltec_rc52_companion_radio_ble_diag
 build_flags =
   ${env:heltec_rc52_companion_radio_ble_diag.build_flags}
+  ; Inherits RC52_DISPLAY_BUFFER_INDEXED from the display base and that is
+  ; harmless here: DISABLE_BACKBUFFER short-circuits allocFrameBuffer() before
+  ; the format is ever consulted, so frame_buf stays null and no pixel is packed.
   -D RC52_DISPLAY_DISABLE_BACKBUFFER
-
-; ---------------------------------------------------------------------------
-; #856: HALF-DEPTH BACK BUFFER. Candidate shipping config, not a throwaway.
-;
-; Keeps a FULL-FRAME buffer -- so the flicker stays fixed -- at RGB332 instead of
-; RGB565. 28,160 B rather than 56,320 B, handing 28 KB back to the heap without
-; touching MAX_CONTACTS, MAX_GROUP_CHANNELS or OFFLINE_QUEUE_SIZE. The owner's
-; position is that a companion should not lose contact capacity for a display
-; problem until that is genuinely the only lever left.
-;
-; What it costs, honestly: colour fidelity. 3 bits red, 3 green, 2 blue. Text
-; antialiasing resolves through fewer distinct shades and the colour splash art
-; quantises. The blend ARITHMETIC still runs at full 565 precision -- only the
-; stored result is reduced -- so the coarsening is one step, not two.
-;
-; The SPI cost is unchanged: the panel takes 56,320 bytes either way, and the
-; expansion happens on the way out through a stack chunk buffer. CPU, not bus.
-[env:heltec_rc52_companion_radio_ble_diag_8bpp]
-extends = env:heltec_rc52_companion_radio_ble_diag
-build_flags =
-  ${env:heltec_rc52_companion_radio_ble_diag.build_flags}
-  -D RC52_DISPLAY_BUFFER_8BPP
-
-; ---------------------------------------------------------------------------
 [env:heltec_rc52_companion_radio_usb]
 extends = Heltec_RC52_with_display
 board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
@@ -547,26 +550,3 @@ extends = env:heltec_rc52_without_display_companion_radio_usb_diag
 build_flags =
   ${env:heltec_rc52_without_display_companion_radio_usb_diag.build_flags}
   -D OFFBAND_CRASHLOG_DISABLED
-
-; ---------------------------------------------------------------------------
-; #856: INDEXED-PALETTE BACK BUFFER. The candidate shipping config.
-;
-; Same 28,160 B as RGB332 and the same flicker fix, but the byte is an index into
-; a 256-entry RGB565 table instead of a packed colour -- so the brand colours are
-; stored EXACTLY and only text-antialiasing blends are approximated.
-;
-; RGB332 was measured on this palette and is not good enough: DEEP (#1A7A44, the
-; title-bar green) came back dR -24 dG -12 dB +16 -- all of its red gone and blue
-; added, reading visibly more blue-green, which the owner spotted on hardware.
-; MUTED drifted +33 blue. Blue gets only 2 bits in 332, four levels for the whole
-; channel, so anything with a small blue component snaps to the nearest quarter.
-;
-; Costs: 512 B of .bss for the table, a nearest-match search on blend pixels only
-; (exact colours short-circuit, plus a memo for runs), and the colour splash goes
-; direct to the panel because full-colour art cannot live in a UI palette. The
-; splash draws once at boot, so that repaint costs nothing worth having.
-[env:heltec_rc52_companion_radio_ble_diag_idx]
-extends = env:heltec_rc52_companion_radio_ble_diag
-build_flags =
-  ${env:heltec_rc52_companion_radio_ble_diag.build_flags}
-  -D RC52_DISPLAY_BUFFER_INDEXED

--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -1,10 +1,12 @@
 ; ---------------------------------------------------------------------------
 ; Heltec RadioCore RC52 -- nRF52840 + HT-RA62A (SX1262 + FEM)
 ;
-; HEADLESS BY DESIGN (#854). There is no display env here. NV3001BDisplay does
-; not compile for nRF52 today -- its hardware-SPI path calls ESP32-only SPI APIs
-; and its `SPIClass spi;` member has no nRF52 default constructor, so even
-; NV3001B_USE_SOFTWARE_SPI=1 does not sidestep it. Adding a display env is #872.
+; HEADLESS FIRST (#854), NOT HEADLESS ONLY. The shared NV3001BDisplay still does
+; not compile for nRF52 -- its hardware-SPI path calls ESP32-only SPI APIs and
+; its `SPIClass spi;` member has no nRF52 default constructor -- and that is
+; exactly why #948/#949 put a VARIANT-LOCAL driver in this directory
+; (RC52Display.{h,cpp}) rather than porting the shared one. Display envs live
+; under [Heltec_RC52_with_display] below.
 ;
 ; No WiFi on nRF52840, so there is NO observer env and none of the MQTT/TLS-heap
 ; configuration that the RCC6 carries. That whole thread is inapplicable here.
@@ -15,7 +17,15 @@
 ; RCC6 -- the carrier is NOT pin-consistent across the family.
 ; ---------------------------------------------------------------------------
 
-[heltec_rc52]
+; Everything both the headless and the with-display roles share. The ONLY reason
+; this is split out from [heltec_rc52] is DISPLAY_CLASS: a section cannot
+; subtract an inherited -D, and redefining one on the same command line is a
+; warning GCC buries in a 1,600-line log. So the display choice is made once, by
+; whichever block you extend, and never overridden.
+;
+; [heltec_rc52] still exists below and still means "headless", so every existing
+; env keeps extending exactly what it always did. No role env changed here.
+[heltec_rc52_common]
 extends = nrf52_base
 board = heltec_rc52
 board_build.ldscript = boards/nrf52840_s140_v6.ld
@@ -69,14 +79,9 @@ build_flags = ${nrf52_base.build_flags}
   -D MAX_LORA_TX_POWER=22
   ; --- Battery: divider gate. Ratio + polarity live in variant.h. ---
   -D PIN_VBAT_READ=BATTERY_PIN
-  ; --- Headless: no display, no LED (PIN_LED1 is -1 in the vendor BSP) ---
-  -D DISPLAY_CLASS=NullDisplayDriver
 build_src_filter = ${nrf52_base.build_src_filter}
   +<helpers/*.cpp>
   +<../variants/heltec_rc52>
-  ; DISPLAY_CLASS is NullDisplayDriver here, so the inert driver and the button
-  ; handler both need compiling in -- same as heltec_rc32's _without_display_ envs.
-  +<helpers/ui/NullDisplayDriver.cpp>
   +<helpers/ui/MomentaryButton.cpp>
   ; EnvironmentSensorManager is referenced by every role's main.cpp, so its
   ; sources must link. NOTE: sensor_base's build_flags are deliberately NOT
@@ -89,6 +94,93 @@ build_src_filter = ${nrf52_base.build_src_filter}
 lib_deps =
   ${nrf52_base.lib_deps}
 upload_protocol = nrfutil
+
+; ---------------------------------------------------------------------------
+; HEADLESS BASE -- unchanged in meaning. Every pre-existing role env extends
+; this and resolves exactly the flags it always did; the two lines below simply
+; moved here out of [heltec_rc52_common] so the with-display block can make the
+; opposite choice without an override.
+;
+; No display, and no LED either (PIN_LED1 is -1 in the vendor BSP). The inert
+; driver and the button handler both need compiling in -- same as heltec_rc32's
+; _without_display_ envs.
+[heltec_rc52]
+extends = heltec_rc52_common
+build_flags =
+  ${heltec_rc52_common.build_flags}
+  -D DISPLAY_CLASS=NullDisplayDriver
+build_src_filter = ${heltec_rc52_common.build_src_filter}
+  +<helpers/ui/NullDisplayDriver.cpp>
+
+; ===========================================================================
+; WITH-DISPLAY BASE (#948 / #949 / #950)
+;
+; The T108 NV3001B panel, driven by variants/heltec_rc52/RC52Display.cpp -- a
+; VARIANT-LOCAL driver. Nothing under src/helpers/ui/ is modified by this
+; board, which is #948's acceptance criterion: RC32 and RCC6 cannot regress
+; from RC52 display work, rather than merely should not.
+;
+; THIS EXTENDS [heltec_rc52_common], NOT [heltec_rc52] -- that is the whole
+; reason the common block exists. The headless base defines
+; DISPLAY_CLASS=NullDisplayDriver, and there is no way to subtract an inherited
+; -D. `-U DISPLAY_CLASS` was tried first and does NOT work: PlatformIO does not
+; pass it through intact, and the build dies with
+; `<command-line>:0:1: error: macro names must be identifiers` on ~40 TinyUSB
+; objects, which points nowhere near the actual cause. Do not reintroduce it.
+;
+; NullDisplayDriver.cpp is simply never added here (rather than excluded), since
+; common does not pull it in. That matters: it defines the nine UIColor::
+; statics, and so does RC52Display.cpp -- compiling both is a duplicate-symbol
+; link failure.
+; ===========================================================================
+[Heltec_RC52_with_display]
+extends = heltec_rc52_common
+build_flags =
+  ${heltec_rc52_common.build_flags}
+  -D HELTEC_RC52_WITH_DISPLAY
+  -D DISPLAY_CLASS=RC52Display
+  ; Colour splash: opt-in, and scoped to this block on purpose -- it pulls in a
+  ; 16.8 KB RGB565 asset that has no business in the headless envs.
+  -D OFFBAND_COLOUR_SPLASH
+  ; Rotation 0 = MY|MV = landscape. The glass is physically 128x220 portrait;
+  ; that is the GLASS, not the required UI orientation. Same mapping as RC32,
+  ; where 0 was owner-confirmed on hardware after 1/2/3 were each rejected.
+  ; UNVERIFIED ON RC52 HARDWARE -- this board has never rendered. Confirm the
+  ; orientation on the panel before treating this value as settled.
+  -D DISPLAY_ROTATION=0
+  ; 8 MHz matches what the shared driver runs on RC32 with this same glass.
+  ; SPIM3 can go faster; that is a separate measured change, not a free win.
+  -D SPI_FREQUENCY=8000000
+build_src_filter = ${heltec_rc52_common.build_src_filter}
+lib_deps =
+  ${heltec_rc52_common.lib_deps}
+
+; ---------------------------------------------------------------------------
+; #950: repeater WITH display. First display role on this board on purpose --
+; it has ~190 KB of region free against the 56 KB back buffer, so the driver
+; can be proven without the allocation question attached. The BLE companion has
+; ~75 KB free and is where #856 actually bites; it comes last, not first.
+[env:heltec_rc52_repeater]
+extends = Heltec_RC52_with_display
+build_src_filter = ${Heltec_RC52_with_display.build_src_filter}
+  +<../examples/simple_repeater>
+build_flags =
+  ${Heltec_RC52_with_display.build_flags}
+  -D ADVERT_NAME='"RC52 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+
+; ---------------------------------------------------------------------------
+; Diag twin. Owner directive 2026-08-22: until a near-release beta, EVERY env
+; built during bring-up is a full diagnostic build. The suffix is `_diag` --
+; the RCC6 terminology, one vocabulary across the family.
+[env:heltec_rc52_repeater_diag]
+extends = env:heltec_rc52_repeater
+build_flags =
+  ${env:heltec_rc52_repeater.build_flags}
+  ${rc52_diag.build_flags}
 
 ; ---------------------------------------------------------------------------
 [env:heltec_rc52_without_display_repeater]

--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -264,6 +264,54 @@ build_flags =
   ${rc52_diag.build_flags}
 
 ; ---------------------------------------------------------------------------
+; BENCH EXPERIMENT ONLY -- #856/#951. NOT a shipping env, NOT in CI, NOT in the
+; release matrix. Do not "complete the set" by adding twins of this.
+;
+; Drops the 56,320 B back buffer, returning it to the heap. Two questions in one
+; flash:
+;   1. Does `new HomeScreen` then succeed? If yes, the silent null (#973) really
+;      is a memory problem on this board and not something structural.
+;   2. What does the unbuffered draw path actually look like? It was written as a
+;      supported degraded state and has NEVER executed on hardware on any board
+;      in this fleet.
+;
+; Expected to look worse, on two counts, both structural rather than tunable:
+;   * flicker -- startFrame() erases the panel over SPI before drawing, which is
+;     the exact defect #747's back buffer fixed on RC32;
+;   * aliased text -- drawChar() antialiases by reading the prior pixel back out
+;     of the buffer, and there is no buffer to read.
+;
+; Naming follows the established _diag_nocrashlog precedent on this board: the
+; _diag suffix stays, with the qualifier appended.
+[env:heltec_rc52_companion_radio_ble_diag_nobuf]
+extends = env:heltec_rc52_companion_radio_ble_diag
+build_flags =
+  ${env:heltec_rc52_companion_radio_ble_diag.build_flags}
+  -D RC52_DISPLAY_DISABLE_BACKBUFFER
+
+; ---------------------------------------------------------------------------
+; #856: HALF-DEPTH BACK BUFFER. Candidate shipping config, not a throwaway.
+;
+; Keeps a FULL-FRAME buffer -- so the flicker stays fixed -- at RGB332 instead of
+; RGB565. 28,160 B rather than 56,320 B, handing 28 KB back to the heap without
+; touching MAX_CONTACTS, MAX_GROUP_CHANNELS or OFFLINE_QUEUE_SIZE. The owner's
+; position is that a companion should not lose contact capacity for a display
+; problem until that is genuinely the only lever left.
+;
+; What it costs, honestly: colour fidelity. 3 bits red, 3 green, 2 blue. Text
+; antialiasing resolves through fewer distinct shades and the colour splash art
+; quantises. The blend ARITHMETIC still runs at full 565 precision -- only the
+; stored result is reduced -- so the coarsening is one step, not two.
+;
+; The SPI cost is unchanged: the panel takes 56,320 bytes either way, and the
+; expansion happens on the way out through a stack chunk buffer. CPU, not bus.
+[env:heltec_rc52_companion_radio_ble_diag_8bpp]
+extends = env:heltec_rc52_companion_radio_ble_diag
+build_flags =
+  ${env:heltec_rc52_companion_radio_ble_diag.build_flags}
+  -D RC52_DISPLAY_BUFFER_8BPP
+
+; ---------------------------------------------------------------------------
 [env:heltec_rc52_companion_radio_usb]
 extends = Heltec_RC52_with_display
 board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
@@ -499,3 +547,26 @@ extends = env:heltec_rc52_without_display_companion_radio_usb_diag
 build_flags =
   ${env:heltec_rc52_without_display_companion_radio_usb_diag.build_flags}
   -D OFFBAND_CRASHLOG_DISABLED
+
+; ---------------------------------------------------------------------------
+; #856: INDEXED-PALETTE BACK BUFFER. The candidate shipping config.
+;
+; Same 28,160 B as RGB332 and the same flicker fix, but the byte is an index into
+; a 256-entry RGB565 table instead of a packed colour -- so the brand colours are
+; stored EXACTLY and only text-antialiasing blends are approximated.
+;
+; RGB332 was measured on this palette and is not good enough: DEEP (#1A7A44, the
+; title-bar green) came back dR -24 dG -12 dB +16 -- all of its red gone and blue
+; added, reading visibly more blue-green, which the owner spotted on hardware.
+; MUTED drifted +33 blue. Blue gets only 2 bits in 332, four levels for the whole
+; channel, so anything with a small blue component snaps to the nearest quarter.
+;
+; Costs: 512 B of .bss for the table, a nearest-match search on blend pixels only
+; (exact colours short-circuit, plus a memo for runs), and the colour splash goes
+; direct to the panel because full-colour art cannot live in a UI palette. The
+; splash draws once at boot, so that repaint costs nothing worth having.
+[env:heltec_rc52_companion_radio_ble_diag_idx]
+extends = env:heltec_rc52_companion_radio_ble_diag
+build_flags =
+  ${env:heltec_rc52_companion_radio_ble_diag.build_flags}
+  -D RC52_DISPLAY_BUFFER_INDEXED

--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -183,6 +183,106 @@ build_flags =
   ${rc52_diag.build_flags}
 
 ; ---------------------------------------------------------------------------
+; #950: room server WITH display. Second-safest role for the back buffer --
+; 50,208 B static headless, so ~187 KB of region free against 56 KB.
+[env:heltec_rc52_room_server]
+extends = Heltec_RC52_with_display
+build_src_filter = ${Heltec_RC52_with_display.build_src_filter}
+  +<../examples/simple_room_server>
+build_flags =
+  ${Heltec_RC52_with_display.build_flags}
+  -D ADVERT_NAME='"RC52 Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+
+[env:heltec_rc52_room_server_diag]
+extends = env:heltec_rc52_room_server
+build_flags =
+  ${env:heltec_rc52_room_server.build_flags}
+  ${rc52_diag.build_flags}
+
+; ---------------------------------------------------------------------------
+; #950 / #856: companion WITH display -- THE MEMORY-CONSTRAINED PAIR.
+;
+; Read this before treating a blank companion panel as a driver fault.
+;
+; The back buffer is 220*128*2 = 56,320 B, malloc'd at begin(). Headless static
+; RAM on this board, measured:
+;
+;   repeater          46,512 B  ->  ~187 KB free  -- comfortable
+;   room server       50,208 B  ->  ~183 KB free  -- comfortable
+;   companion USB    115,576 B  ->  ~119 KB free  -- fits with room to spare
+;   companion BLE    162,496 B  ->   ~73 KB free  -- 56 KB of that is the buffer
+;
+; The BLE figure is the one that matters. It is not RC52 bloat: every nRF52840
+; BLE companion in this tree lands in 162-166 KB (RAK4631, T1000-E, Wio, T096,
+; XIAO all measured in the same tree), and RC52 is the LEANEST of the six. The
+; cost is `the_mesh` at 120,288 B, sized by MAX_CONTACTS/MAX_GROUP_CHANNELS/
+; OFFLINE_QUEUE_SIZE -- fleet-standard values this board shares exactly.
+;
+; So a failed allocation here is EXPECTED-POSSIBLE, not a bug. The driver
+; degrades to unbuffered direct-to-panel writes and says so on the serial log;
+; it does not lose the display. That fallback has never executed on hardware on
+; ANY board, which makes this the first place it must actually be exercised
+; rather than assumed.
+;
+; If the buffered path is wanted here and does not fit, the lever is trimming
+; the companion caps for THIS env only -- heltec_v3/heltec_v4 observer envs cut
+; MAX_CONTACTS 350->50 and OFFLINE_QUEUE_SIZE 256->16 for the same reason. That
+; is a user-visible capacity cut and is the owner's call, not a silent fix.
+[env:heltec_rc52_companion_radio_ble]
+extends = Heltec_RC52_with_display
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_flags =
+  ${Heltec_RC52_with_display.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+build_src_filter = ${Heltec_RC52_with_display.build_src_filter}
+  +<helpers/nrf52/SerialBLEInterface.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${Heltec_RC52_with_display.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:heltec_rc52_companion_radio_ble_diag]
+extends = env:heltec_rc52_companion_radio_ble
+build_flags =
+  ${env:heltec_rc52_companion_radio_ble.build_flags}
+  ${rc52_diag.build_flags}
+
+; ---------------------------------------------------------------------------
+[env:heltec_rc52_companion_radio_usb]
+extends = Heltec_RC52_with_display
+board_build.ldscript = boards/nrf52840_s140_v6_extrafs.ld
+board_upload.maximum_size = 712704
+build_flags =
+  ${Heltec_RC52_with_display.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D ENABLE_USB_INTERFACE
+build_src_filter = ${Heltec_RC52_with_display.build_src_filter}
+  +<helpers/nrf52/*.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${Heltec_RC52_with_display.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:heltec_rc52_companion_radio_usb_diag]
+extends = env:heltec_rc52_companion_radio_usb
+build_flags =
+  ${env:heltec_rc52_companion_radio_usb.build_flags}
+  ${rc52_diag.build_flags}
+
+; ---------------------------------------------------------------------------
 [env:heltec_rc52_without_display_repeater]
 extends = heltec_rc52
 build_src_filter = ${heltec_rc52.build_src_filter}

--- a/variants/heltec_rc52/target.h
+++ b/variants/heltec_rc52/target.h
@@ -9,16 +9,24 @@
 #include <helpers/sensors/EnvironmentSensorManager.h>
 #include <helpers/sensors/LocationProvider.h>
 
-// Headless variant (#854). DISPLAY_CLASS is bound to NullDisplayDriver rather
-// than left undefined, following heltec_rc32's `_without_display_` envs: that
-// keeps the button/UI surface compiled in -- and the RC52 does have a real USER
-// button (P1.10) -- while the panel itself is inert.
+// DISPLAY_CLASS is always bound to something -- NullDisplayDriver on the
+// headless roles, RC52Display on the with-display ones -- rather than left
+// undefined, following heltec_rc32. That keeps the button/UI surface compiled
+// in (the RC52 does have a real USER button, P1.10) while an inert panel simply
+// draws nowhere.
 //
-// The real panel is NOT here because NV3001BDisplay does not compile for nRF52
-// today. Adding it is #872.
+// The with-display arm points at the VARIANT-LOCAL driver in this directory, not
+// at src/helpers/ui/NV3001BDisplay.h. The shared driver still does not compile
+// for nRF52; #948 chose duplication inside this variant over a fleet-wide port
+// so that RC32 and RCC6 cannot regress from RC52 work. Same shape as RC32's
+// switch below -- deliberately, so the two read alike.
 #ifdef DISPLAY_CLASS
 #include <helpers/ui/MomentaryButton.h>
+#ifdef HELTEC_RC52_WITH_DISPLAY
+#include "RC52Display.h"
+#else
 #include <helpers/ui/NullDisplayDriver.h>
+#endif
 #endif
 
 extern RC52Board board;

--- a/variants/heltec_rc52/variant.h
+++ b/variants/heltec_rc52/variant.h
@@ -218,17 +218,30 @@
 
 #define PIN_SPI1_MISO           (0 + 12)    // P0.12 -- NOT wired to the panel;
                                             // SPIClass still needs a valid pin
-#define PIN_SPI1_MOSI           (32 + 3)    // P1.03
-#define PIN_SPI1_SCK            (0 + 30)    // P0.30
+#define PIN_SPI1_MOSI           (32 + 2)    // P1.02 -- carrier header pin 17
+#define PIN_SPI1_SCK            (0 + 30)    // P0.30 -- carrier header pin 6
 
 ////////////////////////////////////////////////////////////////////////////////
-// TFT (T108 / NV3001B) -- DECLARED FOR REFERENCE, NOT USED BY THIS VARIANT.
+// TFT (T108 / NV3001B) -- LIVE. Driven by variants/heltec_rc52/RC52Display.cpp
+// under HELTEC_RC52_WITH_DISPLAY (#948/#949/#950).
 //
-// This variant is headless (#854). The display port is #872, because
-// NV3001BDisplay does not compile for nRF52 today: its hardware-SPI path calls
-// spi.begin(sck,miso,mosi,ss) / writeBytes() / writePattern(), all ESP32-only,
-// and its `SPIClass spi;` member is unconditional with no nRF52 default ctor --
-// so NV3001B_USE_SOFTWARE_SPI=1 does not sidestep it either.
+// ⚠ EVERY VALUE BELOW IS THE VENDOR'S, TAKEN FROM THE SOURCE OF RECORD --
+// HelTecAutomation/RadioCore_Library :: src/boards/heltec_rc52.h, read as raw
+// bytes via the GitHub API on 2026-08-23, not from a summary or a diagram:
+//
+//   RADIOCORE_NV3001B_SCK   (0 + 30)    RADIOCORE_NV3001B_MOSI  (32 + 2)
+//   RADIOCORE_NV3001B_CS    (32 + 4)    RADIOCORE_NV3001B_DC    (0 + 28)
+//   RADIOCORE_NV3001B_RST   (0 + 10)    RADIOCORE_NV3001B_ENABLE (32 + 13) LOW
+//   RADIOCORE_NV3001B_BACKLIGHT (0 + 9) HIGH
+//   USE_HARDWARE_SPI 1, SPI_INSTANCE SPI1, SPI_FREQUENCY 8000000UL
+//
+// ⚠⚠ MOSI AND CS WERE BOTH WRONG BY ONE UNTIL 2026-08-23 -- P1.03 and P1.05
+// instead of P1.02 and P1.04. Neither P1.03 nor P1.05 appears ANYWHERE in
+// Heltec's RC52 pin map; P1.02 and P1.04 are broken out on carrier header pins
+// 17 and 16. The board flashed, booted, ran the radio and lit its backlight
+// with the panel receiving nothing at all, because a write-only panel has no
+// readback to fail on and begin() returns true regardless. If this file ever
+// disagrees with the vendor header again, THIS FILE is the defect.
 //
 // !! THE TFT OCCUPIES CARRIER HEADER PINS 6-10. Anything wired to those pins
 // conflicts with a display build, and SWDIO (P0.30) is also TFT_SCK, so SWD and
@@ -236,11 +249,17 @@
 //
 // !! TFT_EN is ACTIVE LOW while TFT_BL is ACTIVE HIGH. Opposite polarities on the
 // two power/backlight controls; getting one backwards presents as a dead panel.
+//
+// !! RST is P0.10 = NFC1 and BL is P0.09 = NFC2. On nRF52840 those are reserved
+// for NFC unless UICR NFCPINS is cleared, which needs CONFIG_NFCT_PINS_AS_GPIOS
+// -- defined NOWHERE in this tree or the framework (checked 2026-08-23). If the
+// panel is still dark after the pin fix above, that is the next hypothesis, and
+// the cost of testing it is a one-way UICR write.
 
 #define PIN_TFT_SCK             (0 + 30)    // P0.30 -- also SWDIO, header pin 6
-#define PIN_TFT_MOSI            (32 + 3)    // P1.03
+#define PIN_TFT_MOSI            (32 + 2)    // P1.02 -- header pin 17
 #define PIN_TFT_MISO            (-1)        // write-only panel, no readback
-#define PIN_TFT_CS              (32 + 5)    // P1.05
+#define PIN_TFT_CS              (32 + 4)    // P1.04 -- header pin 16
 #define PIN_TFT_DC              (0 + 28)    // P0.28 -- header pin 7
 #define PIN_TFT_RST             (0 + 10)    // P0.10 -- header pin 10
 #define PIN_TFT_VDD_CTL         (32 + 13)   // P1.13 -- header pin 8


### PR DESCRIPTION
Epic [#948](https://github.com/OffbandMesh/meshcore-firmware/issues/948) — RC52 display. Stacks on [#986](https://github.com/OffbandMesh/meshcore-firmware/pull/986) (headless bring-up), now merged.

## What this is

The T108 / NV3001B TFT on the Heltec RadioCore RC52, driven over hardware SPI on SPI1/SPIM3 at 8 MHz. Eight display envs — repeater, room server, companion USB/BLE, each with a `_diag` twin — plus one bench env.

**Zero shared-code changes.** `git diff --name-only` against the base returns nothing outside `variants/heltec_rc52/` and `tools/`. `src/helpers/ui/` is untouched, so **RC32 and RCC6 cannot regress from this** — that was the epic's explicit constraint, not an accident.

## Hardware-verified on `rc52-bench-1`

- Splash renders, **colour art holds for the full splash**, text correct
- Home screen renders — the #973 failure does not reproduce
- Colours correct, no flicker on the repaint cycle
- Repeater, room server and companion roles all render

## Three defects fixed, all mine, all found by the gate or by chasing it

**1. The verified fix was never shipped.** `RC52_DISPLAY_BUFFER_INDEXED` existed on exactly one line — the `_diag_idx` bench env. Every *shipping* env still built the 56,320 B RGB565 buffer that measured **zero** allocatable bytes and made `new HomeScreen` (480 B) fail, which silently stops all rendering ([#973](https://github.com/OffbandMesh/meshcore-firmware/issues/973)). Trimming `MAX_CONTACTS` / `MAX_GROUP_CHANNELS` / `OFFLINE_QUEUE_SIZE` was ruled out, indexed was built instead, confirmed on hardware — and then left in a bench env. Moved to the shared `[Heltec_RC52_with_display]` base so all nine display envs inherit it.

**2. Colour art was erased by the very next blit.** The indexed path wrote art **straight to the panel**, bypassing the buffer, on the reasoning that *"the splash draws once at boot, so the repaint costs nothing."* That was wrong: `SplashScreen::render()` runs **inside** `startFrame()`/`endFrame()` and returns `1000`, so once a second for the whole boot screen — and every `endFrame()` blits the buffer over the entire panel. Observed on hardware as **"the lockup graphic flashed in and out"** while the text below it, which lives in the buffer, stayed put.

Fixed by **compositing**, not bypassing and not quantising. Quantising would posterise the art through a UI palette — the exact thing the bypass existed to avoid — and dropping to the mono lockup is not acceptable on a colour LCD. The art is recorded for the frame and substituted into the blit's **existing** per-pixel unpack loop, which only runs for indexed anyway. Art pixels pass at full RGB565; every other pixel is the same palette lookup as before. One transfer, no flash, no posterisation, and no extra RAM — the source stays in flash and only a pointer and a rect are held. Cleared by `startFrame()`, so it lives exactly one frame. Hoisted behind a null check, so **non-splash frames run the loop byte-for-byte as before**.

**3. `px_nonbg` was a lying instrument.** `endFrame()`'s beacon compared each buffer entry against a hard-coded byte-swapped `uint16_t` RGB565 background. Correct at 16bpp; wrong the moment the buffer holds 8-bit values, since a `uint8_t` index can never equal a `uint16_t` above 255 — so it printed `px_nonbg=28160` (every pixel, 128×220) **on every frame, unconditionally**, reading as a rendering anomaly. Now compares against `pxPack(window_bkg)`, which answers "what would the background be stored as" for all three formats.

## Bench envs

`_8bpp` and `_idx` **removed** (owner decision). The format A/B is finished — indexed won on hardware. With indexed now in the base, `_8bpp` would *inherit* it and silently build **as indexed**, because `pxPack()` tests INDEXED first — turning an A/B into a comparison of indexed against itself. `-U` does not survive PlatformIO (`macro names must be identifiers`, the same failure as the earlier `-U DISPLAY_CLASS` attempt), so opting out isn't available. A `#error` guard is kept as a tripwire against re-adding a conflicting format flag.

`_nobuf` **kept**: it inherits INDEXED harmlessly (`DISABLE_BACKBUFFER` short-circuits `allocFrameBuffer()` before the format is consulted) and remains the only way to exercise the unbuffered draw path, which **has never executed on any board in this fleet** ([#856](https://github.com/OffbandMesh/meshcore-firmware/issues/856)).

## Review gate — Gemini 2.5 Pro, adversarial

- **Finding 1 (High)** — *"back buffer and panel desynchronize in indexed mode."* The stated mechanism (stale blend) is **refuted**: `startFrame()` fills the entire buffer each frame, so no stale region survives. But tracing it found the **real** defect above — the art erased by the blit. Fixed, hardware-verified.
- **Finding 2 (High)** — *"memory optimization not applied to the primary target env."* **Confirmed and fixed.** This was the most valuable finding in the review.
- **Finding 3** — the `pxPack` static memo could go stale if the palette were rebuilt. **Declined**: the palette is built once (`if (s_pal_used) return; // built once`) and never rebuilt, so there is nothing to go stale.
- **Finding 4** — free the back buffer on `turnOff()`. **Declined.** `begin()` re-runs on every `turnOn()`; that is exactly the leak fixed in #856, where each off→on cycle abandoned a buffer and presented as *"8bpp didn't fix the flicker"* when 8bpp was working. The `if (frame_buf) return;` guard is the fix. Free-on-off / realloc-on-on reintroduces a window where a transient allocation failure costs the buffer permanently. Holding 28 KB for the device's life is the deliberate trade.

## Verification

`pio run` **9/9 SUCCESS**, re-run after rebase: all eight display envs plus `_nobuf`. Secrets/private-IP scan clean over the diff and commit messages (`ADMIN_PASSWORD` / `ROOM_PASSWORD` are upstream defaults in 88 and 68 of 91 variants).

## Merge

**Ben merges.** `ci-green` is a required gate.
