### PR TITLE
task: T096 bench diag env — three deferred boards written and disabled

### DIFF
--- a/variants/heltec_t096/platformio.ini
+++ b/variants/heltec_t096/platformio.ini
@@ -176,3 +176,35 @@ lib_deps =
 extends = Heltec_t096
 build_src_filter = ${Heltec_t096.build_src_filter}
   +<../examples/kiss_modem/>
+
+; =============================================================================
+; BENCH DIAG ENVS (#979) -- NOT RELEASED.
+;
+; Diag envs are diagnostic instruments, not products. `.github/release-envs.txt`
+; is the authority: they ship ONLY where explicitly excepted, and the RadioCore
+; entries there carry "Do NOT cite these entries as precedent for releasing diag
+; builds elsewhere." These are bench/CI only and are deliberately ABSENT from the
+; release matrix.
+;
+; Owner-directed 2026-08-24: the nRF52 boards that can be instrumented without
+; opening a case. Wio Tracker Pro (needs the case opened) and SenseCAP (sealed
+; housing) are out of scope by the same decision.
+; =============================================================================
+
+[heltec_t096_diag]
+build_flags =
+  -D OFFBAND_FORCE_CAPLOG
+  -D OFFBAND_BOOT_BEACON
+  -D OFFBAND_LOG_MIRROR_UART=1
+  ; P0.25 -- Serial1. MUST NOT be Serial2: PIN_SERIAL2_TX is P0.10, an nRF52840 NFC
+; antenna pin, which needs CONFIG_NFCT_PINS_AS_GPIOS (set by no variant in this tree).
+  -D OFFBAND_LOG_MIRROR_TX_PIN=PIN_SERIAL1_TX
+  -D OFFBAND_LOG_MIRROR_BAUD=115200
+
+; Heltec_t096_repeater_diag -- the shipped role plus the diag channel, nothing else. A diag
+; build that diverges from the shipped build diagnoses the wrong firmware.
+[env:Heltec_t096_repeater_diag]
+extends = env:Heltec_t096_repeater
+build_flags =
+  ${env:Heltec_t096_repeater.build_flags}
+  ${heltec_t096_diag.build_flags}

--- a/variants/heltec_t096/platformio.ini
+++ b/variants/heltec_t096/platformio.ini
@@ -196,13 +196,39 @@ build_flags =
   -D OFFBAND_FORCE_CAPLOG
   -D OFFBAND_BOOT_BEACON
   -D OFFBAND_LOG_MIRROR_UART=1
-  ; P0.25 -- Serial1. MUST NOT be Serial2: PIN_SERIAL2_TX is P0.10, an nRF52840 NFC
-; antenna pin, which needs CONFIG_NFCT_PINS_AS_GPIOS (set by no variant in this tree).
-  -D OFFBAND_LOG_MIRROR_TX_PIN=PIN_SERIAL1_TX
+  ; ---------------------------------------------------------------------------
+  ; MIRROR TX = PIN_SERIAL2_TX = MCU pin P0.10 (Serial2 TX).
+  ;
+  ; ⚠ THAT IS THE MCU PIN, NOT A SILKSCREEN LABEL. Nothing here tells you which
+  ; pad, castellation or test point on the physical T096 carries P0.10 -- that has
+  ; NOT been established and must be identified on the board before landing a wire.
+  ; Do not assume a marking called "TX", "TX2" or "10" is this pin.
+  ;
+  ; WHY THIS PIN, and not Serial1:
+  ;   * Serial1 is the GPS. The env sets -D PIN_GPS_RX=25 and PIN_SERIAL1_TX is
+  ;     (0 + 25) -- the same pin. Mirroring there would drive log text into the
+  ;     GPS module's receive line. The T096 has a built-in GPS, so this is real,
+  ;     not hypothetical.
+  ;   * Serial2 (P0.09 RX / P0.10 TX) is claimed by nothing else in this variant
+  ;     or env -- verified by mapping all 29 assigned pins.
+  ;
+  ; WHY THE NFC CONCERN DOES NOT APPLY: P0.09/P0.10 are NFC2/NFC1 and normally
+  ; need CONFIG_NFCT_PINS_AS_GPIOS, which is defined nowhere in this tree or the
+  ; framework. Two things say they work anyway:
+  ;   1. [verified on OUR hardware] RC52 -- same nRF52840, same Adafruit core --
+  ;      drives its TFT reset and backlight on P0.09/P0.10 with no UICR change.
+  ;   2. This board's own Heltec_t096_repeater_bridge_rs232 env already uses
+  ;      P0.09/P0.10 as an external RS232 UART, which could not work if the pins
+  ;      were NFC-locked -- and implies Heltec routes them out.
+  ;
+  ; ⚠ DO NOT add this diag block to Heltec_t096_repeater_bridge_rs232. That env
+  ; owns P0.09/P0.10 (WITH_RS232_BRIDGE_RX=9 / _TX=10) and the two would collide.
+  ; ---------------------------------------------------------------------------
+  -D OFFBAND_LOG_MIRROR_TX_PIN=PIN_SERIAL2_TX
   -D OFFBAND_LOG_MIRROR_BAUD=115200
 
-; Heltec_t096_repeater_diag -- the shipped role plus the diag channel, nothing else. A diag
-; build that diverges from the shipped build diagnoses the wrong firmware.
+; Heltec_t096_repeater_diag -- the shipped role plus the diag channel, nothing else.
+; A diag build that diverges from the shipped build diagnoses the wrong firmware.
 [env:Heltec_t096_repeater_diag]
 extends = env:Heltec_t096_repeater
 build_flags =

--- a/variants/rak3401/RAK3401Board.cpp
+++ b/variants/rak3401/RAK3401Board.cpp
@@ -45,7 +45,11 @@ void RAK3401Board::begin() {
 
   Wire.begin();
 
-  // PIN_3V3_EN (WB_IO2, P0.34) controls the 3V3_S switched peripheral rail
+  // PIN_3V3_EN (WB_IO2, P1.02 = Arduino pin 34) controls the 3V3_S switched rail.
+  // NOTE: this read "P0.34" until 2026-08-26. There is no P0.34 -- nRF52840 has
+  // P0.00-P0.31 and P1.00-P1.15, so Arduino pin 34 is P1.02. RAK4631Board.cpp had
+  // it right for the same pin. Comment-only correction; the pin number was always
+  // correct and nothing behavioural changes.
   // AND the 5V boost regulator (U5) on the RAK13302 that powers the SKY66122 PA.
   // Must stay HIGH during radio operation — do not toggle for power saving.
   pinMode(PIN_3V3_EN, OUTPUT);

--- a/variants/rak3401/platformio.ini
+++ b/variants/rak3401/platformio.ini
@@ -154,3 +154,35 @@ build_src_filter = ${rak3401.build_src_filter}
 extends = rak3401
 build_src_filter = ${rak3401.build_src_filter}
   +<../examples/kiss_modem/>
+
+; =============================================================================
+; BENCH DIAG ENVS (#979) -- NOT RELEASED.
+;
+; Diag envs are diagnostic instruments, not products. `.github/release-envs.txt`
+; is the authority: they ship ONLY where explicitly excepted, and the RadioCore
+; entries there carry "Do NOT cite these entries as precedent for releasing diag
+; builds elsewhere." These are bench/CI only and are deliberately ABSENT from the
+; release matrix.
+;
+; Owner-directed 2026-08-24: the nRF52 boards that can be instrumented without
+; opening a case. Wio Tracker Pro (needs the case opened) and SenseCAP (sealed
+; housing) are out of scope by the same decision.
+; =============================================================================
+
+[rak3401_diag]
+build_flags =
+  -D OFFBAND_FORCE_CAPLOG
+  -D OFFBAND_BOOT_BEACON
+  -D OFFBAND_LOG_MIRROR_UART=1
+  ; P0.06 -- Serial2. MUST NOT be Serial1: variant.h defines PIN_GPS_TX/PIN_GPS_RX AS
+; PIN_SERIAL1_*, so mirroring there would collide with the GPS UART.
+  -D OFFBAND_LOG_MIRROR_TX_PIN=PIN_SERIAL2_TX
+  -D OFFBAND_LOG_MIRROR_BAUD=115200
+
+; RAK_3401_repeater_diag -- the shipped role plus the diag channel, nothing else. A diag
+; build that diverges from the shipped build diagnoses the wrong firmware.
+[env:RAK_3401_repeater_diag]
+extends = env:RAK_3401_repeater
+build_flags =
+  ${env:RAK_3401_repeater.build_flags}
+  ${rak3401_diag.build_flags}

--- a/variants/rak3401/platformio.ini
+++ b/variants/rak3401/platformio.ini
@@ -169,20 +169,59 @@ build_src_filter = ${rak3401.build_src_filter}
 ; housing) are out of scope by the same decision.
 ; =============================================================================
 
-[rak3401_diag]
-build_flags =
-  -D OFFBAND_FORCE_CAPLOG
-  -D OFFBAND_BOOT_BEACON
-  -D OFFBAND_LOG_MIRROR_UART=1
-  ; P0.06 -- Serial2. MUST NOT be Serial1: variant.h defines PIN_GPS_TX/PIN_GPS_RX AS
-; PIN_SERIAL1_*, so mirroring there would collide with the GPS UART.
-  -D OFFBAND_LOG_MIRROR_TX_PIN=PIN_SERIAL2_TX
-  -D OFFBAND_LOG_MIRROR_BAUD=115200
-
-; RAK_3401_repeater_diag -- the shipped role plus the diag channel, nothing else. A diag
-; build that diverges from the shipped build diagnoses the wrong firmware.
-[env:RAK_3401_repeater_diag]
-extends = env:RAK_3401_repeater
-build_flags =
-  ${env:RAK_3401_repeater.build_flags}
-  ${rak3401_diag.build_flags}
+; =============================================================================
+; RAK3401 DIAG ENV -- WRITTEN, DELIBERATELY DISABLED, UNTESTED (#979).
+;
+; Deferred by owner decision 2026-08-26. Commented out ON PURPOSE -- the pin is
+; not merely unvalidated, it is not yet KNOWN. Uncomment only after the checks.
+;
+; INTENDED MIRROR TX = WB_IO1, which THIS VARIANT DOES NOT DEFINE.
+;
+; ⚠ THAT IS THE WHOLE PROBLEM. variants/rak3401/variant.h defines WB_IO2 (as an
+; alias of PIN_3V3_EN) and never defines WB_IO1 at all, so the symbol below will
+; not compile as written until someone adds it. It is left in this shape
+; deliberately, so the gap is visible rather than papered over with a number.
+;
+; WHY IT IS PROBABLY 17, AND WHY THAT IS STILL A GUESS: this board sits on the
+; SAME RAK19007 base as the RAK4631, whose variant maps WB_IO1 to 17. The two
+; agree on WB_IO2 -- rak3401 says PIN_3V3_EN (34), rak4631 says WB_IO2 = 34 --
+; i.e. the same pad, two spellings. So WB_IO1 being absent here reads as an
+; OMISSION in this variant rather than a hardware difference. [hypothesis:
+; untested] Confirm against the RAK3401 core pinout before defining it; the two
+; cores are different modules and are not obliged to map slot pins identically.
+;
+; WHY NOT Serial2 (P0.06), which was the first (wrong) choice: it is free in
+; firmware but is NOT on the RAK19007 pad header (BAT / IO2 / IO1 / AIN1 / TX1 /
+; RX1 / GND / BOOT0 / SDA / SCL / GND / VDD). Electrically free, physically
+; unreachable without going into a slot connector.
+;
+; WHY NOT Serial1: -D PIN_GPS_RX=PIN_SERIAL1_TX -- Serial1 is the GPS UART.
+;
+; ⚠ WHY NOT IO2, AND THIS ONE BITES HARDER HERE THAN ON THE RAK4631: on this
+; board WB_IO2 = PIN_3V3_EN (P0.34) is the 5V BOOST ENABLE FOR THE PA. Driving it
+; for a log mirror would disturb the power amplifier. This is the same conflict
+; family as the known GPS-vs-PA problem on this board -- the GPS wake probe
+; toggles WB_IO2 and a failed probe leaves it floating, which stops the SX1262
+; TCXO (-707). Do not use IO2 here for anything.
+;
+; BEFORE UNCOMMENTING:
+;   1. Establish which MCU pin the "IO1" pad reaches on the RAK3401 core.
+;   2. Define WB_IO1 in variants/rak3401/variant.h with that value.
+;   3. Re-check it against the PA and GPS paths -- this board has a documented
+;      history of slot IO lines doubling as power control.
+;   4. Flash, wire, and confirm the beacon arrives.
+;
+; [rak3401_diag]
+; build_flags =
+;   -D OFFBAND_FORCE_CAPLOG
+;   -D OFFBAND_BOOT_BEACON
+;   -D OFFBAND_LOG_MIRROR_UART=1
+;   -D OFFBAND_LOG_MIRROR_TX_PIN=WB_IO1     ; UNDEFINED on this core -- see above
+;   -D OFFBAND_LOG_MIRROR_BAUD=115200
+;
+; [env:RAK_3401_repeater_diag]
+; extends = env:RAK_3401_repeater
+; build_flags =
+;   ${env:RAK_3401_repeater.build_flags}
+;   ${rak3401_diag.build_flags}
+; =============================================================================

--- a/variants/rak3401/platformio.ini
+++ b/variants/rak3401/platformio.ini
@@ -198,7 +198,8 @@ build_src_filter = ${rak3401.build_src_filter}
 ; WHY NOT Serial1: -D PIN_GPS_RX=PIN_SERIAL1_TX -- Serial1 is the GPS UART.
 ;
 ; ⚠ WHY NOT IO2, AND THIS ONE BITES HARDER HERE THAN ON THE RAK4631: on this
-; board WB_IO2 = PIN_3V3_EN (P0.34) is the 5V BOOST ENABLE FOR THE PA. Driving it
+; board WB_IO2 = PIN_3V3_EN (P1.02, Arduino pin 34) is the 5V BOOST ENABLE FOR THE
+; PA. Driving it
 ; for a log mirror would disturb the power amplifier. This is the same conflict
 ; family as the known GPS-vs-PA problem on this board -- the GPS wake probe
 ; toggles WB_IO2 and a failed probe leaves it floating, which stops the SX1262

--- a/variants/rak3401/variant.h
+++ b/variants/rak3401/variant.h
@@ -160,7 +160,9 @@ static const uint8_t AREF = PIN_AREF;
 //   Setting IO3 HIGH enables the FEM (LNA for RX, PA path for TX).
 //   CTX is connected to SX1262 DIO2 — the radio handles TX/RX switching
 //   in hardware via SetDIO2AsRfSwitchCtrl (microsecond-accurate, no GPIO needed).
-//   The 5V boost for the PA is enabled by WB_IO2 (P0.34 = PIN_3V3_EN).
+//   The 5V boost for the PA is enabled by WB_IO2 (P1.02, Arduino pin 34, =
+//   PIN_3V3_EN). Corrected 2026-08-26: this said "P0.34", which does not exist --
+//   nRF52840 is P0.00-P0.31 then P1.00-P1.15.
 #define SX126X_POWER_EN (21)        // P0.21 = IO3 -> SKY66122 CSD+CPS (FEM enable)
 
 // CTX is driven by SX1262 DIO2, not a GPIO

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -293,3 +293,38 @@ build_src_filter = ${rak4631.build_src_filter}
   +<../examples/kiss_modem/>
 lib_deps =
   ${rak4631.lib_deps}
+
+; =============================================================================
+; BENCH DIAG ENVS (#979) -- NOT RELEASED.
+;
+; Diag envs are diagnostic instruments, not products. `.github/release-envs.txt`
+; is the authority: they ship ONLY where explicitly excepted, and the RadioCore
+; entries there carry "Do NOT cite these entries as precedent for releasing diag
+; builds elsewhere." These are bench/CI only and are deliberately ABSENT from the
+; release matrix.
+;
+; Owner-directed 2026-08-24: the nRF52 boards that can be instrumented without
+; opening a case. Wio Tracker Pro (needs the case opened) and SenseCAP (sealed
+; housing) are out of scope by the same decision.
+; =============================================================================
+
+[rak4631_diag]
+build_flags =
+  -D OFFBAND_FORCE_CAPLOG
+  -D OFFBAND_BOOT_BEACON
+  -D OFFBAND_LOG_MIRROR_UART=1
+  ; P0.16 -- Serial1. Free on this board: the GPS module uses PIN_GPS_1PPS (P0.17),
+; not a UART. Serial2 (P0.20) is the alternative if a WisBlock module claims Serial1.
+  -D OFFBAND_LOG_MIRROR_TX_PIN=PIN_SERIAL1_TX
+  -D OFFBAND_LOG_MIRROR_BAUD=115200
+;
+; The RS232 bridge envs claim Serial1/Serial2 for their own use -- do NOT add this
+; diag block to those without moving the mirror to a pin they do not take.
+
+; RAK_4631_repeater_diag -- the shipped role plus the diag channel, nothing else. A diag
+; build that diverges from the shipped build diagnoses the wrong firmware.
+[env:RAK_4631_repeater_diag]
+extends = env:RAK_4631_repeater
+build_flags =
+  ${env:RAK_4631_repeater.build_flags}
+  ${rak4631_diag.build_flags}

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -308,23 +308,54 @@ lib_deps =
 ; housing) are out of scope by the same decision.
 ; =============================================================================
 
-[rak4631_diag]
-build_flags =
-  -D OFFBAND_FORCE_CAPLOG
-  -D OFFBAND_BOOT_BEACON
-  -D OFFBAND_LOG_MIRROR_UART=1
-  ; P0.16 -- Serial1. Free on this board: the GPS module uses PIN_GPS_1PPS (P0.17),
-; not a UART. Serial2 (P0.20) is the alternative if a WisBlock module claims Serial1.
-  -D OFFBAND_LOG_MIRROR_TX_PIN=PIN_SERIAL1_TX
-  -D OFFBAND_LOG_MIRROR_BAUD=115200
+; =============================================================================
+; RAK4631 DIAG ENV -- WRITTEN, DELIBERATELY DISABLED, UNTESTED (#979).
 ;
-; The RS232 bridge envs claim Serial1/Serial2 for their own use -- do NOT add this
-; diag block to those without moving the mirror to a pin they do not take.
-
-; RAK_4631_repeater_diag -- the shipped role plus the diag channel, nothing else. A diag
-; build that diverges from the shipped build diagnoses the wrong firmware.
-[env:RAK_4631_repeater_diag]
-extends = env:RAK_4631_repeater
-build_flags =
-  ${env:RAK_4631_repeater.build_flags}
-  ${rak4631_diag.build_flags}
+; Everything below is ready to go and is commented out ON PURPOSE: the pin has
+; NOT been validated on hardware. Uncomment only after the checks at the bottom.
+;
+; INTENDED MIRROR TX = WB_IO1 = MCU pin P0.17 (Arduino pin 17).
+;
+; ⚠ P0.17 IS THE MCU PIN, NOT A SILKSCREEN LABEL. The RAK19007 base does carry a
+; solder pad silkscreened "IO1" [verified: owner photo of the board, 2026-08-26],
+; and variant.h maps WB_IO1 to 17 -- but that those two are the SAME physical net
+; is an inference from the WisBlock slot convention, NOT something confirmed
+; against a RAK schematic or measured with a meter. Confirm before wiring.
+;
+; WHY NOT Serial1, which was the first (wrong) choice: the env sets
+;   -D PIN_GPS_RX=PIN_SERIAL1_TX
+; so Serial1 IS the GPS UART on this board. GPS is ACTIVE on the repeater role --
+; ENV_INCLUDE_GPS=1 is set globally in the root platformio.ini, RAK_BOARD is
+; defined here, RAK3401_NO_GPS is not, so RAK_WISBLOCK_GPS is defined and
+; EnvironmentSensorManager.cpp says outright "Repeater (has GPS) keeps the path."
+; Mirroring on Serial1 would drive log text into the GPS receive line.
+;
+; WHY NOT Serial2 (P0.20): not brought out to the RAK19007 pad header. The pads
+; are BAT / IO2 / IO1 / AIN1 / TX1 / RX1 / GND / BOOT0 / SDA / SCL / GND / VDD;
+; TX1/RX1 are Serial1. Everything else is inside the SLOT_C / SLOT_D connectors.
+;
+; ⚠ WHY NOT IO2: WB_IO2 (P1.02, pin 34) is the WisBlock SLOT POWER SWITCH.
+; RAK4631Board.cpp drives it HIGH from an early constructor, the RAK13800
+; Ethernet code reuses it as power-enable, and the GPS wake probe toggles it.
+; Driving it for a log mirror would cut power to the slots. Do not use IO2.
+;
+; BEFORE UNCOMMENTING:
+;   1. Confirm the "IO1" pad really is P0.17 on this core (schematic or meter).
+;   2. Confirm nothing is fitted in a slot that needs IO1.
+;   3. Flash, land a wire, and confirm the beacon actually arrives on the wire --
+;      a silent mirror looks identical to a board that never booted.
+;
+; [rak4631_diag]
+; build_flags =
+;   -D OFFBAND_FORCE_CAPLOG
+;   -D OFFBAND_BOOT_BEACON
+;   -D OFFBAND_LOG_MIRROR_UART=1
+;   -D OFFBAND_LOG_MIRROR_TX_PIN=WB_IO1
+;   -D OFFBAND_LOG_MIRROR_BAUD=115200
+;
+; [env:RAK_4631_repeater_diag]
+; extends = env:RAK_4631_repeater
+; build_flags =
+;   ${env:RAK_4631_repeater.build_flags}
+;   ${rak4631_diag.build_flags}
+; =============================================================================

--- a/variants/xiao_nrf52/platformio.ini
+++ b/variants/xiao_nrf52/platformio.ini
@@ -151,19 +151,56 @@ lib_deps =
 ; housing) are out of scope by the same decision.
 ; =============================================================================
 
-[xiao_nrf52_diag]
-build_flags =
-  -D OFFBAND_FORCE_CAPLOG
-  -D OFFBAND_BOOT_BEACON
-  -D OFFBAND_LOG_MIRROR_UART=1
-  ; P0.06 (D6) -- Serial1, a castellated pad. This variant defines no Serial2.
-  -D OFFBAND_LOG_MIRROR_TX_PIN=PIN_SERIAL1_TX
-  -D OFFBAND_LOG_MIRROR_BAUD=115200
-
-; Xiao_nrf52_repeater_diag -- the shipped role plus the diag channel, nothing else. A diag
-; build that diverges from the shipped build diagnoses the wrong firmware.
-[env:Xiao_nrf52_repeater_diag]
-extends = env:Xiao_nrf52_repeater
-build_flags =
-  ${env:Xiao_nrf52_repeater.build_flags}
-  ${xiao_nrf52_diag.build_flags}
+; =============================================================================
+; XIAO nRF52 DIAG ENV -- WRITTEN, DELIBERATELY DISABLED, UNTESTED (#979).
+;
+; Not enabled because turning it on requires GIVING UP A FEATURE, which is an
+; owner decision and has not been made. Uncomment only with that decision.
+;
+; INTENDED MIRROR TX = D0, MCU pin P0.02.
+;
+; ⚠ P0.02 IS THE MCU PIN. "D0" is the XIAO's own silkscreen convention and is
+; the reliable label here -- the board has 14 header pins, 11 signal (D0..D10)
+; plus 3V3 / GND / 5V -- but confirm D0 on the physical board before wiring.
+;
+; WHY THIS IS THE ONLY CANDIDATE: every one of the 11 signal pins is assigned.
+;   D0  PIN_USER_BTN            D6  PIN_WIRE_SCL
+;   D1  P_LORA_DIO_1            D7  PIN_WIRE_SDA
+;   D2  P_LORA_RESET            D8  PIN_SPI_SCK  -> P_LORA_SCLK
+;   D3  P_LORA_BUSY             D9  PIN_SPI_MISO -> P_LORA_MISO
+;   D4  P_LORA_NSS              D10 PIN_SPI_MOSI -> P_LORA_MOSI
+;   D5  SX126X_RXEN
+; Five to the radio, three to SPI, two to I2C, one to the button. Nothing spare.
+;
+; ⚠ THE COST: D0 is only free if the repeater DROPS PIN_USER_BTN, which the base
+; [Xiao_nrf52] section sets for every env. The XIAO has no stock button on D0 --
+; it is a header pin waiting for one to be wired -- and upstream already drops
+; PIN_USER_BTN from the RAK repeater env on the reasoning that "repeaters don't
+; have user buttons". So the cost is probably zero. But it IS a behaviour change
+; to a shipping role, and a diag build that diverges from the shipped build
+; diagnoses the wrong firmware, so it needs a deliberate yes.
+;
+; The alternative, D6/D7, is worse: they are the I2C bus. Nominally free if no
+; sensor is fitted, but the firmware may still probe, and a mirror driving SCL
+; corrupts the bus rather than merely sharing it.
+;
+; BEFORE UNCOMMENTING:
+;   1. Owner decision: the XIAO repeater gives up its user button.
+;   2. Add -D PIN_USER_BTN=-1 (or equivalent) to the diag env so D0 is really free.
+;   3. Flash, wire D0, confirm the beacon arrives -- a silent mirror looks exactly
+;      like a board that never booted.
+;
+; [xiao_nrf52_diag]
+; build_flags =
+;   -D OFFBAND_FORCE_CAPLOG
+;   -D OFFBAND_BOOT_BEACON
+;   -D OFFBAND_LOG_MIRROR_UART=1
+;   -D OFFBAND_LOG_MIRROR_TX_PIN=D0     ; requires PIN_USER_BTN released -- see above
+;   -D OFFBAND_LOG_MIRROR_BAUD=115200
+;
+; [env:Xiao_nrf52_repeater_diag]
+; extends = env:Xiao_nrf52_repeater
+; build_flags =
+;   ${env:Xiao_nrf52_repeater.build_flags}
+;   ${xiao_nrf52_diag.build_flags}
+; =============================================================================

--- a/variants/xiao_nrf52/platformio.ini
+++ b/variants/xiao_nrf52/platformio.ini
@@ -136,3 +136,34 @@ build_src_filter = ${Xiao_nrf52.build_src_filter}
   +<../examples/kiss_modem/*.cpp>
 lib_deps =
   ${Xiao_nrf52.lib_deps}
+
+; =============================================================================
+; BENCH DIAG ENVS (#979) -- NOT RELEASED.
+;
+; Diag envs are diagnostic instruments, not products. `.github/release-envs.txt`
+; is the authority: they ship ONLY where explicitly excepted, and the RadioCore
+; entries there carry "Do NOT cite these entries as precedent for releasing diag
+; builds elsewhere." These are bench/CI only and are deliberately ABSENT from the
+; release matrix.
+;
+; Owner-directed 2026-08-24: the nRF52 boards that can be instrumented without
+; opening a case. Wio Tracker Pro (needs the case opened) and SenseCAP (sealed
+; housing) are out of scope by the same decision.
+; =============================================================================
+
+[xiao_nrf52_diag]
+build_flags =
+  -D OFFBAND_FORCE_CAPLOG
+  -D OFFBAND_BOOT_BEACON
+  -D OFFBAND_LOG_MIRROR_UART=1
+  ; P0.06 (D6) -- Serial1, a castellated pad. This variant defines no Serial2.
+  -D OFFBAND_LOG_MIRROR_TX_PIN=PIN_SERIAL1_TX
+  -D OFFBAND_LOG_MIRROR_BAUD=115200
+
+; Xiao_nrf52_repeater_diag -- the shipped role plus the diag channel, nothing else. A diag
+; build that diverges from the shipped build diagnoses the wrong firmware.
+[env:Xiao_nrf52_repeater_diag]
+extends = env:Xiao_nrf52_repeater
+build_flags =
+  ${env:Xiao_nrf52_repeater.build_flags}
+  ${xiao_nrf52_diag.build_flags}


### PR DESCRIPTION
Task [#979](https://github.com/OffbandMesh/meshcore-firmware/issues/979) under Epic [#990](https://github.com/OffbandMesh/meshcore-firmware/issues/990).

## What ships: one board

**`Heltec_t096_repeater_diag`** — the T096 repeater plus the diag channel (boot beacon, UART mirror, forced caplog), so a boot that fails can be witnessed on a wire instead of a USB console that dies with the chip.

`pio project config` lists **exactly one** new env. RAK4631, RAK3401 and XIAO nRF52 are written and **deliberately commented out**.

## Three of the four original pins were wrong

The first commit picked a mirror TX pin per board from `variant.h`. Three collided with peripherals, and every one of them would have **built clean, flashed clean, and then quietly driven something**:

| Board | Original pin | Collided with |
|---|---|---|
| RAK4631 | `PIN_SERIAL1_TX` | env sets `PIN_GPS_RX=PIN_SERIAL1_TX` — Serial1 **is** the GPS UART, and GPS is active on the repeater |
| T096 | `PIN_SERIAL1_TX` | env sets `PIN_GPS_RX=25`; this board has a **built-in GPS** |
| XIAO | `PIN_SERIAL1_TX` = D6 | `PIN_WIRE_SCL=D6` — the I2C clock |
| RAK3401 | `PIN_SERIAL2_TX` | free in firmware, but **not on the RAK19007 pad header** — unreachable |

**Root cause:** pins were read from `variant.h` and the **env** was never read. On these variants `platformio.ini` is where peripherals are actually assigned. The original `[verified: read from each variant.h]` tag was true about what was read and false about what it proved.

## T096's replacement pin, and why

**`PIN_SERIAL2_TX` (P0.10)**, on three independent lines:

1. **Unclaimed** — all 29 pins assigned across `variant.h` and the env were mapped; 9/10 appear nowhere else.
2. **This board's own `Heltec_t096_repeater_bridge_rs232` env already drives P0.09/P0.10 as an external RS232 UART**, which implies Heltec routes them out and they work as a UART.
3. **The NFC objection is disproven on our own hardware.** P0.09/P0.10 are NFC2/NFC1 and normally need `CONFIG_NFCT_PINS_AS_GPIOS`, defined nowhere in tree or framework — but RC52, same nRF52840 and same Adafruit core, drives its TFT reset and backlight on those pins with no UICR change. Serial2 was originally rejected on a theory our own bench had already falsified.

⚠ The comment states plainly that **P0.10 is the MCU pin, not a silkscreen label**, and that which physical pad carries it is **not established** — per owner direction, because knowing the MCU pin does not tell anyone where to land a wire.

⚠ Do **not** add the diag block to `Heltec_t096_repeater_bridge_rs232`; it owns those pins.

## The three disabled boards

Written, inert, each documenting its intended pin, why the alternatives are wrong, and its preconditions. Carried by [#989](https://github.com/OffbandMesh/meshcore-firmware/issues/989).

- **RAK4631** → `WB_IO1` (P0.17). `IO1` **is** a pad on the base `[verified: owner photo]`; that the pad and pin 17 are the same net is inferred from the WisBlock convention, not measured. Not IO2 — that is the **slot power switch**.
- **RAK3401** → `WB_IO1`, **which this variant does not define**. Left referencing the undefined symbol so the gap is visible rather than papered over with a guess. Probably 17 (same base; the two variants already agree on `WB_IO2`, spelled `PIN_3V3_EN(34)` and `WB_IO2=34`), but different cores are not obliged to match. Not IO2 — here it is the **PA's 5 V boost enable**.
- **XIAO** → `D0`, which requires the repeater to release `PIN_USER_BTN`. All 11 signal pins are assigned — five to the radio, three to SPI, two to I2C, one to the button — so D0 is the only candidate, and freeing it is a behaviour change to a shipping role. Owner decision.

## Also fixed: a pin designation that does not exist

Three RAK3401 files described `WB_IO2` / `PIN_3V3_EN` as **`P0.34`**. There is no such pin — nRF52840 is P0.00–P0.31 then P1.00–P1.15, so Arduino pin 34 is **P1.02**, exactly as our own `RAK4631Board.cpp` states for the same pin. Corrected in `variant.h`, `RAK3401Board.cpp` and the disabled diag block, each noting what it used to say. Comment-only; the pin *number* was always right.

That line is a warning about the PA's 5 V boost enable on a board with a documented GPS-vs-PA power conflict, so a wrong designation there is the kind of thing that gets acted on.

## Not released

Bench and CI instruments only. `.github/release-envs.txt` is the authority: diag envs *"are not released anywhere it is not explicitly excepted,"* and the RadioCore entries carry *"Do NOT cite these entries as precedent for releasing diag builds elsewhere."* Zero `*_diag` entries added.

## Review gate

First pass found the pin collisions — **it was right on every count** and the change was reworked around it. Re-run against the rework came back sound on all five questions asked: P0.10 safe on the repeater, the NFC argument holds, the disabled blocks are genuinely inert, the diag env differs from its sibling only in diag flags, and the disabled-block documentation is accurate. One trivial finding — the `P0.34` designation — fixed above.

## Verification

`pio run` **6/6 SUCCESS** after rebase: `Heltec_t096_repeater_diag`, `Heltec_t096_repeater`, `Heltec_t096_repeater_bridge_rs232` (owns the same pins), plus `RAK_4631_repeater`, `RAK_3401_repeater`, `Xiao_nrf52_repeater` — the three prod repeaters whose files were edited.

`envdump` confirms the diag build carries `OFFBAND_LOG_MIRROR_TX_PIN=PIN_SERIAL2_TX` and the prod build carries **zero** mirror flags. Beacon markers present in the diag ELF, so the instrumentation is compiled in and not merely flagged. Secrets/private-IP scan clean.

## Not verified here

**The T096 mirror has not been observed on the wire.** A clean build is not evidence — a mirror on a wrong or unrouted pin compiles and flashes identically to a correct one. Hardware confirmation is Epic verification under [#990](https://github.com/OffbandMesh/meshcore-firmware/issues/990).

## Merge

**Ben merges.**
