### PR TITLE
chore(#1092): move standards pointers local and redact private data

### DIFF
--- a/.claude/hooks/require-agent-mail-check.py
+++ b/.claude/hooks/require-agent-mail-check.py
@@ -18,7 +18,7 @@ discipline had no mechanical trigger - it relied on me remembering to
 check inbox at every milestone, and the work-flow momentum reliably
 overrode that intent.
 
-block-raw-flash.py and block-raw-curl-ota.py are the precedent: SAFELANE
+block-raw-flash.py and block-raw-curl-ota.py are the precedent:
 "mechanical block does not degrade under momentum." This hook applies the
 same principle to the Agent Mail coordination requirement.
 

--- a/.claude/hooks/require-agent-mail-check.py
+++ b/.claude/hooks/require-agent-mail-check.py
@@ -31,7 +31,7 @@ Behavior
 - If a state-mutating pattern matches and the ack file is stale (or
   missing), refuses with exit 2 and an instructive stderr message.
 - Honors DW_SKIP_AGENT_MAIL_CHECK=1 env var for genuine emergencies
-  (matches DW_SKIP_CITADEL_CHECK convention from CLAUDE-BASE). Bypass is
+  (matches the DW_SKIP_CITADEL_CHECK convention). Bypass is
   logged to stderr so the user sees it in real-time.
 - Fail-OPEN on JSON parse errors or unexpected exceptions (don't break
   legitimate work because of a hook bug - matches existing hook

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,10 @@ hardware-devices.yaml
 # -- never commit. Symlink/mirror of canonical C:\Dev\LoRa\HARDWARE.md; read before any hardware work.
 HARDWARE.local.md
 
+# Local, never committed: standards pointers and repo-local working notes.
+STANDARDS.local.md
+CLAUDE.local.md
+
 # per-host flash audit log + full-flash backups (device MACs/DeviceIDs) -- never commit
 flash-history.jsonl
 flash-backups/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -556,7 +556,7 @@ on the **MeshCore 1.16.0** base.
   the per-field read.
 
 ### Changed
-- **Honest observer config writes (SAFELANE §6, #181)** — the config / NVS write path used
+- **Honest observer config writes (#181)** — the config / NVS write path used
   to silently swallow failures (a broker disable could ACK success while nothing changed).
   Every writer, the live-reload path, and the crash logger itself now surface + log
   failures with context. This is what root-caused #179.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,10 @@
 # Offband (meshcore-firmware) -- Project CLAUDE.md
 
-> **Read and follow [`C:\Dev\DifferentWire\standards\SAFELANE.md`](../../DifferentWire/standards/SAFELANE.md). No exceptions.**
-> **Read and follow [`C:\Dev\DifferentWire\standards\CLAUDE-BASE.md`](../../DifferentWire/standards/CLAUDE-BASE.md). No exceptions.**
+> **Read and follow the development standards listed in `STANDARDS.local.md` (gitignored, per-host). No exceptions.**
 
-These two documents are the canonical inheritance for this project. Anything below extends or parameterizes them; nothing below overrides them. If there is a conflict, SAFELANE and CLAUDE-BASE win.
+Those documents are the canonical inheritance for this project. Anything below extends or parameterizes them;
+nothing below overrides them. If there is a conflict, the standards win. Repo-local working notes that must
+not be published live in `CLAUDE.local.md` (also gitignored).
 
 ---
 
@@ -118,7 +119,7 @@ Device inventory, RF chain (FEM / TX power), per-device MACs/roles, slot/pin map
 ## PR definition-of-done (#477 — CI matrix is a required merge gate)
 
 - `firmware-base` branch protection requires the **`ci-green`** check (aggregates `config-lint` + the FULL curated build matrix, incl. nRF52 + room_server envs). `gh pr merge --auto --rebase` therefore **waits for the matrix** — enabling auto-merge is no longer merging.
-- **A PR task is NOT complete — and must not be closed in Citadel — until `gh pr view <n> --json state` reports `MERGED`.** A red matrix leaves the PR sitting unmerged; closing the task anyway is the SAFELANE §5 "declaring success without the artifact" violation. If `ci-green` fails, fixing the build (all matrix envs, not just the ones you tested on — the #350/#463 lesson) is part of the same task.
+- **A PR task is NOT complete — and must not be closed in Citadel — until `gh pr view <n> --json state` reports `MERGED`.** A red matrix leaves the PR sitting unmerged; closing the task anyway is the "declaring success without the artifact" failure. If `ci-green` fails, fixing the build (all matrix envs, not just the ones you tested on — the #350/#463 lesson) is part of the same task.
 - Do not shrink or bypass the matrix to get green; matrix changes are owner-approved only.
 
 ## Follow-ups (bootstrap gaps to close)

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -25,7 +25,7 @@ firmware identifiers. Neither one alone identifies a build; both together do.
 
 Tag format: `offband-vMAJOR.MINOR.PATCH`
 
-Increments per CLAUDE-BASE §Versioning:
+Increments per the versioning standard:
 
 | Increment | When |
 |-----------|------|
@@ -180,7 +180,7 @@ see FF2 / #179); the release workflow also accepts legacy `crosswire-v*` tags.
 
 ## Related references
 
-- CLAUDE-BASE §Versioning (`C:\Dev\DifferentWire\standards\CLAUDE-BASE.md`)
+- The versioning standard (located via the gitignored `STANDARDS.local.md`)
 - `docs/cli-and-mqtt-commands.md` -- CLI + MQTT command reference (`version` command, `wifi on N`, MQTT `ota_enable`, etc.)
 - `docs/safeboot-maintenance.md` -- SafeBoot-specific tag scheme details
 - Epic #176 / LoRa-edl -- this versioning discipline initiative

--- a/docs/architecture/2026-06-06-ci-release-pipeline.md
+++ b/docs/architecture/2026-06-06-ci-release-pipeline.md
@@ -89,7 +89,7 @@ The Release body documents this mapping so a community member knows what to down
 ## 6. Per-task plan (design + test + acceptance)
 
 Dependency/sequence: **T1 accepted -> T2 -> T3 -> T4 -> T5**. All work on branch
-`epic/14-ci-release-pipeline`; one PR at epic completion (after T5). Each task is a commit (per CLAUDE-BASE).
+`epic/14-ci-release-pipeline`; one PR at epic completion (after T5). Each task is a commit.
 
 ### T2 (#16) -- ci.yml dev-channel artifact
 - **Design:** add one `actions/upload-artifact@v4` step after the existing `Build ${{ matrix.env }}` step;
@@ -198,7 +198,7 @@ Cost: GitHub-hosted minutes; matrix parallel. Mitigation if too slow: the env li
   #15-#18 (all done), NOT #19, so the epic push follows process with no bypass -- T5 simply stays
   open until post-merge. (An earlier erroneous attempt closed T5 as a false `done` and created a
   duplicate #23/T6; #19 was reopened and #23 closed as not-planned. No separate T6 exists.)
-- **Deliberate deviation from CLAUDE-BASE Branch&PR** ("integration test passes BEFORE the PR"):
+- **Deliberate deviation from the branch-and-PR standard** ("integration test passes BEFORE the PR"):
   T5 runs AFTER merge. Justified -- the pipeline under test triggers only on `firmware-base` + tags
   and cannot run on the pre-merge feature branch. User-directed (2026-06-07).
 - **T4 `branch-cleanup.yml` -> DELETED** (was "REVIEW"). Inert here (guarded to `Strycher/LoRa`)

--- a/docs/architecture/2026-06-06-ci-release-pipeline.md
+++ b/docs/architecture/2026-06-06-ci-release-pipeline.md
@@ -203,7 +203,7 @@ Cost: GitHub-hosted minutes; matrix parallel. Mitigation if too slow: the env li
   and cannot run on the pre-merge feature branch. User-directed (2026-06-07).
 - **T4 `branch-cleanup.yml` -> DELETED** (was "REVIEW"). Inert here (guarded to `Strycher/LoRa`)
   and pruned UNMERGED stale branches (unsafe for the one-epic-one-branch model). Not repurposed:
-  branch hygiene is handled canonically in SAFELANE/standards.
+  branch hygiene is handled canonically in the standards.
 - **Status:** T1/T2/T3/T4 done (local validation per task: YAML parse + logic review). Final
   workflow set: `ci.yml`, `release.yml`, `build-safeboot-firmwares.yml`, `sync-labels-to-board.yml`.
   Next: epic PR (human tollgate) -> merge -> T5 post-merge live test -> human sign-off closes #14.

--- a/docs/architecture/2026-07-19-heltec-v4-fem-lna-research.md
+++ b/docs/architecture/2026-07-19-heltec-v4-fem-lna-research.md
@@ -9,7 +9,7 @@
 Adversarial re-verification of every Heltec V4 FEM/LNA claim carried in this repo. Prior in-repo
 material (firmware comments, `HARDWARE.md`, issue #298, the 2026-07-18 LLM-consult logs) was
 treated as **unverified assertion**, not as input. Claims are tagged `[verified: <source>]` or
-`[hypothesis: untested]` per SAFELANE §11. Where a source could not be obtained, that is recorded
+`[hypothesis: untested]`. Where a source could not be obtained, that is recorded
 as the finding rather than inferred around.
 
 **Source hierarchy used:** Heltec schematics and Heltec official documentation > component vendor

--- a/docs/architecture/2026-07-28-384-serial-capture-design-of-record.md
+++ b/docs/architecture/2026-07-28-384-serial-capture-design-of-record.md
@@ -325,7 +325,7 @@ a bug. Tracked on the client issue (#430).
 
 ## 10. Proposed implementation breakdown (child issues — created AFTER sign-off)
 
-> Each a single-PR task (CLAUDE-BASE sizing). Created + parent-linked to #384 on 2026-07-28.
+> Each a single-PR task. Created + parent-linked to #384 on 2026-07-28.
 > **Not blocked-by #350** — soft coordination only (see §9). #394 was folded into #393.
 
 1. **[#393](https://github.com/OffbandMesh/meshcore-firmware/issues/393) — Core tee sink**

--- a/docs/architecture/2026-07-28-384-serial-capture-design-of-record.md
+++ b/docs/architecture/2026-07-28-384-serial-capture-design-of-record.md
@@ -5,7 +5,7 @@
 **Status:** DRAFT — pending Gemini adversarial review + Ben sign-off ·
 **Author:** TopazHill (session `ce5045af`) · **Date:** 2026-07-28
 
-> SAFELANE PLAN phase. This document is design-of-record only — **no firmware code lands
+> PLAN phase. This document is design-of-record only — **no firmware code lands
 > under #385.** Implementation + hardware-test child issues are created off this doc *after*
 > sign-off. All code claims below are tagged `[verified: …]` (checked against `firmware-base`
 > this session) or `[hypothesis: …]`.
@@ -140,7 +140,7 @@ role is covered by construction.
   makes the live-mirror decision authoritative at the transport layer. `[F-A3, MEDIUM]`
 
 > Perf target ~5–15 µs/line (mirror CrashLog's guard cost). `[hypothesis: validate on bench]`
-> A non-reentrant sink is a non-starter (SAFELANE §11 rules 8 + 10) — reentrancy is the
+> A non-reentrant sink is a non-starter — reentrancy is the
 > acceptance bar, not the perf number.
 
 ### 4.2 The capture buffer — separate plain-RAM ring (Q1/Q6 decision)

--- a/docs/architecture/2026-08-10-meshcore-1.17.0-base-update-assessment.md
+++ b/docs/architecture/2026-08-10-meshcore-1.17.0-base-update-assessment.md
@@ -232,7 +232,7 @@ Design directions to evaluate (none yet chosen, none verified):
 
 **Requirements (revised):**
 1. Detect per path, per filename. Length is an input, **not the sole signal** — see §4.7.
-2. **Log the detected layout, the length, and the evidence that decided it**, every time (SAFELANE §6).
+2. **Log the detected layout, the length, and the evidence that decided it**, every time.
 3. **Fail closed.** If the layout cannot be determined unambiguously, **do not migrate**: log at error level, leave the legacy file untouched, and run this boot on defaults so an operator must intervene. Do **not** fall back to either offset table — the earlier "default to upstream" rule was itself a corruption path for truncated or older-Offband files.
 4. Retain the legacy file on disk after migration so a wrong choice is recoverable.
 5. Compare mtimes: a legacy file **newer** than `/prefs.json` indicates a downgrade cycle — warn loudly and do not silently discard it.

--- a/docs/assessments/2026-06-10-meshcore-1.16.0-base-update-impact.md
+++ b/docs/assessments/2026-06-10-meshcore-1.16.0-base-update-impact.md
@@ -8,7 +8,7 @@
 | **Type** | Spike (read-only assessment; no migration performed) |
 | **Status** | For review |
 
-> **Scope note:** This is a *diagnostics* spike per SAFELANE. It maps the impact surface only. It does **not** perform the migration and proposes no code changes. The migration itself is a separate, not-yet-started epic gated on review of this document.
+> **Scope note:** This is a *diagnostics* spike. It maps the impact surface only. It does **not** perform the migration and proposes no code changes. The migration itself is a separate, not-yet-started epic gated on review of this document.
 
 ---
 

--- a/docs/cli-and-mqtt-commands.md
+++ b/docs/cli-and-mqtt-commands.md
@@ -158,7 +158,7 @@ The OTA enable action's response includes:
 
 ```json
 {
-  "ota_url": "http://192.168.50.177/update",
+  "ota_url": "http://192.0.2.177/update",
   "window_sec": 600
 }
 ```
@@ -202,7 +202,7 @@ Use when: device has no home WiFi (e.g., field deploy outside coverage), or firs
 ```
 1. Ensure device WiFi is up (e.g., CLI "wifi on 30" if it isn't already)
 2. MQTT publish to <prefix>/<node>/cmd: {"action":"ota_enable", "auth":"...", "window_sec":600}
-3. Device responds with ota_url (e.g., http://192.168.50.177/update)
+3. Device responds with ota_url (e.g., http://192.0.2.177/update)
 4. POST firmware to that ota_url
 5. Device reboots, runs new firmware
 ```
@@ -279,7 +279,7 @@ import configparser, json, paho.mqtt.client as mqtt, time
 secret = configparser.ConfigParser()
 secret.read('meshcore-firmware/platformio.local.ini')
 c = mqtt.Client()
-c.connect('192.168.50.24', 1883, 30)
+c.connect('192.0.2.24', 1883, 30)
 c.publish('meshcore/stp-lab/cmd', json.dumps({
     'action':'ota_enable',
     'auth': secret['ota_secrets']['trigger_secret'],

--- a/docs/ha-ota-flash.md
+++ b/docs/ha-ota-flash.md
@@ -242,7 +242,7 @@ next natural 15-min publish; a 60s default false-negatived real OTAs.
 
 ```yaml
     ota:
-      lan_ip: "192.168.50.197"                 # device's home-WiFi IP (DHCP; re-check if push fails)
+      lan_ip: "192.0.2.197"                 # device's home-WiFi IP (DHCP; re-check if push fails)
       node_id: "wsmj898-ltb"                   # MQTT/cmdrelay node id
       mqtt_topic_prefix: "meshcore"            # topic root (default "meshcore")
       verify_channel: "mqtt"                   # serial | mqtt | telemetry
@@ -250,8 +250,8 @@ next natural 15-min publish; a 60s default false-negatived real OTAs.
 ```
 
 Real examples in the registry:
-- **ST-P (`stp-lab`)** — bench, USB cabled, `verify_channel: serial`, lan_ip `192.168.50.177`.
-- **patio (`wsmj898-ltb`)** — deployed, `verify_channel: mqtt`, lan_ip `192.168.50.197`.
+- **ST-P (`stp-lab`)** — bench, USB cabled, `verify_channel: serial`, lan_ip `192.0.2.177`.
+- **patio (`wsmj898-ltb`)** — deployed, `verify_channel: mqtt`, lan_ip `192.0.2.197`.
 
 > The registry stores a **pointer** (`section.key`) to the password, never the
 > password itself, so an accidental commit of `hardware-devices.yaml` leaks

--- a/docs/handoffs/2026-06-10-observer-mqtt-session-handoff.md
+++ b/docs/handoffs/2026-06-10-observer-mqtt-session-handoff.md
@@ -9,7 +9,7 @@
 - **Observer MQTT connectivity shipped as `crosswire-v0.15.0`** -- hardware-validated against 3 real brokers (CoreScope tcp/anon, eastme.sh wss/jwt, LetsMesh-US wss/jwt). Packets confirmed landing on eastme.sh.
 - The whole multi-hour failure (`rc=5` on wss/jwt brokers) came down to **one missing field**: the firmware sent MQTT CONNECT `username = nullptr`; the brokers require `v1_<UPPERCASE 64-hex pubkey>`. Fixed (#68).
 - Repo is **clean and releasable**: `firmware-base @ e03ef09a`, one worktree, one local branch, remote = `firmware-base` + 3 intentional experimental branches. The owner's stated next goal is to **transfer the filesystem location** -- the repo is ready for that.
-- **The biggest takeaway is process, not code** (see section 6). This session started by violating SAFELANE (guessing root causes and having the user hardware-test each guess) and recovered by switching to **empirical diagnosis** (probe the live broker). Do not regress.
+- **The biggest takeaway is process, not code** (see section 6). The session began by guessing root causes and having the user hardware-test each guess and recovered by switching to **empirical diagnosis** (probe the live broker). Do not regress.
 
 ---
 
@@ -64,7 +64,7 @@ Also: CHANGELOG `[0.15.0]` added + `[0.14.0]` completed (it had only documented 
   - **LetsMesh-US** = STRICT: audience must be **bare host** (`https://...` REJECTED), and `exp` is enforced (1970 token REJECTED -> **needs a valid wall clock**).
 - **Device clock:** firmware has **no SNTP**; it only gets time from the companion app (`CMD_SET_DEVICE_TIME` on BLE connect). Power-cycle wipes it. So an **unattended** LetsMesh observer fails until SNTP lands (epic #69). eastme.sh doesn't care (lax on exp).
 - **`analyzer.eastme.sh/api/observers` is a ~40-min STALE periodic snapshot** (timestamps batch-clustered). **Do not read freshness from it.** To verify a device is publishing live, **SUBSCRIBE to the broker** with a minted observer token and watch for `meshcore/<IATA>/<PUBKEY>/{status,packets,raw}`.
-- **Verified broker config values** (so they're never re-asked): see `reference_mqtt_broker_configs.md`. eastme.sh -> `ca_cert letsencrypt`, audience `mqtt.eastme.sh`. LetsMesh-US -> `ca_cert gts-r4`, audience `mqtt-us-v1.letsmesh.net` (bare). Owner pubkey `18315e8b...`, email `strycher@gmail.com`, IATA `HAO`.
+- **Verified broker config values** (so they're never re-asked): see `reference_mqtt_broker_configs.md`. eastme.sh -> `ca_cert letsencrypt`, audience `mqtt.eastme.sh`. LetsMesh-US -> `ca_cert gts-r4`, audience `mqtt-us-v1.letsmesh.net` (bare). Owner pubkey `<redacted>`, email `you@example.com`, IATA `HAO`.
 
 ### The diagnostic method (the antidote to guessing -- reuse it)
 For ANY broker-auth question: mint a real MeshCore token in Python (`cryptography` Ed25519 + `paho` wss), **prove the minter correct locally** (sign+verify roundtrip) so a rejection means the *broker* rejected a *valid* token, then **probe the live broker one variable at a time** reading the actual CONNACK rc, then **subscribe** to confirm packets land. Working scripts/patterns are in this session's transcript. The canonical client-side signer is HA's `mqtt_uploader.py::_create_auth_token_python` on the Pi5.
@@ -84,28 +84,18 @@ For ANY broker-auth question: mint a real MeshCore token in Python (`cryptograph
 
 ---
 
-## 6. SAFELANE / process lessons -- DO NOT LOSE THESE
+## 6. Process lessons
 
-The owner explicitly flagged multiple SAFELANE failures this session. They were corrected, but the patterns recur -- internalize them:
-
-1. **Diagnose empirically; do not guess and have the user test your guesses.** The session burned hours cycling hypotheses (audience -> clock -> registration) and asking the owner to hardware-test each. The fix was to **probe the live broker** with a proven-correct minter. SAFELANE section 1/section 2: gather evidence at the failing layer before theorizing.
-2. **A reference implementation existing != verified working.** I called HA "canonical" and diffed against it without ever observing HA's token *accepted* by eastme.sh (its path was down). Don't treat a code-read as proof.
-3. **Use the infra access you already have.** Pi5 / HA / docker / DB access was available the entire time; I asked the owner to "check HA" instead of reading it (`ssh pi5`, `docker exec homeassistant ...`). Read it yourself.
-4. **Agent Mail is communication, not hook-satisfaction.** Registering + `fetch_inbox` to refresh the ack while never *sending* coordination (and ignoring DustyFox's ack-required message all day) is "fetch-only theater." Actually reply and broadcast at milestones.
-5. **Verify the FULL state, not the convenient slice.** I called the repo "pristine" when only *local* was clean -- the remote had 6 stray branches. Check local **and** remote.
-6. **Don't claim verification from an inadequate observation.** "boot verified" was false: a 12s serial read < the 15s crash period, and the read itself (CP2102 port-open) **rebooted the device**. State precisely what was observed and what it does/doesn't show.
-7. **Verify before deleting** (patch-id, not assumption). "Safe to delete" was wrong twice -- `chore/16` was a squash-merged *different* patch; `main` looked like it had unique content. Use `git cherry` / content diff before any force-delete; record recovery SHAs.
-8. **CP2102 boards (HV3) reset on serial port-open** (DTR/RTS). Any read reboots the chip and drops BLE. Class-B "port-opening reads don't reset" only holds for native-USB S3, NOT UART-bridged boards. Bounded reads count as resets in any timing forensics.
-9. **Respect per-PR merge tollgates absolutely.** The owner approves each merge explicitly ("Merge 72"). Never `--auto` a merge off an inherited "proceed."
+Relocated to `CLAUDE.local.md` (gitignored). Working-practice notes, not engineering record.
 
 ---
 
 ## 7. Hardware & infra map
 
-- **HV3** (bench) = Heltec V3 observer. **COM6**, CP2102 `VID:PID 10C4:EA60`. Node `WSMJ898-HV3-OBS`, pubkey `8AA6DA6C...` (companion `_sys @ 8aa6da6c`). Currently flashed with `crosswire-v0.14.0-rc1-19-ge7b11cb` (= the 0.15.0 content). **Port-open resets it.**
-- **Pi5** = `192.168.50.24`, ssh alias `pi5` (= `strycher@`, key `~/.ssh/id_ed25519`). Runs (docker): `homeassistant` (meshcore-ha integration = the canonical observer client; config in `/config/.storage/core.config_entries`, signer in `custom_components/meshcore/mqtt_uploader.py`), `mosquitto`, `frigate`, `meshmonitor`, etc. `heimdalld` = systemd, currently **inactive**. NOTE: HA's *map.meshcore.io* uploader had a DNS-timeout problem; the MQTT *observer* path works (HEIMDALL node `18315e8b` publishes live).
+- **HV3** (bench) = Heltec V3 observer. **COM6**, CP2102 `VID:PID 10C4:EA60`. Node `WSMJ898-HV3-OBS`, pubkey `<redacted>` (companion `_sys @ <redacted>`). Currently flashed with `crosswire-v0.14.0-rc1-19-ge7b11cb` (= the 0.15.0 content). **Port-open resets it.**
+- **Pi5** = the mesh-gateway host (address, account and key are in `HARDWARE.local.md`, not here). Runs (docker): `homeassistant` (meshcore-ha integration = the canonical observer client; config in `/config/.storage/core.config_entries`, signer in `custom_components/meshcore/mqtt_uploader.py`), `mosquitto`, `frigate`, `meshmonitor`, etc. `heimdalld` = systemd, currently **inactive**. NOTE: HA's *map.meshcore.io* uploader had a DNS-timeout problem; the MQTT *observer* path works (HEIMDALL node `18315e8b` publishes live).
 - **Brokers:** CoreScope `mqtt.w8oof.net:1883` (tcp/anon); eastme.sh `mqtt.eastme.sh:443` (wss/jwt, `letsencrypt`, aud `mqtt.eastme.sh`); LetsMesh-US `mqtt-us-v1.letsmesh.net:443` (wss/jwt, `gts-r4`, aud bare).
-- **Owner identity:** pubkey `18315e8b...`, email `strycher@gmail.com`, IATA `HAO`.
+- **Owner identity:** recorded in `HARDWARE.local.md`, not here.
 - **FOREIGN -- NEVER TOUCH:** `COM3` = CH340K `VID:PID 1A86:7522` = `desk_command_center` (ESP32-P4). Hard-refuse any flash/serial against it.
 
 ---
@@ -127,4 +117,4 @@ The owner explicitly flagged multiple SAFELANE failures this session. They were 
 4. Pick from section 5 -- the natural next is the **#66/#67/#70 cosmetic-display fix** (one small PR, same `ObserverCli` status path) and/or pinging DustyFox to start the 1.16.0 merge.
 5. If returning to broker work: re-read section 4 and use the empirical-probe method, not guesses.
 
-**Key memory files:** `findings_2026-06-10_eastmesh_jwt_username.md`, `reference_mqtt_broker_configs.md`, `reference_meshcore_observer_ecosystem.md`, `findings_2026-05-31_heap_optimization_levers.md`, plus the SAFELANE/feedback memories.
+**Key memory files:** `findings_2026-06-10_eastmesh_jwt_username.md`, `reference_mqtt_broker_configs.md`, `reference_meshcore_observer_ecosystem.md`, `findings_2026-05-31_heap_optimization_levers.md`, plus the process/feedback memories.

--- a/docs/plans/2026-06-03-observer-onto-safeboot-base-migration.md
+++ b/docs/plans/2026-06-03-observer-onto-safeboot-base-migration.md
@@ -1,6 +1,6 @@
 # Crosswire Firmware Base Unification: Observer -> feature/safeboot
 
-> **For agentic workers:** execute phase-by-phase with the build-verify gate after each. Every step has an exact command + a rollback. Tier-2 actions (compile, push) require explicit approval per SAFELANE.
+> **For agentic workers:** execute phase-by-phase with the build-verify gate after each. Every step has an exact command + a rollback. Tier-2 actions (compile, push) require explicit approval.
 
 **Goal:** Establish one canonical Crosswire firmware base by making `feature/safeboot` the base (full history, Crosswire rebrand, SafeBoot + variant matrix, MeshCore v1.15.0) and porting the Observer/companion line onto it via granular cherry-pick.
 

--- a/docs/safeboot-maintenance.md
+++ b/docs/safeboot-maintenance.md
@@ -351,7 +351,7 @@ estimates below.
 
 - [ ] ST-P is on the bench and accessible via USB serial (`pio device list`
       shows ST-P's port; cross-check VID:PID and MAC against
-      `hardware-devices.yaml` per SAFELANE pre-touch checklist).
+      `hardware-devices.yaml` per the pre-touch checklist).
 - [ ] Bench supply present with LiIon-range current settings ready
       (3.5V test point + 4.0V test point).
 - [ ] `meshcore-fork/` working tree clean: `git status` shows no
@@ -396,7 +396,7 @@ overrides or thresholds need re-tuning for whatever upstream changed.
 
 - [ ] Flash the heltec_v4_repeater build to ST-P:
       `python scripts/pio-flash.py flash st-p --env=heltec_v4_repeater`
-      (per SAFELANE flashing discipline, named-target only).
+      (per flashing discipline, named-target only).
 - [ ] **Normal-voltage boot** (bench supply at 4.0V): SafeBoot does NOT
       intervene; boot completes; banner observed in serial monitor.
 - [ ] **Low-voltage** (bench supply at 3.5V): SafeBoot sleeps; serial

--- a/docs/superpowers/plans/2026-06-11-observer-time-and-position.md
+++ b/docs/superpowers/plans/2026-06-11-observer-time-and-position.md
@@ -12,7 +12,7 @@
 
 **Test strategy (firmware-adapted):** There is no fast unit-test loop for the GPS/SNTP paths (they need hardware). "Verify" steps are therefore (a) **host/target compile** via `pio run -e <env>` (Tier-2 — needs per-action approval) and (b) **runtime serial verification on ST-P** (collected into Task F). Where a pure-logic host test is cheap (payload JSON), add one.
 
-**SAFELANE:** `pio run` (build), `git push`, flash, and merge are **all Tier-2** — explicit per-action approval for each, every time. "commit"/"land"/"finalize" do **not** authorize merge; only the word "merge" does. Frequent local commits are fine.
+**Approvals:** `pio run` (build), `git push`, flash, and merge are **all Tier-2** — explicit per-action approval for each, every time. "commit"/"land"/"finalize" do **not** authorize merge; only the word "merge" does. Frequent local commits are fine.
 
 ---
 

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -781,7 +781,7 @@ bool MyMesh::textMentionsSelf(const char* text) const {
     }
   }
 
-  // NO SILENT FAILURE (SAFELANE §6). A mention that did not match used to produce
+  // NO SILENT FAILURE. A mention that did not match used to produce
   // nothing at all, so a field failure left zero evidence and cost several test
   // cycles to reconstruct. If the message carried a bracketed token but it did not
   // match us, say so and show BOTH sides in full, codepoint-rendered.

--- a/examples/companion_radio/ui-orig/Button.cpp
+++ b/examples/companion_radio/ui-orig/Button.cpp
@@ -61,7 +61,7 @@ void Button::begin() {
                 break;
             }
         }
-        // SAFELANE §6: if every slot is taken, say so. The polled producer still runs,
+        // if every slot is taken, say so. The polled producer still runs,
         // so the button keeps working -- just without interrupt-grade capture.
         if (_irq_slot < 0) {
             MESH_DEBUG_PRINTLN("[btn] WARNING no IRQ slot free for pin %d, polling only", (int)_pin);
@@ -205,7 +205,7 @@ void Button::update() {
     // Resolve anything whose window has now closed.
     drainSequencer(now);
 
-    // SAFELANE §6: a dropped edge is lost user input. Report it once per occurrence
+    // a dropped edge is lost user input. Report it once per occurrence
     // rather than letting a miscounted press look like a press that never happened.
     uint32_t dropped = _dropped;
     if (dropped != _dropped_reported) {

--- a/examples/companion_radio/ui-orig/Button.h
+++ b/examples/companion_radio/ui-orig/Button.h
@@ -62,7 +62,7 @@ public:
     bool isPressed() const { return _seq.isDown(); }
     EventType getLastEvent() const { return _lastEvent; }
 
-    // #527 / SAFELANE §6: input loss must be VISIBLE, never silent. Non-zero means edges
+    // #527 / input loss must be VISIBLE, never silent. Non-zero means edges
     // arrived faster than update() drained them and were discarded.
     uint32_t droppedEdges() const { return _dropped; }
 

--- a/hardware-devices.example.yaml
+++ b/hardware-devices.example.yaml
@@ -4,7 +4,7 @@
 #
 # Copy this to `hardware-devices.yaml` (gitignored) and populate with YOUR
 # devices. NEVER commit the populated file -- it contains LAN IPs, MAC
-# addresses, and node identifiers (SAFELANE redaction discipline). This
+# addresses, and node identifiers (redaction discipline). This
 # example contains only placeholders.
 #
 # The wrapper (scripts/pio-flash) + the block-raw-flash / block-raw-curl-ota

--- a/scripts/offband-cmd.py
+++ b/scripts/offband-cmd.py
@@ -10,7 +10,7 @@ adopted in-repo with a pure-HTTP /caplog endpoint (#572). Part of the Remote
 Diagnostics epic (#565).
 
 Config via env (so no secret lives in the repo):
-  OFFBAND_CMDRELAY_URL          e.g. http://192.168.50.24:8765
+  OFFBAND_CMDRELAY_URL          e.g. http://192.0.2.24:8765
   OFFBAND_CMDRELAY_ADMIN_TOKEN  the cmdrelay ADMIN bearer token
   OFFBAND_PI_SSH    (tail only) e.g. user@host   (ssh target for the log host)
   OFFBAND_CAPLOG_PATH (tail)    default /var/log/offband-caplog.log

--- a/scripts/test_observer_broker_format.py
+++ b/scripts/test_observer_broker_format.py
@@ -66,7 +66,7 @@ int main() {
     // Non-secret config the operator must be able to verify.
     strcpy(cfg.jwt_audience, "mqtt.meshmapper.net");
     strcpy(cfg.jwt_owner,    "18315E8B18315E8B18315E8B18315E8B18315E8B18315E8B18315E8B18315E8B");
-    strcpy(cfg.jwt_email,    "strycher@gmail.com");
+    strcpy(cfg.jwt_email,    "you@example.com");
     strcpy(cfg.ca_cert_name, "isrg-x2");
     strcpy(cfg.topic_prefix, "meshcore");
     cfg.jwt_refresh_sec = 3600;
@@ -91,7 +91,7 @@ int main() {
     if (!strstr(buf, "username=auto(v1_+pubkey)"))      return fail("username missing", buf);
     if (!strstr(buf, "jwt_audience=mqtt.meshmapper.net")) return fail("jwt_audience missing", buf);
     if (!strstr(buf, "jwt_owner=18315E8B"))             return fail("jwt_owner missing", buf);
-    if (!strstr(buf, "jwt_email=strycher@gmail.com"))   return fail("jwt_email missing", buf);
+    if (!strstr(buf, "jwt_email=you@example.com"))   return fail("jwt_email missing", buf);
     if (!strstr(buf, "jwt_refresh=3600"))               return fail("jwt_refresh missing", buf);
     if (!strstr(buf, "ca_cert=isrg-x2"))                return fail("ca_cert missing", buf);
     if (!strstr(buf, "iata=(global)"))                  return fail("iata missing", buf);

--- a/scripts/test_pio_flash_mac.py
+++ b/scripts/test_pio_flash_mac.py
@@ -9,7 +9,7 @@ first 6 bytes carry the ff:fe EUI-64 fill and are NOT the device base MAC. The
 real address is on the "BASE MAC:" line. The old naive regex mis-parsed this.
 
 Fixtures use synthetic, locally-administered (02:..) MACs on purpose -- never a
-real device MAC (SAFELANE redaction discipline; real MACs live only in the
+real device MAC (redaction discipline; real MACs live only in the
 gitignored hardware-devices.yaml). The output *shape* mirrors esptool v5.2.0 as
 observed on an ESP32-C6 (2026-07-14).
 """

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -162,7 +162,7 @@ public:
   virtual bool isBootValidationPending() const { return false; }
 
   // Epic E (#64) / E1 #65: persistent on-device safety/diagnostic logging.
-  // Fixes SAFELANE Error Visibility violation discovered during D7 (#61) test:
+  // Fixes an error-visibility defect found during D7 (#61) test:
   // D9 SAFETY and OTA events were emitted only via Serial.println, lost if no
   // monitor attached or if monitor dropped on USB re-enumeration. These getters
   // expose the NVS-backed event ring buffer + current snapshot. Default no-op

--- a/src/helpers/CdcConsoleFlush.h
+++ b/src/helpers/CdcConsoleFlush.h
@@ -47,7 +47,7 @@ static inline void flushSerialConsole() {
   // header says to flush "when usb_serial_jtag_ll_txfifo_writable() returns true". Checking
   // once and skipping raced with the in-flight packet and left ~1% of 64-multiple replies
   // unterminated (#1035). The 2 ms bound means an unread/stalled host can never wedge the
-  // reply path (SAFELANE rule 8); on timeout we flush best-effort, which is harmless.
+  // reply path; on timeout we flush best-effort, which is harmless.
   uint32_t t0 = micros();
   while (!usb_serial_jtag_ll_txfifo_writable() && (uint32_t)(micros() - t0) < 2000) { }
   usb_serial_jtag_ll_txfifo_flush();            // zero-length packet ends the USB transfer

--- a/src/helpers/ClockSanity.cpp
+++ b/src/helpers/ClockSanity.cpp
@@ -61,7 +61,7 @@ uint32_t clampLastmod(uint32_t lastmod) {
 void logClockSet(const char* source, uint32_t old_epoch, uint32_t new_epoch) {
 #ifdef ARDUINO
   // One line per accepted set; sets are rare human/GPS events, so this cannot
-  // flood the pipe (SAFELANE rule 10). Serial-stream so caplog tees it.
+  // flood the pipe. Serial-stream so caplog tees it.
   // %lld: a correction from a decades-poisoned clock exceeds what 32-bit
   // %ld can represent (Gemini review 2026-08-09).
   Serial.printf("[clock] set by %s: %lu -> %lu (delta %+lld s)\n",
@@ -76,7 +76,7 @@ void logClockReject(const char* source, uint32_t current, uint32_t attempted) {
 #ifdef ARDUINO
   // Rejections from AUTOMATED sources can repeat every loop while the bad
   // input persists (e.g. a GPS stuck on a rolled-over week). Cap the total
-  // per boot so diagnostics exist without flooding the pipe (SAFELANE 10).
+  // per boot so diagnostics exist without flooding the pipe.
   static uint8_t budget = 3;
   if (budget == 0) return;
   budget--;

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -292,7 +292,7 @@ void CommonCLI::loadPrefs(FILESYSTEM* fs) {
         // FAIL CLOSED. Do NOT migrate and do NOT fall back to either table --
         // guessing here is the corruption path this whole mechanism exists to
         // prevent. Leave the legacy file untouched, run this boot on defaults,
-        // and make it loud so an operator intervenes (SAFELANE 6).
+        // and make it loud so an operator intervenes.
         MESH_DEBUG_PRINTLN("[prefs] ERROR: cannot determine legacy layout of %s "
                            "(len=%u) -- MIGRATION REFUSED, booting on defaults. "
                            "The legacy file is untouched.", legacy, (unsigned)ev.length);

--- a/src/helpers/ESP32Board.cpp
+++ b/src/helpers/ESP32Board.cpp
@@ -197,7 +197,7 @@ static bool s_validation_pending = false;
 
 // ======================================================================// Epic E (#64) / E1 #65: Persistent safety/diagnostic event ring buffer.
 //
-// SAFELANE Error Visibility violation fix discovered during D7 (#61) testing:
+// Error-visibility fix found during D7 (#61) testing:
 // D9 SAFETY logs and OTA events were emitted only via Serial.println, lost if
 // no monitor attached or if monitor dropped on USB re-enumeration. This block
 // adds an NVS-backed ring buffer that persists events across reboots, giving

--- a/src/helpers/LogMirrorUart.h
+++ b/src/helpers/LogMirrorUart.h
@@ -40,7 +40,7 @@
 // THE ONE SAFETY RULE
 // -------------------
 // Every wait on hardware MUST be finitely bounded. A diagnostic that can hang
-// the board it is observing is not a diagnostic (SAFELANE 11.8). The ESP32 arm
+// the board it is observing is not a diagnostic. The ESP32 arm
 // learned this the hard way: its first version spun on a FIFO-count read,
 // assuming an unclocked peripheral reads 0. A gated peripheral commonly reads
 // all-ones instead, which made the wait permanent. Worst case here is losing

--- a/src/helpers/config/ConfigDispatch.cpp
+++ b/src/helpers/config/ConfigDispatch.cpp
@@ -32,7 +32,7 @@ Provider g_providers[kMaxProviders];
 int      g_count;
 
 // Latched so a client polling config cannot turn this into a log flood
-// (SAFELANE 11 rule 10: diagnostics must not become the outage).
+// (diagnostics must not become the outage).
 bool g_warned_empty;
 
 // #366: count of key-space collisions detected across all registrations. Lets a
@@ -121,7 +121,7 @@ void flushOverlapWarnings() {
     }
 }
 
-// SAFELANE 6: an unregistered config surface must not silently masquerade as
+// an unregistered config surface must not silently masquerade as
 // "unknown config key" to the client. Report it once, visibly.
 void warnIfNoProvider(const char* op) {
     if (g_count != 0 || g_warned_empty) return;

--- a/src/helpers/config/ConfigDispatch.h
+++ b/src/helpers/config/ConfigDispatch.h
@@ -76,7 +76,7 @@ static const int kMaxProviders = 4;
 //                  key ("mqtt.iata"). See prefixesCollide in the .cpp.
 //   prefix_count : entries in key_prefixes (0 + nullptr allowed, but then this
 //                  provider is EXEMPT from overlap detection -- discouraged).
-// Returns false if the table is full (SAFELANE 6: the caller must not ignore).
+// Returns false if the table is full (the caller must not ignore).
 //
 // OVERLAP DETECTION (#366): at registration, this provider's entries are checked
 // against each already-registered provider's. A collision (some key both would
@@ -84,7 +84,7 @@ static const int kMaxProviders = 4;
 // #301 trap) bumps overlapWarningCount() immediately AND stores a record. The
 // human-visible LOUD diagnostic (Serial / stderr, naming both roles + entries)
 // is emitted LAZILY on the first dispatchSet/dispatchGet -- NOT at registration,
-// which runs during static init before Serial.begin() (review BLOCKER-1). This
+// which runs during static init before Serial.begin(). This
 // converts the silent first-provider-wins shadow into a visible error without
 // depending on unready hardware. Registration still proceeds; dispatch is
 // unchanged -- the diagnostic is only a signal.

--- a/src/helpers/config/DisplayConfigProvider.cpp
+++ b/src/helpers/config/DisplayConfigProvider.cpp
@@ -128,7 +128,7 @@ void setDisplayAlwaysOnApplier(void (*fn)(bool)) {
 bool handleDisplayAlwaysOn(char* reply, size_t reply_size, bool on) {
     // #181: if persistence fails, surface it and do NOT apply to the live display
     // -- applying a setting that won't survive a reboot would mislead the user
-    // about what's actually stored (SAFELANE 6: state must match the ACK).
+    // about what's actually stored (state must match the ACK).
     if (!setDisplayAlwaysOn(on)) {                                     // persist (offband_ui NVS)
         snprintf(reply, reply_size, "ERROR: failed to save display setting (NVS write failed)\n");
         return true;

--- a/src/helpers/diagnostics/CrashLog.cpp
+++ b/src/helpers/diagnostics/CrashLog.cpp
@@ -387,7 +387,7 @@ void crashLogBegin() {
 void crashLogf(const char* fmt, ...) {
     // #181: NEVER drop a line on the floor pre-begin. The crash logger silently
     // losing a line is the one failure that erases the very evidence the log
-    // exists to capture (SAFELANE 6/1). Before crashLogBegin(), still emit to the
+    // exists to capture. Before crashLogBegin(), still emit to the
     // live path (Serial/stdout); only the RTC ring -- which begin() initializes --
     // is skipped until ready (mirrors crashlog_vprintf's pre-begin handling).
     char line[kCrashLogLineMax + 1];
@@ -672,7 +672,7 @@ void heartbeatBegin() {
         s_nvs_boot_count       = s_boot_prefs.getUInt("count", 0) + 1;
         s_prev_boot_uptime_s   = s_boot_prefs.getUInt("last_up_s", 0);
         // #181: the boot counter IS crash-cycle evidence -- a silent put failure
-        // would freeze the count and mask a reboot loop (SAFELANE 6). Surface it.
+        // would freeze the count and mask a reboot loop. Surface it.
         if (s_boot_prefs.putUInt("count", s_nvs_boot_count) == 0) {
             crashLogf("[boot] WARN: NVS cw_boot 'count' write FAILED (count=%u not persisted)",
                       (unsigned)s_nvs_boot_count);
@@ -715,7 +715,7 @@ static void maybeSaveUptime(uint32_t now_ms) {
     // #181: feeds "prev boot lasted Ns" -- the crash-cycle-PERIOD evidence. Runs
     // every 5s, so a silent failure would erase that evidence indefinitely. Log a
     // failure ONCE and re-arm on the next success, rather than flooding the 4KB
-    // ring with a repeating warning (SAFELANE 6).
+    // ring with a repeating warning.
     static bool s_uptime_save_warned = false;
     ::Preferences p;
     if (!p.begin("cw_boot", /*readOnly=*/false)) {

--- a/src/helpers/diagnostics/CrashLog.h
+++ b/src/helpers/diagnostics/CrashLog.h
@@ -186,7 +186,7 @@ inline bool crashLogShouldEmitDeferred(bool pending, uint32_t now_ms, bool host_
 void crashLogTick(uint32_t now_ms);
 
 // ---------------------------------------------------------------------------
-// CrashLog v2 additions (SAFELANE "no silent failure" enforcement)
+// CrashLog v2 additions (no-silent-failure enforcement)
 // ---------------------------------------------------------------------------
 
 // Install the ESP-IDF log capture hook via esp_log_set_vprintf().

--- a/src/helpers/esp32/SerialBLEInterface.cpp
+++ b/src/helpers/esp32/SerialBLEInterface.cpp
@@ -26,7 +26,7 @@ void SerialBLEInterface::begin(const char* prefix, char* name, uint32_t pin_code
   // Create the BLE Device
   NimBLEDevice::init(dev_name);
   // #711: setMTU() returns false if the stack refused it, and the return was
-  // previously discarded -- a silent failure (SAFELANE §6). It matters because
+  // previously discarded -- a silent failure. It matters because
   // getMTU() then reports NimBLE's DEFAULT preferred MTU (256), not ours, and any
   // sizing that trusts it will oversize. The frame ceiling no longer depends on
   // this succeeding (see BleFrameSizing::deliverableFrame), but a failure here is

--- a/src/helpers/prefs/PrefsLayout.h
+++ b/src/helpers/prefs/PrefsLayout.h
@@ -55,7 +55,7 @@
 //    we do NOT fall back to either table -- falling back to "upstream" was an
 //    earlier proposal and is itself a corruption path for a truncated Offband
 //    record. The caller must leave the legacy file untouched, log at error
-//    level, and boot on defaults so an operator intervenes (SAFELANE 6).
+//    level, and boot on defaults so an operator intervenes.
 //
 // This header is deliberately free of Arduino/ESP-IDF dependencies so the
 // decision logic is unit-testable on the host. Reading the file length, the
@@ -92,7 +92,7 @@ enum class PrefsFamily : uint8_t {
 };
 
 // Why a decision was reached. Surfaced so the caller can log the deciding
-// evidence rather than just the verdict (SAFELANE 6: no silent choices).
+// evidence rather than just the verdict (no silent choices).
 enum class PrefsLayoutReason : uint8_t {
   LengthUniqueOffband  = 0,  // length matches only Offband releases
   LengthUniqueUpstream = 1,  // length matches only upstream releases

--- a/src/helpers/ui/NV3001BDisplay.cpp
+++ b/src/helpers/ui/NV3001BDisplay.cpp
@@ -466,7 +466,7 @@ void NV3001BDisplay::allocFrameBuffer() {
   if (!frame_buf) frame_buf = (uint16_t*)malloc(bytes);
 
   if (!frame_buf) {
-    // Loud, not silent (SAFELANE 6). The display still works, just unbuffered
+    // Loud, not silent. The display still works, just unbuffered
     // and flickering, so this must not be diagnosed as "the fix didn't work".
     Serial.printf("NV3001B: back buffer alloc FAILED (%u B) -- direct panel writes, expect flicker\n",
                   (unsigned)bytes);
@@ -542,7 +542,7 @@ void NV3001BDisplay::drawRGB565(int x, int y, const uint16_t* px, int w, int h) 
 
   // Unbuffered fallback. #747 treats a failed back-buffer allocation as a
   // supported degraded state rather than losing the display, so this path is real
-  // and must draw rather than silently skip (SAFELANE 6). It shares clip() with the
+  // and must draw rather than silently skip. It shares clip() with the
   // buffered path above so the two cannot disagree about geometry.
   const rgb565::Clip c = rgb565::clip(NV3001B_SCREEN_WIDTH, NV3001B_SCREEN_HEIGHT, x, y, w, h);
   if (!c.visible) return;

--- a/src/helpers/ui/NV3001BDisplay.h
+++ b/src/helpers/ui/NV3001BDisplay.h
@@ -66,7 +66,7 @@ class NV3001BDisplay : public DisplayDriver {
   // BYTE-SWAPPED (panel wants big-endian RGB565) so the blit is a plain
   // writeBytes with no per-pixel conversion.
   // Null is a supported state: allocation failure degrades to the original
-  // direct-to-panel behaviour rather than losing the display (SAFELANE 6).
+  // direct-to-panel behaviour rather than losing the display.
   uint16_t* frame_buf = nullptr;
 
   void allocFrameBuffer();

--- a/src/helpers/wifi_observer/ConfigSchema.cpp
+++ b/src/helpers/wifi_observer/ConfigSchema.cpp
@@ -29,7 +29,7 @@ void mqttBrokerNamespace(uint8_t broker_index, char* out, size_t out_len) {
 
 #ifdef ARDUINO
 
-// #181: surface a config-write failure (SAFELANE 6 -- never silent) AND measure
+// #181: surface a config-write failure (never silent) AND measure
 // the cause (free-entry count answers "is NVS full?" with evidence, not a guess).
 // Shared by every NVS writer below. Real-device only; the host round-trip test
 // gets the no-op stub (it defines ARDUINO but not ESP_PLATFORM).
@@ -51,7 +51,7 @@ static void logCfgWriteFailure(const char*, const char*) {}
 // 30s interval, display off/0deg, empty-url broker), and the Arduino read-only
 // API can't distinguish "key absent" -- the legitimate first-boot/unset state --
 // from a deeper error, so silence-with-safe-default IS the correct, documented
-// contract for a read-miss (NOT a SAFELANE 6 violation). This is exactly why
+// contract for a read-miss (NOT an error-visibility violation). This is exactly why
 // writeBrokerConfig can safely REMOVE an empty field's key (#182): an absent key
 // just reads back as the default.
 //
@@ -224,7 +224,7 @@ bool writeBrokerConfig(uint8_t slot, const BrokerConfig& cfg) {
         if (f.val[0] == '\0') p.remove(f.key);
     }
 
-    // Phase 2 -- value puts, each CHECKED (the #181 SAFELANE-6 honesty is kept).
+    // Phase 2 -- value puts, each CHECKED (the #181 honesty is kept).
     // Only non-empty strings; topic_prefix is ALWAYS stored because its read-default
     // is "meshcore", not "" -- removing it would lose an explicit value to the default.
     bool ok = true;
@@ -459,7 +459,7 @@ void populateDefaultBrokers() {
     }
     // #181: each failed write already self-logged its NVS cause + free-entry
     // stats; surface a single boot-time summary so an incomplete default-seed
-    // is never silent (SAFELANE 6). Boot-time best-effort: a failed seed retries
+    // is never silent. Boot-time best-effort: a failed seed retries
     // on the next boot (populateDefaultBrokers is idempotent / skip-if-present).
     if (!all_ok) {
         logCfgWriteFailure("populateDefaultBrokers", "(default-seed: 1+ write failed)");

--- a/src/helpers/wifi_observer/ConfigSchema.h
+++ b/src/helpers/wifi_observer/ConfigSchema.h
@@ -79,7 +79,7 @@ constexpr const char* kDefaultTopicPrefix = "meshcore";
 // Returns false if NVS error / missing. Defaults applied at call site.
 bool readGlobalIata(char* out, size_t out_len);
 // #181: writers return false on NVS failure (begin/put), and self-log the cause
-// (+ free-entry stats) before returning -- never silent (SAFELANE 6). Callers
+// (+ free-entry stats) before returning -- never silent. Callers
 // must surface the failure rather than ACK success on an unverified write.
 bool writeGlobalIata(const char* iata);
 

--- a/src/helpers/wifi_observer/MqttBroker.cpp
+++ b/src/helpers/wifi_observer/MqttBroker.cpp
@@ -510,7 +510,7 @@ void MqttBroker::eventHandler(void* handler_args,
                 } else if (eh->esp_transport_sock_errno != 0) {
                     err = BrokerErrorClass::Tcp;
                 }
-                // SAFELANE no-silent-failure: surface the ACTUAL reason
+                // No silent failure: surface the ACTUAL reason
                 // esp-mqtt/esp-tls reported, not just the coarse class.
                 //   sock_errno   -> ECONNREFUSED(111)=refused, EHOSTUNREACH(113/118)
                 //                   =unreachable, ETIMEDOUT(110)=timeout (TCP layer)

--- a/src/helpers/wifi_observer/MqttBrokerPool.cpp
+++ b/src/helpers/wifi_observer/MqttBrokerPool.cpp
@@ -500,7 +500,7 @@ void MqttBrokerPool::reconcileSlot(uint8_t slot) {
     }
     // #181: the worker runs off any user channel, so a reconcile that fails to
     // bring up a configured + ENABLED slot must surface in the persistent crash
-    // log (SAFELANE 6) -- otherwise the slot silently stays Down with only
+    // log -- otherwise the slot silently stays Down with only
     // rt_.state as evidence. begin() returns false on bad auth / client-init OOM;
     // a DISABLED slot returns true with no client (expected, not a failure).
     // URL is omitted from the log -- a broker URL may carry inline credentials.

--- a/src/helpers/wifi_observer/ObserverCli.cpp
+++ b/src/helpers/wifi_observer/ObserverCli.cpp
@@ -216,7 +216,7 @@ static bool handleEnableSet(char* reply, size_t reply_size, MqttBrokerPool& pool
     if (!pool.reloadSlot((uint8_t)slot)) {
         // #181: NVS is updated, but the live client wasn't reconciled now (worker
         // queue full / not ready). Surface it instead of ACKing a clean toggle --
-        // the change still takes effect at the next reboot (SAFELANE 6).
+        // the change still takes effect at the next reboot.
         snprintf(reply, reply_size,
                  "mqtt slot %d: %s saved, but live reload failed -- effective after reboot\n",
                  slot, enable ? "enabled" : "disabled");
@@ -389,7 +389,7 @@ static bool handleSetBrokerField(char* reply, size_t reply_size,
     if (!pool.reloadSlot((uint8_t)slot)) {
         // #181: saved to NVS, but the cached cfg_ wasn't refreshed (worker queue
         // full / not ready) -- `mqtt status` shows stale until reboot. Surface it
-        // rather than ACK a clean set (SAFELANE 6).
+        // rather than ACK a clean set.
         snprintf(reply, reply_size,
                  "mqtt.broker.%d.%s saved, but live reload failed -- effective after reboot\n",
                  slot, key);

--- a/test/test_prefs_layout/test_prefs_layout.cpp
+++ b/test/test_prefs_layout/test_prefs_layout.cpp
@@ -403,7 +403,7 @@ TEST(PathB, NonBoundaryOrCorruptLengthsAreRefused) {
 // -------------------------------------------------------------- Reporting --
 
 TEST(Reporting, EveryVerdictAndReasonHasALogString) {
-  // The migration MUST log what it chose and why (SAFELANE 6). A missing
+  // The migration MUST log what it chose and why. A missing
   // string would degrade that to "unknown".
   EXPECT_STREQ(toString(PrefsLayout::Offband),  "offband");
   EXPECT_STREQ(toString(PrefsLayout::Upstream), "upstream");

--- a/tools/diag/rc32-boot-740/rc32_uart_sniffer_v3/rc32_uart_sniffer_v3.ino
+++ b/tools/diag/rc32-boot-740/rc32_uart_sniffer_v3/rc32_uart_sniffer_v3.ino
@@ -477,7 +477,7 @@ void loop() {
 
   uint32_t now = millis();
 
-  // Dead-man: never leave the target held. Loud, never silent (SAFELANE 6).
+  // Dead-man: never leave the target held. Loud, never silent.
   if (od_deadline && (int32_t)(now - od_deadline) >= 0) {
     od_release(PIN_RC32_RST);
     od_release(PIN_RC32_BOOT);

--- a/tools/diag/rc32-boot-740/rc32_uart_sniffer_v3_esp32_s3_wroom_1/rc32_uart_sniffer_v3_esp32_s3_wroom_1.ino
+++ b/tools/diag/rc32-boot-740/rc32_uart_sniffer_v3_esp32_s3_wroom_1/rc32_uart_sniffer_v3_esp32_s3_wroom_1.ino
@@ -477,7 +477,7 @@ void loop() {
 
   uint32_t now = millis();
 
-  // Dead-man: never leave the target held. Loud, never silent (SAFELANE 6).
+  // Dead-man: never leave the target held. Loud, never silent.
   if (od_deadline && (int32_t)(now - od_deadline) >= 0) {
     od_release(PIN_RC32_RST);
     od_release(PIN_RC32_BOOT);

--- a/tools/diag/rc32-boot-740/scripts/capture.py
+++ b/tools/diag/rc32-boot-740/scripts/capture.py
@@ -187,7 +187,7 @@ def do_capture(port: str, baud: int, out_path: str, cmd_path: str = None) -> int
                 f.write(f"[{ts()}] <capture stopped by operator>\n")
                 return 0
             except Exception as e:
-                # Loud, never silent (SAFELANE 6). A dropped port is recorded in
+                # Loud, never silent. A dropped port is recorded in
                 # the artifact itself so a gap in the log is always explained.
                 f.write(f"[{ts()}] <port error: {e!r}; retrying in 2s>\n")
                 try:

--- a/tools/diag/rc32-boot-740/scripts/make_merged.py
+++ b/tools/diag/rc32-boot-740/scripts/make_merged.py
@@ -112,7 +112,7 @@ def main() -> int:
 
     r = subprocess.run(cmd, capture_output=True, text=True)
     if r.returncode != 0:
-        # Loud, never silent (SAFELANE 6).
+        # Loud, never silent.
         print(r.stdout)
         print(r.stderr, file=sys.stderr)
         sys.exit(f"merge failed (rc={r.returncode})")

--- a/tools/diag/rc32-tester/sniffer/capture.py
+++ b/tools/diag/rc32-tester/sniffer/capture.py
@@ -187,7 +187,7 @@ def do_capture(port: str, baud: int, out_path: str, cmd_path: str = None) -> int
                 f.write(f"[{ts()}] <capture stopped by operator>\n")
                 return 0
             except Exception as e:
-                # Loud, never silent (SAFELANE 6). A dropped port is recorded in
+                # Loud, never silent. A dropped port is recorded in
                 # the artifact itself so a gap in the log is always explained.
                 f.write(f"[{ts()}] <port error: {e!r}; retrying in 2s>\n")
                 try:

--- a/tools/diag/rc32-tester/sniffer/rc32_uart_sniffer_v3_esp32_s3_wroom_1/rc32_uart_sniffer_v3_esp32_s3_wroom_1.ino
+++ b/tools/diag/rc32-tester/sniffer/rc32_uart_sniffer_v3_esp32_s3_wroom_1/rc32_uart_sniffer_v3_esp32_s3_wroom_1.ino
@@ -477,7 +477,7 @@ void loop() {
 
   uint32_t now = millis();
 
-  // Dead-man: never leave the target held. Loud, never silent (SAFELANE 6).
+  // Dead-man: never leave the target held. Loud, never silent.
   if (od_deadline && (int32_t)(now - od_deadline) >= 0) {
     od_release(PIN_RC32_RST);
     od_release(PIN_RC32_BOOT);

--- a/tools/diag/sniffer/rc_uart_sniffer_v3/rc_uart_sniffer_v3.ino
+++ b/tools/diag/sniffer/rc_uart_sniffer_v3/rc_uart_sniffer_v3.ino
@@ -791,7 +791,7 @@ void loop() {
 
   uint32_t now = millis();
 
-  // Dead-man: never leave the target held. Loud, never silent (SAFELANE 6).
+  // Dead-man: never leave the target held. Loud, never silent.
   if (od_deadline && (int32_t)(now - od_deadline) >= 0) {
     od_release(PIN_RC32_RST);
     od_release(PIN_RC32_BOOT);

--- a/variants/heltec_rc52/RC52Display.cpp
+++ b/variants/heltec_rc52/RC52Display.cpp
@@ -26,7 +26,7 @@
 #include <Arduino.h>
 #include <string.h>
 // Unconditional: the back-buffer failure paths report through crashLogf on EVERY
-// build, not only diag ones. A silent allocation failure is a SAFELANE 6 defect
+// build, not only diag ones. A silent allocation failure is an error-visibility defect
 // regardless of which env is being built, and gating the reporting on a diag flag
 // would mean the one configuration nobody is watching is also the one that says
 // nothing. crashLogf itself is unconditional in CrashLog.h.
@@ -460,7 +460,7 @@ void RC52Display::busWritePattern(const uint8_t* pattern, size_t plen, uint32_t 
 
   if (plen > sizeof(expanded)) {
     // Not expected -- callers use a 2-byte pixel pattern. Degrade to a plain
-    // per-repeat write rather than silently truncating (SAFELANE 6).
+    // per-repeat write rather than silently truncating.
     while (count--) busWriteBytes(pattern, plen);
     return;
   }
@@ -726,7 +726,7 @@ void RC52Display::allocFrameBuffer() {
   frame_buf = (rc52_px_t*)malloc(bytes);
 
   if (!frame_buf) {
-    // Loud, not silent (SAFELANE 6) -- but loud ON A CHANNEL SOMEONE READS.
+    // Loud, not silent -- but loud ON A CHANNEL SOMEONE READS.
     //
     // This previously used Serial.print. On a _ble build `Serial` is USB-CDC and
     // is a debug channel nothing is attached to, so the message was effectively
@@ -926,7 +926,7 @@ void RC52Display::drawRGB565(int x, int y, const uint16_t* px, int w, int h) {
 
   // Unbuffered fallback. A failed back-buffer allocation is a supported degraded
   // state rather than a lost display, so this path is real and must draw rather
-  // than silently skip (SAFELANE 6). It shares clip() with the buffered path so
+  // than silently skip. It shares clip() with the buffered path so
   // the two cannot disagree about geometry.
   //
   // NOTE this is the path #856 says has never executed on hardware on ANY board.

--- a/variants/heltec_rc52/RC52Display.h
+++ b/variants/heltec_rc52/RC52Display.h
@@ -118,7 +118,7 @@ class RC52Display : public DisplayDriver {
   // byte write with no per-pixel conversion.
   //
   // Null is a SUPPORTED state: allocation failure degrades to direct-to-panel
-  // writes rather than losing the display (SAFELANE 6). On this board that is
+  // writes rather than losing the display. On this board that is
   // not hypothetical -- 220*128*2 = 56,320 B against 237,568 B of region, and
   // the BLE companion role already spends ~162 KB of it. See #856.
   rc52_px_t* frame_buf = nullptr;

--- a/variants/heltec_rcc6/platformio.ini
+++ b/variants/heltec_rcc6/platformio.ini
@@ -238,7 +238,7 @@ build_flags =
 ; and it reads UART_TXFIFO_CNT_S from the target's own soc/uart_reg.h -- but it
 ; has never run on RISC-V. The FIFO spin is bounded precisely so an unclocked or
 ; differently-mapped UART degrades to silent writes instead of wedging the board
-; it is supposed to be observing (SAFELANE 11.8). Worst case here is no beacon
+; it is supposed to be observing. Worst case here is no beacon
 ; output, not a hang. If APP:CTOR appears after a reset, the bootloader and IDF
 ; startup both completed and the fault is in our ctors/setup().
 ;

--- a/variants/heltec_v4/LoRaFEMControl.cpp
+++ b/variants/heltec_v4/LoRaFEMControl.cpp
@@ -93,7 +93,7 @@ void LoRaFEMControl::init(void)
     // only re-attach afterwards, by which time a single print is long gone. Each
     // repeat costs 1 s of boot delay, and at ~1 Hz this WILL drown CLI replies on
     // the same serial endpoint -- which is exactly why it is opt-in. Bounded so it
-    // can never become the outage it is meant to diagnose (SAFELANE §11 r10).
+    // can never become the outage it is meant to diagnose.
     //
     //   -D FEM_DEBUG_PROBE                      -> 60 lines / ~60 s boot delay
     //   -D FEM_DEBUG_PROBE -D FEM_DEBUG_PROBE_REPEAT=1  -> single line, no delay


### PR DESCRIPTION
Epic #1092 · implementation #1098 (closed on commit-land) · private-data finding #1095 · verification #1099 (open, gates the epic)

## Why

This repository is public. Tracked files carried inline citations to a private engineering-standards document by name and rule number, and a handful carried real private-subnet addresses and a personal email. Neither belongs in a published artifact.

**Text only. No behavioral change.** 54 files, +90/−95.

## What changed

- **`CLAUDE.md` points at a gitignored `STANDARDS.local.md`** instead of naming the documents and their paths inline — the same pattern `HARDWARE.local.md` already uses for per-host hardware facts. `CLAUDE.local.md` is added as the home for repo-local working notes. Both are gitignored; verified with `git check-ignore`.
- **Inline citations removed across 52 files.** The overwhelming majority were decorative: the comment already stated the engineering reason in plain English beside the rule number, so only the reference is gone — `// Loud, never silent (<ref>).` becomes `// Loud, never silent.`
- **Process artifacts removed or rewritten.** A retrospective about a past session, approval tiers, review-phase stamps, and an internal review marker — none of which belong in shipped code or docs.
- **The 2026-06-10 handoff document's process-lessons section is RELOCATED**, not deleted, to `CLAUDE.local.md`. The lessons are useful; the venue was wrong.
- **Private data redacted.** Real subnet addresses replaced with the RFC 5737 `192.0.2.0/24` range reserved for documentation; personal email replaced. The handoff document's infrastructure map no longer carries host address, ssh alias, key path, identity, or node public keys. `192.168.4.1` is deliberately untouched — it is the ESP32 SoftAP default, not anyone's LAN.

## One citation arrived from outside this branch

`src/helpers/CdcConsoleFlush.h` is a new file from `3430d851` (#1039), which landed while this branch was in flight and introduced a fresh reference. Removed here, but worth stating plainly: **cleaning the tree does not stop the next one.** #1029 proposes the write-time guard that would, and extending it to cover this alongside private addresses is the durable fix.

## Verification

| Check | Result |
|---|---|
| `heltec_v4_companion_observer_wifi` | **SUCCESS** — re-run after the rebase, and again after the final header edit |
| `heltec_rc52_companion_radio_ble` | **SUCCESS** |
| `native test_prefs_layout` | **PASSED**, 14 cases |
| Added lines: secrets / private addresses | none |
| Repo-wide residual grep | zero outside the committed consultation logs |
| Line-ending churn | none — `git diff` and `git diff --ignore-cr-at-eol` report identical counts |

Build results are read from PlatformIO's per-env status table, not from a wrapper exit code.

## Adversarial review — findings, and what was done

Ran on the highest-risk edited headers. **It confirmed no code corruption**, having specifically checked macro bodies, string literals, preprocessor directives, and a disclosed earlier bug of mine that had stripped parentheses from function references.

Four findings. One accepted, three rejected with reasons:

**ACCEPTED — internal review marker in a shipped header.** `ConfigDispatch.h` carried `(review BLOCKER-1)`, an artifact of a past code review. Removed; it is the same class of leak this PR exists to clear.

**REJECTED — "a comment claiming a log line is mandatory lost its justification."** The flagged line was **not touched by this change**; `git diff | grep -c` on it returns 0. The review stated the claim "was likely backed by a citation that was just removed" and reported that speculation as a defect. The comment predates this branch.

**REJECTED — "engineering rationale erased, leaving a bare order."** The actual edit was `(<ref>: the caller must not ignore)` → `(the caller must not ignore)`. The rationale *is* "the caller must not ignore" and it survived intact; only the reference went, which is the purpose of the change.

**REJECTED — "inconsistent redaction: project identifiers and an NVS namespace left behind."** The identifiers flagged (`Epic E (#64)`, `#63`, `Epic #300`) are this repository's **own public issue numbers**; redacting them from their own public repo is meaningless. The NVS namespace is visible in open-source firmware regardless and is not a secret.

## Deliberate residual

- **Six committed consultation logs**, untouched: editing a recorded review conversation would falsify a historical record.
- **One generic example address** in upstream-derived doc text.
- **22 commit messages** in published history. Rewriting `firmware-base` history is out of scope, so the references and the addresses remain recoverable from any clone. This stops accretion and removes them from what a reader sees; it does not unpublish them. **Treat the subnet as disclosed.**

## What this PR does not prove

#1099 stays open and gates the epic. A grep that is clean locally says nothing about what merged, and a comment-only change compiles whether or not a comment now misleads — which is the failure mode only reading catches. #1099 verifies the outcome on `firmware-base` after merge.

**Merge is the owner's call, not mine.**

Agent: CloudyGrove (session fcc043c7)
