### PR TITLE
task(#1041): correct the diag-build log-mirror flag to the post-#888 name

### DIFF
--- a/.github/workflows/diag-build.yml
+++ b/.github/workflows/diag-build.yml
@@ -6,9 +6,15 @@ name: Diagnostic Build (on-demand)
 #
 # The diagnostic triad is injected via PLATFORMIO_BUILD_FLAGS, matching the
 # standing diag surface (owner directive 2026-08-22):
-#   -DOFFBAND_FORCE_CAPLOG   caplog pinned ON (serial/mesh log capture)
-#   -DOFFBAND_BOOT_BEACON    raw-UART0 boot beacon (survives early-boot crashes)
-#   -DOFFBAND_MESHLOG_UART0  mirror the mesh log to UART0
+#   -DOFFBAND_FORCE_CAPLOG      caplog pinned ON (serial/mesh log capture)
+#   -DOFFBAND_BOOT_BEACON       raw-UART0 boot beacon (survives early-boot crashes)
+#   -DOFFBAND_LOG_MIRROR_UART   mirror the mesh log to UART0
+#
+# NOTE (#1034): the mirror flag was OFFBAND_MESHLOG_UART0 until #888 renamed it.
+# LogMirrorUart.h carries an #error tripwire on the old name, so this workflow
+# failed at compile on every dispatch between that rename and 2026-09-03. When a
+# build flag is renamed, sweep .yml too -- workflows inject
+# PLATFORMIO_BUILD_FLAGS from outside the build config the tree can see.
 # The boot beacon + pinned caplog make a diag build self-announce at runtime, and
 # the output filename/artifact carry "-diag" so it is never mistaken for a release.
 # (A version-STRING diag marker is a firmware follow-up -- build.sh stamps the
@@ -80,7 +86,7 @@ jobs:
           # Output-filename marker only; the compiled FIRMWARE_VERSION is derived
           # inside build.sh from MyMesh.h + the commit hash.
           FIRMWARE_VERSION: "diag"
-          PLATFORMIO_BUILD_FLAGS: "-DOFFBAND_FORCE_CAPLOG -DOFFBAND_BOOT_BEACON -DOFFBAND_MESHLOG_UART0"
+          PLATFORMIO_BUILD_FLAGS: "-DOFFBAND_FORCE_CAPLOG -DOFFBAND_BOOT_BEACON -DOFFBAND_LOG_MIRROR_UART=1"
         run: /usr/bin/env bash build.sh build-firmware "$INPUT_ENV"
 
       - name: Verify a diagnostic .bin was produced


### PR DESCRIPTION
Fixes the flag name `diag-build.yml` injects, so the diagnostic-build workflow compiles
again.

Parent bug: #1034 · Implementation task: #1041 (closed) · Verification: #1042 · Epic: #736

## What was broken

The workflow injected `-DOFFBAND_MESHLOG_UART0`. #888 renamed that flag to
`OFFBAND_LOG_MIRROR_UART` and left a deliberate tripwire in `src/helpers/LogMirrorUart.h`:

```c
#if defined(OFFBAND_MESHLOG_UART0)
  #error "OFFBAND_MESHLOG_UART0 was renamed to OFFBAND_LOG_MIRROR_UART (#888) ..."
#endif
```

So **every `workflow_dispatch` failed at compile** from that rename onward. The last
successful diagnostic build predates it, and no instrumented build could reach a field
tester — which is what #956 has been waiting on.

The tripwire did its job: without it the build would have succeeded and produced a
diagnostic image **silently missing its log mirror**.

## Why the rename missed it

The #888 sweep covered `.ini`, `.h` and `.cpp`. A workflow injects
`PLATFORMIO_BUILD_FLAGS` from **outside the build configuration the source tree can
see**, so no amount of grepping the tree would have found it. A note recording that is
added to the workflow header so the next flag rename does not repeat it.

## Changes

- `-DOFFBAND_MESHLOG_UART0` -> `-DOFFBAND_LOG_MIRROR_UART=1`
- header comment updated to the current flag name, plus the note above

One file, 10 insertions, 4 deletions.

## Gemini review — 4 findings, all addressed

Run with `scripts/llm-consult.py --backend gemini --model gemini-2.5-pro`; audit log at
`docs/llm-consultations/2026-09-04-1041-diag-build-flag-gemini-gemini-2.5-pro.log`
(`finish_reason: STOP`). Full write-up on #1041.

| # | Finding | Disposition |
|---|---|---|
| 1 | A local build cannot exercise the publish step; only an end-to-end dispatch is a valid test | **Accepted.** Scoped as #1042 rather than claimed here |
| 2 | Bare `-D` relies on the compiler's implicit `1`; brittle against a future guard change | **Fixed** — passed as `=1`, rebuilt green |
| 3 | Sweep every `PLATFORMIO_BUILD_FLAGS` injection site, not just the flag name | **Done** — `build.sh` lines 117 and 159 are the only others; debug `-U` undefines and version stamps, neither a diag flag, and both append rather than overwrite |
| 4 | Keep the added comment | **No change** |

Finding 2's failure case is the one worth reading: if the guard ever became a value
comparison, a bare `-D` would leave the mirror **silently disabled** — reintroducing
exactly the "quietly does nothing" class the tripwire exists to prevent.

## Evidence

Both observer envs built green with the corrected triad, read from the per-env SUCCESS
table rather than the exit code:

| Env | Result | Duration |
|---|---|---|
| `Heltec_v3_companion_observer_wifi` | SUCCESS | 00:02:34 |
| `heltec_v4_companion_observer_wifi` | SUCCESS | 00:01:37 |

Zero error lines — the `#error` tripwire does not fire. `heltec_v4` rebuilt green
(00:01:03) after the `=1` change.

## What this PR does NOT prove

That a dispatch publishes a downloadable asset. A local build cannot reach the
`gh release upload` step, so that claim is not made here — it is #1042, which runs
against this branch.

Agent: CloudyGrove (session fcc043c7)
