### PR TITLE
epic(#1037): terminate USB-CDC console replies with a zero-length packet

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -4,6 +4,7 @@
 #include <Mesh.h>
 #include <MeshLog.h>  // #396: serial-capture buffer access for the caplog download
 #include <helpers/ClockSanity.h>  // #607: owner-path clock sets + audit log
+#include "helpers/CdcConsoleFlush.h"   // #1035: right-flush (ZLP) for the USB-Serial-JTAG console
 
 // Offband fork-only companion-API frame codes (config 0xC0 / GPS 0xC1 / block 0xC2)
 // + shared enums. Self-contained (only <stdint.h>); included unconditionally so the
@@ -3713,6 +3714,7 @@ void MyMesh::checkObserverSerialCli() {
       char reply[256];
       offband::cliPassthroughExecute(_obs_cli_buf, reply, sizeof(reply));
       Serial.println(reply);
+      flushSerialConsole();   // #1035: emit the USB-CDC terminator so a 64-multiple reply isn't held host-side
       _obs_cli_len = 0;
       _obs_cli_redact = false;
       continue;

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -18,6 +18,7 @@
 // ((void)0) otherwise -- so non-diag builds of this role are byte-identical.
 #define OFFBAND_BEACON_DEFINE_CTOR
 #include "helpers/BootBeacon.h"
+#include "helpers/CdcConsoleFlush.h"   // #1035: right-flush (ZLP) for the USB-Serial-JTAG console
 
 
 #ifdef PIN_STATUS_LED
@@ -1323,17 +1324,63 @@ void loop() {
   if (len > 0 && command[len - 1] == '\r') {  // received complete line
     Serial.print('\n');
     command[len - 1] = 0;  // replace newline with C string null terminator
-    char reply[160];
-    reply[0] = 0;
-#ifdef ETHERNET_ENABLED
-    if (!ethernet_handle_command(command, reply)) {
-      the_mesh.handleCommand(0, command, reply);
+    bool handled_diag = false;
+#ifdef OFFBAND_FORCE_CAPLOG
+    // #1035 gap x granularity control (diag build only). Reproduces the version
+    // path's structure --  echo  ->  [handleCommand gap]  ->  reply  -- with every
+    // variable under host control, so ONE flash sweeps the whole space and no
+    // theory needs a reflash.
+    //
+    //   emit <bytes> [delay_us] [bulk]
+    //     bytes    payload size 0..1024, emitted with NO "  -> " wrapper / no newline
+    //     delay_us busy-wait gap before the payload, 0..16000. Mimics the CPU-bound
+    //              sprintf+callbacks that run between the echo and the reply in the
+    //              version path; interrupts stay enabled so the HWCDC TX ISR can
+    //              drain the 9-byte echo as its own completed short transfer.
+    //     bulk     0 = byte-at-a-time Serial.write() (default), 1 = one Serial.write(buf,n)
+    //
+    // Hypothesis under test (see #1035): a hold needs BOTH bytes % 64 == 0 AND a
+    // real gap (>= ~1 USB frame) isolating the echo, so the payload rides as
+    // all-full 64-byte packets with no terminating short packet. delay=0 (either
+    // bulk) is the already-measured DELIVERED case; the new axes are delay>0 and bulk=1.
+    if (memcmp(command, "emit ", 5) == 0) {
+      static uint8_t emit_buf[1024];
+      int n = atoi(command + 5);
+      const char* a2 = strchr(command + 5, ' ');
+      int delay_us = a2 ? atoi(a2 + 1) : 0;
+      const char* a3 = a2 ? strchr(a2 + 1, ' ') : nullptr;
+      int bulk = a3 ? atoi(a3 + 1) : 0;
+      const char* a4 = a3 ? strchr(a3 + 1, ' ') : nullptr;
+      int zlp = a4 ? atoi(a4 + 1) : 0;   // #1035 A/B: 1 => apply the flushSerialConsole() fix after the payload
+      if (n < 0) n = 0;
+      if (n > 1024) n = 1024;
+      if (delay_us < 0) delay_us = 0;
+      if (delay_us > 16000) delay_us = 16000;
+      if (delay_us > 0) delayMicroseconds(delay_us);
+      if (bulk) {
+        for (int i = 0; i < n; i++) emit_buf[i] = (uint8_t)('0' + (i % 10));
+        Serial.write(emit_buf, n);
+      } else {
+        for (int i = 0; i < n; i++) Serial.write((uint8_t)('0' + (i % 10)));
+      }
+      if (zlp) flushSerialConsole();     // #1035: emit the terminating ZLP -- proves the fix on the reproducer
+      handled_diag = true;
     }
-#else
-    the_mesh.handleCommand(0, command, reply);  // NOTE: there is no sender_timestamp via serial!
 #endif
-    if (reply[0]) {
-      Serial.print("  -> "); Serial.println(reply);
+    if (!handled_diag) {
+      char reply[160];
+      reply[0] = 0;
+#ifdef ETHERNET_ENABLED
+      if (!ethernet_handle_command(command, reply)) {
+        the_mesh.handleCommand(0, command, reply);
+      }
+#else
+      the_mesh.handleCommand(0, command, reply);  // NOTE: there is no sender_timestamp via serial!
+#endif
+      if (reply[0]) {
+        Serial.print("  -> "); Serial.println(reply);
+        flushSerialConsole();  // #1035: emit the USB-CDC terminator so a 64-multiple reply isn't held host-side
+      }
     }
 
     command[0] = 0;  // reset command buffer

--- a/examples/simple_room_server/main.cpp
+++ b/examples/simple_room_server/main.cpp
@@ -18,6 +18,7 @@
 // ((void)0) otherwise -- so non-diag builds of this role are byte-identical.
 #define OFFBAND_BEACON_DEFINE_CTOR
 #include "helpers/BootBeacon.h"
+#include "helpers/CdcConsoleFlush.h"   // #1035: right-flush (ZLP) for the USB-Serial-JTAG console
 
 
 #ifdef ETHERNET_ENABLED
@@ -170,6 +171,7 @@ void loop() {
 #endif
     if (reply[0]) {
       Serial.print("  -> "); Serial.println(reply);
+      flushSerialConsole();  // #1035: emit the USB-CDC terminator so a 64-multiple reply isn't held host-side
     }
 
     command[0] = 0;  // reset command buffer

--- a/examples/simple_sensor/main.cpp
+++ b/examples/simple_sensor/main.cpp
@@ -15,6 +15,7 @@
 // ((void)0) otherwise -- so non-diag builds of this role are byte-identical.
 #define OFFBAND_BEACON_DEFINE_CTOR
 #include "helpers/BootBeacon.h"
+#include "helpers/CdcConsoleFlush.h"   // #1035: right-flush (ZLP) for the USB-Serial-JTAG console
 
 
 #ifdef DISPLAY_CLASS
@@ -197,6 +198,7 @@ void loop() {
     the_mesh.handleCommand(0, command, reply);  // NOTE: there is no sender_timestamp via serial!
     if (reply[0]) {
       Serial.print("  -> "); Serial.println(reply);
+      flushSerialConsole();  // #1035: emit the USB-CDC terminator so a 64-multiple reply isn't held host-side
     }
 
     command[0] = 0;  // reset command buffer

--- a/src/helpers/CdcConsoleFlush.h
+++ b/src/helpers/CdcConsoleFlush.h
@@ -1,0 +1,57 @@
+#pragma once
+// #1035 -- the "right" flush for the ESP32 USB-Serial-JTAG console.
+//
+// On the USB-Serial-JTAG console (Arduino HWCDC), a reply whose on-wire length is an
+// exact multiple of the 64-byte USB max packet size is emitted as full 64-byte packets
+// with NO terminating short/zero-length packet. The host (e.g. Windows usbser.sys) then
+// holds the final packet in its own buffer until the next write -- documented by
+// Espressif as data getting "stuck in host memory" (ESP-IDF USB-Serial-JTAG console
+// guide). It is host-side and intermittent; the bytes are delayed, not lost. See #1035.
+//
+// Draining the ring with Serial.flush() does NOT fix this -- HWCDC::flush() only empties
+// the TX ring and never emits the terminating zero-length packet (ZLP). The fix is the
+// Espressif-documented recipe from hal/usb_serial_jtag_ll.h:
+//
+//   "To send a zero-length packet, call usb_serial_jtag_ll_txfifo_flush() again when
+//    usb_serial_jtag_ll_txfifo_writable() returns true."
+//
+// This is the same primitive the (unreleased) arduino-esp32 master HWCDC ISR uses; we
+// invoke it from our code at the console-reply boundary instead of waiting for the
+// framework. On transports without USB-Serial-JTAG this degrades to a plain flush.
+//
+// A ZLP is preferred over appending a byte: a trailing character would change the exact
+// reply bytes a host tool matches against; a zero-length packet only terminates the USB
+// transfer and leaves the payload byte-for-byte unchanged.
+#include <Arduino.h>
+
+// Gate on the chip HAVING the USB-Serial-JTAG peripheral AND `Serial` actually being its
+// USB-CDC console (ARDUINO_USB_CDC_ON_BOOT). A board can have the peripheral yet route
+// `Serial` to a UART bridge -- e.g. Heltec V3 (esp32-s3 + CP2102), where Serial is UART0;
+// there the ZLP bug does not occur and we must not poke the idle JTAG FIFO. On such boards
+// this degrades to a plain Serial.flush(). (#1035, Gemini review.)
+#if defined(ARDUINO_ARCH_ESP32)
+  #include "soc/soc_caps.h"
+  #if SOC_USB_SERIAL_JTAG_SUPPORTED && defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT
+    #include "hal/usb_serial_jtag_ll.h"
+    #define OFFBAND_USJ_CONSOLE 1
+  #endif
+#endif
+
+// Drain the console TX and emit the terminating zero-length packet so a reply whose
+// length is a multiple of 64 is delivered immediately instead of held host-side (#1035).
+static inline void flushSerialConsole() {
+#if defined(OFFBAND_USJ_CONSOLE)
+  Serial.flush();                               // drain the HWCDC TX ring to the FIFO
+  // The last real 64-byte packet may still be draining from the FIFO. Wait (bounded) for
+  // the FIFO to become writable, THEN emit the terminating zero-length packet -- the LL
+  // header says to flush "when usb_serial_jtag_ll_txfifo_writable() returns true". Checking
+  // once and skipping raced with the in-flight packet and left ~1% of 64-multiple replies
+  // unterminated (#1035). The 2 ms bound means an unread/stalled host can never wedge the
+  // reply path (SAFELANE rule 8); on timeout we flush best-effort, which is harmless.
+  uint32_t t0 = micros();
+  while (!usb_serial_jtag_ll_txfifo_writable() && (uint32_t)(micros() - t0) < 2000) { }
+  usb_serial_jtag_ll_txfifo_flush();            // zero-length packet ends the USB transfer
+#else
+  Serial.flush();
+#endif
+}


### PR DESCRIPTION
Epic **#1037** — diagnose → fix → verify the ESP32 USB-Serial-JTAG console reply hold. This PR carries the Fix commit; Epic verification (#1040) gates the merge.

## What & why

On the ESP32 USB-Serial-JTAG console (Arduino HWCDC), a console reply whose on-wire length is an exact multiple of the 64-byte USB max packet size is emitted as full 64-byte packets with **no terminating zero-length packet (ZLP)**. The host (Windows `usbser.sys`) then holds the final packet until the next write — documented by Espressif as data "stuck in host memory". Held-not-lost, host-side, intermittent; it strands synchronous serial tooling (pio-flash identity read, provisioning) on ×64-length replies. This is the root cause of the #1035 symptom (rf_sweep records no firmware identity when the `version` read returns only its echo).

## The fix (#1039)

`src/helpers/CdcConsoleFlush.h::flushSerialConsole()`: drain the HWCDC ring, then wait (2 ms bounded) for the FIFO to become writable and emit the terminating ZLP via `usb_serial_jtag_ll_txfifo_flush()` — the Espressif-documented recipe from `usb_serial_jtag_ll.h`, the same primitive the **unreleased** arduino-esp32 `master` HWCDC ISR uses (no released version ≤3.3.8 has it; we are pinned to 3.1.3 / IDF 5.3.2 via pioarduino). `HWCDC::flush()` alone does **not** fix this — it only drains the ring.

Gated on `SOC_USB_SERIAL_JTAG_SUPPORTED && ARDUINO_USB_CDC_ON_BOOT` — the chip has the peripheral **and** `Serial` is its USB-CDC console; degrades to a plain flush on UART-bridge consoles (e.g. Heltec V3 = esp32-s3 + CP2102) and non-ESP32. Called at the four serial-CLI reply sites (repeater, companion, room server, sensor). Retains an `OFFBAND_FORCE_CAPLOG`-gated `emit` diag command used to reproduce/A-B the issue.

## Structure

| Child | Status |
|---|---|
| #1038 Diagnosis | done — root cause + bench reproduction |
| #1039 Fix (this commit) | implementation complete |
| #1040 Epic verification | **open — gates this merge** (CI matrix + non-C6 hardware + human sign-off) |

## Evidence

- **Bench-verified on ESP32-C6 (rcc6-bench-1):** fix OFF → 64-multiple replies hang 10–33% of reps; fix ON → **0/90** (bulk write, delay=1000 µs, 30 reps × {128,192,256}). A first cut used a single `writable()` check and left a 1/30 residual; hardened to the 2 ms bounded wait → 0/90.
- **Compile-verified** across C6 (`rcc6` repeater + companion), S3 (`Heltec_v3`, `Ebyte_EoRa-S3` room), and the sensor example; nRF52 exercises the plain-flush degrade path.
- The `ARDUINO_USB_CDC_ON_BOOT` guard is compile-time and keeps the C6 code path identical (rcc6 sets it =1), so the 0/90 result carries over.

## Gemini adversarial review

`gemini-2.5-pro` (log: `docs/llm-consultations/2026-09-04-1035-usb-cdc-zlp-fix-gemini-gemini-2.5-pro.log`). Verdict: production-quality. **One finding — guard scope** (chip-capability-only; a UART-bridge board would poke the idle JTAG peripheral). **Fixed** by adding the `ARDUINO_USB_CDC_ON_BOOT` gate — the repo's existing precedent for HV3. All other points (ISR race, 2 ms bound, `micros()` rollover, HAL include chain, `static inline` placement) passed with no change.

## Not in this PR / gating merge

- **#1040 Epic verification** must pass before merge: `ci-green` matrix + hardware confirmation on a non-C6 board whose `Serial` is the native USB-CDC console + human sign-off.
- #1035 (rf_sweep symptom) closes when this epic lands; its fail-open half is a separate task (`Crosswire-5ho`), untouched here.

Refs #1037, #1039, #1035. Merges: **Ben**, after Epic verification.
