### PR TITLE
task(#1005): AUTO_SHUTDOWN_MILLIVOLTS=3400 on the RC52 BLE companion envs

### DIFF
--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -290,13 +290,21 @@ build_flags =
   ; once in checkBootVoltage() at startup; this acts during the run.
   ;
   ; RC52 is the only board in the fleet carrying BOTH (RC32/RCC6 have no boot
-  ; gate), so the interaction was reviewed rather than assumed. A cutoff ABOVE
-  ; the boot gate cannot boot-loop the board: below 3300 checkBootVoltage()
-  ; calls initiateShutdown() and the part enters SYSTEMOFF, and between 3300
-  ; and 3400 it boots and then shuts down cleanly again on the runtime path.
-  ; Neither is a brownout -- the nRF52840 browns out near 1.7 V, far below
-  ; both numbers. The visible effect is a short boot/shutdown cycle on a
-  ; near-flat cell, not damage. [reviewed 2026-08-26, #1005]
+  ; gate). The cutoff cannot boot-loop the board -- below 3300
+  ; checkBootVoltage() calls initiateShutdown() and the part enters SYSTEMOFF,
+  ; and the nRF52840 browns out near 1.7 V, far below either number.
+  ;
+  ; But do NOT read those two as the whole picture, because a THIRD gate runs
+  ; before both of them and is the one that actually fires:
+  ; SafeBoot::checkAndMaybeSleep() (simple_repeater/main.cpp, before
+  ; board.begin()) is compiled in on this board -- PIN_VBAT_READ is defined
+  ; above, which satisfies the SafeBoot.cpp gate -- and it sleeps below
+  ; SLEEP_MV 3400, higher than the 3300 bootlock and equal to this cutoff.
+  ; The board therefore never reaches begin() in the 3300-3400 band, which
+  ; makes PWRMGT_VOLTAGE_BOOTLOCK effectively unreachable: armed protection
+  ; that reads as live and is not. Three thresholds, three mechanisms, no
+  ; single owner. Being fixed as one coherent policy in #1007 (under #882) --
+  ; do not tune any of these three in isolation. [verified 2026-08-26, #1005]
   -D AUTO_SHUTDOWN_MILLIVOLTS=3400
 build_src_filter = ${Heltec_RC52_with_display.build_src_filter}
   +<helpers/nrf52/SerialBLEInterface.cpp>

--- a/variants/heltec_rc52/platformio.ini
+++ b/variants/heltec_rc52/platformio.ini
@@ -273,6 +273,31 @@ build_flags =
   -D MAX_GROUP_CHANNELS=40
   -D BLE_PIN_CODE=123456
   -D OFFLINE_QUEUE_SIZE=256
+  ; Battery cutoff. The firmware shuts the board down cleanly at this reading
+  ; rather than running the cell flat -- without it the shutdown path compiles
+  ; out entirely and a discharge run has no defined endpoint (#1005).
+  ;
+  ; 3400 matches RC32 and RCC6 so the three RadioCore runtimes are directly
+  ; comparable: RC32 21h34m (#833), RCC6 43h22m (#903), RC52 pending (#1004).
+  ; The in-tree nRF52 boards (lilygo_techo) use 3300; comparability was judged
+  ; the stronger argument and the divergence is deliberate.
+  ;
+  ; NOT on the USB companion (tethered, no cell to protect) and NOT on
+  ; repeater/room_server (mains or solar -- self-shutdown on a dip is worse
+  ; behavior than continuing, and changing that is a fleet-wide policy call).
+  ;
+  ; This is NOT the boot gate. PWRMGT_VOLTAGE_BOOTLOCK (variant.h, 3300) acts
+  ; once in checkBootVoltage() at startup; this acts during the run.
+  ;
+  ; RC52 is the only board in the fleet carrying BOTH (RC32/RCC6 have no boot
+  ; gate), so the interaction was reviewed rather than assumed. A cutoff ABOVE
+  ; the boot gate cannot boot-loop the board: below 3300 checkBootVoltage()
+  ; calls initiateShutdown() and the part enters SYSTEMOFF, and between 3300
+  ; and 3400 it boots and then shuts down cleanly again on the runtime path.
+  ; Neither is a brownout -- the nRF52840 browns out near 1.7 V, far below
+  ; both numbers. The visible effect is a short boot/shutdown cycle on a
+  ; near-flat cell, not damage. [reviewed 2026-08-26, #1005]
+  -D AUTO_SHUTDOWN_MILLIVOLTS=3400
 build_src_filter = ${Heltec_RC52_with_display.build_src_filter}
   +<helpers/nrf52/SerialBLEInterface.cpp>
   +<../examples/companion_radio/*.cpp>
@@ -414,6 +439,8 @@ build_flags =
   -D MAX_GROUP_CHANNELS=40
   -D BLE_PIN_CODE=123456
   -D OFFLINE_QUEUE_SIZE=256
+  ; See the with-display companion above for why 3400 and why BLE-only (#1005).
+  -D AUTO_SHUTDOWN_MILLIVOLTS=3400
 build_src_filter = ${heltec_rc52.build_src_filter}
   +<helpers/nrf52/SerialBLEInterface.cpp>
   +<../examples/companion_radio/*.cpp>


### PR DESCRIPTION
Adds the runtime battery cutoff the RC52 discharge run ([#1004](https://github.com/OffbandMesh/meshcore-firmware/issues/1004)) needs to have an endpoint at all. Closes [#1005](https://github.com/OffbandMesh/meshcore-firmware/issues/1005).

## What was wrong

`AUTO_SHUTDOWN_MILLIVOLTS` appeared **nowhere** in `variants/heltec_rc52/platformio.ini` — zero occurrences on `firmware-base`. The shutdown path compiles out when the macro is undefined, so a discharge run had no defined termination and would pull the cell below safe voltage instead of the board stopping itself. Same blocker [#878](https://github.com/OffbandMesh/meshcore-firmware/issues/878) cleared for RCC6.

`PWRMGT_VOLTAGE_BOOTLOCK` (3300) does **not** cover this — that is the boot gate in `checkBootVoltage()`, a different mechanism that only acts at startup.

## The change

`-D AUTO_SHUTDOWN_MILLIVOLTS=3400` on the two **BLE companion** envs — with-display and without-display. `_diag` and `_diag_nobuf` inherit through `extends`, so it is not duplicated.

**3400 for comparability.** It is what makes the three RadioCore runtimes mean anything against each other:

| Board | MCU | Runtime to 3400 mV | Avg current |
|---|---|---|---|
| RC32 | ESP32-S3 | 21 h 34 m 31 s | ~116 mA |
| RCC6 | ESP32-C6 | 43 h 21 m 55 s | ~58 mA |
| RC52 | nRF52840 | *this PR enables it* | ~10–16 mA observed |

The in-tree nRF52 boards (`lilygo_techo`) use 3300; the divergence is deliberate and documented inline.

**Not applied** to USB companion envs (tethered, no cell to protect) or repeater/room_server (mains or solar — self-shutdown on a dip is worse behavior than continuing). This matches RC32 and RCC6, which exclude the same roles.

## Verification

Confirmed from the **resolved compiler defines** (`pio run -t idedata`), not read off the ini:

```
AUTO_SHUTDOWN_MILLIVOLTS=3400   <- this PR
OFFBAND_POWER_TELEMETRY         <- via #1003
OFFBAND_FORCE_CAPLOG
OFFBAND_LOG_MIRROR_UART=1
```

The macro resolves **once** in `heltec_rc52_companion_radio_ble_diag`, proving the `extends` inheritance rather than assuming it. Builds SUCCESS on all three affected envs (`..._companion_radio_ble`, `..._companion_radio_ble_diag`, `..._without_display_companion_radio_ble`).

## Gemini adversarial gate — 5 findings, all dispositioned

| # | Finding | Disposition |
|---|---|---|
| 1 | `extends` works; duplicate `-D` harmless | No defect; matches the empirical check |
| 2 | `;` comments inside `build_flags` "will break the build" | **Refuted.** Three envs build SUCCESS with them, RC32 already uses this pattern throughout, and the resolved defines are clean |
| 3 | 3400 above the 3300 boot gate causes a brownout boot loop | **Refuted by the code.** Below 3300 `checkBootVoltage()` calls `initiateShutdown()` → SYSTEMOFF, so it cannot loop; 3.3–3.4 V is far above the nRF52840's ~1.7 V brownout; and the stated mechanism had cell relaxation moving the wrong way. RC52 is the only board carrying both gates, so the analysis is recorded inline rather than left implicit |
| 4 | Excluding repeater/room_server is "indefensible" — a battery repeater runs its cell flat | **Referred to the owner, not silently dismissed.** The point is fair, but RC32 and RCC6 exclude these roles too, so this PR matches convention rather than opening a new gap. Widening it is a fleet-wide policy change |
| 5 | Single unaveraged ADC sample against a nominal 4.90 divider | **Accepted as caveats.** Tracked on [#982](https://github.com/OffbandMesh/meshcore-firmware/issues/982) and [#857](https://github.com/OffbandMesh/meshcore-firmware/issues/857). ±3.5% is ±119 mV at 3400, so **"3400" is nominal per board, not actual** — the MAX17048 reading at termination is the honest cross-board figure and will be reported alongside the runtime |

## Scope

One file, one macro, two envs. No source changes, no shared-driver changes, no behavior change on any board other than RC52 BLE companions.

Epic #1004 stays open and carries the burn.
