### PR TITLE
epic(#1113): keep log text out of the companion protocol stream on USB companions

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -256,17 +256,50 @@ void setup() {
   Serial.setTxTimeoutMs(1);
 #endif
 
+#if defined(ENABLE_USB_INTERFACE)
+  // #1087: FAIL SAFE BEFORE THE FIRST LINE OF OUTPUT. This must stay the first
+  // statement in setup() that can affect logging -- everything below it, the
+  // build stamp included, depends on the guard already being in place.
+  //
+  // The authoritative test is isConsoleSharedWithProtocol(), but it compares the
+  // interface's bound stream against Serial and so cannot be asked until
+  // usb_serial_interface.begin(Serial) has run -- roughly 250 lines below, after
+  // crashLogStandardInit() has already emitted the boot banner and replayed any
+  // previous-boot ring. Gemini review found that window: a guard set after the
+  // damage is not a guard.
+  //
+  // ENABLE_USB_INTERFACE is decidable here and is sufficient, because begin() is
+  // called with Serial unconditionally on this path -- so on these builds the
+  // console IS the protocol, always. Start closed and let the authoritative
+  // check below re-affirm it, rather than starting open and hoping nothing
+  // speaks first.
+  meshLogSetMirror(false);
+#endif
+
   // #149: stamp the running build on the serial console at boot. Every test build
   // looks identical otherwise, so there's no way to confirm what's actually flashed.
+  // #1087: raw Serial.print, so it bypasses both loggers -- route it through
+  // crashLogf() where the console carries the framed protocol. The stamp still
+  // reaches the UART0 mirror and the retained ring, so nothing is lost on a diag
+  // build; it simply stops being injected into the client's frame decoder.
 #ifdef OFFBAND_VERSION
-  Serial.print("\n=== Offband build: "); Serial.print(OFFBAND_VERSION);
-  #ifdef OFFBAND_GIT_SHA
-  Serial.print(" sha "); Serial.print(OFFBAND_GIT_SHA);
-  #endif
-  Serial.println(" ===");
+  if (meshLogMirrorEnabled()) {
+    Serial.print("\n=== Offband build: "); Serial.print(OFFBAND_VERSION);
+    #ifdef OFFBAND_GIT_SHA
+    Serial.print(" sha "); Serial.print(OFFBAND_GIT_SHA);
+    #endif
+    Serial.println(" ===");
+  } else {
+    #ifdef OFFBAND_GIT_SHA
+    offband::crashLogf("=== Offband build: %s sha %s ===", OFFBAND_VERSION, OFFBAND_GIT_SHA);
+    #else
+    offband::crashLogf("=== Offband build: %s ===", OFFBAND_VERSION);
+    #endif
+  }
 #endif
 
   // SafeBoot: pre-init power guard. See src/SafeBoot.h.
+
   // #740: bracketed -- SafeBoot can deep-sleep here, which looks identical to a
   // hang from outside. A "before" with no "post" names it unambiguously.
   OFFBAND_BEACON("setup:before SafeBoot::checkAndMaybeSleep");
@@ -293,7 +326,15 @@ void setup() {
     snprintf(rr, sizeof(rr), "[boot] last reset: %s (RESETREAS=0x%lX)",
              board.getResetReasonString(board.getResetReason()),
              (unsigned long)board.getResetReason());
-    Serial.println(rr);
+    // #1087: not on a console that carries the framed protocol. This is a raw
+    // Serial.println, so it bypasses both loggers' guards and would land in the
+    // client's frame decoder as text. crashLogf() reaches the UART0 mirror and
+    // the retained ring, so a diag build loses nothing by routing it there.
+    if (meshLogMirrorEnabled()) {
+      Serial.println(rr);
+    } else {
+      offband::crashLogf("%s", rr);
+    }
   }
 #endif
 

--- a/src/helpers/diagnostics/CrashLog.cpp
+++ b/src/helpers/diagnostics/CrashLog.cpp
@@ -10,6 +10,9 @@
 // USB CDC vanish. On a native-USB board it is the ONLY channel that can carry
 // a crash log off the device at the moment the crash log matters.
 #include "../LogMirrorUart.h"
+// #1087: meshLogMirrorEnabled() -- the single source of truth for "is this
+// console shared with the framed protocol". CrashLog and MeshLog must agree.
+#include "../../MeshLog.h"
 
 #include <cstdarg>
 #include <cstdio>
@@ -215,6 +218,28 @@ static size_t crashLogSerialWrite(const char* data, size_t len) {
 #else
     const size_t mirrored = 0;
 #endif
+
+    // #1087: NEVER write into a console that is carrying the framed protocol.
+    //
+    // On a `_usb` companion `Serial` IS the companion protocol, so every line
+    // emitted here lands in the client's frame decoder as raw text. A stock
+    // MeshCore client reports one "unexpected frame type" per BYTE -- 117, 112,
+    // 59, 32 ... decodes to "up; reset", i.e. our own boot line. The session then
+    // degrades: settings render empty, the channel list never syncs, and under
+    // sustained traffic the board stops transmitting.
+    //
+    // Volume is what makes it fatal rather than cosmetic on ESP32: crashLogBegin
+    // installs an ESP-IDF log capture, so the whole IDF stream routes through
+    // here. One bench capture held 498 lines.
+    //
+    // MeshLog already solved this -- main.cpp sets the mirror from
+    // isConsoleSharedWithProtocol() -- and CrashLog simply never asked. Reuse
+    // that single source of truth rather than introducing a second policy:
+    // shared console => Serial is off limits, everywhere, for both loggers.
+    //
+    // Diagnostics are NOT lost. The UART0 mirror above already took every byte,
+    // which is exactly why a diag build reads that wire instead of USB.
+    if (!meshLogMirrorEnabled()) return mirrored;
 
     // Serial stays best-effort on exactly the old terms: never wait, never
     // block, drop what does not fit.


### PR DESCRIPTION
> ## ⚠ NOT READY TO MERGE
> The fix is implemented and its narrow claim is proven on hardware. **Epic verification (#1115) is still open** — the fix has not been in front of the #1053 tester. Merge is the owner's call after verification and sign-off.

Epic #1113 · bug #1087 · Fix task #1114 (closed) · Verification #1115 (open)

## What and why

On a `_usb` companion, `Serial` **is** the framed companion protocol. Log text was being written into it, so a stock MeshCore client parsed our own debug output as frames and reported one "unexpected frame type" per byte. Decoding a bench capture: `117 112 59 32 114 101 115 101 116` is `up; reset` — our own `[boot]` line.

It was severe rather than cosmetic because CrashLog installs an ESP-IDF log capture at boot, so the entire IDF stream went down the unguarded path. One capture held 498 lines.

MeshLog already solved this: `main.cpp` sets its mirror from `isConsoleSharedWithProtocol()`. CrashLog and two raw prints never asked. This reuses that single predicate rather than inventing a second policy.

## Changes

- **`src/helpers/diagnostics/CrashLog.cpp`** — `crashLogSerialWrite()` returns before touching `Serial` when the console is shared. The UART0 mirror above it is untouched, so a diag build keeps every byte on the sniffer wire.
- **`examples/companion_radio/main.cpp`** — on `ENABLE_USB_INTERFACE` builds, `meshLogSetMirror(false)` is now the **first** logging-affecting statement in `setup()`, before any output. The build stamp and the nRF52 reset-reason line, both raw `Serial.print` calls that bypassed both loggers, now route through `crashLogf()` when the console carries the protocol.

## Evidence

**Build:** green on `heltec_rc32_companion_radio_usb`, `heltec_rc32_companion_radio_ble`, `heltec_rc32_repeater`, `RAK_4631_companion_radio_usb`.

**Hardware (rc32-bench-1, ESP32-S3 USB-Serial-JTAG), stock MeshCore client over USB:**

| | Before | After |
|---|---|---|
| "unexpected frame type" in client log | continuous stream | **zero** |
| Board on independent UART0 capture | healthy | healthy — no reset, no silence |

**Not proven by this PR:** settings and the channel list still fail to populate. That is #1093 (VioletBarn), a separate defect in `writeFrame` underneath this one, and it is deliberately out of scope here.

## Gemini adversarial gate — two rounds

**Round 1 rejected the fix, correctly.** It found the guard was established at `main.cpp:532` while `crashLogStandardInit()` runs at `:351` and the build stamp at `:287`, so every boot had a window in which the exact text under investigation was emitted before the guard existed. → **Fixed**: the safe state is now the default from the first line of `setup()`. `ENABLE_USB_INTERFACE` is a sound proxy because `usb_serial_interface.begin(Serial)` is unconditional on that path.

Round 1 also found the two raw `Serial.print` calls in `setup()`. → **Fixed.**

Round 1 claimed the CrashLog → MeshLog include was a layering violation that would break host builds. → **Rejected with evidence**: the native env already compiles both deliberately (`platformio.ini:245` and `:254`), with a comment stating MESH_DEBUG routes into `mesh_log_line()`. The dependency predates this change.

**Round 2**, on the revised code:

- *Guard is after `Serial.begin()`, leaving a window.* → **Refuted**: a grep of the span between `Serial.begin(115200)` and the guard finds no Serial writes. The fragility point is fair for future edits and is addressed by a comment pinning the guard as the first logging-affecting statement.
- *`ENABLE_USB_INTERFACE` over-broad; a USB+BLE build would silence its BLE debug console.* → **Refuted**: no env combines them. The `_companion_radio_usb_` and `_companion_radio_ble_` envs are strictly separate in every variant.
- *Routing the build stamp through `crashLogf()` hides it from a casual serial monitor.* → **Refuted**: on a `_usb` build `Serial` carries binary frames, not a human-readable console, so the stamp was never usefully visible there. It still reaches the retained ring and the UART0 mirror.
- *Third-party libraries can still write to `Serial`.* → **Out of scope**: pre-existing and unbounded; not something this change claims to address.

Audit logs: `docs/llm-consultations/2026-09-09-1087-crashlog-protocol-guard-*` and `2026-09-10-1087-crashlog-guard-r2-*`.

## Unaffected

`_ble` companions: `Serial` is a debug channel there, the mirror stays true, logging continues. Non-companion roles never call `meshLogSetMirror`, so the flag stays true and their behavior is unchanged.

Refs #1087, #1053, #1093, #1083.

Agent: SunnyHollow (session e75a0ac9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
