### PR TITLE
fix(#984): set RAK3401_NO_GPS on every RAK3401 env — the GPS probe kills TX

### DIFF
--- a/variants/rak3401/platformio.ini
+++ b/variants/rak3401/platformio.ini
@@ -6,7 +6,20 @@ build_flags = ${nrf52_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/rak3401
   -D RAK_3401
-  -D RAK_BOARD               ; #104: compile the WisBlock RAK12500 (u-blox ZOE-M8Q) I2C GPS path. Probe is slot-agnostic; Slot D is the RAK19007 GNSS slot.
+  ; #984: -D RAK_BOARD REMOVED. #104 added it to compile the WisBlock RAK12500
+  ; I2C GPS path. It is the ONLY thing that gates gpsIsAwake(), whose probe drives
+  ; WB_IO2 == PIN_3V3_EN -- the 3V3_S rail and the 5V boost feeding the SX1262 and
+  ; its SKY66122 PA -- then abandons that pin floating when no GPS answers.
+  ;
+  ; Upstream MeshCore does NOT define RAK_BOARD for this variant, so upstream never
+  ; compiles the probe at all. Every other RAK3401 file here is functionally
+  ; identical to upstream (variant.cpp, target.cpp/h, RAK3401Board.h byte-identical;
+  ; variant.h and RAK3401Board.cpp differ by comments only). This define was the
+  ; whole divergence.
+  ;
+  ; RAK3401_NO_GPS is kept per-env as defense in depth -- it independently blocks the
+  ; probe if RAK_BOARD is ever reinstated. Re-enabling GPS needs the pin conflict
+  ; solved first; that work was investigated and deferred. See #984.
   ; #104: GPS pins mirror rak4631 -- the RAK12500 path references these (Serial1 setup + PIN_GPS_EN) even though the module is I2C.
   -D PIN_GPS_TX=PIN_SERIAL1_RX
   -D PIN_GPS_RX=PIN_SERIAL1_TX

--- a/variants/rak3401/platformio.ini
+++ b/variants/rak3401/platformio.ini
@@ -49,6 +49,7 @@ build_flags =
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
   -D MAX_NEIGHBOURS=50
+  -D RAK3401_NO_GPS              ; #984: boot probe floats WB_IO2 (radio power) -> kills TX (-707)
   ; PIN_STATUS_LED now inherited from the [rak3401] base (was repeater-only) -- #7/#9
   ;-D MESH_PACKET_LOGGING=1
   ;-D MESH_DEBUG=1
@@ -68,6 +69,7 @@ build_flags =
   -D ROOM_PASSWORD='"hello"'
   ;-D MESH_PACKET_LOGGING=1
   ;-D MESH_DEBUG=1
+  -D RAK3401_NO_GPS              ; #984: boot probe floats WB_IO2 (radio power) -> kills TX (-707)
 build_src_filter = ${rak3401.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_room_server>
@@ -129,6 +131,7 @@ build_flags =
   -D MAX_GROUP_CHANNELS=1
   ;-D MESH_PACKET_LOGGING=1
   ;-D MESH_DEBUG=1
+  -D RAK3401_NO_GPS              ; #984: boot probe floats WB_IO2 (radio power) -> kills TX (-707)
 build_src_filter = ${rak3401.build_src_filter}
   +<../examples/simple_secure_chat/main.cpp>
 lib_deps =
@@ -146,12 +149,18 @@ build_flags =
   -D ADMIN_PASSWORD='"password"'
   ;-D MESH_PACKET_LOGGING=1
   ;-D MESH_DEBUG=1
+  -D RAK3401_NO_GPS              ; #984: boot probe floats WB_IO2 (radio power) -> kills TX (-707)
 build_src_filter = ${rak3401.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_sensor>
 
 [env:RAK_3401_kiss_modem]
 extends = rak3401
+; This env had no build_flags of its own; one is added solely to carry the #984
+; flag. Everything else still comes from the [rak3401] base.
+build_flags =
+  ${rak3401.build_flags}
+  -D RAK3401_NO_GPS              ; #984: boot probe floats WB_IO2 (radio power) -> kills TX (-707)
 build_src_filter = ${rak3401.build_src_filter}
   +<../examples/kiss_modem/>
 


### PR DESCRIPTION
## Root cause: the GPS probe drives and then floats the radio's power rail

`EnvironmentSensorManager::gpsIsAwake()` drives WisBlock IO pins hunting for a GPS module. On RAK3401, `variant.h` aliases **`WB_IO2` to `PIN_3V3_EN`** — the switched 3V3_S rail and 5V boost feeding the SX1262 and its SKY66122 PA, driven HIGH on purpose by `RAK3401Board::begin()`, which runs **before** the probe.

The probe pulls that rail LOW for 500 ms and, when no GPS answers, abandons the pin as a floating `INPUT`.

**Only the two companion envs carried `RAK3401_NO_GPS`. The other five did not.** That is the single build difference that touches the radio — every RF define is identical across roles:

| | repeater | companion |
|---|---|---|
| `LORA_TX_POWER` | 22 | 22 |
| `SX126X_CURRENT_LIMIT` | 140 | 140 |
| `SX126X_DIO2_AS_RF_SWITCH` | via variant.h | via variant.h |
| `SX126X_POWER_EN` | via variant.h | via variant.h |
| **`RAK3401_NO_GPS`** | **absent** | **present** |

That is why the companion works and the repeater does not, on a factory-sealed unit.

## What is NOT claimed

The existing comment on this flag says the TCXO cannot start and RadioLib returns `-707`. **That was not observed here and is not asserted.** `simple_repeater/main.cpp:1207` calls `halt()` when `radio_init()` fails, so a genuine init failure would leave the board mute. The un-flagged build answered every CLI command sent to it — `set name`, `set radio`, `set tx`, reboot, six read-backs. `radio_init()` succeeded.

What the measurements support is that the radio comes up while its front end does not: firmware acknowledges every transmit and almost nothing leaves the board.

`[hypothesis: untested]` the floating rail leaves the PA unpowered or marginal while the SX1262 core still runs. **The exact electrical mechanism is not diagnosed.**

## Evidence

Two units, one factory-sealed, forced transmits via `advert.zerohop`, zero-span analyser, `send_failed=0` on every level:

- No relationship between commanded TX power and output — tx 8 read hotter than tx 18
- 2 of 11 cycles captured anything at all; five levels captured nothing
- Range −21.6 to −55.1 dBm against +20.30 from healthy boards
- Healthy boards the same night: `stale=0`, spread ≤1.0 dB, monotonic

A hypothesis that the build-visibility of `SX126X_DIO2_AS_RF_SWITCH` was the cause was **disproven** by preprocessor probe — the macro is visible and `setDio2AsRfSwitch(true)` is called on both roles.

## The fix

`-D RAK3401_NO_GPS` on all seven RAK3401 envs. `kiss_modem` had no `build_flags` block, so one was added inheriting the base solely to carry the flag.

Fixing the probe itself was investigated on this hardware, found to be a nest of conflicts, and **deferred indefinitely**. Disabling GPS here is the standing decision — it was simply never applied beyond the companions. This applies it; it does not change it.

## Verification

Preprocessor `#pragma message` in both branches of the `RAK_WISBLOCK_GPS` guard, built, then removed:

| env | probe |
|---|---|
| all seven RAK3401 envs | **COMPILED OUT** |
| `RAK_4631_repeater` (control) | COMPILED IN — unaffected |

Eight envs build SUCCESS. Flashed to `RAK3401-radio-3`, sha256 `f16e3fa37bba8a80ef42d838db973db1af27518b6b1d00e84455734d3e43a62c`; config read-back intact.

## ⚠ Still owed

**RF confirmation. The board has not been re-swept.** The fix is not yet proven to restore transmit — that requires a sweep on the fixed measurement tool, with `tx=10` on this unit (not 22) and adverts forced, since it is configured silent.

## Follow-ups not actioned here

- `EnvironmentSensorManager.cpp:205` still reads *"Repeater (has GPS) keeps the path"* — now false, and invites re-enabling the probe.
- A RAK3401 that genuinely has a GPS module fitted now cannot use it. `sensor` is the most affected role.
