### PR TITLE
task(#889): RC52 BLE companion diag was missing power telemetry

### DIFF
--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -286,6 +286,43 @@ extends = env:heltec_rc52_companion_radio_ble
 build_flags =
   ${env:heltec_rc52_companion_radio_ble.build_flags}
   ${rc52_diag.build_flags}
+  ; -------------------------------------------------------------------------
+  ; POWER TELEMETRY -- this env only, matching RC32 and RCC6 (#889).
+  ;
+  ; Emits `[pwr] mv=... up=...s` every 30 s. It is NOT part of the shared
+  ; [rc52_diag] block on purpose: RC32 records why it is kept off the boot-
+  ; diagnosis builds -- "a battery line every 30 s is noise when the question is
+  ; 'why will it not boot'". So it belongs on the BLE companion diag and nowhere
+  ; else, which is exactly where RC32 and RCC6 put it:
+  ;   heltec_rc32_companion_radio_ble_diag  -D OFFBAND_POWER_TELEMETRY
+  ;   heltec_rcc6_companion_radio_ble_diag  -D OFFBAND_POWER_TELEMETRY
+  ;
+  ; WHY IT IS LOAD-BEARING, not decoration: #857's runtime burn defines runtime
+  ; as (last [pwr] timestamp - first on-battery [pwr] timestamp). Without this
+  ; flag the burn cannot be measured the way RC32 (21 h 34 m 31 s) and RCC6
+  ; (43 h 21 m 55 s) were, and a number produced any other way is not comparable
+  ; to either -- same cell, same cutoff, same role, same instrument, or it does
+  ; not go in the table.
+  ;
+  ; This was the last gap against #889's "union of both predecessors" bar. RC52
+  ; had the beacon, the mirror and forced caplog; power telemetry was missed.
+  ;
+  ; ⚠ THE INSTRUMENT COSTS POWER, AND ITS COST IS NOT THE SAME ON EVERY BOARD.
+  ; This flag periodically wakes the CPU, enables the battery divider, takes an
+  ; ADC read and logs a line -- energy a non-diag build does not spend, so every
+  ; measured runtime is shorter than the shipped firmware's would be. That is
+  ; acceptable for comparing RC52 against RC32 and RCC6 only because all three
+  ; were measured the same way. It is NOT a shipped-build runtime and must never
+  ; be quoted to a user as one.
+  ;
+  ; And the comparison carries an assumption worth stating: RC52 is nRF52840
+  ; while RC32/RCC6 are ESP32. Different ADC architecture, different wake and
+  ; sample costs, so the instrumentation overhead is NOT guaranteed equal across
+  ; the three. [hypothesis: untested] The overhead is similar enough not to
+  ; distort the comparison. If a runtime difference ever lands within a few
+  ; percent, measure the overhead before believing it. (#889 review gate.)
+  ; -------------------------------------------------------------------------
+  -D OFFBAND_POWER_TELEMETRY
 
 ; ---------------------------------------------------------------------------
 ; BENCH EXPERIMENT ONLY -- #856/#951. NOT a shipping env, NOT in CI, NOT in the


### PR DESCRIPTION
Task [#889](https://github.com/OffbandMesh/meshcore-firmware/issues/889) under Epic [#879](https://github.com/OffbandMesh/meshcore-firmware/issues/879). One flag, one env.

## The gap

RC52 carried `OFFBAND_POWER_TELEMETRY` on **zero** envs. RC32 and RCC6 each carry it on exactly one — their BLE companion diag. #889's bar was explicitly *"the union of both predecessors, not either one"* and named power telemetry in RC32's column, so RC52 was short of it. This was missed when the rest of #889's structural work landed.

## Scoped to one env, matching both predecessors

**Not** added to the shared `[rc52_diag]` block, deliberately. RC32 records why it is kept off the boot-diagnosis builds:

> a battery line every 30 s is noise when the question is "why will it not boot", and the tester has no battery instrumentation rig

So it belongs on the burndown env and nowhere else, which is where RC32 and RCC6 put it.

## Why it is load-bearing

[#857](https://github.com/OffbandMesh/meshcore-firmware/issues/857) defines runtime as *(last `[pwr]` timestamp − first on-battery `[pwr]` timestamp)*. Without this flag an RC52 burn cannot be measured the way RC32 (**21 h 34 m 31 s**) and RCC6 (**43 h 21 m 55 s**) were, and a number produced any other way is not comparable to either.

## Verified on the wire, not merely built

`[verified: rc52-bench-1, 2026-08-26 06:51Z]`

```
[4964]  [pwr] mv=4152 up=4s
[34964] [pwr] mv=4170 up=34s
[64964] [pwr] mv=4163 up=64s
```

Correct format, 30 s cadence, arriving over the UART mirror. Boot clean through `setup:DONE`, beacons intact.

## #889's other open criterion, closed by control

The last acceptance line was *"caplog output, on a role that is not the BLE companion."* Proven by building the identical env **without** `FORCE_CAPLOG`, keeping beacon and mirror:

| | with `FORCE_CAPLOG` | control |
|---|---|---|
| `[BEACON]`, `[boot]`, `[rc52disp]`, `[gauge]`, `[ina]`, `[xchk]` | ✅ | ✅ |
| **`DEBUG:` MeshLog stream** | **✅ from [4810]** | **❌ none** |

The `DEBUG:` stream vanished entirely while everything else stayed — so `FORCE_CAPLOG` is what puts it there, and this board does **not** carry `caplog_enabled` persisted, which was the alternative explanation. The control env was temporary, removed, and never entered a commit (worktree verified clean, `pio project config` shows zero occurrences).

## Review gate

**Taken** — the instrument costs power, and its cost is not the same on every board. The flag wakes the CPU, enables the divider, takes an ADC read and logs, so every measured runtime is shorter than the shipped firmware's would be. Worse, RC52 is nRF52840 while RC32/RCC6 are ESP32 — different ADC architecture, different wake and sample costs, so the overhead is **not guaranteed equal** across the three. Recorded in the comment, tagged `[hypothesis: untested]`, with the instruction to measure the overhead before believing any runtime difference that lands within a few percent. Also stated plainly: this is not a shipped-build runtime and must never be quoted to a user as one.

**Declined** — *"also add it to `_usb_diag`."* That would go **beyond** the predecessors, not match them: RC32's USB testdiag block says in terms *"Deliberately NOT included: `OFFBAND_POWER_TELEMETRY`."* Following the precedent means keeping it off the USB diag. The burndown methodology for both existing boards is BLE companion, and a USB-role number would not be comparable to either.

Clean on the other three questions checked: no effect on the shipped non-diag env, cadence consistent at 30 s, and no factual errors in the comment.

## Verification

`pio run -e heltec_rc52_companion_radio_ble_diag` **SUCCESS**. `envdump` confirms `OFFBAND_POWER_TELEMETRY`, `OFFBAND_FORCE_CAPLOG`, `OFFBAND_BOOT_BEACON` and `OFFBAND_LOG_MIRROR_UART` all present. Secrets/private-IP scan clean. Rebased onto `firmware-base`, 0 behind, single commit.

## Merge

**Ben merges.** Epic closure remains a human-only gate — [#876](https://github.com/OffbandMesh/meshcore-firmware/issues/876) reports, the owner decides.
