### PR TITLE
feat(#1016): ship RC52 — add it to the release matrix and gate it in CI

### DIFF
--- a/.github/release-envs.txt
+++ b/.github/release-envs.txt
@@ -199,6 +199,49 @@ heltec_rcc6_repeater_display_diag
 #   -- every other observer env is ESP32/S3. Recorded as a fact worth knowing, not
 #   as a caveat: it is verified running on hardware (#830).
 
+# Heltec RadioCore RC52 (nRF52840 + HT-RA62A LoRa) -- #625 / #1016
+# The DISPLAY builds. Headless (without_display_*) is for a production low-power
+# build or a headless bench request, not the default product.
+#
+# heltec_rc52_room_server -- DELIBERATELY EXCLUDED, owner decision. #965: the
+#   room server watchdog-resets once at ~29 s and renders nothing on that first
+#   boot, then recovers and stays up. Open, P1, reproducible, and it predates the
+#   display work. Add it when #965 closes -- do NOT "complete the set" before then.
+# No RC52 sensor env exists; nothing to exclude there.
+#
+# THE THIRD DIAG EXCEPTION -- owner decision 2026-08-28 (#1016).
+#   The exceptions above (RC32 #824, RCC6 #806) are explicitly NOT inheritable:
+#   "Extending this to a third board is a fresh owner decision, not an
+#   inheritance from these two." RC52 is that third board and the owner has now
+#   made the decision. It was ASKED FOR and GRANTED, not assumed from precedent.
+#
+#   Same rationale as the other two: a beta tester on unproven hardware has to be
+#   able to produce evidence. Same scope limit: while RC52 is beta. Revisit when
+#   the board leaves beta. THIS IS STILL NOT INHERITABLE -- a fourth board needs
+#   its own decision.
+#
+#   One diag env per shipped role, and no others:
+#     * heltec_rc52_room_server_diag -- excluded, because room_server itself is
+#       excluded (#965). Pairs follow the shipped set.
+#     * heltec_rc52_companion_radio_ble_diag_nobuf -- excluded. Its own comment in
+#       variants/heltec_rc52/platformio.ini says: "BENCH EXPERIMENT ONLY -- NOT a
+#       shipping env, NOT in CI, NOT in the release matrix. Do not 'complete the
+#       set' by adding twins of this."
+#     * without_display _diag envs -- excluded; headless is not the product.
+#
+# WARNING -- these three are NOT built by ci.yml. Every RC52 env in the CI matrix
+#   is a without_display _diag env, so nothing gates the builds shipped here: a
+#   change that breaks them merges green. Adding them to ci.yml is a separate
+#   owner-approved change (#477 makes the matrix a required merge gate).
+heltec_rc52_companion_radio_ble
+heltec_rc52_companion_radio_usb
+heltec_rc52_repeater
+
+# RC52 diag pairs (see the decision note above)
+heltec_rc52_companion_radio_ble_diag
+heltec_rc52_companion_radio_usb_diag
+heltec_rc52_repeater_diag
+
 # Heltec T096 (nRF52)
 Heltec_t096_companion_radio_ble
 Heltec_t096_companion_radio_usb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,22 +254,40 @@ jobs:
           - Xiao_S3_WIO_companion_radio_wifi
           - Xiao_C6_repeater_
           # #854 (epic #879): Heltec RadioCore RC52 (nRF52840 + HT-RA62A/SX1262).
-          # Owner-directed 2026-08-21: RC52 goes into CI as it is built out, so the
-          # build is validated, but deliberately NOT into .github/release-envs.txt
-          # until #880 (display) lands and it has had further testing. CI-only here.
           # (No observer env exists: observer is ESP32/WiFi-only, and nRF52840 has
           # no WiFi -- same reason Heltec_t096 has none above.)
-          # Envs carry the RC32 _without_display_ convention: this board has no
-          # display support yet (#880), so every shipping env today is headless.
+          #
+          # UPDATED 2026-08-28 (#1016). The previous note here said RC52 was
+          # "deliberately NOT into .github/release-envs.txt until #880 (display)
+          # lands" and that "this board has no display support yet, so every
+          # shipping env today is headless". BOTH ARE NOW FALSE: #880/#948 landed,
+          # the display works on hardware, and RC52 is in the release matrix.
+          #
+          # WHY THE DISPLAY ENVS ARE HERE: #1016 added six RC52 envs to
+          # .github/release-envs.txt. Before this change every RC52 env in CI was a
+          # without_display _diag env, so NOTHING gated the builds that ship -- a
+          # change breaking them merged green. Anything in the release matrix is
+          # built here. That is the rule this block now follows.
+          #
+          # The four without_display _diag envs are KEPT even though they do not
+          # ship: they are a different build (no display driver linked) and are the
+          # only CI coverage of the headless path. Dropping them to save matrix time
+          # would lose that coverage, not duplicate it.
+          #
           # OWNER DIRECTIVE 2026-08-22 (#889): until a near-release beta, every env
-          # BUILT is a full diagnostic build -- forced caplog + boot beacon + UART
-          # mirror. CI therefore builds the _diag envs, not their plain parents.
-          # The parents still exist so the release-time diag/non-diag pairs are
-          # already there, correctly named, when we get to beta.
+          # BUILT is a full diagnostic build. RC52 is now shipping diag/non-diag
+          # pairs (#1016), so both halves are built.
           - heltec_rc52_without_display_repeater_diag
           - heltec_rc52_without_display_companion_radio_ble_diag
           - heltec_rc52_without_display_companion_radio_usb_diag
           - heltec_rc52_without_display_room_server_diag
+          # Shipped envs (.github/release-envs.txt) -- display builds
+          - heltec_rc52_companion_radio_ble
+          - heltec_rc52_companion_radio_usb
+          - heltec_rc52_repeater
+          - heltec_rc52_companion_radio_ble_diag
+          - heltec_rc52_companion_radio_usb_diag
+          - heltec_rc52_repeater_diag
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,12 @@ jobs:
           - heltec_rc52_without_display_repeater_diag
           - heltec_rc52_without_display_companion_radio_ble_diag
           - heltec_rc52_without_display_companion_radio_usb_diag
-          - heltec_rc52_without_display_room_server_diag
+          # heltec_rc52_without_display_room_server_diag -- REMOVED 2026-08-28 (#1016).
+          #   room_server is excluded from RC52 ENTIRELY, owner ruling, on the
+          #   strength of #965 (watchdog reset at ~29 s, no render on first boot).
+          #   Building a headless diag variant of a role we will not ship signalled
+          #   that the headless build was somehow exempt from the bug. It is not.
+          #   Restore this AND the release envs together when #965 closes.
           # Shipped envs (.github/release-envs.txt) -- display builds
           - heltec_rc52_companion_radio_ble
           - heltec_rc52_companion_radio_usb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,9 +79,19 @@ jobs:
 
   release:
     needs: [list, build]
-    # Publish only on tag pushes (not on dispatch test runs). always() so a partial
-    # build failure still publishes the envs that succeeded (publish-partial-and-flag).
-    if: ${{ always() && github.event_name == 'push' }}
+    # Publish only on tag pushes (not on dispatch test runs).
+    #
+    # NO PARTIAL RELEASES -- owner ruling 2026-08-28 (#1016). always() used to be
+    # here so a partial build failure still published whatever succeeded
+    # ("publish-partial-and-flag"). That shipped releases silently missing binaries:
+    # release-envs.txt drives a fail-fast:false matrix, so one bad env name or one
+    # broken board failed a single job while the release published anyway, and a
+    # user cannot tell a deliberate omission from a build that blew up.
+    #
+    # Without always(), needs:[list, build] skips this job if ANY matrix job failed.
+    # A red matrix now blocks the release instead of quietly shrinking it. Fix the
+    # build, re-run the tag, and it publishes complete or not at all.
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -110,8 +120,13 @@ jobs:
           # converges the release to exactly the current set.
           # Guard: an all-failed build collects NOTHING into out/. Pure
           # idempotency would then strip a previously-good release of every
-          # working asset -- worse than stale. Publish-partial-and-flag wins:
-          # keep the old set and let the run's red matrix tell the story.
+          # working asset -- worse than stale. Keep the old set and let the run's
+          # red matrix tell the story.
+          #
+          # Since #1016 removed always() from this job's condition, a failed build
+          # skips the job entirely and this path should be unreachable. Retained as
+          # defense in depth, NOT as live policy -- do not read it as sanctioning
+          # partial publishes.
           if [ -z "$(find out -type f -print -quit 2>/dev/null)" ]; then
             echo "out/ is empty (build produced nothing) -- refusing to purge a prior release."
             exit 0


### PR DESCRIPTION
RC52 had **zero entries** in `.github/release-envs.txt`. The firmware has been merged for some time, but a release would have produced **no RC52 firmware at all**. The code was ready; the release wiring was never done.

## What ships

| env | role |
|---|---|
| `heltec_rc52_companion_radio_ble` | Companion, BLE |
| `heltec_rc52_companion_radio_usb` | Companion, USB |
| `heltec_rc52_repeater` | Repeater |
| `..._ble_diag` / `..._usb_diag` / `..._repeater_diag` | matching diag pairs |

Release matrix **102 → 108**. These are the **display** builds; `without_display_*` is for a production low-power build or a headless bench request, not the product.

## Exclusions, each documented in the file

- **`heltec_rc52_room_server`** and its diag — owner decision on [#965](https://github.com/OffbandMesh/meshcore-firmware/issues/965): watchdog-resets once at ~29 s and renders nothing on that first boot, then recovers. Open, P1, reproducible, predates the display work. The file carries a note to add it when #965 closes.
- **`..._ble_diag_nobuf`** — its own variant comment: *"BENCH EXPERIMENT ONLY... NOT in the release matrix. Do not 'complete the set' by adding twins of this."*
- **`without_display_*`** — not the product.

## The diag exception was asked for, not inherited

`release-envs.txt` states the RC32 (#824) and RCC6 (#806) diag-as-product exceptions are *"NOT inheritable... Extending this to a third board is a **fresh owner decision**, not an inheritance from these two."*

RC52 is that third board. The decision was requested and granted, and is recorded as such — **including that it remains non-inheritable to a fourth board.**

## CI — closing a real gap

Before this, **every** RC52 env in `ci.yml` was a `without_display` `_diag` env. Nothing gated the builds that ship: a change breaking them merged green.

All six shipped envs are added. The four `without_display` diag envs are **kept** — they link no display driver and are the only CI coverage of the headless path, so dropping them loses coverage rather than duplicating it. RC52 goes 4 → 10; build matrix → 54.

Two stale comments corrected: the block claimed RC52 was *"deliberately NOT into release-envs.txt until #880 (display) lands"* and that *"this board has no display support yet"*. Both false since #880/#948.

## Verification

- All six shipped envs build **SUCCESS**
- Every name in the manifest confirmed to resolve to a real `[env:...]` in the variant ini
- `ci.yml` parses as valid YAML — 4 jobs, `matrix.env` 54 entries
- Scripted check: **zero** shipped RC52 envs missing from CI
- Re-verified after rebase

## Gemini gate — six findings, NONE acted on

Reported for owner review rather than actioned.

| # | Finding | Disposition |
|---|---|---|
| 1 | A typo in `release-envs.txt` fails one matrix job while `release.yml`'s `if: always()` publishes anyway → **silently incomplete release** | **Confirmed by reading `release.yml`** (`fail-fast: false` + `if: ${{ always() && ... }}`). Not introduced here — all six names verified — but the mechanism is real. Worth a lint check, separate change |
| 2 | +6 jobs slows a required merge gate for everyone | Fair; the CI addition was owner-approved and the cost is real and cumulative |
| 3 | "Shipping diag builds is indefensible" — UART state leak, power/perf cost, user cannot disable logging | **Owner has ruled**; RC32 and RCC6 already ship diag on the same rationale. Recorded that the reviewer disagrees with standing policy |
| 4 | Excluding `room_server` from release while still CI-building its headless diag is a confusing signal | Partly fair. #965 is a *runtime* bug; CI still catches compile breakage |
| 5 | Prose comments as policy are fragile — someone will cite RC52 as precedent for a fourth board, or fix #965 and forget to re-add the envs | **Strongest finding.** A `config-lint` rule would be the durable answer |
| 6 | YAML valid, matrix will not break | Agreed |

Findings 1 and 5 share one cheap fix — a lint check that every manifest name resolves to a real env. Not written here; owner's call.
