### PR TITLE
task: defer the companion USB-CDC frame terminator (non-blocking) (#1093)

### DIFF
--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -19,6 +19,7 @@
 #define OFFBAND_BEACON_DEFINE_CTOR
 #include "helpers/BootBeacon.h"
 #include "helpers/CdcConsoleFlush.h"   // #1035: right-flush (ZLP) for the USB-Serial-JTAG console
+#include "helpers/ArduinoSerialInterface.h"   // #1093: emitw drives the real writeFrame()+loop() path for the v4.1 A/B
 
 
 #ifdef PIN_STATUS_LED
@@ -1364,6 +1365,67 @@ void loop() {
         for (int i = 0; i < n; i++) Serial.write((uint8_t)('0' + (i % 10)));
       }
       if (zlp) flushSerialConsole();     // #1035: emit the terminating ZLP -- proves the fix on the reproducer
+      handled_diag = true;
+    }
+    // #1093 companion writeFrame() reproducer: emit EXACTLY the on-wire pattern of
+    // ArduinoSerialInterface::writeFrame() -- a 3-byte header ('>' + len16 LE) then <len>
+    // payload bytes, as TWO Serial.write() calls (same as writeFrame), total 3+len bytes on
+    // the same HWCDC transport. Tests whether a frame whose on-wire length 3+len is a
+    // multiple of 64 holds host-side like the console reply did.
+    //   emitf <len> [delay_us] [zlp]     delay_us: busy-wait after the echo so the frame is
+    //   emitted as its own clean transfer (models the companion processing a command THEN
+    //   calling writeFrame -- the real frame path has no echo). zlp=1 => flushSerialConsole()
+    //   after, to A/B the terminator.
+    if (memcmp(command, "emitf ", 6) == 0) {
+      static uint8_t frame_buf[1024];
+      int len = atoi(command + 6);
+      const char* a2 = strchr(command + 6, ' ');
+      int delay_us = a2 ? atoi(a2 + 1) : 0;
+      const char* a3 = a2 ? strchr(a2 + 1, ' ') : nullptr;
+      int zlp = a3 ? atoi(a3 + 1) : 0;
+      if (len < 0) len = 0;
+      if (len > 1021) len = 1021;                  // keep 3+len <= 1024
+      if (delay_us < 0) delay_us = 0;
+      if (delay_us > 16000) delay_us = 16000;
+      if (delay_us > 0) delayMicroseconds(delay_us);  // let the echo drain, isolating the frame
+      uint8_t hdr[3] = { '>', (uint8_t)(len & 0xFF), (uint8_t)((len >> 8) & 0xFF) };
+      Serial.write(hdr, 3);                         // writeFrame() header write
+      for (int i = 0; i < len; i++) frame_buf[i] = (uint8_t)('0' + (i % 10));
+      Serial.write(frame_buf, len);                 // writeFrame() payload write
+      if (zlp) flushSerialConsole();                // #1093 A/B: the ZLP terminator after the frame
+      handled_diag = true;
+    }
+    // #1093 v4.1 validation: drive the REAL ArduinoSerialInterface::writeFrame() + loop()
+    // deferred-terminator path -- NOT a raw byte replay like emitf. This is the faithful
+    // hardware test of the shipped code: writeFrame() arms the deferred ZLP; loop() emits it
+    // once the TX ring has drained (availableForWrite back to the seeded ring capacity) and
+    // the FIFO is writable. No manual flushSerialConsole().
+    //   emitw <len> [delay_us] [pump]
+    //     len      payload bytes; on-wire frame is 3+len. 61 -> 64, 125 -> 128 (the 64-multiples);
+    //              126 -> 129 is the offset control. Capped at MAX_FRAME_SIZE (writeFrame refuses more).
+    //     delay_us busy-wait before the write, so the command echo drains and the frame is its own transfer.
+    //     pump=1 (default): service iface.loop() after the write -> the deferred ZLP fires -> delivered.
+    //     pump=0:           writeFrame() only, loop() NOT serviced -> ZLP never emitted -> held (control arm).
+    if (memcmp(command, "emitw ", 6) == 0) {
+      static ArduinoSerialInterface w_iface;
+      static bool w_init = false;
+      static uint8_t w_buf[MAX_FRAME_SIZE];
+      if (!w_init) { w_iface.begin(Serial); w_iface.enable(); w_init = true; }
+      int len = atoi(command + 6);
+      const char* a2 = strchr(command + 6, ' ');
+      int delay_us = a2 ? atoi(a2 + 1) : 0;
+      const char* a3 = a2 ? strchr(a2 + 1, ' ') : nullptr;
+      int pump = a3 ? atoi(a3 + 1) : 1;
+      if (len < 0) len = 0;
+      if (len > MAX_FRAME_SIZE) len = MAX_FRAME_SIZE;   // writeFrame refuses a frame larger than this
+      if (delay_us < 0) delay_us = 0;
+      if (delay_us > 16000) delay_us = 16000;
+      if (delay_us > 0) delayMicroseconds(delay_us);    // let the echo drain, isolating the frame
+      for (int i = 0; i < len; i++) w_buf[i] = (uint8_t)('0' + (i % 10));
+      w_iface.writeFrame(w_buf, (size_t)len);           // real path: '>' + len16 + payload, arms the deferred ZLP
+      if (pump) {
+        for (int k = 0; k < 400; k++) { w_iface.loop(); delayMicroseconds(50); }  // ~20 ms: ring drains, deferred ZLP fires
+      }
       handled_diag = true;
     }
 #endif

--- a/src/helpers/ArduinoSerialInterface.cpp
+++ b/src/helpers/ArduinoSerialInterface.cpp
@@ -1,16 +1,31 @@
 #include "ArduinoSerialInterface.h"
+#include "CdcConsoleFlush.h"   // #1093: ZLP terminator for 64-multiple frames on the HWCDC console
 
 #define RECV_STATE_IDLE        0
 #define RECV_STATE_HDR_FOUND   1
 #define RECV_STATE_LEN1_FOUND  2
 #define RECV_STATE_LEN2_FOUND  3
 
-void ArduinoSerialInterface::enable() { 
+void ArduinoSerialInterface::enable() {
   _isEnabled = true;
   _state = RECV_STATE_IDLE;
+#if defined(OFFBAND_USJ_CONSOLE)
+  // #1093: seed the "fully drained" reference with the known HWCDC ring capacity BEFORE any
+  // frame is written, so it can never be under-learned under sustained load (writeFrame's
+  // running max only ever raises it, e.g. for a larger custom ring). Without this seed a
+  // stream that keeps the ring backlogged from boot could learn a too-low capacity and fire
+  // the terminator a hair early; with it, the terminator fires only when the ring is truly
+  // empty. See CdcConsoleFlush.h for why the capacity cannot be measured live at init.
+  if (_zlp_ring_capacity < HWCDC_DEFAULT_TX_RING) {
+    _zlp_ring_capacity = HWCDC_DEFAULT_TX_RING;
+  }
+#endif
 }
 void ArduinoSerialInterface::disable() {
   _isEnabled = false;
+#if defined(OFFBAND_USJ_CONSOLE)
+  _zlp_pending = false;   // #1093: drop any deferred terminator so a re-enable starts clean
+#endif
 }
 
 bool ArduinoSerialInterface::isConnected() const { 
@@ -62,7 +77,60 @@ size_t ArduinoSerialInterface::writeFrame(const uint8_t src[], size_t len) {
     return 0;
   }
   const size_t n = _serial->write(src, len);
-  return n == len ? n : 0;
+  if (n != len) {
+    return 0;   // refused: nothing reached the wire, so leave any prior _zlp_pending intact
+  }
+#if defined(OFFBAND_USJ_CONSOLE)
+  // #1093: the ESP32 USB-Serial-JTAG console (HWCDC) emits no terminating zero-length
+  // packet after a transfer whose on-wire length is a multiple of the 64-byte USB packet
+  // size, so such a frame holds host-side until the next write -- the mechanism #1044
+  // fixed for text-console replies. We must NOT drain it inline here: flushSerialConsole()
+  // blocks (Serial.flush + up-to-2 ms wait), which would regress the #149 non-blocking
+  // contract on this hot path. Instead ARM a deferred terminator; loop() emits the ZLP
+  // once the TX ring has fully drained, without ever waiting (see CdcConsoleFlush.h).
+  //
+  // `writable` is the ring free space BEFORE this write, so its running maximum is the
+  // empty-ring capacity -- the level availableForWrite() returns to once every queued byte
+  // has reached the host. loop() uses it as the "fully drained" mark.
+  if (writable > _zlp_ring_capacity) {
+    _zlp_ring_capacity = writable;
+  }
+  // This frame's bytes have already begun a new USB transfer, which terminates any prior
+  // held 64-multiple frame on the host -- so SET (not OR) the pending state from THIS
+  // frame: re-arm iff it is itself a 64-multiple on the shared USB-Serial-JTAG console,
+  // else clear (it self-terminates and has superseded any prior hold). Back-to-back
+  // 64-multiple frames arm once and are terminated by a single ZLP after the whole batch
+  // drains. A dedicated-UART bridge companion (_serial != Serial) never arms. Verified: #1093.
+  if (isConsoleSharedWithProtocol() && (frame_len % USB_FS_BULK_MAX_PACKET) == 0) {
+    _zlp_pending = true;
+  } else {
+    _zlp_pending = false;
+  }
+#endif
+  return n;
+}
+
+void ArduinoSerialInterface::loop() {
+#if defined(OFFBAND_USJ_CONSOLE)
+  // #1093: emit the deferred USB-Serial-JTAG terminator armed by writeFrame(), non-blocking.
+  // Fire only once the TX ring has fully drained (availableForWrite() back to the learned
+  // empty-ring capacity) AND the FIFO is writable -- then the last packet on the wire is the
+  // frame's own tail, so the ZLP terminates it rather than an early chunk. This is correct
+  // even for several 64-multiple frames written back to back (one ZLP after the whole batch
+  // drains). Until drained this defers to the next pass; a stalled or not-yet-connected host
+  // simply leaves the data in the ring, so availableForWrite() stays below capacity and no
+  // ZLP is emitted -- the path cannot wedge (#149).
+  //
+  // availableForWrite() is the SAME call writeFrame() already makes every frame (#718); it
+  // is reached here only while a terminator is pending (a brief window after a 64-multiple
+  // frame), and on this single-writer companion its tx_lock is uncontended so it returns
+  // without blocking. emitConsoleZlpIfReady() never waits.
+  if (_zlp_pending && _zlp_ring_capacity > 0
+      && _serial->availableForWrite() >= _zlp_ring_capacity
+      && emitConsoleZlpIfReady()) {
+    _zlp_pending = false;
+  }
+#endif
 }
 
 size_t ArduinoSerialInterface::checkRecvFrame(uint8_t dest[]) {

--- a/src/helpers/ArduinoSerialInterface.h
+++ b/src/helpers/ArduinoSerialInterface.h
@@ -11,8 +11,24 @@ class ArduinoSerialInterface : public BaseSerialInterface {
   Stream* _serial;
   uint8_t rx_buf[MAX_FRAME_SIZE];
 
+  // #1093: deferred, non-blocking USB-Serial-JTAG terminator. A frame whose on-wire length
+  // is a multiple of the 64-byte USB packet size is held host-side until the next write
+  // (see CdcConsoleFlush.h). Rather than block writeFrame() draining it inline (which would
+  // regress the #149 non-blocking contract), writeFrame() arms _zlp_pending and loop() emits
+  // the terminating zero-length packet once the TX ring has fully drained (availableForWrite
+  // back to _zlp_ring_capacity) and the FIFO is writable -- so the ZLP terminates the frame's
+  // final packet, correctly even for several 64-multiple frames written back to back, and
+  // never fires early (while the host is still draining, or is not yet connected -- the data
+  // then sits in the ring and availableForWrite stays below capacity, so loop() defers).
+  // _zlp_ring_capacity is the empty-ring free level (== ring capacity): seeded at enable()
+  // from the known HWCDC default so it is never under-learned under sustained load, and
+  // raised by the running max in writeFrame() if a larger ring is ever configured. loop()
+  // treats availableForWrite() >= this as "ring fully drained". See CdcConsoleFlush.h.
+  bool _zlp_pending;
+  int  _zlp_ring_capacity;
+
 public:
-  ArduinoSerialInterface() { _isEnabled = false; _state = 0; }
+  ArduinoSerialInterface() { _isEnabled = false; _state = 0; _zlp_pending = false; _zlp_ring_capacity = 0; }
 
   void begin(Stream& serial) { 
     _serial = &serial; 
@@ -43,6 +59,11 @@ public:
   // CDC) implements it. Do not bind a Stream that does not.
   size_t writeFrame(const uint8_t src[], size_t len) override;
   size_t checkRecvFrame(uint8_t dest[]) override;
+
+  // #1093: per-main-loop service (driven by MultiSerialInterface::loop). Emits the deferred
+  // USB-Serial-JTAG terminator armed by writeFrame(), non-blocking. No-op on every other
+  // transport and on non-USB-Serial-JTAG boards.
+  void loop() override;
 
   // #411: shared with the console only when the framed protocol runs on `Serial`
   // itself (USB-serial companion). A dedicated-UART bridge (begin(companion_serial))

--- a/src/helpers/CdcConsoleFlush.h
+++ b/src/helpers/CdcConsoleFlush.h
@@ -37,6 +37,22 @@
   #endif
 #endif
 
+// USB Full-Speed bulk max packet size. A CDC transfer whose on-wire length is an exact
+// multiple of this is emitted as full packets with NO terminating short packet, so the
+// host holds the final packet until the next write -- the #1035/#1093 hold. Named so the
+// framing math that decides "does this frame need a terminator?" is not a bare 64.
+static constexpr size_t USB_FS_BULK_MAX_PACKET = 64;
+
+// HWCDC's default TX ring size: arduino-esp32 HWCDC::begin() calls setTxBufferSize(256) and
+// the companion never overrides it, so 256 IS the ring capacity. ArduinoSerialInterface
+// seeds its "fully drained" reference with this so the reference can never be under-learned
+// under sustained load (a boot banner dirties the ring before the interface can measure it
+// empty, so it cannot be read live at init -- see the #1093 review). If a future board did
+// configure a LARGER ring, the running max in writeFrame() raises the reference to match; a
+// SMALLER ring would leave the reference too high, which merely no-ops the terminator (a
+// stale host-side hold, never a truncation) -- fail-safe, not fail-corrupt.
+static constexpr int HWCDC_DEFAULT_TX_RING = 256;
+
 // Drain the console TX and emit the terminating zero-length packet so a reply whose
 // length is a multiple of 64 is delivered immediately instead of held host-side (#1035).
 static inline void flushSerialConsole() {
@@ -53,5 +69,37 @@ static inline void flushSerialConsole() {
   usb_serial_jtag_ll_txfifo_flush();            // zero-length packet ends the USB transfer
 #else
   Serial.flush();
+#endif
+}
+
+// Non-blocking deferred terminator for the framed-protocol hot path (#1093).
+//
+// flushSerialConsole() is fit for the console-reply boundary but NOT for writeFrame(): its
+// Serial.flush() + up-to-2 ms busy-wait would reintroduce a stall on a path that #149
+// deliberately keeps non-blocking (a stalled USB host must never wedge the loop and starve
+// BLE/radio). This variant NEVER waits: it emits the terminating zero-length packet iff the
+// TX FIFO is already writable -- i.e. the host has accepted the last real packet -- and
+// otherwise does nothing so the caller retries on the next loop pass. Returns true iff the
+// ZLP was emitted (or there is nothing to terminate off USB-Serial-JTAG), so the caller can
+// clear its pending flag.
+//
+// PRECONDITION (enforced by the caller, ArduinoSerialInterface::loop): the TX ring has
+// fully drained -- availableForWrite() is back to the ring capacity. Only then is the FIFO's
+// last packet the frame's own tail, so the ZLP terminates the FINAL packet rather than an
+// early chunk; this is what makes the single writable() check sufficient and correct even
+// for several 64-multiple frames written back to back. With the ring empty the HWCDC ISR is
+// in its empty-ring path, which does NOT touch this flush register (it only disables its own
+// interrupt), so there is no cross-core race and no critical section is needed. Detecting
+// drain from the ring (a cross-core-safe, framework-stable signal) rather than from the
+// ISR's interrupt-enable side effects is deliberate -- see the #1093 review history.
+static inline bool emitConsoleZlpIfReady() {
+#if defined(OFFBAND_USJ_CONSOLE)
+  if (usb_serial_jtag_ll_txfifo_writable()) {
+    usb_serial_jtag_ll_txfifo_flush();          // zero-length packet ends the USB transfer
+    return true;
+  }
+  return false;                                 // FIFO not writable yet -- retry next pass
+#else
+  return true;                                  // no USB-Serial-JTAG => nothing to terminate
 #endif
 }


### PR DESCRIPTION
## What & why

A companion `_usb` frame whose on-wire length (`3 + payload`) is a multiple of the 64-byte USB max packet size is held host-side by `usbser.sys` until the next write — the same ESP32 USB-Serial-JTAG (HWCDC) no-ZLP behaviour #1044 fixed for text-console replies. The framed path can't borrow that fix: `writeFrame()` is the #149 non-blocking hot path, and `flushSerialConsole()` blocks (`Serial.flush` + up-to-2 ms wait).

**Fix (deferred, non-blocking):** `writeFrame()` arms a terminator on a 64-multiple frame; `ArduinoSerialInterface::loop()` emits the zero-length packet once the TX ring has fully drained (`availableForWrite()` back to the ring capacity) and the FIFO is writable. Drain is read from the ring — not inferred from ISR interrupt-enable state — so it's cross-core-safe and needs no critical section; the ring capacity is seeded from the HWCDC default (256) so it can't be under-learned under load. A stalled or not-yet-connected host just leaves the frame in the ring and `loop()` retries — never waits. Guarded on `OFFBAND_USJ_CONSOLE` + the shared-`Serial` check: a no-op on UART bridges / non-USJ boards, and correct across the USJ family (C3/S3/C6/H2).

`simple_repeater` gains `emitf`/`emitw` diag reproducers (kept as tools); `emitw` drives the real `writeFrame()`+`loop()` path the hardware A/B measures.

## Issues
- Closes #1093 · under Epic #1037 · follow-up Epic #1141 (tighter verification).

## Evidence
- **Build:** `heltec_rcc6_companion_radio_usb_diag` (C6) and `Xiao_S3_companion_radio_usb` (S3) green post-rebase.
- **Gemini adversarial gate:** 5 rounds converged the design (inline→threshold→quiescent→ring-drain→capacity-seed); the round-5 review verified correctness (race-free, disconnected-safe, no data corruption, under-learning defeated). A final pre-push review ran on the shipped diff.
- **Hardware A/B (rcc6-bench-1, ESP32-C6):** `emitw` drives the real `writeFrame()`+`loop()`. With the terminator serviced: **0/40 aligned (64,128) frames held → delivered**; without it: **15/40 held**; the 129-byte offset control never holds via the mechanism.

## Gemini pre-push findings — addressed / justified
1. **`emitw` uses a separate `ArduinoSerialInterface` + a manual pump, so the A/B doesn't exercise the production instance through `interface_manager.loop()`.** *Justified + tracked.* The A/B exercises the real class methods on real hardware; the production loop-wiring is verified by inspection — `MultiSerialInterface::loop()` calls `iface.instance->loop()` for every registered interface, `usb_serial_interface` is registered, and `interface_manager.loop()` runs every main pass. Same code, called the same way the pump calls it. A runtime test of the production instance is deferred to **#1141** (owner decision: ship this, log the tighter test).
2. **`loop()` calls `availableForWrite()` (a `tx_lock` mutex) on the hot path.** *Acknowledged, accepted.* It runs only while a terminator is pending (a brief window after ~1-in-64 frames) and the lock is uncontended on the single-writer companion; it's inherent to reading drain from the ring. Documentation/evaluation tracked in #1141.
3. **Minor:** `enable()`/`disable()` comment precision and a possible `_zlp_ring_capacity` → `_zlp_drain_threshold` rename — tracked in #1141.

## Not merging
This PR is for review; **Ben merges** (`/merge`).

Agent: VioletBarn (session 82e07da7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
