### PR TITLE
task: INA228 decode for the sniffer — identified but never read

### DIFF
--- a/tools/diag/sniffer/rc_uart_sniffer_v3/rc_uart_sniffer_v3.ino
+++ b/tools/diag/sniffer/rc_uart_sniffer_v3/rc_uart_sniffer_v3.ino
@@ -209,6 +209,45 @@
 // the chip, and no averaging setting recovers it.
 #define INA219_SHUNT_MILLIOHM  100
 
+// ---------------------------------------------------------------------------
+// INA228 (#991). Different part, different register map, DIFFERENT SHUNT.
+//
+// THE SHUNT IS A PROPERTY OF THE FITTED PART, NOT OF THE RIG. The INA219 bench
+// module carries R100 = 0.100 ohm; the Adafruit INA228 breakout carries
+// R015 = 0.015 ohm [verified: owner photo of the fitted board, 2026-08-26].
+// Reusing the INA219 constant here would under-report by 100/15 = 6.67x and look
+// entirely plausible doing it.
+//
+// NO CALIBRATION WRITE, deliberately -- same reasoning as the INA219 path above.
+// SHUNT_CAL only feeds the CURRENT/POWER/ENERGY/CHARGE registers. Reading VSHUNT
+// and dividing by a known resistance on the host needs no magic constant, cannot
+// be half-configured, and survives a part reset that would silently invalidate a
+// written calibration.
+//
+// VSHUNT and VBUS are 24-bit registers holding 20-bit data LEFT-ALIGNED in bits
+// 23:4, so both are >>4 before scaling. VSHUNT is SIGNED (two's complement over
+// 20 bits); VBUS is unsigned.
+//
+// The VSHUNT scale depends on ADCRANGE (CONFIG bit 4), so it is READ rather than
+// assumed -- if anything ever configures this part, the decode follows instead of
+// silently scaling by 4x:
+//     ADCRANGE=0   312.5   nV/LSB  ->  +/-163.84 mV  ->  +/-10.9 A at 15 mohm
+//     ADCRANGE=1    78.125 nV/LSB  ->  +/- 40.96 mV  ->  +/- 2.73 A at 15 mohm
+// At R015 that is 20.83 uA or 5.21 uA per count. A LoRa node's draw sits well
+// inside either range, so resolution is the only thing at stake.
+// ---------------------------------------------------------------------------
+#define INA228_SHUNT_MILLIOHM  15
+
+#define INA228_REG_CONFIG   0x00
+#define INA228_REG_VSHUNT   0x04
+#define INA228_REG_VBUS     0x05
+#define INA228_CONFIG_ADCRANGE  0x0010
+
+// Scales in nV per LSB, x1000 so the integer maths keeps a fractional digit.
+#define INA228_VSHUNT_NV_X1000_R0   312500UL   // 312.5   nV
+#define INA228_VSHUNT_NV_X1000_R1    78125UL   //  78.125 nV
+#define INA228_VBUS_NV_X1000       195312500UL // 195.3125 uV = 195312.5 nV
+
 #define MAX1704X_ADDR    0x36
 #define MAX1704X_VCELL   0x02
 #define MAX1704X_SOC     0x04
@@ -251,6 +290,19 @@ static bool gaugeRead16At(uint8_t addr, uint8_t reg, uint16_t* out) {
 
 static bool gaugeRead16(uint8_t reg, uint16_t* out) {
   return gaugeRead16At(MAX1704X_ADDR, reg, out);
+}
+
+// INA228's measurement registers are 24 bits, not 16. Same transaction shape as
+// gaugeRead16At, three bytes instead of two. Returned right-aligned; the caller
+// does the >>4 and sign-extension, because the field width differs per register.
+static bool gaugeRead24At(uint8_t addr, uint8_t reg, uint32_t* out) {
+  Wire1.beginTransmission(addr);
+  Wire1.write(reg);
+  if (Wire1.endTransmission(false) != 0) return false;
+  if (Wire1.requestFrom(addr, (uint8_t)3) != 3) return false;
+  uint8_t b2 = Wire1.read(), b1 = Wire1.read(), b0 = Wire1.read();
+  *out = ((uint32_t)b2 << 16) | ((uint32_t)b1 << 8) | b0;
+  return true;
 }
 
 // Forward declaration: gaugeBegin() calls this, and it is defined below.
@@ -457,8 +509,68 @@ static void inaProbe() {
 // wrong is the classic INA219 failure -- current and power silently read ZERO
 // until it is right. Reading the raw shunt voltage and dividing on the host
 // needs no magic constant and cannot be half-configured.
+// INA228 read path (#991). Emits the SAME [ina] line shape as the INA219 path so
+// existing captures, greps and parsers keep working -- bus_mv, ma, shunt_uv, then
+// the raw registers. Raw values are printed for the same reason the gauge prints
+// raw_vcell: if a scale is ever wrong, a captured log stays correctable after the
+// fact instead of being silently wrong for hours.
+static uint32_t ina228Tick() {
+  uint32_t rs = 0, rb = 0;
+  uint16_t cfg = 0;
+  if (!gaugeRead24At(ina_addr, INA228_REG_VSHUNT, &rs) ||
+      !gaugeRead24At(ina_addr, INA228_REG_VBUS,   &rb)) {
+    Serial.println("[ina] read FAILED (INA228)");
+    return 0;
+  }
+
+  // ADCRANGE is read, not assumed -- see the constants block. A failed CONFIG
+  // read falls back to the part's own reset default (ADCRANGE=0), which is the
+  // wider, coarser range: it under-resolves rather than over-reporting.
+  const bool have_cfg = gaugeRead16At(ina_addr, INA228_REG_CONFIG, &cfg);
+  const bool adcrange1 = have_cfg && (cfg & INA228_CONFIG_ADCRANGE);
+  const uint32_t nv_x1000 = adcrange1 ? INA228_VSHUNT_NV_X1000_R1
+                                      : INA228_VSHUNT_NV_X1000_R0;
+
+  // 20-bit signed, left-aligned in bits 23:4. Shift first, THEN sign-extend from
+  // bit 19 -- sign-extending the unshifted value would carry the low nibble in.
+  int32_t sh = (int32_t)(rs >> 4);
+  if (sh & 0x00080000L) sh -= 0x00100000L;
+
+  // nV then uV. int64 because 524287 * 312500 overflows int32 by a wide margin.
+  const int64_t shunt_nv = (int64_t)sh * (int64_t)nv_x1000 / 1000;
+  const int32_t shunt_uv = (int32_t)(shunt_nv / 1000);
+
+  // I(uA) = V(nV) / R(ohm) / 1000 = shunt_nv / milliohm  (the 1e3/1e3 cancels)
+  const int64_t ua = shunt_nv / (int64_t)INA228_SHUNT_MILLIOHM;
+  const int32_t ma_x10 = (int32_t)(ua / 100);
+
+  // VBUS: 20-bit unsigned, left-aligned, 195.3125 uV/LSB.
+  const uint32_t bus_mv =
+      (uint32_t)(((uint64_t)(rb >> 4) * INA228_VBUS_NV_X1000) / 1000000000ULL);
+
+  Serial.print("[ina] bus_mv=");
+  Serial.print(bus_mv);
+  Serial.print(" ma=");
+  // Negate into an UNSIGNED accumulator: `x = -x` is undefined for INT32_MIN.
+  // Unreachable at 20 bits, but the pattern is wrong and costs nothing to write
+  // correctly -- same fix as the INA219 path took in the #938 Gemini review.
+  uint32_t mag = (ma_x10 < 0) ? (uint32_t)-(int64_t)ma_x10 : (uint32_t)ma_x10;
+  if (ma_x10 < 0) Serial.print('-');
+  Serial.print(mag / 10); Serial.print('.'); Serial.print(mag % 10);
+  Serial.print("  shunt_uv=");
+  Serial.print(shunt_uv);
+  Serial.print("  raw_shunt=0x"); Serial.print(rs, HEX);
+  Serial.print(" raw_bus=0x");    Serial.print(rb, HEX);
+  Serial.print(adcrange1 ? "  adcrange=1" : "  adcrange=0");
+  if (!have_cfg) Serial.print(" (CONFIG read failed, assumed)");
+  Serial.println();
+  return bus_mv;
+}
+
 static uint32_t inaTick() {
-  if (ina_kind != INA_219_CLASS || ina_addr == 0) return 0;
+  if (ina_addr == 0) return 0;
+  if (ina_kind == INA_228) return ina228Tick();
+  if (ina_kind != INA_219_CLASS) return 0;
 
   uint16_t rs = 0, rb = 0;
   if (!gaugeRead16At(ina_addr, INA219_REG_SHUNT, &rs) ||

--- a/tools/diag/sniffer/rc_uart_sniffer_v3/rc_uart_sniffer_v3.ino
+++ b/tools/diag/sniffer/rc_uart_sniffer_v3/rc_uart_sniffer_v3.ino
@@ -283,8 +283,13 @@ static bool gaugeRead16At(uint8_t addr, uint8_t reg, uint16_t* out) {
   Wire1.write(reg);
   if (Wire1.endTransmission(false) != 0) return false;
   if (Wire1.requestFrom(addr, (uint8_t)2) != 2) return false;
-  uint8_t hi = Wire1.read(), lo = Wire1.read();
-  *out = ((uint16_t)hi << 8) | lo;
+  // TwoWire::read() returns int and yields -1 when the buffer is empty, which an
+  // implicit uint8_t cast turns into 0xFF -- a plausible value, silently wrong.
+  // A successful requestFrom() should guarantee the bytes, so this is defensive
+  // against a non-standard Wire, but "no silent failures" is cheap here.
+  const int hi = Wire1.read(), lo = Wire1.read();
+  if (hi < 0 || lo < 0) return false;
+  *out = ((uint16_t)hi << 8) | (uint8_t)lo;
   return true;
 }
 
@@ -300,8 +305,13 @@ static bool gaugeRead24At(uint8_t addr, uint8_t reg, uint32_t* out) {
   Wire1.write(reg);
   if (Wire1.endTransmission(false) != 0) return false;
   if (Wire1.requestFrom(addr, (uint8_t)3) != 3) return false;
-  uint8_t b2 = Wire1.read(), b1 = Wire1.read(), b0 = Wire1.read();
-  *out = ((uint32_t)b2 << 16) | ((uint32_t)b1 << 8) | b0;
+  // Same -1-becomes-0xFF trap as gaugeRead16At. It matters MORE here: an all-0xFF
+  // VBUS decodes to ~204.8 V, which is nonsense a reader would notice, but an
+  // all-0xFF VSHUNT sign-extends to -1 LSB and reads as a harmless -0.02 mA --
+  // wrong in a way nobody would ever question. (#991 review finding 1.)
+  const int b2 = Wire1.read(), b1 = Wire1.read(), b0 = Wire1.read();
+  if (b2 < 0 || b1 < 0 || b0 < 0) return false;
+  *out = ((uint32_t)(uint8_t)b2 << 16) | ((uint32_t)(uint8_t)b1 << 8) | (uint8_t)b0;
   return true;
 }
 


### PR DESCRIPTION
Task [#991](https://github.com/OffbandMesh/meshcore-firmware/issues/991) under Epic [#990](https://github.com/OffbandMesh/meshcore-firmware/issues/990). Bench tooling only — `tools/diag/sniffer/`, one Arduino sketch. **No firmware change; no shipped env is touched.**

## The problem

An INA228 replaced the INA219-class current monitor on the Feather sniffer rig. The sketch **identified it correctly and then never read it** — `inaTick()` opened with `if (ina_kind != INA_219_CLASS ...) return 0;`, so a recognised INA228 was silently ignored. No `[ina]` lines at all.

**There was no flash reversion**, and the log rules one out: the *same* firmware reported `no TI mfg ID (INA219-class)` through 2026-08-25 08:06 and `mfg=0x5449 dev=0x2281 -> INA228` at 23:59:26. The part changed, not the image.

## What this adds

- `gaugeRead24At()` — 24-bit register read, modelled on the existing 16-bit helper
- `ina228Tick()` — reads `VSHUNT` (0x04) and `VBUS` (0x05), emits the **same `[ina]` line shape** as the INA219 path so existing captures, greps and parsers keep working, plus an `adcrange=` field
- `inaTick()` dispatches by part instead of early-returning

## Three deliberate choices

**No calibration write.** `SHUNT_CAL` only feeds CURRENT/POWER/ENERGY/CHARGE. This reads `VSHUNT` and divides by a known resistance on the host: no magic constant to get wrong, cannot be half-configured, and survives a part reset that would silently invalidate a written calibration. Same reasoning the INA219 path already used.

**The shunt is a property of the part, not the rig.** `INA228_SHUNT_MILLIOHM 15` (Adafruit INA228 breakout carries `R015`), kept separate from the INA219 path's `100` (that module carried `R100`). Mixing them under-reports by 6.67× and looks entirely plausible doing it. A previous note recorded `R100` as a rig-level fact with no part attached — it was only ever confirmed for the INA219, and generalising it made a swapped part look like a firmware defect.

**ADCRANGE is read from CONFIG, not assumed** — a 4× scale difference (312.5 vs 78.125 nV/LSB). Reading it every tick means the decode follows if anything ever configures the part; a failed read falls back to the part's reset default, the coarser range, so it under-resolves rather than over-reports.

## Hardware-verified on `rc52-bench-1`

`[verified: owner-operated bench, 2026-08-26 05:30–05:52Z]`

**Bus voltage, cross-checked against an independent part on the same cell:**

```
[ina]   bus_mv=4164  raw_bus=0x53480
[gauge] mv=4163
```

Recomputed by hand: `0x53480` → `>>4` = 21,320 → × 195.3125 µV = **4164.06 mV**, exactly as printed — and within 1–2 mV of the MAX17048.

**Sign, confirmed by controlled state change rather than assumption:**

| Time | `ma` | State |
|---|---|---|
| 05:49:37 | 0.0 | USB connected, battery full |
| **05:50:07** | **10.1** | **USB unplugged** |
| 05:50:37 → 05:52:07 | 9.7 ×4 | steady on battery |

**Positive = discharge.** `bus_mv` stepped 4165 → 4161 at the same moment, gauge tracking exactly. Noise floor measured at ±7 LSB ≈ **±0.15 mA**.

## ⚠ The old rig's numbers were wrong by an order of magnitude

Idle draw measures **9.7 mA**. The previous INA219-class setup reported **117–182 mA** for the same board. 9.7 mA is what an idle companion should draw — nRF52840 plus SX1262 in RX, display off. 150 mA was never plausible.

**Treat every current figure taken before this commit as suspect**, including the "charging, constant-voltage tail" reading of 2026-08-25. The *direction* was independently corroborated by SOC rising; the magnitudes were not.

## Review gate

Register numbers and LSB values **verified against the TI datasheet (SBOS855F)** — `CONFIG` 0x00, `VSHUNT` 0x04, `VBUS` 0x05, ADCRANGE bit 4, 312.5/78.125 nV, 195.3125 µV. Also confirmed sound: the int64 intermediates, the 20-bit sign extension, the no-calibration approach, and that the dispatch change does not disturb the INA219 path.

**Fixed** — unchecked `Wire.read()`: it returns `int` and yields −1 on an empty buffer, which an implicit `uint8_t` cast turns into `0xFF`. The gate called the result "a large, fictitious current"; that is only half right, and the wrong half is the dangerous one. An all-`0xFF` VBUS decodes to ~204.8 V, obvious nonsense someone would catch — but an all-`0xFF` VSHUNT sign-extends to −1 LSB and reads as **−0.02 mA**, entirely unremarkable. Applied to `gaugeRead16At` too, which carries the identical defect and feeds every gauge reading.

**Declined** — caching ADCRANGE at identification instead of reading it per tick. Reading it is the point: a cached value would silently keep scaling by the wrong factor of 4 if anything reconfigured the part. It saves one 16-bit read per 30 s.

## Scoped out on purpose

The INA228's hardware **charge accumulator** — the feature that makes a runtime figure honest when the load is bursty, which is exactly a LoRa node's TX profile. **The 9.7 mA above is a 30-second sample, so it is idle draw, not average draw under traffic.** It needs `SHUNT_CAL` written and 40-bit reads, so it is [#997](https://github.com/OffbandMesh/meshcore-firmware/issues/997) rather than half-done here.

## Verification

`arduino-cli compile --fqbn esp32:esp32:adafruit_feather_esp32s3` — **395,472 bytes (13%), no warnings.** Secrets/private-IP scan clean. Rebased onto `firmware-base`, 0 behind.

CI's PlatformIO matrix does not compile `.ino` sketches, so it exercises nothing here — that is why the compile was run explicitly and the result stated above.

## Merge

**Ben merges.**
