### PR TITLE
fix(#1012): one registry, one flash history, outside every checkout

### DIFF
--- a/.claude/hooks/block-raw-curl-ota.py
+++ b/.claude/hooks/block-raw-curl-ota.py
@@ -50,7 +50,28 @@ import sys
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-REGISTRY_PATH = PROJECT_ROOT / "hardware-devices.yaml"
+
+# #1012: the registry is per-host and canonical, NOT checkout-local.
+#
+# Resolution lives in scripts/offband_state.py and is NOT duplicated here: a
+# second copy of the path logic drifts, and a security hook reading a
+# different registry than the tool it guards is worse than no hook.
+#
+# sys.path.append (NOT insert(0)) so a file dropped in scripts/ cannot shadow
+# a stdlib module for this hook.
+sys.path.append(str(PROJECT_ROOT / "scripts"))
+try:
+    from offband_state import registry_path
+except ImportError as _e:  # no silent second implementation -- see below
+    print(
+        "WARN: block-raw-curl-ota: cannot import scripts/offband_state.py "
+        f"({_e}); OTA IP guard is OPEN. Fix the checkout.",
+        file=sys.stderr,
+    )
+    registry_path = None
+
+REGISTRY_PATH = registry_path() if registry_path else None
+
 WRAPPER_PATH = "scripts/ota-push.py"
 
 
@@ -60,7 +81,7 @@ def load_known_lora_ips() -> list[str]:
     have an 'ota' block. Returns empty list on any registry load failure
     (intentional fail-open: bad registry shouldn't block all curl usage).
     """
-    if not REGISTRY_PATH.exists():
+    if REGISTRY_PATH is None or not REGISTRY_PATH.exists():
         return []
     try:
         import yaml

--- a/scripts/companion_harness.py
+++ b/scripts/companion_harness.py
@@ -111,23 +111,14 @@ def parse_self_info(body: bytes) -> dict:
 
 
 def _registry_clone_root():
-    """Locate the clone that holds the gitignored hardware-devices.yaml. It lives
-    only in the primary clone (main worktree), so resolve it via the shared git
-    common dir -- this makes the harness work whether it runs from the primary
-    clone or any worktree (where the registry file is absent)."""
-    here = os.path.dirname(os.path.abspath(__file__))
-    try:
-        common = subprocess.run(
-            ["git", "-C", here, "rev-parse", "--path-format=absolute", "--git-common-dir"],
-            capture_output=True, text=True, timeout=10,
-        ).stdout.strip()
-        if common:
-            root = os.path.dirname(common)  # <primary>/.git -> <primary>
-            if os.path.exists(os.path.join(root, "hardware-devices.yaml")):
-                return root
-    except Exception:
-        pass
-    return os.path.dirname(here)  # fallback: this script's own clone
+    """Directory holding scripts/pio-flash.py -- this script's own clone."""
+    # Before #1012 this hunted for "the clone that has hardware-devices.yaml",
+    # because the registry was checkout-local and absent from worktrees. That
+    # hunt was a workaround for the fork bug, not a feature: the registry is
+    # now ONE per-host file outside every checkout (scripts/offband_state.py),
+    # so any copy of pio-flash.py resolves the same registry and there is
+    # nothing to search for.
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 def parse_caplog_status(body: bytes) -> dict:

--- a/scripts/offband_state.py
+++ b/scripts/offband_state.py
@@ -1,0 +1,57 @@
+r"""Canonical per-host state locations for this repo (#1012).
+
+ONE registry and ONE flash history for meshcore-firmware, living OUTSIDE every
+checkout. Not in the clone, not in a worktree, not shared with any other repo.
+
+Why this module exists
+----------------------
+Before #1012 each consumer computed its own path as
+``Path(__file__).parent.parent / "hardware-devices.yaml"`` -- i.e. relative to
+the checkout the script happened to be running from. Every worktree that ran a
+flash silently forked the registry, the history and the backups. Measured
+2026-08-27: 80 worktrees, three registry copies (one 7 days stale) and the
+flash audit trail split 2805 / 6 across two files.
+
+That is a safety problem. #503 made the registry the thing that decides WHICH
+PHYSICAL DEVICE gets written, and the history is the record of what was
+written to it.
+
+Scope
+-----
+THIS REPO ONLY. C:\Dev\LoRa and C:\Dev\wadamesh keep their own registries and
+their own histories; nothing here reads, writes or merges them. Their device
+short-names are not guaranteed to mean the same hardware.
+
+Override precedence (matches the #27 pattern used by pio-flash FIRMWARE_DIR):
+    per-artifact env var  >  OFFBAND_STATE_DIR  >  platform default
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def default_state_dir() -> Path:
+    """Beside the clones, never inside one."""
+    if os.name == "nt":
+        # NB: the trailing separator matters -- Path("C:") / "Dev" is
+        # DRIVE-RELATIVE on Windows, not C:\Dev.
+        return Path(os.environ.get("SystemDrive", "C:") + "/") / "Dev" / ".offband"
+    return Path.home() / ".offband"
+
+
+def state_dir() -> Path:
+    return Path(os.environ.get("OFFBAND_STATE_DIR") or default_state_dir())
+
+
+def registry_path() -> Path:
+    return Path(os.environ.get("PIO_FLASH_REGISTRY") or (state_dir() / "hardware-devices.yaml"))
+
+
+def flash_history_path() -> Path:
+    return Path(os.environ.get("PIO_FLASH_HISTORY") or (state_dir() / "flash-history.jsonl"))
+
+
+def backups_dir() -> Path:
+    return Path(os.environ.get("PIO_FLASH_BACKUPS") or (state_dir() / "flash-backups"))

--- a/scripts/ota-push.py
+++ b/scripts/ota-push.py
@@ -75,8 +75,14 @@ except ImportError:
 # Constants
 # ---------------------------------------------------------------------------
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
-REGISTRY_PATH = PROJECT_ROOT / "hardware-devices.yaml"
-FLASH_HISTORY_PATH = PROJECT_ROOT / "flash-history.jsonl"
+
+# #1012: ONE registry and ONE history for this repo, outside every checkout.
+# Never checkout-local -- see scripts/offband_state.py for why.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from offband_state import registry_path, flash_history_path  # noqa: E402
+
+REGISTRY_PATH = registry_path()
+FLASH_HISTORY_PATH = flash_history_path()
 # Secrets source. LoRa#209 moved secrets out of a co-located (and now
 # deprecated) platformio.local.ini into a canonical file the BUILD reads via
 # `extra_configs = ${sysenv.PIO_SECRETS_FILE}` (see platformio.ini). ota-push

--- a/scripts/pio-flash.py
+++ b/scripts/pio-flash.py
@@ -68,8 +68,41 @@ from firmware_identity import get_firmware_identity  # noqa: E402
 # Constants
 # ---------------------------------------------------------------------------
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
-REGISTRY_PATH = PROJECT_ROOT / "hardware-devices.yaml"
-FLASH_HISTORY_PATH = PROJECT_ROOT / "flash-history.jsonl"
+
+# ---------------------------------------------------------------------------
+# Canonical per-host state directory (#1012).
+#
+# Durable per-host state MUST NOT be addressed through a checkout. PROJECT_ROOT
+# is derived from THIS SCRIPT'S OWN LOCATION, and this script is committed to
+# the repo -- so before #1012 every worktree that ran a flash silently forked
+# the device registry, the flash history and the backups. Measured 2026-08-27:
+# 80 worktrees, three registry copies (one 7 days stale), and the flash audit
+# trail split 2805 / 6 records across two files.
+#
+# That is a safety problem, not untidiness: #503 made the registry the thing
+# that decides WHICH PHYSICAL DEVICE gets written, and the history is the
+# record of what was written to it.
+#
+# One location, outside every repo, that nothing copies or relocates.
+# The resolution lives in ONE place -- scripts/offband_state.py -- because a
+# second copy of the path logic is the same class of bug as a second copy of
+# the registry. Override precedence is documented there.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from offband_state import (  # noqa: E402
+    registry_path,
+    flash_history_path,
+    backups_dir as _backups_dir,
+)
+
+STATE_DIR = registry_path().parent
+REGISTRY_PATH = registry_path()
+FLASH_HISTORY_PATH = flash_history_path()
+BACKUPS_DIR = _backups_dir()
+
+# Where these lived before #1012. Used ONLY to produce an actionable error --
+# never read as a fallback, because silently falling back to a checkout-local
+# registry is the exact failure this change exists to remove.
+_LEGACY_REGISTRY_PATH = PROJECT_ROOT / "hardware-devices.yaml"
 # #500 OWNER RULING: tokens have NO wall-clock expiry. ONE APPROVAL = ONE
 # FLASH; the owner's GO does not rot while he is away. A token is single-use
 # (deleted on confirm) and hard-invalidates on real state drift — port,
@@ -150,10 +183,25 @@ def refuse(msg: str, *, exit_code: int = 1) -> "NoReturn":
 # ---------------------------------------------------------------------------
 def load_registry() -> dict:
     if not REGISTRY_PATH.exists():
-        refuse(
-            f"hardware-devices.yaml not found at {REGISTRY_PATH}. "
-            "Run A1 first or fix PROJECT_ROOT in this script."
-        )
+        lines = [
+            f"hardware-devices.yaml not found at {REGISTRY_PATH}.",
+            "  This is the canonical per-host location (#1012); it is NOT "
+            "inside any repo or worktree.",
+        ]
+        if _LEGACY_REGISTRY_PATH.exists():
+            lines += [
+                f"  A pre-#1012 registry still exists at {_LEGACY_REGISTRY_PATH}.",
+                "  It is NOT used as a fallback -- a checkout-local registry is "
+                "the bug #1012 fixed.",
+                "  Migrate it deliberately:",
+                f"    mkdir -p '{STATE_DIR}'",
+                f"    mv '{_LEGACY_REGISTRY_PATH}' '{REGISTRY_PATH}'",
+                "  If several copies exist, pick the newest by hand -- registries "
+                "cannot be merged mechanically.",
+            ]
+        else:
+            lines.append("  Run 'pio-flash bootstrap' to register the first device.")
+        refuse(chr(10).join(lines))
     with REGISTRY_PATH.open(encoding="utf-8") as f:
         data = yaml.safe_load(f)
     if not isinstance(data, dict):
@@ -2310,7 +2358,7 @@ def cmd_backup(args, registry):
     port, entry = resolve_device(args.device, registry)
     _verify_bridge_mac(port, entry, args.device)  # #468: chip resets anyway
 
-    backups_dir = PROJECT_ROOT / "flash-backups"
+    backups_dir = BACKUPS_DIR  # #1012: canonical, not checkout-local
     backups_dir.mkdir(exist_ok=True)
 
     timestamp = time.strftime("%Y%m%d-%H%M%S")


### PR DESCRIPTION
Fixed in `d30f69fc` on `epic/736-canonical-flash-state`.

## One registry, one history, this repo

```
C:\Dev\.offband\hardware-devices.yaml
C:\Dev\.offband\flash-history.jsonl
C:\Dev\.offband\flash-backups\
```

Outside every checkout. Not in the clone, not in any of the 80 worktrees, never read from or merged with `C:\Dev\LoRa` or `C:\Dev\wadamesh` — their device short-names are not guaranteed to mean the same hardware.

## Verified, not asserted

| Check | Result |
|---|---|
| All four consumers resolve one path | ✅ 1 unique path |
| Copies remaining in clone / worktrees | **0** |
| Path logic definitions in the tree | **1** (`scripts/offband_state.py`) |
| OTA guard IPs | **0 → 2** (it was silently fail-open after the move) |
| History consolidation | 2805 + 6 = **2811**, content-hash verified, 0 dupes, 0 lost, 0 foreign |
| Backups | 57 / 57 files |
| Registry | 27 devices, all fields intact |

Originals preserved at `C:\Dev\.offband\_migrated-2026-08-27\` — nothing deleted.

## Consumers repointed

`scripts/pio-flash.py`, `scripts/ota-push.py`, `.claude/hooks/block-raw-curl-ota.py`, and `scripts/companion_harness.py` — whose "find the clone that holds the registry" search was itself a workaround for this bug and is gone.

## Gemini gate — 6 findings

**Fixed (3):**
1. **`_default_state_dir` was copy-pasted into `pio-flash.py`** as well as living in `offband_state.py` — a second copy of the path logic, which is the same class of bug this change exists to remove. The most damning finding; it directly contradicted the change's purpose. `pio-flash` now imports.
2. **The OTA hook's `except ImportError` fallback reimplemented the path logic incorrectly** — it ignored `PIO_FLASH_REGISTRY` and the POSIX default, creating a new silent-failure path in a security hook. Removed; the hook now warns loudly and reports the guard as open rather than guessing.
3. **`sys.path.insert(0, ...)` in a security hook** allowed a file in `scripts/` to shadow a stdlib module. Changed to `append`.

**Refuted with evidence (2):**
4. *"Merging JSONL by non-unique `ts_unix` will cause data loss on collision."* — False. The merge is `sorted(a + b, key=ts)`; sorting a concatenation never drops records. Demonstrated with a deliberate same-second collision: 2 + 2 → 4 records, none lost. The real merge was independently verified by content hash — every source record present, zero extras.
5. *"Clearly a manual spot-check; 77+ worktrees never scanned."* — False. A full-tree sweep was run (`find C:/Dev -name flash-history.jsonl` and the same for the registry). It is what found the LoRa and wadamesh histories and the 7-day-stale `meshcore-firmware-prefix` registry.

**Referred to the owner (1):**
6. *"Hardcoded `C:\Dev` is indefensible; use `%LOCALAPPDATA%`."* — A fair convention argument. `C:\Dev\.offband` was chosen because it sits beside the clones and is discoverable; `%LOCALAPPDATA%` is more conventional but hidden. `OFFBAND_STATE_DIR` overrides either way. Owner's call, not the reviewer's.

## Residual risk, stated rather than hidden

The 80 existing worktrees hold **old copies of these scripts** that still compute checkout-local paths. They cannot be patched retroactively. Because the old files have been moved away, those old scripts now **refuse** with "registry not found" rather than reading stale data — which is the safe failure. The remaining exposure is someone running `pio-flash bootstrap` from an old worktree and creating a fresh empty registry there.
